### PR TITLE
fix: keep ssh private key as file path

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Typecheck
+        run: yarn typecheck
+
       - name: Run project lint (if defined)
         run: yarn lint:check
   rust-check:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+yarn typecheck
 yarn run lint
 yarn run eslint
 yarn run precommit

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,7 @@
     "lib"
   ],
   "scripts": {
-    "tsc": "tsup"
+    "tsup": "tsup"
   },
   "dependencies": {
     "@argonprotocol/commander-core": "workspace:*",

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -16,7 +16,7 @@ export * from './BlockWatch.js';
 export * from './CohortBidder.js';
 export * from './MiningBids.js';
 export * from './VaultMonitor.js';
-export * from './IBitcoinBlockMeta.ts';
+export * from './IBitcoinBlockMeta.js';
 
 export { convertBigIntStringToNumber, bigNumberToBigInt, JsonExt, filterUndefined, createNanoEvents } from './utils.js';
 

--- a/nodejs.Dockerfile
+++ b/nodejs.Dockerfile
@@ -19,6 +19,6 @@ COPY cli/ ./cli/
 COPY bot/ ./bot/
 COPY core/ ./core/
 
-RUN yarn tsc
+RUN yarn build:workspace
 
 CMD ["node", "cli/lib/cli.js"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "tsc": "tsc && yarn workspaces foreach --all run tsc",
     "build": "yarn build:version && yarn build:server && vue-tsc --noEmit && vite build",
+    "build:workspace": "yarn workspaces foreach --all run build",
     "build:server": "yarn workspace @argonprotocol/commander-bot run build && tsx scripts/buildServer.ts",
     "build:version": "tsx scripts/syncVersions.ts",
     "build:config": "tsx scripts/updateNetworkConfigs.ts",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,10 +21,10 @@ async fn open_ssh_connection(
     host: &str,
     port: u16,
     username: String,
-    private_key: String,
+    private_key_path: String,
 ) -> Result<String, String> {
     log::info!("ensure_ssh_connection");
-    ssh_pool::open_connection(address, host, port, username, private_key)
+    ssh_pool::open_connection(address, host, port, username, private_key_path)
         .await
         .map_err(|e| {
             log::error!("Error connecting to SSH: {:#}", e);
@@ -133,13 +133,13 @@ async fn overwrite_security(
     app: AppHandle,
     master_mnemonic: String,
     ssh_public_key: String,
-    ssh_private_key: String,
+    ssh_private_key_path: String,
 ) -> Result<String, String> {
     log::info!("overwrite_security");
     let new_security = security::Security {
         master_mnemonic,
         ssh_public_key,
-        ssh_private_key,
+        ssh_private_key_path,
     };
     new_security.save(&app).map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -12,7 +12,7 @@ use crate::{ssh::SSH, utils::Utils};
 pub struct Security {
     pub master_mnemonic: String,
     pub ssh_public_key: String,
-    pub ssh_private_key: String,
+    pub ssh_private_key_path: String,
 }
 
 impl Security {
@@ -28,23 +28,19 @@ impl Security {
 
             // Load SSH keys
             let ssh_public_key = fs::read_to_string(&public_key_path)?;
-            let ssh_private_key = fs::read_to_string(&private_key_path)?;
 
             Ok(Self {
                 ssh_public_key,
-                ssh_private_key,
+                ssh_private_key_path: private_key_path.to_string_lossy().to_string(),
                 master_mnemonic,
             })
         } else {
-            let security = Security::new()?;
-            security.save(app)?;
-            Ok(security)
+            Security::create(app)
         }
     }
 
     pub fn save(&self, app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         let absolute_config_dir = Utils::get_absolute_config_instance_dir(app);
-
         // Save mnemonics
         fs::write(absolute_config_dir.join("mnemonic"), &self.master_mnemonic)?;
 
@@ -53,31 +49,32 @@ impl Security {
             absolute_config_dir.join("serverkey.pub"),
             &self.ssh_public_key,
         )?;
-        fs::write(
-            absolute_config_dir.join("serverkey.pem"),
-            &self.ssh_private_key,
-        )?;
 
         // Set private key permissions to 600
         #[cfg(not(target_os = "windows"))]
         {
-            let private_key_path = absolute_config_dir.join("serverkey.pem");
-            let mut perms = fs::metadata(&private_key_path)?.permissions();
+            let mut perms = fs::metadata(&self.ssh_private_key_path)?.permissions();
             perms.set_mode(0o600);
-            fs::set_permissions(&private_key_path, perms)?;
+            fs::set_permissions(&self.ssh_private_key_path, perms)?;
         }
 
         Ok(())
     }
 
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn create(app: &AppHandle) -> Result<Self, Box<dyn std::error::Error>> {
         let (private_key, public_key) = SSH::generate_keys()?;
-
-        Ok(Self {
-            master_mnemonic: Self::generate_mnemonic()?,
+        let master_mnemonic = Self::generate_mnemonic()?;
+        let config_dir = Utils::get_absolute_config_instance_dir(app);
+        let ssh_private_key_path = config_dir.join("serverkey.pem");
+        fs::create_dir_all(&config_dir)?;
+        fs::write(&ssh_private_key_path, private_key)?;
+        let instance = Self {
+            master_mnemonic,
             ssh_public_key: public_key,
-            ssh_private_key: private_key,
-        })
+            ssh_private_key_path: ssh_private_key_path.to_string_lossy().to_string(),
+        };
+        instance.save(app)?;
+        Ok(instance)
     }
 
     fn generate_mnemonic() -> Result<String, Box<dyn std::error::Error>> {

--- a/src-tauri/src/ssh_pool.rs
+++ b/src-tauri/src/ssh_pool.rs
@@ -12,12 +12,8 @@ lazy_static! {
 
 pub async fn close_connection(address: &str) -> Result<()> {
     let address = address.to_string();
-    let mut connections_by_address = CONNECTIONS_BY_ADDRESS.lock().await;
-    if let Some(ssh) = connections_by_address.remove(&address) {
-        log::info!("Closing SSH connection to {}", address);
-        if let Err(e) = ssh.close().await {
-            log::error!("Error closing SSH connection to {}: {:#}", address, e);
-        }
+    if let Some(ssh) = CONNECTIONS_BY_ADDRESS.lock().await.remove(&address) {
+        ssh.close().await
     }
 
     Ok(())
@@ -25,8 +21,7 @@ pub async fn close_connection(address: &str) -> Result<()> {
 
 pub async fn get_connection(address: &str) -> Result<Option<SSH>> {
     let address = address.to_string();
-    let connections_by_address = CONNECTIONS_BY_ADDRESS.lock().await;
-    Ok(connections_by_address.get(&address).cloned())
+    Ok(CONNECTIONS_BY_ADDRESS.lock().await.get(&address).cloned())
 }
 
 pub async fn open_connection(
@@ -34,46 +29,36 @@ pub async fn open_connection(
     host: &str,
     port: u16,
     username: String,
-    private_key: String,
+    private_key_path: String,
 ) -> Result<SSH> {
     let address = address.to_string();
-    let ssh_config = SSHConfig::new(host, port, username, private_key).unwrap();
+    let ssh_config = SSHConfig::new(host, port, username, private_key_path)?;
 
-    let mut connections_by_address = CONNECTIONS_BY_ADDRESS.lock().await;
+    let timeout_duration = Duration::from_secs(10);
+    if let Some(existing) = CONNECTIONS_BY_ADDRESS.lock().await.get_mut(&address) {
+        if existing.config != ssh_config {
+            log::info!("Closing connection to SSH: {:#}", existing.config.host());
+            existing.close().await;
 
-    let needs_new_connection = match connections_by_address.get(&address) {
-        Some(ssh) => {
-            log::info!("Reconnecting to SSH: {:#}", ssh.config != ssh_config);
-            ssh.config != ssh_config
+            log::info!(
+                "Recreating SSH connection to {} with {:?} timeout",
+                ssh_config.host(),
+                timeout_duration
+            );
+            *existing = SSH::connect(&ssh_config, timeout_duration).await?;
         }
-        None => {
-            log::info!("No SSH connection found for {}, creating new one", address);
-            true
-        }
-    };
-
-    if needs_new_connection {
-        // Close existing connection if it exists
-        if let Some(ssh) = connections_by_address.remove(&address) {
-            log::info!("Closing existing SSH connection to {}", address);
-            if let Err(e) = ssh.close().await {
-                log::error!("Error closing existing SSH connection: {:#}", e);
-            }
-        }
-
-        // Create new connection with custom timeout
-        let timeout_duration = Duration::from_secs(10);
-        log::info!(
-            "Creating new SSH connection to {} with {:?} timeout",
-            ssh_config.host(),
-            timeout_duration
-        );
-        let new_ssh = SSH::connect(&ssh_config, timeout_duration).await?;
-        connections_by_address.insert(address.clone(), new_ssh.clone());
+        return Ok(existing.clone());
     }
 
-    connections_by_address
-        .get(&address)
-        .ok_or_else(|| anyhow::anyhow!("Failed to create or retrieve SSH connection"))
-        .cloned()
+    log::info!(
+        "Creating new SSH connection to {} with {:?} timeout",
+        ssh_config.host(),
+        timeout_duration
+    );
+    let ssh = SSH::connect(&ssh_config, timeout_duration).await?;
+    CONNECTIONS_BY_ADDRESS
+        .lock()
+        .await
+        .insert(address.clone(), ssh.clone());
+    Ok(ssh)
 }

--- a/src-vue/interfaces/ISecurity.ts
+++ b/src-vue/interfaces/ISecurity.ts
@@ -1,5 +1,5 @@
 export default interface ISecurity {
   masterMnemonic: string;
   sshPublicKey: string;
-  sshPrivateKey: string;
+  sshPrivateKeyPath: string;
 }

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -53,7 +53,7 @@ export class Config {
     this._security = {
       masterMnemonic: '',
       sshPublicKey: '',
-      sshPrivateKey: '',
+      sshPrivateKeyPath: '',
     };
     this._loadedData = {
       version: packageJson.version,

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -72,7 +72,7 @@ export default class Importer {
       sshUser: this.config.serverDetails.sshUser,
     };
 
-    const serverData = await this.fetchServerData(serverDetails, this.config.security.sshPrivateKey);
+    const serverData = await this.fetchServerData(serverDetails, this.config.security.sshPrivateKeyPath);
 
     if (!serverData) {
       throw new Error('Failed to fetch server data');
@@ -93,11 +93,11 @@ export default class Importer {
 
   private async fetchServerData(
     serverDetails: IConfigServerDetails,
-    sshPrivateKey: string,
+    sshPrivateKeyPath: string,
   ): Promise<ITryServerData | undefined> {
-    if (!serverDetails.ipAddress || !sshPrivateKey) return;
+    if (!serverDetails.ipAddress || !sshPrivateKeyPath) return;
 
-    const serverData = await SSH.tryConnection(serverDetails, sshPrivateKey);
+    const serverData = await SSH.tryConnection(serverDetails, sshPrivateKeyPath);
     return serverData;
   }
 }

--- a/src-vue/lib/SSH.ts
+++ b/src-vue/lib/SSH.ts
@@ -33,7 +33,7 @@ export class SSH {
       this.connection = new SSHConnection({
         address: this.config.serverDetails.ipAddress,
         username: this.config.serverDetails.sshUser,
-        privateKey: this.config.security.sshPrivateKey,
+        privateKeyPath: this.config.security.sshPrivateKeyPath,
       });
       await this.connection.connect();
     }
@@ -42,12 +42,12 @@ export class SSH {
 
   public static async tryConnection(
     serverDetails: IConfigServerDetails,
-    sshPrivateKey: string,
+    sshPrivateKeyPath: string,
   ): Promise<ITryServerData> {
     const connection = new SSHConnection({
       address: serverDetails.ipAddress,
       username: serverDetails.sshUser,
-      privateKey: sshPrivateKey,
+      privateKeyPath: sshPrivateKeyPath,
     });
     await connection.connect();
     const server = new Server(connection);

--- a/src-vue/lib/SSHConnection.ts
+++ b/src-vue/lib/SSHConnection.ts
@@ -4,7 +4,7 @@ import { listen } from '@tauri-apps/api/event';
 export interface ISSHConfig {
   address: string;
   username: string;
-  privateKey?: string;
+  privateKeyPath?: string;
 }
 
 export class SSHConnection {
@@ -15,7 +15,7 @@ export class SSHConnection {
   public host: string;
   public port: number;
   public username: string;
-  public privateKey?: string;
+  public privateKeyPath?: string;
 
   constructor(sshConfig: ISSHConfig) {
     const { host, port } = this.extractHostPort(sshConfig.address);
@@ -23,7 +23,7 @@ export class SSHConnection {
     this.host = host;
     this.port = port;
     this.username = sshConfig.username;
-    this.privateKey = sshConfig.privateKey;
+    this.privateKeyPath = sshConfig.privateKeyPath;
   }
 
   public async connect(): Promise<void> {
@@ -37,7 +37,7 @@ export class SSHConnection {
         host: this.host,
         port: this.port,
         username: this.username,
-        privateKey: this.privateKey,
+        privateKeyPath: this.privateKeyPath,
       };
       if (!sshConfig.host) {
         reject(new Error('No SSH host config provided'));

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -90,7 +90,7 @@ async function applyRestoredServer(details: string) {
       if (!parseResult.success) return;
 
       const serverDetails = parseResult.data;
-      await SSH.tryConnection(serverDetails, config.security.sshPrivateKey);
+      await SSH.tryConnection(serverDetails, config.security.sshPrivateKeyPath);
       config.isServerUpToDate = false;
       config.serverDetails = serverDetails;
       await config.save();

--- a/src-vue/overlays/ImportingOverlay.vue
+++ b/src-vue/overlays/ImportingOverlay.vue
@@ -49,7 +49,7 @@ const draggable = Vue.reactive(new Draggable());
 basicEmitter.on('openImportingOverlay', async ({ importer, dataRaw }: { importer: Importer; dataRaw: string }) => {
   isOpen.value = true;
   isLoaded.value = true;
-  importer.importFromFile(dataRaw);
+  await importer.importFromFile(dataRaw);
   console.log('openImportingOverlay', importer);
 });
 </script>

--- a/src-vue/overlays/ServerConfigureOverlay.vue
+++ b/src-vue/overlays/ServerConfigureOverlay.vue
@@ -197,7 +197,7 @@ async function updateServer() {
       ipAddress: ipAddress.value,
     };
     const existing = SSH.connection;
-    await SSH.tryConnection(newServerDetails, config.security.sshPrivateKey);
+    await SSH.tryConnection(newServerDetails, config.security.sshPrivateKeyPath);
 
     config.isServerReadyToInstall = true;
     config.isServerUpToDate = false;

--- a/src-vue/overlays/ServerConnectOverlay.vue
+++ b/src-vue/overlays/ServerConnectOverlay.vue
@@ -310,7 +310,7 @@ async function addServer() {
       ...config.serverDetails,
       ipAddress: ipAddress.value,
     };
-    const serverMeta = await SSH.tryConnection(newServerDetails, config.security.sshPrivateKey);
+    const serverMeta = await SSH.tryConnection(newServerDetails, config.security.sshPrivateKeyPath);
     if (serverMeta.walletAddress && serverMeta.walletAddress !== config.miningAccount.address) {
       hasServerDetailsError.value = true;
     }

--- a/src-vue/overlays/security-settings/Import.vue
+++ b/src-vue/overlays/security-settings/Import.vue
@@ -44,6 +44,6 @@ async function importAccount() {
 
   const dataRaw = await readTextFile(filePath);
   emit('close');
-  controller.importFromFile(dataRaw);
+  await controller.importFromFile(dataRaw);
 }
 </script>

--- a/src-vue/overlays/security-settings/SSHKeys.vue
+++ b/src-vue/overlays/security-settings/SSHKeys.vue
@@ -53,14 +53,14 @@
     <CopyToClipboard
       ref="copyToClipboard"
       @click="highlightCopiedContent"
-      :content="config.security.sshPrivateKey"
+      :content="sshPrivateKey"
       class="relative mb-3"
     >
       <textarea
         :style="{ height: privateKeyTextareaHeight }"
         class="bg-white py-3 pl-3 pr-8 border border-slate-300 rounded-md w-full pointer-events-none resize-none whitespace-pre overflow-hidden font-mono text-md focus:outline-none"
         readonly
-      >{{ config.security.sshPrivateKey }}</textarea>
+      >{{ sshPrivateKey }}</textarea>
       <div
         class="absolute right-px rounded-r-md top-1 w-[72px] bottom-2 bg-gradient-to-r from-transparent to-[40px] to-white pointer-events-auto"
       ></div>
@@ -72,7 +72,7 @@
           ref="privateKeyTextareaShadow"
           class="bg-white py-3 pl-3 pr-8 border border-slate-300 rounded-md w-full pointer-events-none overflow-x-hidden"
         >
-          <pre class="bg-blue-200 whitespace-pre w-full inline-block overflow-visible font-mono text-md">{{ config.security.sshPrivateKey }}</pre>
+          <pre class="bg-blue-200 whitespace-pre w-full inline-block overflow-visible font-mono text-md">{{ sshPrivateKey }}</pre>
         </div>
         <div
           class="flex flex-row items-center absolute right-[1px] top-1 bottom-1 pointer-events-none bg-white pl-2 pr-[15px] rounded-r-md"
@@ -93,6 +93,7 @@ import * as Vue from 'vue';
 import { useConfig } from '../../stores/config';
 import CopyToClipboard from '../../components/CopyToClipboard.vue';
 import CopyIcon from '../../assets/copy.svg?component';
+import { readTextFile } from '@tauri-apps/plugin-fs';
 
 const config = useConfig();
 const copyToClipboard = Vue.ref<typeof CopyToClipboard>();
@@ -122,9 +123,13 @@ function highlightCopiedContent() {
   }
 }
 
+const sshPrivateKey = Vue.ref('');
+
 // Adjust textarea height when component mounts and when content changes
-Vue.onMounted(() => {
+Vue.onMounted(async () => {
   console.log('onMounted');
+  await config.load();
+  sshPrivateKey.value = await readTextFile(config.security.sshPrivateKeyPath);
   adjustTextareaHeight();
   setTimeout(() => {
     adjustTextareaHeight();
@@ -132,7 +137,7 @@ Vue.onMounted(() => {
 });
 
 Vue.watch(
-  () => config.security.sshPrivateKey,
+  () => sshPrivateKey,
   () => {
     Vue.nextTick(() => {
       adjustTextareaHeight();


### PR DESCRIPTION
The ssh private key is now only stored on the file system and the file path is passed around.

The closing of ssh connections is also simplified to avoid repeated invalid closing of connections due to closing on drop asynchonously, which could grab the wrong connection (eg, the newly created one).