### PR TITLE
fix: bitcoin data

### DIFF
--- a/.github/workflows/bitcoin-data.yml
+++ b/.github/workflows/bitcoin-data.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+concurrency:
+  group: bitcoin-data-snapshot
+  cancel-in-progress: true
+
 env:
   GHCR_PROJECT: ghcr.io/argonprotocol/commander
 
@@ -169,25 +173,35 @@ jobs:
       - name: Always tear down bitcoin
         if: always()
         run: |
-          docker compose --env-file=${{ matrix.env_file }} down --profile=all -v || true
+          docker compose --env-file=${{ matrix.env_file }} --profile=all down -v || true
+        working-directory: server
+
+      - name: Create split tar of data
+        run: |
+          bitcoin-data/split.sh ${{ matrix.env_file }}
+          ls -lhart bitcoin-data/splits/
         working-directory: server
 
       - name: Build snapshot image
         run: |
-          docker compose --env-file=${{ matrix.env_file }} --profile=data  config > expanded.yml
-          docker buildx bake \ 
-            --allow=fs.read=${{ env.DATA_PATH }} \
-            -f expanded.yml bitcoin-data --push --load
+          docker compose --env-file=${{ matrix.env_file }} build bitcoin-data \
+            --build-arg SNAPSHOT_HEIGHT=${{ steps.data.outputs.height }} \
+            --build-arg SNAPSHOT_NETWORK=${{ matrix.network }} \
+            --build-arg UTXO_HASH=${{ steps.data.outputs.utxo_hash }} \
+            --build-arg COMMIT_SHA=${{ github.sha }}
         working-directory: server
         env:
-          BUILDKIT_TMPDIR: /mnt/data/tmp
+          SNAPSHOT_HEIGHT: ${{ steps.data.outputs.height }}
+          BITCOIN_DATA_SLUG: ${{ matrix.image_name }}
+
+      - name: Push snapshot image
+        run: docker compose --env-file=${{ matrix.env_file }} push bitcoin-data
+        working-directory: server
+        env:
           SNAPSHOT_HEIGHT: ${{ steps.data.outputs.height }}
           SNAPSHOT_NETWORK: ${{ matrix.network }}
           UTXO_HASH: ${{ steps.data.outputs.utxo_hash }}
           COMMIT_SHA: ${{ github.sha }}
-          BITCOIN_DATA_SLUG: ${{ matrix.image_name }}
-          DATA_PATH: ${{ github.workspace }}/data/bitcoin
-          BITCOIN_DATA_FOLDER: ../data/bitcoin
 
       # --- Attestation ---
       - name: Install Cosign
@@ -210,9 +224,10 @@ jobs:
 
       - name: Prune non-latest images
         run: |
+          rm server/bitcoin-data/splits/* || true
           docker image prune -f || true
           docker buildx prune -af || true
-          for img in $(docker images ghcr.io/argonprotocol/commander/bitcoin-data-signet \
-             --format '{{.Repository}}:{{.Tag}}' | grep -v ':latest$'); do
+          for img in $(docker images --format '{{.Repository}}:{{.Tag}}' ${{ env.GHCR_PROJECT }}/${{ matrix.image_name }} \
+              | grep -v ':latest$'); do
             docker rmi -f "$img" || true
           done

--- a/core/__test__/startArgonTestNetwork.ts
+++ b/core/__test__/startArgonTestNetwork.ts
@@ -19,7 +19,7 @@ export async function startArgonTestNetwork(
   MiningFrames.setNetwork('dev-docker' as any);
   const config = [
     Path.join(Path.dirname(require.resolve('@argonprotocol/testing')), 'docker-compose.yml'),
-    Path.resolve(__dirname, '..', '..', 'miners.docker-compose.yml'),
+    // Path.resolve(__dirname, '..', '..', 'miners.docker-compose.yml'),
   ];
   const env = {
     VERSION: 'dev',

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,3 +5,4 @@ tars
 data
 /bot/src/
 !scripts/conf/*
+bitcoin-data/splits/*

--- a/server/bitcoin-data/Dockerfile
+++ b/server/bitcoin-data/Dockerfile
@@ -1,19 +1,7 @@
-# syntax = docker/dockerfile:latest
+FROM --platform=linux/amd64 debian
 
-FROM --platform=linux/amd64 debian AS init-data
-ARG TAR_PATHS
-ARG REPO_URL
-ARG DATA_PATH
+WORKDIR /init-data
 
-RUN --mount=type=bind,source=${DATA_PATH},target=/data,ro \
-    --mount=type=cache,target=/cache \
-	mkdir -p /cache /init-data && cd /data && \
-    tar cvf - ${TAR_PATHS} | split -b 5G - /cache/data.tar. && \
-    mv /cache/data.tar.* /init-data/
-
-########################
-
-FROM debian
 ARG SNAPSHOT_HEIGHT=unknown
 ARG SNAPSHOT_NETWORK=unknown
 ARG COMMIT_SHA=none
@@ -23,24 +11,13 @@ LABEL snapshot.network=$SNAPSHOT_NETWORK
 LABEL snapshot.utxohash=$UTXO_HASH
 LABEL org.opencontainers.image.revision=$COMMIT_SHA
 LABEL org.opencontainers.image.source=https://github.com/argonprotocol/commander
-# Make sure we put everything is separate layers so we dont trigger rate limits
-# We abuse wildcard here so it doesn't crash if some files don't exist
-# Supports 15 split files, i.e. up to 75GB tarball
-COPY --link --from=init-data /init-data/data.tar.aa* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ab* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ac* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ad* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ae* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.af* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ag* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ah* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ai* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.aj* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ak* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.al* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.am* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.an* /init-data/.
-COPY --link --from=init-data /init-data/data.tar.ao* /init-data/.
+
+COPY splits/data.tar.aa* /init-data/.
+COPY splits/data.tar.ab* /init-data/.
+COPY splits/data.tar.ac* /init-data/.
+COPY splits/data.tar.ad* /init-data/.
+COPY splits/data.tar.ae* /init-data/.
+COPY splits/data.tar.af* /init-data/.
 
 COPY <<-EOF copy.sh
 	#!/bin/bash

--- a/server/bitcoin-data/split.sh
+++ b/server/bitcoin-data/split.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+env_file="${1:-.env}"
+
+set -a
+  source "$(dirname "$0")/../$env_file"
+set +a
+
+DIRNAME="$(dirname "$0")"
+BITCOIN_DATA_DIR="$DIRNAME/../../data/bitcoin"
+OUTDIR="$(cd "$DIRNAME" && mkdir -p splits && cd splits && pwd -P)"
+
+echo "Splitting Bitcoin data from $BITCOIN_DATA_DIR into $OUTDIR ($BITCOIN_TAR_PATHS)"
+
+cd "$BITCOIN_DATA_DIR" || exit 1
+
+tar cvf - ${BITCOIN_TAR_PATHS} | split -b 9500M - "$OUTDIR/data.tar."

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -43,21 +43,14 @@ services:
       context: bitcoin-data
       dockerfile: Dockerfile
       args:
-        - TAR_PATHS=${BITCOIN_TAR_PATHS}
         - SNAPSHOT_HEIGHT=${SNAPSHOT_HEIGHT}
         - SNAPSHOT_NETWORK=${SNAPSHOT_NETWORK}
         - UTXO_HASH=${UTXO_HASH}
         - COMMIT_SHA=${COMMIT_SHA}
-        - DATA_PATH=${DATA_PATH}
-        - BITCOIN_DATA_FOLDER=${BITCOIN_DATA_FOLDER}
       tags:
         - ghcr.io/argonprotocol/commander/${BITCOIN_DATA_SLUG}:height-${SNAPSHOT_HEIGHT}
     volumes:
       - $BITCOIN_DATA_FOLDER:/data
-    environment:
-      - DATA_PATH=${DATA_PATH}
-      - BITCOIN_DATA_FOLDER=${BITCOIN_DATA_FOLDER}
-      - TAR_PATHS=${BITCOIN_TAR_PATHS}
     profiles:
       - data
     deploy:


### PR DESCRIPTION
Moved the creation of the "tar splits" of the bitcoin data to the OS to avoid loading the 30gb context into docker, which then seems to balloon it out to other layers. This version _only_ requires 178gb of disk to create it... docker is rough.