### PR TITLE
Fix coupon validation and roll back failed invites

### DIFF
--- a/bot/__test__/BitcoinLockRelayService.integration.test.ts
+++ b/bot/__test__/BitcoinLockRelayService.integration.test.ts
@@ -115,6 +115,58 @@ describe.sequential('BitcoinLockRelayService integration', () => {
     }
   });
 
+  it('rejects invalid relay inputs without creating a relay row', async () => {
+    const harness = await createRelayServiceHarness();
+    const service = harness.service as unknown as TestRelayService;
+
+    try {
+      vi.spyOn(service, 'startInternal').mockImplementation(async () => {
+        service.vaultId = 1;
+      });
+
+      const cases: Array<{
+        offerCode: string;
+        patch: Partial<IBitcoinLockRelayJobRequest>;
+        errorMatcher: string;
+      }> = [
+        {
+          offerCode: 'missing-account-id',
+          patch: { ownerAccountId: '   ' },
+          errorMatcher: 'owner account id',
+        },
+        {
+          offerCode: 'missing-pubkey',
+          patch: { ownerBitcoinPubkey: '   ' },
+          errorMatcher: 'owner bitcoin pubkey',
+        },
+        {
+          offerCode: 'below-minimum-sats',
+          patch: { requestedSatoshis: 1000n },
+          errorMatcher: 'greater than minimum satoshis',
+        },
+        {
+          offerCode: 'missing-price-quote',
+          patch: { microgonsPerBtc: 0n },
+          errorMatcher: 'current bitcoin price quote',
+        },
+      ];
+
+      for (const { offerCode, patch, errorMatcher } of cases) {
+        insertCoupon(harness.db, offerCode);
+        await expect(
+          harness.service.relayBitcoinLock({
+            ...createRelayRequest(offerCode),
+            ...patch,
+          }),
+        ).rejects.toThrow(errorMatcher);
+
+        expect(getCouponStatus(harness.db, offerCode)?.status).toBe('Open');
+      }
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it('marks pre-inclusion watch failures as failed', async () => {
     const harness = await createRelayServiceHarness();
     const service = harness.service as unknown as TestRelayService;

--- a/bot/src/BitcoinLockRelayService.ts
+++ b/bot/src/BitcoinLockRelayService.ts
@@ -85,11 +85,32 @@ export class BitcoinLockRelayService {
     await this.start();
 
     const { offerCode } = request;
+    const ownerAccountId = request.ownerAccountId?.trim();
+    const ownerBitcoinPubkey = request.ownerBitcoinPubkey?.trim();
 
     const coupon = this.db.bitcoinLockCouponsTable.fetchByOfferCode(offerCode);
     if (!coupon) {
       throw new HttpError('Bitcoin lock coupon not found.', 404);
     }
+
+    if (!ownerAccountId) {
+      throw new HttpError('An owner account id is required for this bitcoin lock.', 400);
+    }
+
+    if (!ownerBitcoinPubkey) {
+      throw new HttpError('An owner bitcoin pubkey is required for this bitcoin lock.', 400);
+    }
+
+    if (request.requestedSatoshis <= 1000n) {
+      throw new HttpError('Requested satoshis must be greater than minimum satoshis.', 400);
+    }
+
+    if (request.microgonsPerBtc == null || request.microgonsPerBtc <= 0n) {
+      throw new HttpError('A current bitcoin price quote is required to initialize this bitcoin lock.', 400);
+    }
+
+    request.ownerAccountId = ownerAccountId;
+    request.ownerBitcoinPubkey = ownerBitcoinPubkey;
 
     const existingRelay = this.db.bitcoinLockRelaysTable.fetchByCouponId(coupon.id);
     if (existingRelay) {

--- a/e2e/driver/client.ts
+++ b/e2e/driver/client.ts
@@ -11,6 +11,7 @@ interface PendingRequest {
 }
 
 interface IAppHelloWaiter {
+  minGeneration: number;
   resolve: (value: UnknownRecord) => void;
   reject: (error: Error) => void;
 }
@@ -75,6 +76,7 @@ export class DriverClient {
   private pending = new Map<string, PendingRequest>();
   private appHello: UnknownRecord | null = null;
   private appHelloError: Error | null = null;
+  private appHelloGeneration = 0;
   private appHelloWaiters: IAppHelloWaiter[] = [];
   private messageBuffer: UnknownRecord[] = [];
   private frontendErrors: string[] = [];
@@ -91,6 +93,10 @@ export class DriverClient {
 
   public getFrontendErrors(): string[] {
     return [...this.frontendErrors];
+  }
+
+  public getAppReloadMarker(): number {
+    return this.appHelloGeneration;
   }
 
   public async connect(): Promise<void> {
@@ -113,10 +119,18 @@ export class DriverClient {
       }
 
       if (payload.type === 'client.hello') {
+        this.appHelloGeneration += 1;
         this.appHello = payload;
         this.appHelloError = null;
-        this.appHelloWaiters.forEach(waiter => waiter.resolve(payload));
-        this.appHelloWaiters = [];
+        const remainingWaiters: IAppHelloWaiter[] = [];
+        for (const waiter of this.appHelloWaiters) {
+          if (this.appHelloGeneration >= waiter.minGeneration) {
+            waiter.resolve(payload);
+            continue;
+          }
+          remainingWaiters.push(waiter);
+        }
+        this.appHelloWaiters = remainingWaiters;
         console.info('[E2E] Received app hello');
         return;
       }
@@ -215,13 +229,13 @@ export class DriverClient {
     this.send({ type: 'driver.hello' });
   }
 
-  public async waitForApp(): Promise<UnknownRecord> {
-    if (this.appHello) return this.appHello;
+  public async waitForApp(minGeneration = 1): Promise<UnknownRecord> {
+    if (this.appHello && this.appHelloGeneration >= minGeneration) return this.appHello;
     if (this.appHelloError) {
       throw this.appHelloError;
     }
     return new Promise((resolve, reject) => {
-      this.appHelloWaiters.push({ resolve, reject });
+      this.appHelloWaiters.push({ minGeneration, resolve, reject });
     });
   }
 

--- a/e2e/flows/helpers/utils.ts
+++ b/e2e/flows/helpers/utils.ts
@@ -30,6 +30,11 @@ export async function pollEvery(
   });
 }
 
+export function isRetryableAppConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message.includes('[app_disconnected]') || error.message.includes('[app_not_connected]');
+}
+
 export function normalizeAmountInput(value: unknown, label: string): string | null {
   if (value == null) return null;
 

--- a/e2e/flows/operations/App.op.prepareAccess.ts
+++ b/e2e/flows/operations/App.op.prepareAccess.ts
@@ -1,6 +1,6 @@
 import { mnemonicGenerate } from '@argonprotocol/mainchain';
 import type { IE2EFlowRuntime, IE2EOperationInspectState } from '../types.ts';
-import { pollEvery } from '../helpers/utils.ts';
+import { isRetryableAppConnectionError, pollEvery } from '../helpers/utils.ts';
 import { Operation } from './index.ts';
 
 interface IAppFlowContext {
@@ -39,6 +39,7 @@ export default new Operation<IAppFlowContext, IPrepareAccessState>(import.meta, 
       return;
     }
 
+    const appReloadMarker = flow.getAppReloadMarker();
     const mnemonic = mnemonicGenerate();
 
     await flow.click('WelcomeOverlay.startImportAccount()', { timeoutMs: 10_000 });
@@ -49,6 +50,7 @@ export default new Operation<IAppFlowContext, IPrepareAccessState>(import.meta, 
 
     await flow.click('WelcomeOverlay.importFromMnemonic()', { timeoutMs: 10_000 });
 
+    let sawReloadError = false;
     await pollEvery(
       500,
       async () => {
@@ -56,7 +58,8 @@ export default new Operation<IAppFlowContext, IPrepareAccessState>(import.meta, 
           const importButton = await flow.isVisible('WelcomeOverlay.importFromMnemonic()');
           return !importButton.exists || !importButton.visible;
         } catch (error) {
-          if (isRetryableReloadError(error)) {
+          if (isRetryableAppConnectionError(error)) {
+            sawReloadError = true;
             return false;
           }
           throw error;
@@ -67,10 +70,45 @@ export default new Operation<IAppFlowContext, IPrepareAccessState>(import.meta, 
         timeoutMessage: 'Welcome overlay did not clear after mnemonic import.',
       },
     );
+
+    let reloadHandled = false;
+    let settledPolls = 0;
+    await pollEvery(
+      250,
+      async () => {
+        try {
+          if (!reloadHandled && (sawReloadError || flow.getAppReloadMarker() > appReloadMarker)) {
+            await flow.waitForReload(appReloadMarker, { timeoutMs: 30_000 });
+            reloadHandled = true;
+            sawReloadError = false;
+            settledPolls = 0;
+            return false;
+          }
+
+          const appState = await flow.queryApp<{ showWelcomeOverlay?: boolean }>(
+            'refs => ({ showWelcomeOverlay: refs.config.showWelcomeOverlay })',
+            { timeoutMs: 1_000 },
+          );
+          if (appState?.showWelcomeOverlay !== false) {
+            settledPolls = 0;
+            return false;
+          }
+
+          settledPolls += 1;
+          return settledPolls >= 5;
+        } catch (error) {
+          if (!isRetryableAppConnectionError(error)) {
+            throw error;
+          }
+          sawReloadError = true;
+          settledPolls = 0;
+          return false;
+        }
+      },
+      {
+        timeoutMs: 30_000,
+        timeoutMessage: 'App did not stabilize after mnemonic import.',
+      },
+    );
   },
 });
-
-function isRetryableReloadError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return error.message.includes('[app_disconnected]') || error.message.includes('[app_not_connected]');
-}

--- a/e2e/flows/runtime.ts
+++ b/e2e/flows/runtime.ts
@@ -1,5 +1,6 @@
 import type { DriverClient } from '../driver/client.ts';
 import { captureE2EScreenshot, getE2EScreenshotMode } from './helpers/screenshotMode.ts';
+import { isRetryableAppConnectionError, sleep } from './helpers/utils.ts';
 import { runOperation } from './operations/index.ts';
 import type {
   E2ECommandArgs,
@@ -143,6 +144,25 @@ export async function executeFlow(
     setActiveOperation: (operationName?: string) => {
       activeOperationName = operationName?.trim() ?? '';
     },
+    getAppReloadMarker: () => driver.getAppReloadMarker(),
+    waitForReload: async (reloadMarker, options = {}) => {
+      const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`[E2E] Timed out waiting for app reload after ${timeoutMs}ms`));
+        }, timeoutMs);
+      });
+
+      try {
+        await Promise.race([driver.waitForApp(reloadMarker + 1), timeout]);
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      }
+      await waitForAppUiReadyAfterReload(driver, withCommandMeta, timeoutMs);
+    },
     command: (command, args) => {
       if (command.startsWith('command.')) {
         throw new Error(`[E2E] '${command}' is reserved for runtime internals. Use a dedicated flow method instead.`);
@@ -281,6 +301,37 @@ export async function executeFlow(
 
 async function ensureRuntimeUiReady(runtime: IE2EFlowRuntime): Promise<void> {
   await runtime.waitFor({ selector: '#app' }, { state: 'exists', timeoutMs: 30_000 });
+}
+
+async function waitForAppUiReadyAfterReload(
+  driver: DriverClient,
+  withCommandMeta: (args?: E2ECommandArgs) => E2ECommandArgs,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+
+    try {
+      await driver.command(
+        'ui.waitFor',
+        withCommandMeta({
+          selector: '#app',
+          state: 'exists',
+          timeoutMs: Math.min(15_000, Math.max(1_000, remainingMs)),
+        }),
+      );
+      return;
+    } catch (error) {
+      if (!isRetryableAppConnectionError(error)) {
+        throw error;
+      }
+      await sleep(250);
+    }
+  }
+
+  throw new Error(`[E2E] Timed out waiting for app UI after reload after ${timeoutMs}ms`);
 }
 
 export { type IE2EFlowDefinition, type E2ECommandArgs } from './types.ts';

--- a/e2e/flows/session.ts
+++ b/e2e/flows/session.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { DriverClient } from '../driver/client.ts';
 import { type DriverServer, startDriverServer } from '../driver/server.ts';
+import { isRetryableAppConnectionError } from './helpers/utils.ts';
 import { getFlow, runFlow } from './index.ts';
 import {
   resolveTestSessionIdentity,
@@ -611,7 +612,7 @@ async function waitForInitialUiReady(driver: DriverClient, appProcess: ChildProc
       }
       return;
     } catch (error) {
-      if (!isRetryableStartupDriverError(error)) {
+      if (!isRetryableAppConnectionError(error)) {
         throw error;
       }
 
@@ -627,11 +628,6 @@ async function waitForInitialUiReady(driver: DriverClient, appProcess: ChildProc
   throw new Error(
     `[E2E] Timed out waiting for initial UI readiness after ${timeoutMs}ms (attempts=${attempt}, pid=${String(appProcess.pid ?? 'n/a')}, exitCode=${String(appProcess.exitCode)}, signal=${String(appProcess.signalCode)})`,
   );
-}
-
-function isRetryableStartupDriverError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return error.message.includes('[app_disconnected]') || error.message.includes('[app_not_connected]');
 }
 
 async function stopChild(child: ChildProcess | null): Promise<void> {

--- a/e2e/flows/types.ts
+++ b/e2e/flows/types.ts
@@ -56,6 +56,8 @@ export interface IE2EFlowRuntime {
   input: E2ECommandArgs;
   defaultTimeoutMs: number;
   setActiveOperation: (operationName?: string) => void;
+  getAppReloadMarker: () => number;
+  waitForReload: (reloadMarker: number, options?: IE2ETimeoutOptions) => Promise<void>;
   command: <T = unknown>(command: string, args?: E2ECommandArgs) => Promise<T>;
   run: {
     <Context, State>(

--- a/router/__test__/Db.test.ts
+++ b/router/__test__/Db.test.ts
@@ -1,0 +1,32 @@
+import * as Fs from 'node:fs';
+import os from 'node:os';
+import Path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Db } from '../src/Db.ts';
+
+describe('Db', () => {
+  let db: Db | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('rejects async transaction callbacks and rolls back their writes', () => {
+    const testDb = new Db(Path.join(Fs.mkdtempSync(Path.join(os.tmpdir(), 'router-db-')), 'router.sqlite'));
+    db = testDb;
+    testDb.migrate();
+
+    expect(() =>
+      testDb.transaction(async () => {
+        testDb.usersTable.insertUser({
+          role: 'treasury_user',
+          name: 'Casey',
+        });
+
+        await Promise.resolve();
+      }),
+    ).toThrowError('Db.transaction callback must be synchronous.');
+
+    expect(testDb.usersTable.fetchByRole('treasury_user')).toEqual([]);
+  });
+});

--- a/router/__test__/RouterServer.test.ts
+++ b/router/__test__/RouterServer.test.ts
@@ -1,0 +1,62 @@
+import * as Fs from 'node:fs';
+import * as Http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import Path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { JsonExt } from '@argonprotocol/apps-core';
+import { Db as RouterDb } from '../src/Db.ts';
+import { RouterServer } from '../src/RouterServer.ts';
+import { TreasuryInviteService } from '../src/TreasuryInviteService.ts';
+
+describe('RouterServer', () => {
+  let routerServer: RouterServer | undefined;
+  let routerDb: RouterDb | undefined;
+  let botServer: Http.Server | undefined;
+
+  afterEach(async () => {
+    await routerServer?.close().catch(() => undefined);
+    routerDb?.close();
+    await new Promise<void>(resolve => botServer?.close(() => resolve()) ?? resolve());
+  });
+
+  it('rolls back invite rows when coupon creation fails', async () => {
+    const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'router-server-test-'));
+    routerDb = new RouterDb(Path.join(tempDir, 'router.sqlite'));
+    routerDb.migrate();
+
+    botServer = Http.createServer((_, res) => {
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JsonExt.stringify({ error: 'Bot coupon creation failed.' }));
+    });
+    await new Promise<void>(resolve => botServer!.listen(0, resolve));
+    const botAddress = botServer.address() as AddressInfo;
+
+    routerServer = new RouterServer({
+      db: routerDb,
+      inviteService: new TreasuryInviteService(routerDb),
+      botInternalUrl: `http://127.0.0.1:${botAddress.port}`,
+      port: 0,
+    });
+    routerServer.start();
+    await routerServer.waitForListening();
+
+    const routerAddress = routerServer.getAddress();
+    const response = await fetch(`http://${routerAddress.host}:${routerAddress.port}/treasury-users/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JsonExt.stringify({
+        name: 'Casey',
+        inviteCode: 'duplicate-safe-code',
+        vaultId: 12,
+        maxSatoshis: 25_000n,
+        expiresAfterTicks: 60,
+      }),
+    });
+
+    expect(response.status).toBe(500);
+    expect(routerDb.userInvitesTable.fetchByCode('duplicate-safe-code')).toBeNull();
+    expect(routerDb.usersTable.fetchByRole('treasury_user')).toEqual([]);
+  });
+});

--- a/router/__test__/TreasuryInviteService.test.ts
+++ b/router/__test__/TreasuryInviteService.test.ts
@@ -1,0 +1,41 @@
+import * as Fs from 'node:fs';
+import os from 'node:os';
+import Path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Db } from '../src/Db.ts';
+import { TreasuryInviteService } from '../src/TreasuryInviteService.ts';
+
+describe('TreasuryInviteService', () => {
+  let db: Db | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('does not leave an orphan user when invite codes collide', () => {
+    db = new Db(Path.join(Fs.mkdtempSync(Path.join(os.tmpdir(), 'treasury-invite-service-')), 'router.sqlite'));
+    db.migrate();
+
+    const service = new TreasuryInviteService(db);
+    service.createInvite({
+      name: 'Casey',
+      inviteCode: 'shared-code',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      expiresAfterTicks: 60,
+    });
+
+    expect(() =>
+      service.createInvite({
+        name: 'Jordan',
+        inviteCode: 'shared-code',
+        vaultId: 12,
+        maxSatoshis: 30_000n,
+        expiresAfterTicks: 60,
+      }),
+    ).toThrowError('This invite code is already in use.');
+
+    expect(db.usersTable.fetchByRole('treasury_user')).toHaveLength(1);
+    expect(db.userInvitesTable.fetchByRole('treasury_user')).toHaveLength(1);
+  });
+});

--- a/router/src/Db.ts
+++ b/router/src/Db.ts
@@ -39,6 +39,23 @@ export class Db {
     return this.#userInvitesTable;
   }
 
+  public transaction<T>(fn: () => T): T {
+    this.sql.exec('BEGIN IMMEDIATE');
+
+    try {
+      const result = fn();
+      if (result && typeof result === 'object' && 'then' in result) {
+        throw new Error('Db.transaction callback must be synchronous.');
+      }
+
+      this.sql.exec('COMMIT');
+      return result;
+    } catch (error) {
+      this.sql.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
   public close(): void {
     this.sql.close();
   }

--- a/router/src/RouterServer.ts
+++ b/router/src/RouterServer.ts
@@ -116,12 +116,24 @@ export class RouterServer {
       safeJsonRoute<ICreateTreasuryInviteResponse>(async req => {
         const body = requireBody<ITreasuryUserInviteCreateRequest>(req);
         const userInvite = inviteService.createInvite(body);
-        const bitcoinLockCoupon = await botCouponClient.createCoupon({
-          userId: userInvite.id,
-          vaultId: body.vaultId,
-          maxSatoshis: body.maxSatoshis,
-          expiresAfterTicks: body.expiresAfterTicks,
-        });
+
+        let bitcoinLockCoupon;
+        try {
+          bitcoinLockCoupon = await botCouponClient.createCoupon({
+            userId: userInvite.id,
+            vaultId: body.vaultId,
+            maxSatoshis: body.maxSatoshis,
+            expiresAfterTicks: body.expiresAfterTicks,
+          });
+        } catch (error) {
+          try {
+            inviteService.deleteInvitedUser(userInvite.id);
+          } catch (cleanupError) {
+            console.error('Failed to roll back invite after coupon creation error:', cleanupError);
+          }
+
+          throw error;
+        }
 
         return {
           invite: {

--- a/router/src/TreasuryInviteService.ts
+++ b/router/src/TreasuryInviteService.ts
@@ -19,12 +19,18 @@ export class TreasuryInviteService {
       throw new RouterError('A vault is required to create an invite.');
     }
 
-    const user = this.db.usersTable.insertUser({
-      role: TREASURY_USER_ROLE,
-      name,
-    });
+    return this.db.transaction(() => {
+      if (this.db.userInvitesTable.fetchByCode(inviteCode)) {
+        throw new RouterError('This invite code is already in use.', 409);
+      }
 
-    return this.db.userInvitesTable.insertInvite(user.id, inviteCode);
+      const user = this.db.usersTable.insertUser({
+        role: TREASURY_USER_ROLE,
+        name,
+      });
+
+      return this.db.userInvitesTable.insertInvite(user.id, inviteCode);
+    });
   }
 
   public openInvite(inviteCode: string, accountId: string): IUserInviteRecord | null {
@@ -44,5 +50,12 @@ export class TreasuryInviteService {
     }
 
     return this.db.userInvitesTable.openInvite(invite.id, trimmedAccountId);
+  }
+
+  public deleteInvitedUser(userId: number): void {
+    this.db.transaction(() => {
+      this.db.userInvitesTable.deleteByUserId(userId);
+      this.db.usersTable.deleteById(userId);
+    });
   }
 }

--- a/router/src/db/UserInvitesTable.ts
+++ b/router/src/db/UserInvitesTable.ts
@@ -172,6 +172,17 @@ export class UserInvitesTable extends BaseTable {
     return this.fetchById(id);
   }
 
+  public deleteByUserId(userId: number): void {
+    this.db.sql
+      .prepare(
+        `
+        DELETE FROM UserInvites
+        WHERE userId = $userId
+      `,
+      )
+      .run({ $userId: userId });
+  }
+
   private mapInvite(record: SqlUserRow): IUserInviteRecord {
     return convertFromSqliteFields<IUserInviteRecord>(record, userFieldTypes);
   }

--- a/router/src/db/UsersTable.ts
+++ b/router/src/db/UsersTable.ts
@@ -118,6 +118,17 @@ export class UsersTable extends BaseTable {
     ).map(record => this.mapUser(record));
   }
 
+  public deleteById(id: number): void {
+    this.db.sql
+      .prepare(
+        `
+        DELETE FROM Users
+        WHERE id = $id
+      `,
+      )
+      .run({ $id: id });
+  }
+
   private mapUser(record: SqlUserRow): IUserRecord {
     return convertFromSqliteFields<IUserRecord>(record, userFieldTypes);
   }


### PR DESCRIPTION
## Summary
- validate relay-backed coupon initialization before any relay row is persisted
- wrap local treasury invite creation in a router DB transaction and reject duplicate invite codes cleanly
- roll back router invite rows if bot coupon creation fails, and add focused regression tests

## Testing
- yarn vitest --run router/__test__/TreasuryInviteService.test.ts router/__test__/RouterServer.test.ts bot/__test__/BitcoinLockRelayService.integration.test.ts