### PR TITLE
Fixes + new deploy strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,5 @@ tsconfig.*.tsbuildinfo
 *.pem
 .yarn/install-state.gz
 docker-compose.yml
-resources/VERSION
-resources/*.tar*
-/server/VERSION
+resources/server-*
+resources/SHASUM256

--- a/calculator/src/ClientWrapper.ts
+++ b/calculator/src/ClientWrapper.ts
@@ -1,0 +1,126 @@
+// util.ts
+import type { ArgonClient } from '@argonprotocol/mainchain';
+
+type AnyFn = (...args: any[]) => any;
+
+const cbCache = new WeakMap<Function, Function>();
+const fnCache = new WeakMap<Function, Function>();
+const reverseObj = new WeakMap<object, object>();
+const methodCache = new WeakMap<Function, Function>();
+
+function captureCallerStack(skip = 2) {
+  const s = new Error().stack ?? '';
+  return s.split('\n').slice(skip).join('\n');
+}
+
+function augment(err: unknown, callerStack: string, name: string): Error {
+  if (err && typeof err === 'object') {
+    const e = err as Error;
+    const msg = e.message ?? String(err);
+    if (!msg.includes(`${name}:`)) {
+      // If the error message does not already include the name, prepend it
+      e.message = `${name}: ${msg}`;
+    }
+    if (e.stack && !e.stack.includes('--- caller stack ---')) {
+      e.stack += `\n\n--- caller stack ---\n${callerStack}`;
+    }
+    return e;
+  }
+  return new Error(`Non-Error thrown: ${String(err)}\n\n--- caller stack ---\n${callerStack}`);
+}
+
+function wrapFunction(fn: AnyFn, name: string): AnyFn {
+  // Reuse a previously wrapped function to keep identity stable
+  const existing = fnCache.get(fn);
+  if (existing) return existing as AnyFn;
+
+  const prox = new Proxy(fn, {
+    apply(target, thisArg, argList) {
+      const callerStack = captureCallerStack();
+
+      // Wrap callbacks but keep identity stable across .on/.off calls
+      const wrappedArgs = argList.map(a => {
+        if (typeof a === 'function') {
+          let wrapped = cbCache.get(a);
+          if (!wrapped) {
+            wrapped = function (this: any, ...cbArgs: any[]) {
+              try {
+                return (a as AnyFn).apply(this, cbArgs);
+              } catch (e) {
+                throw augment(e, callerStack, name);
+              }
+            };
+            cbCache.set(a, wrapped);
+          }
+          return wrapped;
+        }
+        return a;
+      });
+
+      try {
+        const realThis =
+          thisArg && typeof thisArg === 'object' ? (reverseObj.get(thisArg as object) ?? thisArg) : thisArg;
+        const out = Reflect.apply(target, realThis, wrappedArgs);
+
+        // If it’s a Promise/thenable, attach a rejection handler using then(..., ...)
+        if (out && typeof (out as any).then === 'function') {
+          return (out as Promise<any>).then(
+            v => v,
+            e => {
+              throw augment(e, callerStack, name);
+            },
+          );
+        }
+        return out;
+      } catch (e) {
+        throw augment(e, callerStack, name);
+      }
+    },
+  });
+
+  fnCache.set(fn, prox);
+  return prox as unknown as AnyFn;
+}
+
+function deepProxy<T extends object>(obj: T, name: string, seen = new WeakMap<object, any>()): T {
+  if (seen.has(obj)) return seen.get(obj);
+  const prox = new Proxy(obj as any, {
+    get(target, prop, _receiver) {
+      // Use the original target as receiver so getters see the real instance
+      const value = Reflect.get(target, prop, target);
+
+      if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return value;
+
+      if (typeof value === 'function') {
+        if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+          const key = value as Function;
+          let bound = methodCache.get(key);
+          if (!bound) {
+            bound = key.bind(target);
+            methodCache.set(key, bound!);
+          }
+          return bound;
+        }
+        return wrapFunction(value, name);
+      }
+      if (typeof value === 'object') return deepProxy(value, name, seen);
+
+      return value;
+    },
+    // (no set trap needed)
+  });
+  reverseObj.set(prox, obj as any);
+  seen.set(obj, prox);
+  return prox;
+}
+
+const installedSymbol = Symbol('ArgonClientWrapper.installed');
+/** Wrap a Polkadot.js ApiPromise so all calls & callbacks get augmented stacks. */
+export function wrapApi<T extends ArgonClient>(api: T, name: string): T {
+  if (installedSymbol in api) {
+    return api as T; // Already wrapped
+  }
+  const result = deepProxy(api, name);
+  (result as any)[installedSymbol] = true; // Mark as wrapped
+  return result;
+}

--- a/resources/server-0.1.0-rc1.sha256
+++ b/resources/server-0.1.0-rc1.sha256
@@ -1,1 +1,0 @@
-5a37f41fe29cf64426a20589edb1fb3e5babe0babcf9c9155abba50456ff2b4b  resources/server-0.1.0-rc1.tar.gz

--- a/src-vue/lib/Server.ts
+++ b/src-vue/lib/Server.ts
@@ -131,8 +131,8 @@ export class Server {
     await this.connection.runCommandWithTimeout('mkdir -p ~/logs', 5e3);
   }
 
-  public async downloadVersion(): Promise<string> {
-    const [version] = await this.connection.runCommandWithTimeout('cat ~/server/VERSION 2>/dev/null || true', 5e3);
+  public async downloadRemoteShasum(): Promise<string> {
+    const [version] = await this.connection.runCommandWithTimeout('cat ~/server/SHASUM256 2>/dev/null || true', 5e3);
     return version.trim();
   }
 

--- a/src-vue/stores/mainchain.ts
+++ b/src-vue/stores/mainchain.ts
@@ -9,6 +9,7 @@ import { useConfig } from './config';
 import { type IBiddingRules } from '@argonprotocol/commander-calculator/src/IBiddingRules.ts';
 import { useBot } from './bot.ts';
 import { botEmitter } from '../lib/Bot.ts';
+import { wrapApi } from '@argonprotocol/commander-calculator/src/ClientWrapper.ts';
 
 let archiveClient: Promise<MainchainClient>;
 let ourMinerClient: Promise<MainchainClient>;
@@ -31,7 +32,7 @@ export async function getMainchainClient(preferMinerNode = false): Promise<Mainc
     }
   }
 
-  archiveClient ??= getClient(NETWORK_URL);
+  archiveClient ??= getClient(NETWORK_URL).then(x => wrapApi(x, 'ARCHIVE_RPC'));
 
   return archiveClient;
 }
@@ -45,7 +46,7 @@ export function getMinerNodeClient(): Promise<MainchainClient> {
   if (!config.isLoaded) {
     throw new Error('Config must be loaded before miner node client can be initialized');
   }
-  return getClient(`ws://${config.serverDetails.ipAddress}:9944`);
+  return getClient(`ws://${config.serverDetails.ipAddress}:9944`).then(client => wrapApi(client, 'OUR_MINER_RPC'));
 }
 
 export function getMainchain(): Mainchain {


### PR DESCRIPTION
## feat: add named logging + stack to client rpc errors
The client now is wrapped in a "named" rpc proxy that adds to error stacks, along with calling stack traces

## feat(deploy): use shasum file in place of version file for change detection
The resources/VERSION and server/VERSION files are replaced with a resources/SHASUM256 that is copied into server after successful file extraction. Combined with tar.gz determinism, this will make the server packages more predictable. 

## fix: don’t overwrite blocks while processing
The big flaw with block sync was the any best block was triggering a re-sync of blocks, but that could interfere with the processing next block. The new strategy records the latest block header, but only processes any missing blocks before scheduling the next for processing in a single loop

## fix: storage
Force storage mutation to by in a queue so that we don't get cross-writing.