### PR TITLE
#3 Remove hardcoded frames

### DIFF
--- a/bot/__test__/BlockSync.test.ts
+++ b/bot/__test__/BlockSync.test.ts
@@ -19,7 +19,7 @@ afterAll(teardown);
 
 let clientAddress: string;
 beforeAll(async () => {
-  MiningFrames.setNetwork('localnet');
+  MiningFrames.setNetwork('dev-docker');
   const result = await startArgonTestNetwork('block-sync');
   clientAddress = result.archiveUrl;
 });

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { Mining } from './Mining.js';
-import { TICKS_PER_COHORT } from './MiningFrames.js';
+import { MiningFrames } from './MiningFrames.js';
 import { PriceIndex } from './PriceIndex.js';
 import { bigIntMax, bigIntMin, bigNumberToBigInt } from './utils.js';
 import { MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
@@ -34,7 +34,7 @@ export default class BiddingCalculatorData {
     try {
       const priceIndex = new PriceIndex(mining.clients);
       const tickAtStartOfNextCohort = await mining.getTickAtStartOfNextCohort();
-      const tickAtEndOfNextCohort = tickAtStartOfNextCohort + TICKS_PER_COHORT;
+      const tickAtEndOfNextCohort = tickAtStartOfNextCohort + MiningFrames.ticksPerCohort;
 
       const activeMinersCount = await mining.getActiveMinersCount();
       const nextCohortSize = await mining.getNextCohortSize();
@@ -50,7 +50,8 @@ export default class BiddingCalculatorData {
       );
 
       const microgonsMinedPerBlock = await mining.fetchMicrogonsMinedPerBlockDuringNextCohort();
-      this.microgonsToMineThisSeat = (microgonsMinedPerBlock * 14_400n) / BigInt(maxPossibleMinersInNextEpoch);
+      this.microgonsToMineThisSeat =
+        (microgonsMinedPerBlock * BigInt(MiningFrames.ticksPerCohort)) / BigInt(maxPossibleMinersInNextEpoch);
       this.microgonsInCirculation = await priceIndex.fetchMicrogonsInCirculation();
       this.micronotsRequiredForBid = await mining.getMicronotsRequiredForBid();
 

--- a/core/src/MiningFrames.ts
+++ b/core/src/MiningFrames.ts
@@ -5,8 +5,6 @@ import { type ArgonClient, getTickFromHeader, type Header } from '@argonprotocol
 
 dayjs.extend(utc);
 
-export const TICKS_PER_COHORT = 14_400;
-
 /**
  * A frame is the period from noon EDT to the next noon EDT that a cohort of
  * miners rotates. The first frame (frame 0) was the period between bidding start and Frame 1 beginning.
@@ -14,6 +12,14 @@ export const TICKS_PER_COHORT = 14_400;
 export class MiningFrames {
   public static get tickMillis() {
     return this.getConfig().tickMillis;
+  }
+
+  public static get ticksPerCohort() {
+    return this.ticksPerFrame * 10;
+  }
+
+  public static get ticksPerFrame() {
+    return this.getConfig().ticksBetweenFrames;
   }
 
   private static networkName: keyof typeof NetworkConfig | undefined = undefined;

--- a/server/status/server.ts
+++ b/server/status/server.ts
@@ -160,12 +160,7 @@ class BitcoinApis {
     const blockchainInfo = await this.blockchainInfo();
 
     let mainNodeBlockNumber = 0;
-    if (process.env.BITCOIN_CHAIN === 'signet') {
-      const peerinfo = await callBitcoinRpc<{ startingheight: number }[]>('getpeerinfo');
-      for (const peer of peerinfo) {
-        mainNodeBlockNumber = Math.max(peer.startingheight, mainNodeBlockNumber);
-      }
-    } else {
+    if (process.env.BITCOIN_CHAIN === 'mainnet') {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10_000);
       const response = await fetch('https://blockchain.info/latestblock', {
@@ -177,6 +172,11 @@ class BitcoinApis {
       }
       const data = await response.json();
       mainNodeBlockNumber = data.block_index;
+    } else {
+      const peerinfo = await callBitcoinRpc<{ startingheight: number }[]>('getpeerinfo');
+      for (const peer of peerinfo) {
+        mainNodeBlockNumber = Math.max(peer.startingheight, mainNodeBlockNumber);
+      }
     }
     cache.bitcoin = {
       latestBlocks: {

--- a/src-vue/lib/db/CohortsTable.ts
+++ b/src-vue/lib/db/CohortsTable.ts
@@ -2,7 +2,7 @@ import { ICohortRecord } from '../../interfaces/db/ICohortRecord';
 import { BaseTable } from './BaseTable';
 import { convertSqliteBigInts, fromSqliteBigInt, toSqlParams } from '../Utils';
 import BigNumber from 'bignumber.js';
-import { bigNumberToBigInt } from '@argonprotocol/commander-core';
+import { bigNumberToBigInt, MiningFrames } from '@argonprotocol/commander-core';
 
 export class CohortsTable extends BaseTable {
   private bigIntFields: string[] = [
@@ -38,8 +38,7 @@ export class CohortsTable extends BaseTable {
     const record = convertSqliteBigInts<
       ICohortRecord & { firstTick: number; lastBlockNumber: number; lastTick: number }
     >(rawRecords[0], this.bigIntFields);
-    const ticksPerDay = 1_440;
-    const lastTick = record.firstTick + ticksPerDay * 10;
+    const lastTick = record.firstTick + MiningFrames.ticksPerCohort;
 
     return {
       ...record,

--- a/src-vue/lib/db/FramesTable.ts
+++ b/src-vue/lib/db/FramesTable.ts
@@ -1,7 +1,7 @@
 import { IFrameRecord } from '../../interfaces/db/IFrameRecord';
 import { BaseTable, IFieldTypes } from './BaseTable';
 import { convertFromSqliteFields, fromSqliteBigInt, toSqlParams } from '../Utils';
-import { bigNumberToBigInt } from '@argonprotocol/commander-core';
+import { bigNumberToBigInt, MiningFrames } from '@argonprotocol/commander-core';
 import BigNumber from 'bignumber.js';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -201,6 +201,8 @@ export class FramesTable extends BaseTable {
       return record;
     });
 
+    const ticksPerFrame = MiningFrames.ticksPerFrame;
+
     while (records.length < 365) {
       const lastRecord = records[records.length - 1];
       if (!lastRecord) break;
@@ -212,8 +214,8 @@ export class FramesTable extends BaseTable {
       const blankRecord: Omit<IDashboardFrameStats, 'score' | 'expected'> = {
         id: 0,
         date: previousDay.format('YYYY-MM-DD'),
-        firstTick: lastRecord.firstTick - 1_440,
-        lastTick: lastRecord.lastTick - 1_440,
+        firstTick: lastRecord.firstTick - ticksPerFrame,
+        lastTick: lastRecord.lastTick - ticksPerFrame,
         allMinersCount: 0,
         seatCountActive: 0,
         seatCostTotalFramed: 0n,

--- a/src-vue/panels/mining-panel/FirstAuctionStarting.vue
+++ b/src-vue/panels/mining-panel/FirstAuctionStarting.vue
@@ -68,6 +68,7 @@ import {
   type IBiddingRules,
   BiddingCalculatorData,
   BiddingParamsHelper,
+  MiningFrames,
 } from '@argonprotocol/commander-core';
 import basicEmitter from '../../emitters/basicEmitter';
 import { getMining } from '../../stores/mainchain';
@@ -115,8 +116,9 @@ Vue.onMounted(async () => {
   if (!startOfAuctionClosing.value || !startOfNextCohort.value) {
     const tickAtStartOfAuctionClosing = await mainchain.getTickAtStartOfAuctionClosing();
     const tickAtStartOfNextCohort = await mainchain.getTickAtStartOfNextCohort();
-    startOfAuctionClosing.value = dayjs.utc(tickAtStartOfAuctionClosing * 60 * 1000);
-    startOfNextCohort.value = dayjs.utc(tickAtStartOfNextCohort * 60 * 1000);
+    const tickMillis = MiningFrames.tickMillis;
+    startOfAuctionClosing.value = dayjs.utc(tickAtStartOfAuctionClosing * tickMillis);
+    startOfNextCohort.value = dayjs.utc(tickAtStartOfNextCohort * tickMillis);
   }
 });
 </script>

--- a/src-vue/panels/mining-panel/FirstAuctionWinning.vue
+++ b/src-vue/panels/mining-panel/FirstAuctionWinning.vue
@@ -83,6 +83,7 @@ import {
   type IBiddingRules,
   BiddingCalculatorData,
   BiddingParamsHelper,
+  MiningFrames,
 } from '@argonprotocol/commander-core';
 import { type IWinningBid } from '@argonprotocol/commander-core';
 import CountdownClock from '../../components/CountdownClock.vue';
@@ -145,8 +146,9 @@ Vue.onMounted(async () => {
   if (!startOfAuctionClosing.value || !startOfNextCohort.value) {
     const tickAtStartOfAuctionClosing = await mainchain.getTickAtStartOfAuctionClosing();
     const tickAtStartOfNextCohort = await mainchain.getTickAtStartOfNextCohort();
-    startOfAuctionClosing.value = dayjs.utc(tickAtStartOfAuctionClosing * 60 * 1000);
-    startOfNextCohort.value = dayjs.utc(tickAtStartOfNextCohort * 60 * 1000);
+    const tickMillis = MiningFrames.tickMillis;
+    startOfAuctionClosing.value = dayjs.utc(tickAtStartOfAuctionClosing * tickMillis);
+    startOfNextCohort.value = dayjs.utc(tickAtStartOfNextCohort * tickMillis);
   }
 
   const seatCount = await biddingParamsHelper.getMaxSeats();


### PR DESCRIPTION
Frames had the hardcoded 1440 definition of # of ticks (and similar for cohort of 14.4k). This broke once I wired up tests with dev-docker, so I switched it to pull from the network config, which we update before tests for dev-docker (or any ephemeral environment where the genesis tick could change or the definition is different.