### PR TITLE
Prompt users to back up recovery phrase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ server/.env
 /indexer/seeds/*-old.db
 /e2e/argon/chainspec*.json
 /e2e/artifacts
+.claude/worktrees

--- a/src-vue/components/MnemonicBackupBanner.vue
+++ b/src-vue/components/MnemonicBackupBanner.vue
@@ -1,0 +1,73 @@
+<!-- prettier-ignore -->
+<template>
+  <div
+    class="w-full rounded-lg border overflow-hidden"
+    :class="config.hasSavedMnemonic ? 'border-slate-300/60' : 'border-argon-600/30'"
+  >
+    <button
+      type="button"
+      :aria-expanded="isExpanded"
+      aria-controls="mnemonic-backup-panel"
+      class="w-full flex flex-row items-center gap-2 px-3 py-2.5 cursor-pointer hover:bg-argon-menu-hover transition-colors"
+      @click="isExpanded = !isExpanded"
+    >
+      <ShieldCheckIcon v-if="config.hasSavedMnemonic" class="w-4.5 h-4.5 text-emerald-600 shrink-0" />
+      <ShieldExclamationIcon v-else class="w-4.5 h-4.5 text-argon-600 shrink-0" />
+      <span class="grow text-left text-sm" :class="config.hasSavedMnemonic ? 'text-slate-400' : 'text-argon-text-primary'">
+        {{ config.hasSavedMnemonic ? 'Recovery phrase backed up' : "Your account recovery phrase hasn't been backed up" }}
+      </span>
+      <span v-if="!config.hasSavedMnemonic && !isExpanded" class="shrink-0 text-sm text-argon-600">Back Up Now</span>
+      <ChevronDownIcon :class="['w-4 h-4 text-slate-400 shrink-0 transition-transform duration-200', isExpanded ? 'rotate-180' : '']" />
+    </button>
+
+    <div v-if="isExpanded" id="mnemonic-backup-panel" role="region" class="px-3 pb-3 border-t border-argon-600/10">
+      <p class="text-xs text-slate-500 mt-2.5 mb-3">
+        Write down these 12 words and store them somewhere safe. They are the only way to recover your account.
+      </p>
+
+      <MnemonicDisplay v-slot="{ mnemonic }">
+        <div class="flex flex-row items-center justify-between mt-3">
+          <CopyToClipboard :content="mnemonic" class="cursor-pointer">
+            <button type="button" class="text-sm text-slate-500 hover:text-slate-700 underline decoration-dashed underline-offset-4 cursor-pointer">
+              Copy to Clipboard
+            </button>
+            <template #copied>
+              <span class="text-sm text-slate-500">
+                Copied!
+              </span>
+            </template>
+          </CopyToClipboard>
+          <button
+            v-if="!config.hasSavedMnemonic"
+            type="button"
+            @click.stop="confirmSaved"
+            class="text-sm text-argon-600 hover:text-argon-800 underline decoration-dashed underline-offset-4 cursor-pointer"
+          >
+            I've Saved It
+          </button>
+        </div>
+      </MnemonicDisplay>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { ShieldExclamationIcon, ShieldCheckIcon, ChevronDownIcon } from '@heroicons/vue/24/outline';
+import { getConfig } from '../stores/config.ts';
+import MnemonicDisplay from './MnemonicDisplay.vue';
+import CopyToClipboard from './CopyToClipboard.vue';
+
+const config = getConfig();
+const isExpanded = Vue.ref(false);
+
+async function confirmSaved() {
+  try {
+    config.hasSavedMnemonic = true;
+    await config.save();
+    isExpanded.value = false;
+  } catch {
+    config.hasSavedMnemonic = false;
+  }
+}
+</script>

--- a/src-vue/components/MnemonicDisplay.vue
+++ b/src-vue/components/MnemonicDisplay.vue
@@ -1,0 +1,49 @@
+<!-- prettier-ignore -->
+<template>
+  <div v-if="isLoading" class="flex justify-center py-6">
+    <Spinner class="w-8 h-8" />
+  </div>
+
+  <div v-else-if="loadError" class="flex justify-center py-6 text-sm text-red-600">
+    Failed to load recovery phrase. Please ensure your wallet is unlocked and try again.
+  </div>
+
+  <template v-else>
+    <ol class="grid grid-cols-3 gap-x-4 gap-y-1.5 select-text" :class="gridClass">
+      <li v-for="(word, index) in words" :key="index" class="flex items-center gap-2 py-1.5 px-3 rounded-md bg-slate-50 border border-slate-200/60">
+        <span class="text-xs text-slate-400 font-mono w-4 text-right">{{ index + 1 }}</span>
+        <span class="text-sm font-medium text-argon-text-primary">{{ word }}</span>
+      </li>
+    </ol>
+
+    <slot :mnemonic="masterMnemonic" />
+  </template>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { getWalletKeys } from '../stores/wallets.ts';
+import Spinner from './Spinner.vue';
+
+defineProps<{
+  gridClass?: string;
+}>();
+
+const walletKeys = getWalletKeys();
+
+const isLoading = Vue.ref(true);
+const masterMnemonic = Vue.ref('');
+const words = Vue.computed(() => masterMnemonic.value.split(' ').filter(Boolean));
+const loadError = Vue.ref<Error | null>(null);
+
+Vue.onMounted(async () => {
+  try {
+    masterMnemonic.value = await walletKeys.exposeMasterMnemonic();
+  } catch (error) {
+    loadError.value = error instanceof Error ? error : new Error('Failed to load mnemonic');
+    masterMnemonic.value = '';
+  } finally {
+    isLoading.value = false;
+  }
+});
+</script>

--- a/src-vue/interfaces/IConfig.ts
+++ b/src-vue/interfaces/IConfig.ts
@@ -165,6 +165,7 @@ export const ConfigSchema = z.object({
   biddingRules: BiddingRulesSchema,
   vaultingRules: VaultingRulesSchema,
 
+  hasSavedMnemonic: z.boolean(),
   defaultCurrencyKey: CurrencyKeySchema,
   userJurisdiction: z.object({
     ipAddress: z.string(),
@@ -219,6 +220,7 @@ export interface IConfigDefaults {
   isServerInstalling: () => IConfig['isServerInstalling'];
 
   hasReadVaultingInstructions: () => IConfig['hasReadVaultingInstructions'];
+  hasSavedMnemonic: () => IConfig['hasSavedMnemonic'];
 
   hasMiningSeats: () => IConfig['hasMiningSeats'];
   hasMiningBids: () => IConfig['hasMiningBids'];

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -93,6 +93,7 @@ export class Config implements IConfig {
       isServerInstalling: Config.getDefault(dbFields.isServerInstalling) as boolean,
 
       hasReadVaultingInstructions: Config.getDefault(dbFields.hasReadVaultingInstructions) as boolean,
+      hasSavedMnemonic: Config.getDefault(dbFields.hasSavedMnemonic) as boolean,
 
       hasMiningSeats: Config.getDefault(dbFields.hasMiningSeats) as boolean,
       hasMiningBids: Config.getDefault(dbFields.hasMiningBids) as boolean,
@@ -363,6 +364,13 @@ export class Config implements IConfig {
     this.setField('hasReadVaultingInstructions', value);
   }
 
+  public get hasSavedMnemonic(): boolean {
+    return this.getField('hasSavedMnemonic');
+  }
+  public set hasSavedMnemonic(value: boolean) {
+    this.setField('hasSavedMnemonic', value);
+  }
+
   public get hasMiningSeats(): boolean {
     return this.getField('hasMiningSeats');
   }
@@ -493,6 +501,10 @@ export class Config implements IConfig {
       loadedData.showWelcomeOverlay = false;
       stringifiedData[dbFields.showWelcomeOverlay] = JsonExt.stringify(false, 2);
       fieldsToSave.add(dbFields.showWelcomeOverlay);
+
+      loadedData.hasSavedMnemonic = true;
+      stringifiedData[dbFields.hasSavedMnemonic] = JsonExt.stringify(true, 2);
+      fieldsToSave.add(dbFields.hasSavedMnemonic);
     }
   }
 
@@ -549,6 +561,8 @@ export class Config implements IConfig {
     }
 
     this.walletPreviousLifeRecovered = true;
+    this.hasSavedMnemonic = true;
+    this._tryFieldsToSave(dbFields.hasSavedMnemonic, true);
     await this.save();
   }
 
@@ -593,6 +607,7 @@ const dbFields = {
   isServerInstalling: 'isServerInstalling',
 
   hasReadVaultingInstructions: 'hasReadVaultingInstructions',
+  hasSavedMnemonic: 'hasSavedMnemonic',
 
   hasMiningSeats: 'hasMiningSeats',
   hasMiningBids: 'hasMiningBids',
@@ -648,6 +663,7 @@ const defaults: IConfigDefaults = {
   isServerInstalling: () => false,
 
   hasReadVaultingInstructions: () => false,
+  hasSavedMnemonic: () => false,
 
   hasMiningSeats: () => false,
   hasMiningBids: () => false,

--- a/src-vue/overlays-operations/WalletOverlay.vue
+++ b/src-vue/overlays-operations/WalletOverlay.vue
@@ -80,6 +80,8 @@
             </tbody>
           </table>
 
+          <MnemonicBackupBanner class="mt-6" />
+
           <button
             @click="closeOverlay"
             :class="walletIsFullyFunded ? 'bg-argon-600 hover:bg-argon-700 border-argon-700 text-white' : 'bg-slate-600/20 hover:bg-slate-600/15 border border-slate-900/10 text-slate-900'"
@@ -130,6 +132,7 @@ import basicEmitter from '../emitters/basicEmitter';
 import { useOperationsController } from '../stores/operationsController.ts';
 import { WalletType } from '../lib/Wallet.ts';
 import InstructionsIcon from '../assets/instructions.svg?component';
+import MnemonicBackupBanner from '../components/MnemonicBackupBanner.vue';
 import { open as tauriOpen } from '@tauri-apps/plugin-shell';
 
 const isOpen = Vue.ref(false);

--- a/src-vue/overlays-operations/security-settings/Mnemonics.vue
+++ b/src-vue/overlays-operations/security-settings/Mnemonics.vue
@@ -6,41 +6,23 @@
     access your wallet and funds.
   </p>
 
-  <ol class="grid grid-cols-3 gap-2 px-3 mt-5 mb-6 ml-6 cursor-text">
-    <li v-for="(word, index) in words" :key="word" class="flex items-center gap-2 py-1">
-      <span class="text-slate-500">{{ index + 1 }}.</span>
-      <span class="select-text">{{ word }}</span>
-    </li>
-  </ol>
-
-  <button @click="copyToClipboard" class="w-full bg-slate-600/20 hover:bg-slate-600/15 border border-slate-900/10 inner-button-shadow text-slate-900 px-4 py-1 rounded-lg focus:outline-none cursor-pointer">
-    {{ isCopied ? 'Copied!' : 'Copy to Clipboard' }}
-  </button>
+  <MnemonicDisplay gridClass="px-3 mt-5 mb-6" v-slot="{ mnemonic }">
+    <CopyToClipboard :content="mnemonic" class="cursor-pointer">
+      <button class="w-full mt-4 bg-slate-600/20 hover:bg-slate-600/15 border border-slate-900/10 inner-button-shadow text-slate-900 px-4 py-1 rounded-lg focus:outline-none cursor-pointer">
+        Copy to Clipboard
+      </button>
+      <template #copied>
+        <button class="w-full mt-4 bg-slate-600/20 hover:bg-slate-600/15 border border-slate-900/10 inner-button-shadow text-slate-900 px-4 py-1 rounded-lg focus:outline-none cursor-pointer">
+          Copied!
+        </button>
+      </template>
+    </CopyToClipboard>
+  </MnemonicDisplay>
 </template>
 
 <script setup lang="ts">
-import * as Vue from 'vue';
-import { getWalletKeys } from '../../stores/wallets.ts';
+import MnemonicDisplay from '../../components/MnemonicDisplay.vue';
+import CopyToClipboard from '../../components/CopyToClipboard.vue';
 
-const walletKeys = getWalletKeys();
-
-const isCopied = Vue.ref(false);
-const masterMnemonic = Vue.ref('');
-const words = Vue.computed(() => masterMnemonic.value.split(' '));
-
-const emit = defineEmits(['close', 'goTo']);
-
-function copyToClipboard() {
-  navigator.clipboard.writeText(masterMnemonic.value);
-  isCopied.value = true;
-  setTimeout(() => {
-    isCopied.value = false;
-  }, 2000);
-}
-
-Vue.onMounted(() => {
-  walletKeys.exposeMasterMnemonic().then(x => {
-    masterMnemonic.value = x;
-  });
-});
+defineEmits(['close', 'goTo']);
 </script>

--- a/src-vue/screens-operations/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens-operations/mining-screen/SetupInstalling.vue
@@ -17,6 +17,8 @@
         <div class="text-gray-500 text-center font-light mt-3">
           {{progressLabel}}
         </div>
+
+        <MnemonicBackupBanner v-if="!config.hasSavedMnemonic" class="mt-8" />
       </div>
     </div>
   </div>
@@ -28,6 +30,7 @@ import { getConfig } from '../../stores/config';
 import { stepLabels, type IStepLabel } from '../../lib/InstallerStep.ts';
 import { InstallStepStatus, MiningSetupStatus } from '../../interfaces/IConfig';
 import ProgressBar from '../../components/ProgressBar.vue';
+import MnemonicBackupBanner from '../../components/MnemonicBackupBanner.vue';
 import MiningIcon from '../../assets/mining.svg?component';
 import { getTransactionTracker } from '../../stores/transactions.ts';
 import { MoveFrom, MoveTo } from '@argonprotocol/apps-core';

--- a/src-vue/screens-operations/vaulting-screen/SetupInstalling.vue
+++ b/src-vue/screens-operations/vaulting-screen/SetupInstalling.vue
@@ -21,6 +21,8 @@
         <div class="text-gray-500 text-center font-light mt-3">
           {{progressLabel}}
         </div>
+
+        <MnemonicBackupBanner v-if="!config.hasSavedMnemonic" class="mt-8" />
       </div>
     </div>
   </div>
@@ -31,6 +33,7 @@ import * as Vue from 'vue';
 import { getConfig } from '../../stores/config';
 import { getMyVault } from '../../stores/vaults.ts';
 import ProgressBar from '../../components/ProgressBar.vue';
+import MnemonicBackupBanner from '../../components/MnemonicBackupBanner.vue';
 import { DEFAULT_MASTER_XPUB_PATH } from '../../lib/MyVault.ts';
 import VaultIcon from '../../assets/vault.svg?component';
 import { abbreviateAddress, generateProgressLabel } from '../../lib/Utils.ts';


### PR DESCRIPTION
## Summary
- Adds a collapsible mnemonic backup banner to the wallet funding overlay and both setup installing pages
- Extracts shared `MnemonicDisplay` component used by the banner and existing security settings mnemonic screen
- Imported accounts (walletAccountsHadPreviousLife) automatically skip the prompt
- New `hasSavedMnemonic` config flag persists backup confirmation across sessions

## Test plan
- [x] Open wallet overlay during mining/vaulting setup — backup banner appears below funding table
- [x] Expand banner — 12-word grid loads correctly
- [x] Copy to clipboard uses shared CopyToClipboard component with animation
- [x] Click "I've Saved It" — banner collapses to grayed "Recovery phrase backed up" state
- [x] Re-expand after confirming — words still accessible
- [x] Mining/vaulting SetupInstalling pages show banner when mnemonic not yet saved
- [x] Import from mnemonic sets hasSavedMnemonic=true so banner does not appear
- [x] Security Settings > Mnemonics screen works with shared MnemonicDisplay component
- [x] TypeScript typecheck passes