### PR TITLE
feat(db): add ability to encrypt using keystore

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "dirs 6.0.0",
+ "hex",
+ "keyring",
  "lazy_static",
  "log",
  "rand 0.8.5",
@@ -2575,6 +2577,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961983669d57bdfe6c0f3ef8e4c229b5ef751afcc7d87e4271d2f71f6ccfa8b"
+dependencies = [
+ "byteorder",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,7 +2830,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4544,6 +4559,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,8 @@ lazy_static = "1.4.0"
 anyhow = "1.0"
 reqwest = { version = "0.12", features = ["json"] }
 tauri-plugin-log = { version = "2", features = ["colored" ] }
+keyring = {version = "3", features = ["apple-native", "windows-native"] }
+hex = "0.4.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,10 @@
+use crate::db::DbPassword;
 use bidder::Bidder;
 use config::{BiddingRules, Config, Mnemonics, ServerConnection, ServerProgress, ServerStatus};
 use db::{ArgonActivity, BitcoinActivity, BotActivity, DB};
 use log::{info, LevelFilter};
 use provisioner::Provisioner;
 use std::env;
-use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_log::fern::colors::ColoredLevelConfig;
 use window_vibrancy::*;
@@ -299,7 +299,7 @@ pub fn run() {
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
 
-            DB::init().map_err(|e| e.to_string())?;
+            DB::init(DbPassword::Keychain).map_err(|e| e.to_string())?;
 
             // test paths
 


### PR DESCRIPTION
This PR adds code that can encrypt the database using sqlcipher. We might or might not end up wanting this particular part, but it also has a demonstration of keeping a connection alive once we've encrypted the database, as well as how to prompt for a key in the keychain.