### PR TITLE
fix: restore dev Ethereum helper RPC detection

### DIFF
--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -210,14 +210,15 @@ export async function sendDevEthereumAdminTransaction(args: {
 
 export async function resolveDevEthereumRpcUrl(args: { rpcUrl?: string; logPrefix?: string }): Promise<string> {
   const { rpcUrl, logPrefix = 'dev-ethereum' } = args;
-  const envRpc = process.env.ETH_RPC?.trim();
-  if (rpcUrl?.trim()) return rpcUrl.trim();
+  const explicitRpc = readNonEmpty(rpcUrl);
+  const envRpc = readNonEmpty(process.env.ETH_RPC) ?? readNonEmpty(process.env.ETHEREUM_EXECUTION_RPC_URL);
+  if (explicitRpc) return explicitRpc;
   if (envRpc) return envRpc;
 
   const candidates = await detectExecutionRpcUrls();
   if (!candidates.length) {
     throw new Error(
-      'Unable to detect a local Ethereum execution RPC. Pass --rpc http://127.0.0.1:<port> or set ETH_RPC.',
+      'Unable to detect a local Ethereum execution RPC. Pass --rpc http://127.0.0.1:<port>, set ETH_RPC or ETHEREUM_EXECUTION_RPC_URL, or start the local Kurtosis devnet first.',
     );
   }
 
@@ -364,16 +365,28 @@ async function ensureDevEthereumChainConfig(
 
 async function detectExecutionRpcUrls(): Promise<string[]> {
   const candidates: string[] = [];
+  const portRangeSize = 32;
+  const portStart = 32_000;
+  const portScanLimit = 1_024;
 
-  for (let port = 32_000; port < 32_032; port += 1) {
-    const rpcUrl = `http://127.0.0.1:${port}`;
-    try {
-      const chainId = await rpcCall<string>(rpcUrl, 'eth_chainId', []);
-      if (typeof chainId === 'string') {
-        candidates.push(rpcUrl);
+  // Mirror TestEthereum.launch() in @argonprotocol/testing, which allocates the
+  // first free 32-port execution block starting near 32000 for each devnet.
+  for (
+    let rangeStart = portStart;
+    rangeStart < portStart + portScanLimit;
+    rangeStart += portRangeSize
+  ) {
+    for (let port = rangeStart; port < rangeStart + portRangeSize; port += 1) {
+      const rpcUrl = `http://127.0.0.1:${port}`;
+      try {
+        const chainId = await rpcCall<string>(rpcUrl, 'eth_chainId', []);
+        if (typeof chainId === 'string') {
+          candidates.push(rpcUrl);
+          break;
+        }
+      } catch {
+        continue;
       }
-    } catch {
-      continue;
     }
   }
 

--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -371,11 +371,7 @@ async function detectExecutionRpcUrls(): Promise<string[]> {
 
   // Mirror TestEthereum.launch() in @argonprotocol/testing, which allocates the
   // first free 32-port execution block starting near 32000 for each devnet.
-  for (
-    let rangeStart = portStart;
-    rangeStart < portStart + portScanLimit;
-    rangeStart += portRangeSize
-  ) {
+  for (let rangeStart = portStart; rangeStart < portStart + portScanLimit; rangeStart += portRangeSize) {
     for (let port = rangeStart; port < rangeStart + portRangeSize; port += 1) {
       const rpcUrl = `http://127.0.0.1:${port}`;
       try {

--- a/e2e/scripts/fundDevEthereumAccount.ts
+++ b/e2e/scripts/fundDevEthereumAccount.ts
@@ -141,7 +141,7 @@ function printUsage(): void {
 
 Notes:
   - Sends raw ETH from the built-in local dev admin account.
-  - Uses ETH_RPC if set, otherwise probes local geth dev ports.
+  - Uses ETH_RPC or ETHEREUM_EXECUTION_RPC_URL if set, otherwise probes local Kurtosis execution RPC ports.
   - Waits for the funding transaction receipt before returning.
 `);
 }

--- a/e2e/scripts/mintDevEthereumTokens.ts
+++ b/e2e/scripts/mintDevEthereumTokens.ts
@@ -436,7 +436,7 @@ Notes:
   - Uses MintingGateway.adminMintBatch on the configured Ethereum gateway.
   - Also sudo-bumps the Argon crosschain burn-account liquidity for the matching asset.
   - Resolves gateway, ARGN, and ARGNOT addresses from Argon runtime Ethereum chain config.
-  - Uses ETH_RPC if set, otherwise probes local geth dev ports.
+  - Uses ETH_RPC or ETHEREUM_EXECUTION_RPC_URL if set, otherwise probes local Kurtosis execution RPC ports.
   - Uses ARGON_ARCHIVE_URL if set, otherwise defaults to ws://127.0.0.1:9944.
   - Uses the first unlocked devnet account if --from is omitted.
   - The Ethereum sender must be the gateway admin on the local devnet.


### PR DESCRIPTION
## Summary
Dev Ethereum helper scripts can find the live local execution RPC again after Kurtosis moves a devnet onto the next 32-port block, so `yarn dev:eth:fund` and `yarn dev:eth:mint` work against fresh `dev:docker` boots without a manual `--rpc` override.

## What Changed
- accept `ETHEREUM_EXECUTION_RPC_URL` alongside `ETH_RPC` for explicit local overrides
- probe the same rolling 32-port execution ranges that the Kurtosis launcher allocates instead of assuming only `32000-32031`
- update the helper usage text to describe Kurtosis-based RPC detection

## Verification
- booted a fresh `yarn dev:docker`
- ran `yarn dev:eth:fund --to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --amount 0.01` without `--rpc`
- confirmed the script resolved the live devnet RPC and submitted transaction `0x0b4c42badc57d657f6aa892bcc3ea2abc421dc3b8dde193adeb460d502c84e40`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GPT--5-000000)
