### PR TITLE
Fixes

### DIFF
--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -347,11 +347,13 @@ export class Config {
   set isMinerInstalled(value: boolean) {
     this._throwErrorIfNotLoaded();
     this._loadedData.isMinerInstalled = value;
-    this._loadedData.miningAccountPreviousHistory = null;
-    this._loadedData.miningAccountHadPreviousLife = false;
     this._tryFieldsToSave(dbFields.isMinerInstalled, value);
-    this._tryFieldsToSave(dbFields.miningAccountPreviousHistory, null);
-    this._tryFieldsToSave(dbFields.miningAccountHadPreviousLife, false);
+    if (value) {
+      this._loadedData.miningAccountPreviousHistory = null;
+      this._loadedData.miningAccountHadPreviousLife = false;
+      this._tryFieldsToSave(dbFields.miningAccountPreviousHistory, null);
+      this._tryFieldsToSave(dbFields.miningAccountHadPreviousLife, false);
+    }
   }
 
   get isMinerWaitingForUpgradeApproval(): boolean {

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -199,9 +199,21 @@ export class Config {
     return this._loadedData.miningAccountHadPreviousLife;
   }
 
+  set miningAccountHadPreviousLife(value: IConfig['miningAccountHadPreviousLife']) {
+    this._throwErrorIfNotLoaded();
+    this._loadedData.miningAccountHadPreviousLife = value;
+    this._tryFieldsToSave(dbFields.miningAccountHadPreviousLife, value);
+  }
+
   get miningAccountPreviousHistory(): IConfig['miningAccountPreviousHistory'] {
     this._throwErrorIfNotLoaded();
     return this._loadedData.miningAccountPreviousHistory;
+  }
+
+  set miningAccountPreviousHistory(value: IConfig['miningAccountPreviousHistory']) {
+    this._throwErrorIfNotLoaded();
+    this._loadedData.miningAccountPreviousHistory = value;
+    this._tryFieldsToSave(dbFields.miningAccountPreviousHistory, value);
   }
 
   get isBootingUpFromMiningAccountPreviousHistory(): boolean {
@@ -348,12 +360,6 @@ export class Config {
     this._throwErrorIfNotLoaded();
     this._loadedData.isMinerInstalled = value;
     this._tryFieldsToSave(dbFields.isMinerInstalled, value);
-    if (value) {
-      this._loadedData.miningAccountPreviousHistory = null;
-      this._loadedData.miningAccountHadPreviousLife = false;
-      this._tryFieldsToSave(dbFields.miningAccountPreviousHistory, null);
-      this._tryFieldsToSave(dbFields.miningAccountHadPreviousLife, false);
-    }
   }
 
   get isMinerWaitingForUpgradeApproval(): boolean {

--- a/src-vue/lib/InstallerCheck.ts
+++ b/src-vue/lib/InstallerCheck.ts
@@ -138,6 +138,8 @@ export class InstallerCheck {
     if (this.isServerInstallComplete) {
       this.config.isMinerInstalled = true;
       this.config.isMinerUpToDate = true;
+      this.config.miningAccountHadPreviousLife = false;
+      this.config.miningAccountPreviousHistory = null;
     }
     await this.config.save();
   }

--- a/src-vue/lib/Restarter.ts
+++ b/src-vue/lib/Restarter.ts
@@ -72,7 +72,13 @@ export default class Restarter {
     await remove(dbPath, { baseDir: BaseDirectory.AppLocalData });
     await invoke('run_db_migrations');
     await db.reconnect();
-    localStorage.setItem('ConfigRestore', JSON.stringify({ serverDetails: JSON.stringify(serverDetails) }));
+    localStorage.setItem(
+      'ConfigRestore',
+      JSON.stringify({
+        serverDetails: JSON.stringify(serverDetails),
+        hasReadMiningInstructions: config.hasReadMiningInstructions,
+      }),
+    );
   }
 
   public async restart() {

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -86,7 +86,8 @@ async function applyRestoredServer(details: string) {
     const restoreData = JSON.parse(details) as Record<keyof IConfig, string>;
     for (const key of Object.keys(restoreData) as (keyof IConfig)[]) {
       let value = restoreData[key] as any;
-      if (key === 'miningAccountHadPreviousLife' || key === 'miningAccountPreviousHistory' || key == 'version') {
+      // can't set this since it's readonly
+      if (key == 'version') {
         continue;
       }
       if (key === 'serverDetails') {

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -84,17 +84,23 @@ localStorage.removeItem('ConfigRestore');
 async function applyRestoredServer(details: string) {
   try {
     const restoreData = JSON.parse(details) as Record<keyof IConfig, string>;
-    if (restoreData.serverDetails) {
-      const parseResult = ConfigServerDetailsSchema.safeParse(JsonExt.parse(restoreData.serverDetails));
-      console.log(parseResult);
-      if (!parseResult.success) return;
+    for (const key of Object.keys(restoreData) as (keyof IConfig)[]) {
+      let value = restoreData[key] as any;
+      if (key === 'miningAccountHadPreviousLife' || key === 'miningAccountPreviousHistory' || key == 'version') {
+        continue;
+      }
+      if (key === 'serverDetails') {
+        const parseResult = ConfigServerDetailsSchema.safeParse(JsonExt.parse(value));
+        if (!parseResult.success) return;
 
-      const serverDetails = parseResult.data;
-      await SSH.tryConnection(serverDetails, config.security.sshPrivateKeyPath);
-      config.isMinerUpToDate = false;
-      config.serverDetails = serverDetails;
-      await config.save();
+        value = parseResult.data;
+        await SSH.tryConnection(parseResult.data, config.security.sshPrivateKeyPath);
+        config.isMinerUpToDate = false;
+      }
+
+      (config as any)[key] = value as any;
     }
+    await config.save();
   } catch (err) {
     console.error('Error restoring config from localStorage:', err);
   }

--- a/src-vue/overlays/BotHistoryOverlayButton.vue
+++ b/src-vue/overlays/BotHistoryOverlayButton.vue
@@ -19,7 +19,8 @@
             <tr v-for="activity of activities" :key="activity.id" class="whitespace-nowrap">
               <td class="text-left w-[5%]">
                 <ActivityArrowIcon v-if="activity.type === 'bidUp'" class="w-5 h-5 text-green-500" />
-                <ActivityArrowIcon v-if="activity.type === 'bidDown'" class="w-5 h-5 rotate-180 text-red-500" />
+                <ActivityArrowIcon v-if="activity.type === 'bidDown' && activity.isMine" class="w-5 h-5 rotate-180 text-red-500" />
+                <ActivityArrowIcon v-if="activity.type === 'bidDown' && !activity.isMine" class="w-5 h-5 rotate-180 text-gray-200" />
                 <ActivityArrowIcon v-if="activity.type === 'bidInc'" class="w-5 h-5 rotate-90 text-green-500" />
                 <ActivityFailureIcon v-if="activity.type === 'failure'" class="w-5 h-5 text-red-500" />
                 <ActivitySuccessIcon v-if="activity.type === 'success'" class="w-5 h-5 text-green-500" />


### PR DESCRIPTION
- fix(blockSync): load account miners at start point. The account miners that tracks who is an owned account was being initialized to the current state instead of the starting point
- fix: only clear mining history if miner installed
- chore: reduce glare of bot history not mine
- chore: save mining instruction check