### PR TITLE
Various Fixes

### DIFF
--- a/bot/src/History.ts
+++ b/bot/src/History.ts
@@ -231,6 +231,10 @@ export class History {
           if (prevBidAmount !== bidMicrogons) {
             entry.previousMicrogonsPerSeat = prevBidAmount;
           }
+          if (prevBidAmount === bidMicrogons && prevBidIndex === i) {
+            // no change
+            continue;
+          }
           entry.previousBidPosition = prevBidIndex;
         }
         this.appendActivities({

--- a/bot/src/Storage.ts
+++ b/bot/src/Storage.ts
@@ -102,6 +102,7 @@ export class Storage {
           biddingFrameTickRange: tickRange,
           lastBlockNumber: 0,
           seatCountWon: 0,
+          allMinersCount: 0,
           microgonsBidTotal: 0n,
           transactionFeesByBlock: {},
           micronotsStakedPerSeat: 0n,

--- a/bot/src/interfaces/IBidsFile.ts
+++ b/bot/src/interfaces/IBidsFile.ts
@@ -10,6 +10,7 @@ export interface IBidsFile extends ILastModifiedAt {
   micronotsStakedPerSeat: bigint;
   microgonsToBeMinedPerBlock: bigint;
   seatCountWon: number;
+  allMinersCount: number;
   winningBids: Array<IWinningBid>;
 }
 

--- a/core/src/BiddingCalculator.ts
+++ b/core/src/BiddingCalculator.ts
@@ -270,7 +270,9 @@ export default class BiddingCalculator {
 
     const microgonsToMintThisEpochBn = BigNumber(microgonsInCirculation).multipliedBy(epochMultiplier - 1);
     const microgonsToMintThisSeatBn =
-      this.data.miningSeatCount === 0 ? BigNumber(0) : microgonsToMintThisEpochBn.dividedBy(this.data.miningSeatCount);
+      this.data.maxPossibleMiningSeatCount === 0
+        ? BigNumber(0)
+        : microgonsToMintThisEpochBn.dividedBy(this.data.maxPossibleMiningSeatCount);
     const microgonsToMintThisSeat = bigNumberToBigInt(microgonsToMintThisSeatBn);
 
     return microgonsToMintThisSeat;

--- a/core/src/Mainchain.ts
+++ b/core/src/Mainchain.ts
@@ -21,6 +21,8 @@ export class Mainchain {
     return this.clients.prunedClientPromise ?? this.clients.archiveClientPromise;
   }
 
+  private cachedGenesisTick: number | null = null;
+
   constructor(public clients: MainchainClients) {}
 
   public async getClient(needsHistoricalBlocks: boolean): Promise<MainchainClient> {
@@ -72,29 +74,56 @@ export class Mainchain {
     return (await client.query.ticks.currentTick()).toNumber();
   }
 
-  private async getTicksSinceGenesis(currentTick: number): Promise<number> {
-    const client = await this.prunedClientOrArchivePromise;
-    const genesisTick = (await client.query.ticks.genesisTick()).toNumber();
-    return currentTick - genesisTick;
+  public async getTicksSinceGenesis(currentTick: number): Promise<number> {
+    if (this.cachedGenesisTick === null) {
+      const client = await this.prunedClientOrArchivePromise;
+      this.cachedGenesisTick = (await client.query.ticks.genesisTick()).toNumber();
+    }
+    return currentTick - this.cachedGenesisTick;
   }
 
-  public async minimumBlockRewardsAtTick(currentTick: number): Promise<bigint> {
-    const blocksSinceGenesis = await this.getTicksSinceGenesis(currentTick);
+  public async getMicrogonsPerBlockForMiner(api: ApiDecoration<'promise'>) {
+    const minerPercent = convertFixedU128ToBigNumber(api.consts.blockRewards.minerPayoutPercent.toBigInt());
+    const microgonsPerBlock = await api.query.blockRewards.argonsPerBlock().then(x => x.toBigInt());
+    return bigNumberToBigInt(minerPercent.times(microgonsPerBlock));
+  }
+
+  public async minimumBlockRewardsAtTick(
+    currentTick: number,
+  ): Promise<{ rewardsPerBlock: bigint; amountToMinerPercent: BigNumber; ticksSinceGenesis: number }> {
+    const client = await this.prunedClientOrArchivePromise;
+    const ticksSinceGenesis = await this.getTicksSinceGenesis(currentTick);
     const initialReward = 500_000n; // Initial microgons reward per block
+    const amountToMiner = convertFixedU128ToBigNumber(client.consts.blockRewards.minerPayoutPercent.toBigInt());
 
     // Calculate the number of intervals
-    const numIntervals = Math.floor(blocksSinceGenesis / BLOCK_REWARD_INTERVAL);
+    const numIntervals = Math.floor(ticksSinceGenesis / BLOCK_REWARD_INTERVAL);
 
     // Calculate the current reward per block
     const currentReward = initialReward + BigInt(numIntervals) * BLOCK_REWARD_INCREASE_PER_INTERVAL;
-    return bigIntMin(currentReward, BLOCK_REWARD_MAX);
+    const reward = bigIntMin(currentReward, BLOCK_REWARD_MAX);
+    return { rewardsPerBlock: reward, amountToMinerPercent: amountToMiner, ticksSinceGenesis };
   }
 
-  public async getMinimumBlockRewardsDuringTickRange(tickStart: number, tickEnd: number): Promise<bigint> {
-    // TODO: this is wrong, we need to increment the block rewards every 118 blocks
-    const rewardsPerBlock = await this.minimumBlockRewardsAtTick(tickStart);
-    const blocksToCalculate = tickEnd - tickStart;
-    return rewardsPerBlock * BigInt(blocksToCalculate);
+  public async getMinimumMicronotsMinedDuringTickRange(tickStart: number, tickEnd: number): Promise<bigint> {
+    const client = await this.prunedClientOrArchivePromise;
+    const halvingStartTick = client.consts.blockRewards.halvingBeginTick.toNumber();
+    const halvingTicks = client.consts.blockRewards.halvingTicks.toNumber();
+    // eslint-disable-next-line prefer-const
+    let { rewardsPerBlock, amountToMinerPercent } = await this.minimumBlockRewardsAtTick(tickStart);
+    let totalRewards = 0n;
+    for (let i = tickStart; i < tickEnd; i++) {
+      const elapsedTicks = await this.getTicksSinceGenesis(i);
+      if (elapsedTicks >= halvingStartTick) {
+        const halvings = Math.floor((elapsedTicks - halvingStartTick) / halvingTicks);
+        rewardsPerBlock = BigInt(Number(BLOCK_REWARD_MAX) / (halvings + 1));
+      } else if (elapsedTicks % BLOCK_REWARD_INTERVAL === 0) {
+        rewardsPerBlock += BLOCK_REWARD_INCREASE_PER_INTERVAL;
+        rewardsPerBlock = bigIntMin(rewardsPerBlock, BLOCK_REWARD_MAX);
+      }
+      totalRewards += rewardsPerBlock;
+    }
+    return bigNumberToBigInt(amountToMinerPercent.times(totalRewards));
   }
 
   public async getCurrentArgonTargetPrice(): Promise<number> {
@@ -103,7 +132,20 @@ export class Mainchain {
     return convertFixedU128ToBigNumber(argonPrice.argonUsdTargetPrice.toBigInt()).toNumber();
   }
 
-  public async getMiningSeatCount(): Promise<number> {
+  public async getNextCohortSize(): Promise<number> {
+    const client = await this.prunedClientOrArchivePromise;
+    return (await client.query.miningSlot.nextCohortSize()).toNumber();
+  }
+
+  public async getRetiringCohortSize(): Promise<number> {
+    const client = await this.prunedClientOrArchivePromise;
+    const nextFrameId = await client.query.miningSlot.nextFrameId();
+    const rollingCohortId = nextFrameId.toNumber() - 10;
+    if (rollingCohortId < 1) return 0;
+    return await client.query.miningSlot.minersByCohort(rollingCohortId).then(x => x.length);
+  }
+
+  public async getActiveMinersCount(): Promise<number> {
     const client = await this.prunedClientOrArchivePromise;
     const activeMiners = (await client.query.miningSlot.activeMinersCount()).toNumber();
     return Math.max(activeMiners, 100);
@@ -164,7 +206,8 @@ export class Mainchain {
       const startingTick = currentTick - ticksSinceCohortStart;
       const endingTick = startingTick + TICKS_PER_COHORT;
       const microgonsMinedInCohort = (blockReward.toBigInt() * BigInt(TICKS_PER_COHORT)) / 10n;
-      const micronotsMinedInCohort = (await this.getMinimumBlockRewardsDuringTickRange(startingTick, endingTick)) / 10n;
+      const micronotsMinedInCohort =
+        (await this.getMinimumMicronotsMinedDuringTickRange(startingTick, endingTick)) / 10n;
       rewards.microgons += microgonsMinedInCohort;
       rewards.micronots += micronotsMinedInCohort;
     }

--- a/core/src/createBidderParams.ts
+++ b/core/src/createBidderParams.ts
@@ -51,7 +51,7 @@ export class Helper {
   public async getMaxSeats() {
     await this.calculator.data.isInitializedPromise;
 
-    const maxSeats = this.calculator.data.miningSeatCount / 10;
+    const maxSeats = this.calculator.data.nextCohortSize;
 
     if (this.biddingRules.seatGoalType === SeatGoalType.Max) {
       return this.biddingRules.seatGoalCount || 0;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "precommit": "tsx scripts/checkPrecommit.ts",
     "dev": "vite",
     "tsc": "tsc && yarn workspaces foreach --all run tsc",
+    "tsc:watch": "tsc --watch",
     "build": "yarn build:version && yarn build:server && vue-tsc --noEmit && vite build",
     "build:workspace": "yarn workspaces foreach --all run build",
     "build:server": "yarn workspace @argonprotocol/commander-bot run build && tsx scripts/buildServer.ts",

--- a/src-tauri/migrations/01-bootup/up.sql
+++ b/src-tauri/migrations/01-bootup/up.sql
@@ -77,6 +77,7 @@ CREATE TABLE Frames (
   microgonToUsd TEXT NOT NULL DEFAULT '[]',
   microgonToBtc TEXT NOT NULL DEFAULT '[]',
   microgonToArgonot TEXT NOT NULL DEFAULT '[]',
+  allMinersCount INTEGER NOT NULL DEFAULT 0,
   seatCountActive INTEGER NOT NULL DEFAULT 0,
   seatCostTotalFramed INTEGER NOT NULL DEFAULT 0,
   blocksMinedTotal INTEGER NOT NULL DEFAULT 0,

--- a/src-vue/interfaces/IStats.ts
+++ b/src-vue/interfaces/IStats.ts
@@ -15,6 +15,7 @@ export interface IDashboardFrameStats {
   date: string;
   firstTick: number;
   lastTick: number;
+  allMinersCount: number;
   seatCountActive: number;
   seatCostTotalFramed: bigint;
   blocksMinedTotal: number;

--- a/src-vue/interfaces/db/IFrameRecord.ts
+++ b/src-vue/interfaces/db/IFrameRecord.ts
@@ -6,6 +6,17 @@ export interface IFrameRecord {
   microgonToUsd: bigint[];
   microgonToBtc: bigint[];
   microgonToArgonot: bigint[];
+  firstBlockNumber: number;
+  lastBlockNumber: number;
+  allMinersCount: number;
+  seatCountActive: number;
+  seatCostTotalFramed: bigint;
+  blocksMinedTotal: number;
+  micronotsMinedTotal: bigint;
+  microgonsMinedTotal: bigint;
+  microgonsMintedTotal: bigint;
+  microgonFeesCollectedTotal: bigint;
+  accruedMicrogonProfits: bigint;
   isProcessed: boolean;
   createdAt: string;
   updatedAt: string;

--- a/src-vue/lib/Stats.ts
+++ b/src-vue/lib/Stats.ts
@@ -295,7 +295,7 @@ export class Stats {
     for (const cohort of activeCohorts) {
       // Scale factor to preserve precision (cohort.progress has 3 decimal places)
       // factor = (100 - progress) / 100, scaled by 100000 for 3 decimal precision
-      const remainingRewardsPerSeat = this.calculateRemainingRewardsExpectedPerSeat(cohort);
+      const remainingRewardsPerSeat = this.calculateExpectedBlockRewardsPerSeat(cohort, 100 - cohort.progress);
       seatCount += cohort.seatCountWon;
       const seatCost = cohort.microgonsBidPerSeat * BigInt(cohort.seatCountWon);
       microgonsBidTotal += seatCost;
@@ -337,7 +337,10 @@ export class Stats {
     };
   }
 
-  private calculateRemainingRewardsExpectedPerSeat(cohort: ICohortRecord): {
+  private calculateExpectedBlockRewardsPerSeat(
+    cohort: ICohortRecord,
+    percentage: number,
+  ): {
     microgonsToBeMined: bigint;
     microgonsToBeMinted: bigint;
     micronotsToBeMined: bigint;
@@ -345,7 +348,7 @@ export class Stats {
     const microgonsExpected = bigIntMax(cohort.microgonsBidPerSeat, cohort.microgonsToBeMinedPerSeat);
     const microgonsExpectedToBeMinted = microgonsExpected - cohort.microgonsToBeMinedPerSeat;
 
-    const factorBn = BigNumber(100 - cohort.progress).dividedBy(100);
+    const factorBn = BigNumber(percentage).dividedBy(100);
 
     const microgonsToBeMinedBn = BigNumber(cohort.microgonsToBeMinedPerSeat).multipliedBy(factorBn);
     const micronotsToBeMinedBn = BigNumber(cohort.micronotsToBeMinedPerSeat).multipliedBy(factorBn);

--- a/src-vue/lib/db/CohortsTable.ts
+++ b/src-vue/lib/db/CohortsTable.ts
@@ -74,9 +74,7 @@ export class CohortsTable extends BaseTable {
         [],
       );
 
-      const framesExpectedBn = BigNumber(activeStats.cohortCount)
-        .multipliedBy(10)
-        .multipliedBy(activeStats.seatCountTotal);
+      const framesExpectedBn = BigNumber(activeStats.seatCountTotal).multipliedBy(10);
       const framesCompleted = BigNumber(activeStats.accruedProgress).dividedBy(10).toNumber();
       const framesRemaining = framesExpectedBn.minus(framesCompleted).toNumber();
 

--- a/src-vue/lib/db/CohortsTable.ts
+++ b/src-vue/lib/db/CohortsTable.ts
@@ -121,16 +121,26 @@ export class CohortsTable extends BaseTable {
     return convertSqliteBigInts(records, this.bigIntFields);
   }
 
-  async insertOrUpdate(
-    id: number,
-    progress: number,
-    transactionFeesTotal: bigint,
-    micronotsStakedPerSeat: bigint,
-    microgonsBidPerSeat: bigint,
-    seatCountWon: number,
-    microgonsToBeMinedPerSeat: bigint,
-    micronotsToBeMinedPerSeat: bigint,
-  ): Promise<void> {
+  async insertOrUpdate(args: {
+    id: number;
+    progress: number;
+    transactionFeesTotal: bigint;
+    micronotsStakedPerSeat: bigint;
+    microgonsBidPerSeat: bigint;
+    seatCountWon: number;
+    microgonsToBeMinedPerSeat: bigint;
+    micronotsToBeMinedPerSeat: bigint;
+  }): Promise<void> {
+    const {
+      id,
+      progress,
+      transactionFeesTotal,
+      micronotsStakedPerSeat,
+      microgonsBidPerSeat,
+      seatCountWon,
+      microgonsToBeMinedPerSeat,
+      micronotsToBeMinedPerSeat,
+    } = args;
     await this.db.execute(
       `INSERT INTO Cohorts (
           id, 

--- a/src-vue/lib/db/FramesTable.ts
+++ b/src-vue/lib/db/FramesTable.ts
@@ -76,6 +76,7 @@ export class FramesTable extends BaseTable {
     microgonToUsd: bigint[];
     microgonToBtc: bigint[];
     microgonToArgonot: bigint[];
+    allMinersCount: number;
     seatCountActive: number;
     seatCostTotalFramed: bigint;
     blocksMinedTotal: number;
@@ -96,6 +97,7 @@ export class FramesTable extends BaseTable {
       microgonToUsd,
       microgonToBtc,
       microgonToArgonot,
+      allMinersCount,
       seatCountActive,
       seatCostTotalFramed,
       blocksMinedTotal,
@@ -115,7 +117,8 @@ export class FramesTable extends BaseTable {
         lastBlockNumber = ?, 
         microgonToUsd = ?, 
         microgonToBtc = ?, 
-        microgonToArgonot = ?, 
+        microgonToArgonot = ?,
+        allMinersCount = ?,
         seatCountActive = ?, 
         seatCostTotalFramed = ?,
         blocksMinedTotal = ?,
@@ -135,6 +138,7 @@ export class FramesTable extends BaseTable {
         microgonToUsd,
         microgonToBtc,
         microgonToArgonot,
+        allMinersCount,
         seatCountActive,
         seatCostTotalFramed,
         blocksMinedTotal,
@@ -152,7 +156,7 @@ export class FramesTable extends BaseTable {
 
   async fetchLastYear(): Promise<Omit<IDashboardFrameStats, 'score'>[]> {
     const rawRecords = await this.db.select<any[]>(`SELECT 
-      id, firstTick, lastTick, microgonToUsd, microgonToArgonot, seatCountActive, seatCostTotalFramed, blocksMinedTotal, micronotsMinedTotal, microgonsMinedTotal, microgonsMintedTotal, progress
+      id, firstTick, lastTick, microgonToUsd, microgonToArgonot, allMinersCount, seatCountActive, seatCostTotalFramed, blocksMinedTotal, micronotsMinedTotal, microgonsMinedTotal, microgonsMintedTotal, progress
     FROM Frames ORDER BY id DESC LIMIT 365`);
 
     const records = convertFromSqliteFields<IDashboardFrameStats[]>(rawRecords, this.fieldTypes).map((x: any) => {
@@ -177,6 +181,7 @@ export class FramesTable extends BaseTable {
         date,
         firstTick: x.firstTick,
         lastTick: x.lastTick,
+        allMinersCount: x.allMinersCount,
         seatCountActive: x.seatCountActive,
         seatCostTotalFramed: x.seatCostTotalFramed,
         blocksMinedTotal: x.blocksMinedTotal,
@@ -209,6 +214,7 @@ export class FramesTable extends BaseTable {
         date: previousDay.format('YYYY-MM-DD'),
         firstTick: lastRecord.firstTick - 1_440,
         lastTick: lastRecord.lastTick - 1_440,
+        allMinersCount: 0,
         seatCountActive: 0,
         seatCostTotalFramed: 0n,
         microgonToUsd: [0n],

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -79,7 +79,6 @@ const draggable = Vue.reactive(new Draggable());
 
 const syncErrorType = Vue.ref<string | null>(null);
 const toRestore = localStorage.getItem('ConfigRestore');
-localStorage.removeItem('ConfigRestore');
 
 async function applyRestoredServer(details: string) {
   try {
@@ -87,7 +86,7 @@ async function applyRestoredServer(details: string) {
     for (const key of Object.keys(restoreData) as (keyof IConfig)[]) {
       let value = restoreData[key] as any;
       // can't set this since it's readonly
-      if (key == 'version') {
+      if (key === 'version') {
         continue;
       }
       if (key === 'serverDetails') {
@@ -108,7 +107,10 @@ async function applyRestoredServer(details: string) {
 }
 
 if (toRestore) {
-  void applyRestoredServer(toRestore);
+  // only clear out after finished
+  applyRestoredServer(toRestore).finally(() => {
+    localStorage.removeItem('ConfigRestore');
+  });
 }
 async function retry() {
   isRetrying.value = true;

--- a/src-vue/overlays/BotOverlay.vue
+++ b/src-vue/overlays/BotOverlay.vue
@@ -412,7 +412,7 @@ function calculateMicronotsRequired(): bigint {
   if (rules.value?.seatGoalType === SeatGoalType.Max) {
     possibleSeats = Math.min(possibleSeats, rules.value.seatGoalCount);
   }
-  possibleSeats = Math.min(possibleSeats, calculatorData.miningSeatCount);
+  possibleSeats = Math.min(possibleSeats, calculatorData.maxPossibleMiningSeatCount);
 
   const totalMicronotsRequired = BigInt(possibleSeats) * calculatorData.micronotsRequiredForBid;
 
@@ -476,7 +476,7 @@ function updateAPYs() {
   const probableMaxSeatsBn = BigNumber(rules.value.baseMicrogonCommitment).dividedBy(calculator.minimumBidAmount);
   probableMaxSeats.value = Math.min(
     probableMaxSeatsBn.integerValue(BigNumber.ROUND_FLOOR).toNumber(),
-    calculatorData.miningSeatCount,
+    calculatorData.maxPossibleMiningSeatCount,
   );
 
   const slowGrowthEarnings = BigInt(probableMinSeats.value) * calculator.slowGrowthRewards;

--- a/src-vue/overlays/bot/BotCapital.vue
+++ b/src-vue/overlays/bot/BotCapital.vue
@@ -137,7 +137,7 @@ function updateAPYs() {
   const probableMaxSeatsBn = BigNumber(rules.value.baseMicrogonCommitment).dividedBy(calculator.minimumBidAmount);
   probableMaxSeats.value = Math.min(
     probableMaxSeatsBn.integerValue(BigNumber.ROUND_FLOOR).toNumber(),
-    calculatorData.miningSeatCount,
+    calculatorData.maxPossibleMiningSeatCount,
   );
 
   const averageEarningsPerSeat = (calculator.slowGrowthRewards + calculator.fastGrowthRewards) / 2n;

--- a/src-vue/overlays/bot/HowMiningWorks.vue
+++ b/src-vue/overlays/bot/HowMiningWorks.vue
@@ -277,7 +277,7 @@ function cancelOverlay() {
 }
 
 async function load() {
-  mainchain.getMiningSeatCount().then(x => (miningSeats.value = x));
+  mainchain.getActiveMinersCount().then(x => (miningSeats.value = x));
   mainchain.getMicronotsRequiredForBid().then(x => (micronotsRequiredForBid.value = x));
   mainchain.getCurrentFrameId().then(x => (currentFrameId.value = x));
   mainchain.getRecentSeatSummaries().then(x => (seatSummaries.value = x));

--- a/src-vue/panels/mining-panel/BlankSlate.vue
+++ b/src-vue/panels/mining-panel/BlankSlate.vue
@@ -41,7 +41,7 @@
         >
           <li class="w-1/4">
             <div class="text-4xl font-bold">
-              {{ blockchainStore.miningSeatCount ? numeral(blockchainStore.miningSeatCount).format('0,0') : '---' }}
+              {{ blockchainStore.activeMiningSeatCount ? numeral(blockchainStore.activeMiningSeatCount).format('0,0') : '---' }}
             </div>
             <div>Mining Seats</div>
           </li>
@@ -143,7 +143,7 @@ Vue.onMounted(async () => {
   Promise.all([
     blockchainStore.updateAggregateBidCosts(),
     blockchainStore.updateAggregateBlockRewards(),
-    blockchainStore.updateMiningSeatCount(),
+    blockchainStore.updateActiveMiningSeatCount(),
   ]).then(() => {
     isLoaded.value = true;
   });

--- a/src-vue/panels/mining-panel/Dashboard.vue
+++ b/src-vue/panels/mining-panel/Dashboard.vue
@@ -498,7 +498,7 @@ function loadChartData() {
   }
 
   chartRef.value?.reloadData(items);
-  updateFrameSliderPos(items.length - 1);
+  updateFrameSliderPos(items.length - 1, false);
 }
 
 function startDrag(event: PointerEvent) {
@@ -547,12 +547,18 @@ function stopDrag(event: PointerEvent) {
   document.body.classList.remove('isResizing');
 }
 
-function updateFrameSliderPos(index: number) {
+let isUserNavigatingHistory = false;
+
+function updateFrameSliderPos(index: number, isUserAction = true) {
+  if (isUserNavigatingHistory && !isUserAction) return;
   index = Math.max(index || 0, 0);
   sliderFrameIndex.value = index;
+  // if back to latest frame, reset user chosen pos
+  isUserNavigatingHistory = index < stats.frames.length - 1;
 
   const item = stats.frames[index];
   if (!item) return;
+
   const pointPosition = chartRef.value?.getPointPosition(index);
 
   currentFrame.value = item;

--- a/src-vue/panels/mining-panel/Dashboard.vue
+++ b/src-vue/panels/mining-panel/Dashboard.vue
@@ -321,6 +321,7 @@ const currentFrame = Vue.ref<IDashboardFrameStats>({
   date: '',
   firstTick: 0,
   lastTick: 0,
+  allMinersCount: 0,
   seatCountActive: 0,
   seatCostTotalFramed: 0n,
   microgonToUsd: [0n],

--- a/src-vue/panels/mining-panel/FinalSetupChecklist.vue
+++ b/src-vue/panels/mining-panel/FinalSetupChecklist.vue
@@ -279,6 +279,8 @@ async function launchMiningBot() {
   }
   isLaunchingMiningBot.value = true;
   config.isMinerReadyToInstall = true;
+  // in case the entry was skipped
+  config.isPreparingMinerSetup = true;
   await config.save();
   await installer.run();
   isLaunchingMiningBot.value = false;

--- a/src-vue/panels/mining-panel/components/BlankSlateBlocks.vue
+++ b/src-vue/panels/mining-panel/components/BlankSlateBlocks.vue
@@ -160,7 +160,7 @@ async function loadBlocks() {
     await fetchPromise;
   }
 
-  blocksSubscription = blockchainStore.subscribeToBlocks(newBlockData => {
+  blocksSubscription = await blockchainStore.subscribeToBlocks(newBlockData => {
     const blockExists = cachedBlocks.value.find(x => x.number === newBlockData.number);
     if (blockExists) return;
 

--- a/src-vue/stores/blockchain.ts
+++ b/src-vue/stores/blockchain.ts
@@ -28,7 +28,7 @@ export type IBlock = {
 };
 
 export const useBlockchainStore = defineStore('blockchain', () => {
-  const miningSeatCount = Vue.ref(0);
+  const activeMiningSeatCount = Vue.ref(0);
   const aggregatedBidCosts = Vue.ref(0n);
   const aggregatedBlockRewards = Vue.ref({ microgons: 0n, micronots: 0n });
 
@@ -108,8 +108,9 @@ export const useBlockchainStore = defineStore('blockchain', () => {
     });
   }
 
-  async function updateMiningSeatCount() {
-    miningSeatCount.value = await getMainchain().getMiningSeatCount();
+  async function updateActiveMiningSeatCount() {
+    const mainchain = getMainchain();
+    activeMiningSeatCount.value = await mainchain.getActiveMinersCount();
   }
 
   async function updateAggregateBidCosts() {
@@ -123,12 +124,12 @@ export const useBlockchainStore = defineStore('blockchain', () => {
   return {
     aggregatedBidCosts,
     aggregatedBlockRewards,
-    miningSeatCount,
+    activeMiningSeatCount,
     cachedBlocks,
     subscribeToBlocks,
     updateAggregateBidCosts,
     updateAggregateBlockRewards,
-    updateMiningSeatCount,
+    updateActiveMiningSeatCount,
     fetchBlocks,
   };
 });


### PR DESCRIPTION
Fixes:
- Dashboard remaining frames multiplied by cohort count incorrectly
- System using currently "active" miners, when it should be using the possible miner seats in the next epoch
- Tracks `allMinersCount` from bot to use for various calculations
- create bidder params should use next cohort seats
- on restoration, keeps config from local storage until complete to avoid accidental loss due to js page errors
- blank slate not storing unsubscribe correctly, breaking the "reset database" option (as above)
- `isPreparingMinerSetup` should be stored on miner launch because a few recovery windows bypass where it is set, which means the sync shows over blank slate
- Preserve historical frames if the user navigates on dashboard
- Ignore non-changes to bid entries to reduce noise.

**Mining seat and reward calculation improvements:**

* Replaced the use of `miningSeatCount` with `maxPossibleMiningSeatCount`, now calculated as `activeMinersCount + nextCohortSize - retiringCohortSize` in `BiddingCalculatorData`, making seat calculations more accurate and reflective of real-time network state. [[1]](diffhunk://#diff-4438692d6e72e86bfb20103909c482d69982387aea8bd3fb36b7933eb49ee529L30-R31) [[2]](diffhunk://#diff-4438692d6e72e86bfb20103909c482d69982387aea8bd3fb36b7933eb49ee529L41-R47)
* Updated reward calculation logic to use `getMinimumMicronotsMinedDuringTickRange`, which now correctly accounts for block reward increases and halvings over time, and applies the miner payout percent for more accurate distribution. (F434910eL74R74, [[1]](diffhunk://#diff-7ddf4a0b89a5b657b65cb7334e7918fb5894fc6f7354e2637ef0db1368517031L167-R210) [[2]](diffhunk://#diff-4438692d6e72e86bfb20103909c482d69982387aea8bd3fb36b7933eb49ee529L55-R95)

**API and interface changes:**

* Added new methods to `Mainchain` for retrieving cohort sizes, retiring cohort size, and active miners count, replacing the previous static seat count API.
* Updated `IBidsFile`, `IDashboardFrameStats`, and related interfaces to include `allMinersCount`, supporting more granular tracking of miner participation. [[1]](diffhunk://#diff-9070685be8732d29ea10e5480d3dc3e59a74bc7bbaed67ab8d37057e87eb729fR13) [[2]](diffhunk://#diff-f9234ef3131cec0d40a12260947c3a32966cc4bcbca44df72303c06653e91a44R18) [[3]](diffhunk://#diff-aa8ee1d885a76b66ba168a13b46f9c4712df0b9fc163ee45c22a812235f39bc6R9-R19)

**Data model and storage updates:**

* Added `allMinersCount` to the bids file initialization, database schema (`Frames` table), and frame stats objects, ensuring this metric is consistently tracked and available for analytics. [[1]](diffhunk://#diff-d6f5db5eb958e08db838eb007fc44425fb37e1d9ade10e768d042dce36ade39fR105) [[2]](diffhunk://#diff-f98ae8861a82053b6c52643251874357cdc4eca64b2c6faea2a51ace4e5e7410R80) [[3]](diffhunk://#diff-5bd96ee2708d6176a73e13891558f0bde32ed58d009833c6126093e1175c0422R310)

**Bot and sync logic adjustments:**

* Updated `BlockSync` and `BotSyncer` to use the new active miners count for calculations, ensuring cohort and reward computations are based on current miner participation. [[1]](diffhunk://#diff-9b10fbe421591f24eaac731afa563d0f4445a0db4176d98ec36f4803ba3428aeR488) [[2]](diffhunk://#diff-5bd96ee2708d6176a73e13891558f0bde32ed58d009833c6126093e1175c0422R291-R292) [[3]](diffhunk://#diff-5bd96ee2708d6176a73e13891558f0bde32ed58d009833c6126093e1175c0422L372-R400)

**Miscellaneous:**

* Added a `tsc:watch` script to `package.json` for easier TypeScript development.
