### PR TITLE
fix: round to nearest bid increment

### DIFF
--- a/core/src/BiddingCalculator.ts
+++ b/core/src/BiddingCalculator.ts
@@ -191,6 +191,11 @@ export default class BiddingCalculator {
       price += bigNumberToBigInt(adjustmentAmountBn);
     }
 
+    const remainder = price % this.data.allowedBidIncrementMicrogons;
+    if (remainder !== 0n) {
+      price -= remainder;
+    }
+
     return price;
   }
 

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -24,6 +24,7 @@ export default class BiddingCalculatorData {
 
   public maxPossibleMiningSeatCount: number = 0;
   public nextCohortSize: number = 0;
+  public allowedBidIncrementMicrogons = 10_000n;
 
   constructor(mining: Mining) {
     this.isInitializedPromise = this.initialize(mining);
@@ -61,6 +62,8 @@ export default class BiddingCalculatorData {
 
       this.microgonExchangeRateTo = await priceIndex.fetchMicrogonExchangeRatesTo();
       this.maxPossibleMiningSeatCount = maxPossibleMinersInNextEpoch;
+      const client = await mining.clients.prunedClientOrArchivePromise;
+      this.allowedBidIncrementMicrogons = client.consts.miningSlot.bidIncrements.toBigInt();
     } catch (e) {
       console.error('Error initializing BiddingCalculatorData', e);
       throw e;

--- a/core/src/CohortBidder.ts
+++ b/core/src/CohortBidder.ts
@@ -106,6 +106,28 @@ export class CohortBidder {
   }
 
   public async start() {
+    const client = this.client;
+    this.minIncrement = client.consts.miningSlot.bidIncrements.toBigInt();
+    this.bidsForNextSlotCohortKey = client.query.miningSlot.bidsForNextSlotCohort.key();
+    const minBidIncrement = this.options.minBid % this.minIncrement;
+    if (minBidIncrement !== 0n) {
+      this.options.minBid -= minBidIncrement;
+      console.log(
+        `Adjusting min bid to ${formatArgons(this.options.minBid)} to be a multiple of the minimum increment ${formatArgons(
+          this.minIncrement,
+        )}`,
+      );
+    }
+    const maxBidIncrement = this.options.maxBid % this.minIncrement;
+    if (maxBidIncrement !== 0n) {
+      this.options.maxBid -= maxBidIncrement;
+      console.log(
+        `Adjusting max bid to ${formatArgons(this.options.maxBid)} to be a multiple of the minimum increment ${formatArgons(
+          this.minIncrement,
+        )}`,
+      );
+    }
+
     console.log(`Starting cohort ${this.cohortStartingFrameId} bidder`, {
       maxBid: formatArgons(this.options.maxBid),
       minBid: formatArgons(this.options.minBid),
@@ -114,10 +136,6 @@ export class CohortBidder {
       bidDelay: this.options.bidDelay,
       subaccounts: this.subaccounts,
     });
-
-    const client = this.client;
-    this.minIncrement = client.consts.miningSlot.bidIncrements.toBigInt();
-    this.bidsForNextSlotCohortKey = client.query.miningSlot.bidsForNextSlotCohort.key();
 
     this.nextCohortSize = await client.query.miningSlot.nextCohortSize().then(x => x.toNumber());
     if (this.subaccounts.length > this.nextCohortSize) {

--- a/core/src/MainchainClients.ts
+++ b/core/src/MainchainClients.ts
@@ -76,7 +76,7 @@ export class MainchainClients {
 
         if (this.enableApiLogging) {
           const argsJson = args.map(getJson);
-          console.error(`[{${name}] ${path}(${JSON.stringify(argsJson)}) Error:`, error);
+          console.error(`[${name}] ${path}(${JSON.stringify(argsJson)}) Error:`, error);
         }
       },
       onSuccess: (path, result, ...args) => {

--- a/src-vue/navigation/AlertBars.vue
+++ b/src-vue/navigation/AlertBars.vue
@@ -18,7 +18,7 @@
   <div
     InstallerInBackground
     v-else-if="showInstallerInBackgroundAlert"
-    class="group alert-bar error"
+    class="group alert-bar info"
     style="box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.1)"
   >
     <AlertIcon />


### PR DESCRIPTION
The cohort bidder isn’t rounding to the nearest bid increment, which is only uncovered due to using the previous day bids and break even prices as number points for bids

- fix: Blocksync should remove blocks older than best block in the case of reorg
- chore: typo in client logger
- fix: wrong bar color for installer notice