### PR TITLE
chore: resolve vulnerable openzeppelin fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "@argonprotocol/mainchain": "1.4.3-dev.6cdce319",
     "@argonprotocol/testing": "1.4.3-dev.6cdce319",
     "@argonprotocol/bitcoin": "1.4.3-dev.6cdce319",
+    "@openzeppelin/contracts@npm:3.4.1-solc-0.7-2": "npm:3.4.2-solc-0.7",
     "axios": "^1.15.0"
   },
   "packageManager": "yarn@4.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,13 +1440,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:3.4.1-solc-0.7-2":
-  version: 3.4.1-solc-0.7-2
-  resolution: "@openzeppelin/contracts@npm:3.4.1-solc-0.7-2"
-  checksum: 10c0/9959f4951ea8d331ec46441643f020ffeab6156241f240e2ba673fef5873effa1f56fce3aaf335cdc0b2abe6719e4464c838718dc9eb97497260e154f07fb20f
-  languageName: node
-  linkType: hard
-
 "@openzeppelin/contracts@npm:3.4.2-solc-0.7":
   version: 3.4.2-solc-0.7
   resolution: "@openzeppelin/contracts@npm:3.4.2-solc-0.7"


### PR DESCRIPTION
Resolve the legacy Uniswap staker OpenZeppelin descriptor to the already-used 3.4.2 Solidity 0.7 fork so the critical <3.4.2 advisory no longer resolves in the lockfile.