### PR TITLE
fix: bugs launching on testnet

### DIFF
--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -204,6 +204,27 @@ describe('BlockWatch archive recovery', () => {
     expect(blockWatch.finalizedBlockHeader).toBe(finalizedHeader);
   });
 
+  it('drops cached block APIs when subscriptions stop', async () => {
+    const firstBlockApi = { query: { system: { events: vi.fn() } } };
+    const secondBlockApi = { query: { system: { events: vi.fn() } } };
+    const firstPrunedClient = { at: vi.fn().mockResolvedValue(firstBlockApi) };
+    const secondPrunedClient = { at: vi.fn().mockResolvedValue(secondBlockApi) };
+    const clients = createClients(firstPrunedClient, {}) as any;
+    const blockWatch = new BlockWatch(clients);
+    blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+    getInternalBlockWatch(blockWatch).activeSource = 'pruned';
+
+    const block = createHeaderInfo(110, '0xblock', '0xparent');
+    expect(await blockWatch.getApi(block)).toBe(firstBlockApi);
+
+    clients.prunedClientPromise = Promise.resolve(secondPrunedClient);
+    blockWatch.stop();
+
+    expect(await blockWatch.getApi(block)).toBe(secondBlockApi);
+    expect(firstPrunedClient.at).toHaveBeenCalledOnce();
+    expect(secondPrunedClient.at).toHaveBeenCalledOnce();
+  });
+
   it('queues a follow-up restart requested during an active restart', async () => {
     vi.useFakeTimers();
 

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -197,6 +197,8 @@ export class BlockWatch {
       this.restartTimer = undefined;
     }
     this.pendingRestart = undefined;
+    this.apiByBlockHash.clear();
+    this.eventsByBlockHash.clear();
     if (this.unsubscribe) {
       this.unsubscribe();
       this.unsubscribe = undefined;

--- a/router/__test__/RouterServer.test.ts
+++ b/router/__test__/RouterServer.test.ts
@@ -163,27 +163,23 @@ describe('RouterServer', () => {
     });
     expect(unauthenticatedResponse.status).toBe(401);
 
-    const { cookie, session, setCookie } = await login(routerAddress, operator);
-    expect(session).not.toHaveProperty('sessionId');
-    expect(setCookie).toContain('HttpOnly');
+    const { session } = await login(routerAddress, operator);
+    expect(session.sessionId).toBeTruthy();
 
     const authenticatedResponse = await requestJson(
       routerAddress,
-      '/operational-users/create',
+      `/operational-users/create?sessionId=${encodeURIComponent(session.sessionId)}`,
       {
         name: 'Casey',
         fromName: 'Operator One',
         inviteCode,
       },
-      {
-        Cookie: cookie,
-      },
     );
     expect(authenticatedResponse.status).toBe(200);
 
-    const verifyResponse = await fetch(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/admin`, {
-      headers: { Cookie: cookie },
-    });
+    const verifyResponse = await fetch(
+      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/admin?sessionId=${encodeURIComponent(session.sessionId)}`,
+    );
     expect(verifyResponse.status).toBe(204);
     expect(verifyResponse.headers.get('x-user-id')).toBe(operator.address);
     expect(verifyResponse.headers.get('x-user-role')).toBe(UserRole.AdminOperator);
@@ -210,7 +206,7 @@ describe('RouterServer', () => {
     routerServer = started.routerServer;
     botServer = started.botServer;
 
-    const { cookie } = await login(started.routerAddress, operator);
+    const { session } = await login(started.routerAddress, operator);
     await routerServer.close();
     routerServer = undefined;
     await new Promise<void>(resolve => botServer?.close(() => resolve()) ?? resolve());
@@ -228,10 +224,7 @@ describe('RouterServer', () => {
     botServer = restarted.botServer;
 
     const verifyResponse = await fetch(
-      `http://${restarted.routerAddress.host}:${restarted.routerAddress.port}/auth/verify/admin`,
-      {
-        headers: { Cookie: cookie },
-      },
+      `http://${restarted.routerAddress.host}:${restarted.routerAddress.port}/auth/verify/admin?sessionId=${encodeURIComponent(session.sessionId)}`,
     );
     expect(verifyResponse.status).toBe(204);
     expect(verifyResponse.headers.get('x-user-id')).toBe(operator.address);
@@ -317,45 +310,34 @@ describe('RouterServer', () => {
     routerDb.userInvitesTable.insertInvite(user.id, inviteCode, 'Operator One');
     routerDb.userInvitesTable.claimInvite(user.id, treasuryUser.address, treasuryAuth.address);
 
-    const { cookie } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
-    const verifyResponse = await fetch(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/substrate`, {
-      headers: { Cookie: cookie },
-    });
+    const { session } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
+    const verifyResponse = await fetch(withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/substrate`, session.sessionId));
     expect(verifyResponse.status).toBe(204);
     expect(verifyResponse.headers.get('x-user-id')).toBe(treasuryUser.address);
     expect(verifyResponse.headers.get('x-user-role')).toBe(UserRole.TreasuryUser);
 
     const treasuryCouponVerifyResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/treasury-coupon`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/treasury-coupon`, session.sessionId),
     );
     expect(treasuryCouponVerifyResponse.status).toBe(204);
 
-    const botVerifyResponse = await fetch(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/bot`, {
-      headers: { Cookie: cookie },
-    });
+    const botVerifyResponse = await fetch(
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/bot`, session.sessionId),
+    );
     expect(botVerifyResponse.status).toBe(403);
 
     const operationalVerifyResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/operational`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/operational`, session.sessionId),
     );
     expect(operationalVerifyResponse.status).toBe(403);
 
     const managementResponse = await requestJson(
       routerAddress,
-      '/operational-users/create',
+      withSessionId('/operational-users/create', session.sessionId),
       {
         name: 'Riley',
         fromName: 'Operator One',
         inviteCode: InviteCodes.create().inviteCode,
-      },
-      {
-        Cookie: cookie,
       },
     );
     expect(managementResponse.status).toBe(403);
@@ -400,8 +382,8 @@ describe('RouterServer', () => {
     routerDb.userInvitesTable.insertInvite(otherUser.id, InviteCodes.create().inviteCode, 'Operator One');
     routerDb.userInvitesTable.claimInvite(otherUser.id, otherTreasuryUser.address, otherTreasuryAuth.address);
 
-    const { cookie } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
-    const { cookie: otherCookie } = await login(
+    const { session } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
+    const { session: otherSession } = await login(
       routerAddress,
       otherTreasuryUser,
       UserRole.TreasuryUser,
@@ -412,14 +394,10 @@ describe('RouterServer', () => {
     const unauthenticatedListResponse = await fetch(listUrl);
     expect(unauthenticatedListResponse.status).toBe(401);
 
-    const mismatchedListResponse = await fetch(listUrl, {
-      headers: { Cookie: otherCookie },
-    });
+    const mismatchedListResponse = await fetch(withSessionId(listUrl, otherSession.sessionId));
     expect(mismatchedListResponse.status).toBe(403);
 
-    const authenticatedListResponse = await fetch(listUrl, {
-      headers: { Cookie: cookie },
-    });
+    const authenticatedListResponse = await fetch(withSessionId(listUrl, session.sessionId));
     expect(authenticatedListResponse.status).toBe(200);
 
     const initializePath = '/bitcoin-lock-coupons/offer-code/initialize';
@@ -433,14 +411,18 @@ describe('RouterServer', () => {
     const unauthenticatedInitializeResponse = await requestJson(routerAddress, initializePath, initializeBody);
     expect(unauthenticatedInitializeResponse.status).toBe(401);
 
-    const mismatchedInitializeResponse = await requestJson(routerAddress, initializePath, initializeBody, {
-      Cookie: otherCookie,
-    });
+    const mismatchedInitializeResponse = await requestJson(
+      routerAddress,
+      withSessionId(initializePath, otherSession.sessionId),
+      initializeBody,
+    );
     expect(mismatchedInitializeResponse.status).toBe(403);
 
-    const authenticatedInitializeResponse = await requestJson(routerAddress, initializePath, initializeBody, {
-      Cookie: cookie,
-    });
+    const authenticatedInitializeResponse = await requestJson(
+      routerAddress,
+      withSessionId(initializePath, session.sessionId),
+      initializeBody,
+    );
     expect(authenticatedInitializeResponse.status).toBe(200);
   });
 
@@ -493,9 +475,9 @@ describe('RouterServer', () => {
     routerDb.userInvitesTable.insertInvite(operationalRecord.id, InviteCodes.create().inviteCode, 'Operator One');
     routerDb.userInvitesTable.claimInvite(operationalRecord.id, operationalUser.address, operationalAuth.address);
 
-    const { cookie: adminCookie } = await login(routerAddress, operator);
-    const { cookie: treasuryCookie } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
-    const { cookie: operationalCookie } = await login(
+    const { session: adminSession } = await login(routerAddress, operator);
+    const { session: treasurySession } = await login(routerAddress, treasuryUser, UserRole.TreasuryUser, treasuryAuth);
+    const { session: operationalSession } = await login(
       routerAddress,
       operationalUser,
       UserRole.OperationalPartner,
@@ -511,9 +493,7 @@ describe('RouterServer', () => {
     const unauthenticatedResponse = await requestJson(routerAddress, relayPath, relayBody);
     expect(unauthenticatedResponse.status).toBe(401);
 
-    const adminResponse = await requestJson(routerAddress, relayPath, relayBody, {
-      Cookie: adminCookie,
-    });
+    const adminResponse = await requestJson(routerAddress, withSessionId(relayPath, adminSession.sessionId), relayBody);
     expect(adminResponse.status).toBe(200);
     expect(JsonExt.parse(await adminResponse.text())).toEqual({
       outcome: 'Submitted',
@@ -527,9 +507,11 @@ describe('RouterServer', () => {
       throughGatewayActivityNonce: 7n,
     });
 
-    const treasuryResponse = await requestJson(routerAddress, relayPath, relayBody, {
-      Cookie: treasuryCookie,
-    });
+    const treasuryResponse = await requestJson(
+      routerAddress,
+      withSessionId(relayPath, treasurySession.sessionId),
+      relayBody,
+    );
     expect(treasuryResponse.status).toBe(200);
     expect(JsonExt.parse(await treasuryResponse.text())).toEqual({
       outcome: 'Submitted',
@@ -543,9 +525,11 @@ describe('RouterServer', () => {
       throughGatewayActivityNonce: 7n,
     });
 
-    const operationalResponse = await requestJson(routerAddress, relayPath, relayBody, {
-      Cookie: operationalCookie,
-    });
+    const operationalResponse = await requestJson(
+      routerAddress,
+      withSessionId(relayPath, operationalSession.sessionId),
+      relayBody,
+    );
     expect(operationalResponse.status).toBe(200);
     expect(JsonExt.parse(await operationalResponse.text())).toEqual({
       outcome: 'Submitted',
@@ -584,7 +568,7 @@ describe('RouterServer', () => {
     botServer = started.botServer;
     const { routerAddress } = started;
 
-    const { cookie } = await login(routerAddress, operator);
+    const { session } = await login(routerAddress, operator);
 
     const unauthenticatedResponse = await fetch(
       `http://${routerAddress.host}:${routerAddress.port}/ethereum-relay-status`,
@@ -592,10 +576,7 @@ describe('RouterServer', () => {
     expect(unauthenticatedResponse.status).toBe(401);
 
     const authenticatedResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/ethereum-relay-status`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/ethereum-relay-status`, session.sessionId),
     );
     expect(authenticatedResponse.status).toBe(200);
     expect(JsonExt.parse(await authenticatedResponse.text())).toEqual({
@@ -634,34 +615,25 @@ describe('RouterServer', () => {
     routerDb.userInvitesTable.insertInvite(user.id, inviteCode, 'Operator One');
     routerDb.userInvitesTable.claimInvite(user.id, operationalUser.address, operationalAuth.address);
 
-    const { cookie } = await login(routerAddress, operationalUser, UserRole.OperationalPartner, operationalAuth);
+    const { session } = await login(routerAddress, operationalUser, UserRole.OperationalPartner, operationalAuth);
     const substrateVerifyResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/substrate`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/substrate`, session.sessionId),
     );
     expect(substrateVerifyResponse.status).toBe(204);
 
     const operationalVerifyResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/operational`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/operational`, session.sessionId),
     );
     expect(operationalVerifyResponse.status).toBe(204);
 
     const treasuryCouponVerifyResponse = await fetch(
-      `http://${routerAddress.host}:${routerAddress.port}/auth/verify/treasury-coupon`,
-      {
-        headers: { Cookie: cookie },
-      },
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/treasury-coupon`, session.sessionId),
     );
     expect(treasuryCouponVerifyResponse.status).toBe(403);
 
-    const botVerifyResponse = await fetch(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/bot`, {
-      headers: { Cookie: cookie },
-    });
+    const botVerifyResponse = await fetch(
+      withSessionId(`http://${routerAddress.host}:${routerAddress.port}/auth/verify/bot`, session.sessionId),
+    );
     expect(botVerifyResponse.status).toBe(403);
   });
 });
@@ -700,7 +672,7 @@ async function login(
   account: KeyringPair,
   role: RouterAuthRole = UserRole.AdminOperator,
   authAccount?: KeyringPair,
-): Promise<{ session: IRouterAuthSessionResponse; cookie: string; setCookie: string }> {
+): Promise<{ session: IRouterAuthSessionResponse }> {
   const baseUrl = `http://${routerAddress.host}:${routerAddress.port}`;
   const challengeResponse = await fetch(`${baseUrl}/auth/challenge`, {
     method: 'POST',
@@ -723,12 +695,7 @@ async function login(
     body: JsonExt.stringify({ ...challenge, signature }),
   });
   const session = JsonExt.parse<IRouterAuthSessionResponse>(await sessionResponse.text());
-  const setCookie = sessionResponse.headers.get('set-cookie');
-  if (!setCookie) {
-    throw new Error('Router auth session did not set a cookie.');
-  }
-
-  return { session, cookie: setCookie.split(';')[0], setCookie };
+  return { session };
 }
 
 function createOpenInviteBody(
@@ -767,4 +734,15 @@ function requestJson(
     headers: { 'Content-Type': 'application/json', ...headers },
     body: JsonExt.stringify(body),
   });
+}
+
+function withSessionId(path: string, sessionId: string): string {
+  const url = new URL(path, 'http://localhost');
+  url.searchParams.set('sessionId', sessionId);
+
+  if (path.startsWith('http')) {
+    return url.toString();
+  }
+
+  return `${url.pathname}${url.search}`;
 }

--- a/router/src/RouterAuthService.ts
+++ b/router/src/RouterAuthService.ts
@@ -25,14 +25,12 @@ export class RouterAuthService {
   private readonly challengesByNonce = new Map<string, IRouterAuthChallenge>();
   private readonly db?: Db;
   private readonly adminOperatorAccountId?: string;
-  private readonly sessionCookieName: string;
   private readonly sessionTtlSeconds: number;
   private readonly challengeTtlMs: number;
 
   constructor(options: IRouterAuthServiceOptions = {}) {
     this.db = options.db;
     this.adminOperatorAccountId = options.adminOperatorAccountId?.trim() || undefined;
-    this.sessionCookieName = `argon_session_${this.adminOperatorAccountId}`;
 
     this.sessionTtlSeconds = options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS;
     this.challengeTtlMs = options.challengeTtlMs ?? DEFAULT_CHALLENGE_TTL_MS;
@@ -65,7 +63,7 @@ export class RouterAuthService {
     return challenge;
   }
 
-  public createSession(request: IRouterAuthSessionRequest): IRouterAuthSessionResponse & { sessionId: string } {
+  public createSession(request: IRouterAuthSessionRequest): IRouterAuthSessionResponse {
     this.assertEnabled();
 
     const challenge = this.challengesByNonce.get(request.nonce);
@@ -169,17 +167,8 @@ export class RouterAuthService {
     res.sendStatus(204);
   }
 
-  public setSessionCookie(res: Response, session: { sessionId: string }): void {
-    const sessionId = encodeURIComponent(session.sessionId);
-
-    res.setHeader(
-      'Set-Cookie',
-      `${this.sessionCookieName}=${sessionId}; HttpOnly; Secure; SameSite=None; Path=/; Max-Age=${this.sessionTtlSeconds}`,
-    );
-  }
-
   private getRequestUser(req: Request): IUserRecord | null {
-    const sessionId = getCookie(req, this.sessionCookieName);
+    const sessionId = getSessionId(req);
     if (!sessionId) return null;
 
     const session = this.db!.sessionsTable.fetchBySessionId(sessionId);
@@ -258,18 +247,8 @@ export class RouterAuthService {
   }
 }
 
-function getCookie(req: Request, name: string): string | null {
-  const cookieHeader = req.headers.cookie;
-  if (!cookieHeader) return null;
-
-  for (const part of cookieHeader.split(';')) {
-    const [key, ...valueParts] = part.trim().split('=');
-    if (key === name) {
-      return decodeURIComponent(valueParts.join('='));
-    }
-  }
-
-  return null;
+function getSessionId(req: Request): string | null {
+  return new URL(req.originalUrl || req.url, 'http://localhost').searchParams.get('sessionId');
 }
 
 function sendAuthError(res: Response): void {

--- a/router/src/RouterServer.ts
+++ b/router/src/RouterServer.ts
@@ -78,7 +78,6 @@ export class RouterServer {
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
       if (requestOrigin) {
-        res.setHeader('Access-Control-Allow-Credentials', 'true');
         res.setHeader('Vary', 'Origin');
       }
 
@@ -114,11 +113,9 @@ export class RouterServer {
     app.post(
       '/auth/login',
       express.text({ type: '*/*' }),
-      safeJsonRoute<IRouterAuthSessionResponse>(async (req, res) => {
-        const { sessionId, ...session } = routerAuth.createSession(requireBody<IRouterAuthSessionRequest>(req));
-        routerAuth.setSessionCookie(res, { sessionId });
-        return session;
-      }),
+      safeJsonRoute<IRouterAuthSessionResponse>(async req =>
+        routerAuth.createSession(requireBody<IRouterAuthSessionRequest>(req)),
+      ),
     );
 
     app.get('/auth/verify/admin', (req, res) => {

--- a/router/src/interfaces/IRouterApi.ts
+++ b/router/src/interfaces/IRouterApi.ts
@@ -45,6 +45,7 @@ export interface IRouterAuthSessionRequest extends IRouterAuthChallenge {
 }
 
 export interface IRouterAuthSessionResponse {
+  sessionId: string;
   expiresAt: string;
   accountId: string;
   role: RouterAuthRole;

--- a/server/nginx/templates/default.conf.template
+++ b/server/nginx/templates/default.conf.template
@@ -10,7 +10,7 @@ map $request_method $auth_post_limit_key {
 
 limit_req_zone $auth_post_limit_key zone=auth_post_per_ip:10m rate=5r/m;
 limit_req_zone $binary_remote_addr zone=http_per_ip:10m rate=30r/s;
-limit_req_zone $binary_remote_addr zone=ws_handshake_per_ip:10m rate=10r/m;
+limit_req_zone $binary_remote_addr zone=ws_handshake_per_ip:10m rate=15r/s;
 limit_conn_zone $binary_remote_addr zone=conn_per_ip:10m;
 
 server {
@@ -31,26 +31,22 @@ server {
 
   resolver 127.0.0.11 valid=10s ipv6=off;
 
+  auth_request_set $auth_user_id $upstream_http_x_user_id;
+  auth_request_set $auth_user_role $upstream_http_x_user_role;
+
   location = /_auth_bot {
     internal;
-    proxy_pass http://router:8080/auth/verify/bot;
+    proxy_pass http://router:8080/auth/verify/bot?sessionId=$auth_session_id;
     proxy_pass_request_body off;
     proxy_set_header Content-Length "";
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Original-URI $request_uri;
   }
 
   location = /_auth_substrate {
     internal;
-    proxy_pass http://router:8080/auth/verify/substrate;
+    proxy_pass http://router:8080/auth/verify/substrate?sessionId=$auth_session_id;
     proxy_pass_request_body off;
     proxy_set_header Content-Length "";
-    proxy_set_header Cookie $http_cookie;
-    proxy_set_header X-Original-URI $request_uri;
   }
-
-  auth_request_set $auth_user_id $upstream_http_x_user_id;
-  auth_request_set $auth_user_role $upstream_http_x_user_role;
 
   location /auth/ {
     limit_req zone=http_per_ip burst=60 nodelay;
@@ -63,9 +59,10 @@ server {
   }
 
   location ~ ^/substrate(?:/|$) {
+    set $auth_session_id $arg_sessionId;
     auth_request /_auth_substrate;
     limit_req zone=ws_handshake_per_ip burst=5 nodelay;
-    limit_conn conn_per_ip 10;
+    limit_conn conn_per_ip 20;
     set $substrate_upstream http://argon-miner:9945;
     rewrite ^/substrate/?(.*)$ /$1 break;
     proxy_pass $substrate_upstream;
@@ -81,9 +78,10 @@ server {
   }
 
   location /bot/ {
+    set $auth_session_id $arg_sessionId;
     auth_request /_auth_bot;
     limit_req zone=ws_handshake_per_ip burst=5 nodelay;
-    limit_conn conn_per_ip 10;
+    limit_conn conn_per_ip 20;
     set $bot_upstream http://bot:8080;
     rewrite ^/bot/(.*)$ /$1 break;
     proxy_pass $bot_upstream;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -700,7 +700,7 @@ pub fn run() {
             });
 
             init_config_instance_dir(handle, &relative_config_dir)?;
-            migrations::backup_current_instance_database(handle).map_err(|e| e.to_string())?;
+            tauri::async_runtime::block_on(run_db_migrations(handle.clone()))?;
 
             let window = app.get_webview_window("main").unwrap();
 

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -188,7 +188,7 @@ impl SSH {
     }
 
     pub async fn upload_file(&self, contents: &[u8], remote_path: &str) -> Result<()> {
-        let escaped_remote = format!("'{}'", remote_path.replace('\'', "'\\''"));
+        let escaped_remote = shell_escape_remote_path(remote_path);
         let mut channel = self.open_channel().await?;
         let scp_command = format!("cat > {escaped_remote}");
         channel.exec(true, scp_command).await?;
@@ -213,7 +213,7 @@ impl SSH {
         let path = Utils::get_embedded_path(app, file_name)?;
         let file = File::open(&path).await?;
 
-        let escaped_remote = format!("'{}'", remote_path.replace('\'', "'\\''"));
+        let escaped_remote = shell_escape_remote_path(remote_path);
         // ensure old file is removed
         let _ = self.run_command(format!("rm -f {escaped_remote}")).await;
 
@@ -259,8 +259,7 @@ impl SSH {
         local_download_path: &str,
         event_progress_key: String,
     ) -> Result<()> {
-        // Escape the remote path safely for single-quoted shell
-        let escaped_remote = format!("'{}'", remote_path.replace('\'', "'\\''"));
+        let escaped_remote = shell_escape_remote_path(remote_path);
 
         // Best-effort: get remote file size for progress (may fail; then size=0)
         let mut remote_size: u64 = 0;
@@ -358,6 +357,27 @@ impl SSH {
 
         Ok((private_key_openssh, public_key_openssh))
     }
+}
+
+fn shell_escape_remote_path(remote_path: &str) -> String {
+    let escape = |value: &str| value.replace('\'', "'\\''");
+
+    if let Some(stripped) = remote_path.strip_prefix('~') {
+        if stripped.is_empty() {
+            return "~".to_string();
+        }
+
+        if let Some((user, rest)) = stripped.split_once('/') {
+            let prefix = format!("~{user}/");
+            return if rest.is_empty() {
+                prefix.trim_end_matches('/').to_string()
+            } else {
+                format!("{prefix}'{}'", escape(rest))
+            };
+        }
+    }
+
+    format!("'{}'", escape(remote_path))
 }
 
 struct ClientHandler {}

--- a/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
@@ -142,6 +142,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
       data: { txInfos: [] },
       pendingBlockTxInfosAtLoad: [],
       load: vi.fn(async () => {}),
+      ensureStoredEvents: vi.fn(async () => {}),
       submitAndWatch: vi.fn(async () =>
         createTransferOutTxInfo({
           transferId: onChainTransferId,
@@ -250,6 +251,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
       data: { txInfos: [] },
       pendingBlockTxInfosAtLoad: [],
       load: vi.fn(async () => {}),
+      ensureStoredEvents: vi.fn(async () => {}),
       submitAndWatch: vi.fn(async () => ({
         ...txInfo,
         txResult: {
@@ -345,6 +347,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
       data: { txInfos: [] },
       pendingBlockTxInfosAtLoad: [],
       load: vi.fn(async () => {}),
+      ensureStoredEvents: vi.fn(async () => {}),
     };
 
     const tracker = new EthereumOutboundTransferTracker(
@@ -404,6 +407,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
       data: { txInfos: [] },
       pendingBlockTxInfosAtLoad: [],
       load: vi.fn(async () => {}),
+      ensureStoredEvents: vi.fn(async () => {}),
       submitAndWatch: vi.fn(async () =>
         createTransferOutTxInfo({
           transferId: onChainTransferId,

--- a/src-vue/__test__/ServerApiClient.test.ts
+++ b/src-vue/__test__/ServerApiClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ServerType } from '../interfaces/IConfig.ts';
 import { ServerApiClient } from '../lib/ServerApiClient.ts';
+import type { ServerAuthClient } from '../lib/ServerAuthClient.ts';
 
 describe('ServerApiClient', () => {
   afterEach(() => {
@@ -18,6 +19,9 @@ describe('ServerApiClient', () => {
       'https://localhost:59397/auth/challenge',
     );
     expect(ServerApiClient.getGatewayWebsocketUrl(serverDetails, '/bot/')).toBe('wss://localhost:59397/bot/');
+    expect(ServerApiClient.getGatewayWebsocketUrl(serverDetails, '/substrate', 'session-123')).toBe(
+      'wss://localhost:59397/substrate?sessionId=session-123',
+    );
   });
 
   it('keeps the configured host for remote gateway urls', () => {
@@ -43,5 +47,46 @@ describe('ServerApiClient', () => {
         gatewayPort: 443,
       }),
     ).rejects.toThrow('Not Found');
+  });
+
+  it('retries authenticated requests after the session is rejected', async () => {
+    const serverDetails = {
+      type: ServerType.CustomServer,
+      ipAddress: '203.0.113.10',
+      gatewayPort: 443,
+    };
+    const getAdminOperatorSessionId = vi
+      .fn()
+      .mockResolvedValueOnce('stale-session')
+      .mockResolvedValueOnce('fresh-session');
+    const invalidateAdminOperatorSessionId = vi.fn();
+    const serverAuthClient = {
+      getAdminOperatorSessionId,
+      invalidateAdminOperatorSessionId,
+    } satisfies Pick<ServerAuthClient, 'getAdminOperatorSessionId' | 'invalidateAdminOperatorSessionId'>;
+    const client = new ServerApiClient(() => serverDetails, serverAuthClient);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ invites: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(client.getTreasuryAppInvites()).resolves.toEqual([]);
+
+    expect(invalidateAdminOperatorSessionId).toHaveBeenCalledWith('https://203.0.113.10');
+    expect(fetchMock.mock.calls.map(([url]) => new URL(String(url)).searchParams.get('sessionId'))).toEqual([
+      'stale-session',
+      'fresh-session',
+    ]);
   });
 });

--- a/src-vue/__test__/ServerAuthClient.test.ts
+++ b/src-vue/__test__/ServerAuthClient.test.ts
@@ -47,11 +47,11 @@ describe('ServerAuthClient', () => {
       .mockResolvedValueOnce(emptyResponse(204));
     vi.stubGlobal('fetch', fetchMock);
 
-    await serverAuthClient.ensureAdminOperatorSession(baseUrl);
-    await serverAuthClient.ensureAdminOperatorSession(baseUrl);
+    await serverAuthClient.getAdminOperatorSessionId(baseUrl);
+    await serverAuthClient.getAdminOperatorSessionId(baseUrl);
 
     expect(fetchPaths(fetchMock)).toEqual(['/auth/challenge', '/auth/login', '/auth/verify/admin']);
-    expect(fetchCredentials(fetchMock)).toEqual(['include', 'include', 'include']);
+    expect(fetchUrls(fetchMock)[2].searchParams.get('sessionId')).toBe('session-admin-operator');
     expect(walletMock.getOperationalKeypair).toHaveBeenCalledTimes(1);
   });
 
@@ -68,8 +68,8 @@ describe('ServerAuthClient', () => {
       .mockResolvedValueOnce(emptyResponse(204));
     vi.stubGlobal('fetch', fetchMock);
 
-    const firstSession = serverAuthClient.ensureAdminOperatorSession(baseUrl);
-    const secondSession = serverAuthClient.ensureAdminOperatorSession(baseUrl);
+    const firstSession = serverAuthClient.getAdminOperatorSessionId(baseUrl);
+    const secondSession = serverAuthClient.getAdminOperatorSessionId(baseUrl);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -81,7 +81,7 @@ describe('ServerAuthClient', () => {
   });
 
   it('creates a fresh session when a forced session check is rejected', async () => {
-    const baseUrl = 'https://stale-cookie.example';
+    const baseUrl = 'https://stale-session.example';
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse(createChallenge('nonce-1')))
@@ -93,8 +93,8 @@ describe('ServerAuthClient', () => {
       .mockResolvedValueOnce(emptyResponse(204));
     vi.stubGlobal('fetch', fetchMock);
 
-    await serverAuthClient.ensureAdminOperatorSession(baseUrl);
-    await serverAuthClient.ensureAdminOperatorSession(baseUrl, { forceVerify: true });
+    await serverAuthClient.getAdminOperatorSessionId(baseUrl);
+    await serverAuthClient.getAdminOperatorSessionId(baseUrl, { forceVerify: true });
 
     expect(fetchPaths(fetchMock)).toEqual([
       '/auth/challenge',
@@ -113,12 +113,8 @@ describe('ServerAuthClient', () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(emptyResponse(503));
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(serverAuthClient.ensureAdminOperatorSession(baseUrl)).rejects.toThrow(
-      'Server auth is not configured.',
-    );
-    await expect(serverAuthClient.ensureAdminOperatorSession(baseUrl)).rejects.toThrow(
-      'Server auth is not configured.',
-    );
+    await expect(serverAuthClient.getAdminOperatorSessionId(baseUrl)).rejects.toThrow('Server auth is not configured.');
+    await expect(serverAuthClient.getAdminOperatorSessionId(baseUrl)).rejects.toThrow('Server auth is not configured.');
 
     expect(fetchPaths(fetchMock)).toEqual(['/auth/challenge']);
     expect(walletMock.getOperationalKeypair).not.toHaveBeenCalled();
@@ -133,7 +129,7 @@ describe('ServerAuthClient', () => {
       .mockResolvedValueOnce(emptyResponse(204));
     vi.stubGlobal('fetch', fetchMock);
 
-    await serverAuthClient.ensureTreasurySession(baseUrl);
+    await serverAuthClient.getTreasurySessionId(baseUrl);
 
     expect(fetchPaths(fetchMock)).toEqual(['/auth/challenge', '/auth/login', '/auth/verify/treasury-coupon']);
     expect(fetchPayloads(fetchMock)).toMatchObject([
@@ -160,7 +156,14 @@ function createChallenge(nonce = 'nonce', role = UserRole.AdminOperator) {
 }
 
 function createSession(role = UserRole.AdminOperator) {
+  const sessionIdByRole = {
+    [UserRole.AdminOperator]: 'session-admin-operator',
+    [UserRole.TreasuryUser]: 'session-treasury-user',
+    [UserRole.OperationalPartner]: 'session-operational-partner',
+  };
+
   return {
+    sessionId: sessionIdByRole[role],
     role,
     accountId: role === UserRole.AdminOperator ? 'admin-account' : 'treasury-account',
     expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
@@ -179,11 +182,11 @@ function emptyResponse(status: number): Response {
 }
 
 function fetchPaths(fetchMock: ReturnType<typeof vi.fn>): string[] {
-  return fetchMock.mock.calls.map(([url]) => new URL(String(url)).pathname);
+  return fetchUrls(fetchMock).map(url => url.pathname);
 }
 
-function fetchCredentials(fetchMock: ReturnType<typeof vi.fn>): Array<RequestInit['credentials']> {
-  return fetchMock.mock.calls.map(([, init]) => (init as RequestInit | undefined)?.credentials);
+function fetchUrls(fetchMock: ReturnType<typeof vi.fn>): URL[] {
+  return fetchMock.mock.calls.map(([url]) => new URL(String(url)));
 }
 
 function fetchPayloads<T>(fetchMock: ReturnType<typeof vi.fn>): T[] {

--- a/src-vue/__test__/TreasuryAppInvite.integration.test.ts
+++ b/src-vue/__test__/TreasuryAppInvite.integration.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@argonprotocol/apps-core/__test__/startArgonTestNetwork.js';
 import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
 import { setMainchainClients } from '../stores/mainchain.ts';
+import { ServerAuthClient } from '../lib/ServerAuthClient.ts';
 import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
 import { BitcoinLockStatus } from '../lib/db/BitcoinLocksTable.ts';
 import type {
@@ -33,6 +34,7 @@ import {
   createBitcoinLocksClientHarness,
   createBitcoinLocksHarness,
 } from './helpers/bitcoinLocksHarness.ts';
+import { createMockWalletKeys } from './helpers/wallet.ts';
 import {
   BitcoinLockRelayService,
   type Bot,
@@ -105,11 +107,15 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       network: 'dev-docker',
     });
     let operatorHost = '';
+    const operatorServerAuthClient = new ServerAuthClient(() => operatorHarness.walletKeys);
+    const treasuryWalletKeys = createMockWalletKeys();
+    const treasuryServerAuthClient = new ServerAuthClient(() => treasuryWalletKeys);
     const treasuryHarness = await createBitcoinLocksClientHarness({
       archiveUrl: network.archiveUrl,
       esploraHost: network.networkConfigOverride.esploraHost,
       network: 'dev-docker',
-      upstreamOperatorClient: new UpstreamOperatorClient(undefined, () => operatorHost || undefined),
+      walletKeys: treasuryWalletKeys,
+      upstreamOperatorClient: new UpstreamOperatorClient(treasuryServerAuthClient, () => operatorHost || undefined),
     });
     const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'treasury-app-invite-'));
 
@@ -188,6 +194,9 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
         port: 0,
         localNodeUrl: network.archiveUrl,
         mainNodeUrl: network.archiveUrl,
+        auth: {
+          adminOperatorAccountId: operatorHarness.walletKeys.operationalAddress,
+        },
       });
       routerServer.start();
       await routerServer.waitForListening();
@@ -202,7 +211,7 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       const { inviteSecret, inviteCode } = InviteCodes.create();
 
       // Operator issues the invite and should see it tracked immediately in the router api.
-      const createdInvite = await createTreasuryAppInvite(operatorHost, {
+      const createdInvite = await createTreasuryAppInvite(operatorHost, operatorServerAuthClient, {
         name: 'Casey',
         fromName: expectedFromName,
         inviteCode,
@@ -212,7 +221,9 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       });
       expect(createdInvite.bitcoinLockCoupon?.coupon.offerCode).toBeTruthy();
 
-      const issuedInvite = (await getTreasuryAppInvites(operatorHost)).find(x => x.inviteCode === inviteCode);
+      const issuedInvite = (await getTreasuryAppInvites(operatorHost, operatorServerAuthClient)).find(
+        x => x.inviteCode === inviteCode,
+      );
       expect(issuedInvite?.lastClickedAt).toBeFalsy();
 
       // Claiming the invite should update click tracking on the operator api.
@@ -237,21 +248,26 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       ).rejects.toThrow('already claimed by a different account');
 
       const clickedInvite = await waitFor(30e3, 'router invite click tracked', async () => {
-        const invite = (await getTreasuryAppInvites(operatorHost)).find(x => x.inviteCode === inviteCode);
+        const invite = (await getTreasuryAppInvites(operatorHost, operatorServerAuthClient)).find(
+          x => x.inviteCode === inviteCode,
+        );
         if (!invite?.lastClickedAt) return;
         return invite;
       });
       expect(clickedInvite.lastClickedAt).toBeTruthy();
 
       await expect(
-        new UpstreamOperatorClient(undefined, () => operatorHost).initializeBitcoinLock(coupon.coupon.offerCode, {
-          ownerAccountId: operatorHarness.walletKeys.liquidLockingAddress,
-          ownerBitcoinPubkey: '02deadbeef',
-          requestedSatoshis,
-          microgonsAtTargetPerBtc:
-            treasuryHarness.currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN),
-        }),
-      ).rejects.toThrow('claimed by a different account');
+        new UpstreamOperatorClient(treasuryServerAuthClient, () => operatorHost).initializeBitcoinLock(
+          coupon.coupon.offerCode,
+          {
+            ownerAccountId: operatorHarness.walletKeys.liquidLockingAddress,
+            ownerBitcoinPubkey: '02deadbeef',
+            requestedSatoshis,
+            microgonsAtTargetPerBtc:
+              treasuryHarness.currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN),
+          },
+        ),
+      ).rejects.toThrow('Forbidden');
 
       // The treasury app user requests relay-backed lock creation.
       const { txInfo } = await treasuryHarness.bitcoinLocks.initializeLock({
@@ -331,22 +347,44 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
   });
 });
 
-async function createTreasuryAppInvite(operatorHost: string, payload: ITreasuryUserInviteCreateRequest) {
-  const body = await routerRequest<ICreateTreasuryInviteResponse>(operatorHost, '/treasury-users/create', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JsonExt.stringify(payload),
-  });
+async function createTreasuryAppInvite(
+  operatorHost: string,
+  serverAuthClient: ServerAuthClient,
+  payload: ITreasuryUserInviteCreateRequest,
+) {
+  const body = await routerRequest<ICreateTreasuryInviteResponse>(
+    operatorHost,
+    serverAuthClient,
+    '/treasury-users/create',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JsonExt.stringify(payload),
+    },
+  );
   return body.invite;
 }
 
-async function getTreasuryAppInvites(operatorHost: string) {
-  const body = await routerRequest<IListTreasuryInvitesResponse>(operatorHost, '/treasury-users/invites');
+async function getTreasuryAppInvites(operatorHost: string, serverAuthClient: ServerAuthClient) {
+  const body = await routerRequest<IListTreasuryInvitesResponse>(
+    operatorHost,
+    serverAuthClient,
+    '/treasury-users/invites',
+  );
   return body.invites;
 }
 
-async function routerRequest<T>(operatorHost: string, path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(`${operatorHost}${path}`, init);
+async function routerRequest<T>(
+  operatorHost: string,
+  serverAuthClient: ServerAuthClient,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const sessionId = await serverAuthClient.getAdminOperatorSessionId(operatorHost);
+  const url = new URL(`${operatorHost}${path}`);
+  url.searchParams.set('sessionId', sessionId);
+
+  const response = await fetch(url, init);
   const rawBody = await response.text();
 
   if (!response.ok) {

--- a/src-vue/__test__/helpers/bitcoinLocksHarness.ts
+++ b/src-vue/__test__/helpers/bitcoinLocksHarness.ts
@@ -58,6 +58,7 @@ export async function createBitcoinLocksClientHarness(args: {
   esploraHost: string;
   network: string;
   upstreamOperatorClient?: UpstreamOperatorClient;
+  walletKeys?: WalletKeys;
 }): Promise<BitcoinLocksClientHarness> {
   const { archiveUrl, esploraHost, upstreamOperatorClient } = args;
 
@@ -67,7 +68,7 @@ export async function createBitcoinLocksClientHarness(args: {
   const db = await createTestDb();
   setDbPromise(Promise.resolve(db));
 
-  const walletKeys = createMockWalletKeys();
+  const walletKeys = args.walletKeys ?? createMockWalletKeys();
 
   const currency = new CurrencyBase(clients);
   await currency.fetchMainchainRates();

--- a/src-vue/app-operations/navigation/OperationalMenu.vue
+++ b/src-vue/app-operations/navigation/OperationalMenu.vue
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 <template>
-  <div class="relative">
-    <div AlertMenu v-if="isShowingCompletionTooltip" class="z-50 absolute top-6 right-0 pt-[12px]">
+  <div ref="rootRef">
+    <div AlertMenu v-if="isShowingCompletionTooltip" class="fixed z-50 pt-[12px]" :style="alertMenuStyle">
       <Arrow
         class="absolute top-0 right-6 h-3.5 w-6"
         fill="white"
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <div AlertMenu v-else-if="isShowingBonusTooltip" class="z-50 absolute top-6 right-0 pt-[12px]">
+    <div AlertMenu v-else-if="isShowingBonusTooltip" class="fixed z-50 pt-[12px]" :style="alertMenuStyle">
       <Arrow
         class="absolute top-0 right-6 w-6 h-3.5"
         fill="white"
@@ -59,169 +59,168 @@
       </div>
     </div>
 
-    <div ref="rootRef">
-      <NavigationMenuItem class="pointer-events-auto" @mouseenter="onMenuEnter" @mouseleave="onMenuLeave">
-        <NavigationMenuTrigger
-          Trigger
-          :aria-label="controller.isOperationalRewardsFlowActive ? 'Operational rewards' : 'Operational progress'"
-          class="flex h-[30px] cursor-pointer flex-row items-center justify-center overflow-hidden rounded-md border border-slate-400/50 text-argon-600/70 hover:border-slate-400/50 hover:bg-slate-400/10 focus:outline-none data-[state=open]:border-slate-400/60 data-[state=open]:bg-slate-400/10"
-          :class="[
-            controller.isOperationalRewardsFlowActive ? 'w-[42px]' : 'font-mono text-base font-semibold',
-          ]"
-          @focus="onMenuEnter"
-        >
-          <template v-if="controller.isOperationalRewardsFlowActive">
-            <div class="relative flex h-full w-full items-center justify-center">
-              <div class="menu-moon">
-                <div class="menu-moon-crater left-[3px] top-[5px]" />
-                <div class="menu-moon-crater h-[2.5px] w-[2.5px] right-[4px] bottom-[5px]" />
-                <div v-if="hasInviteMoonBase" class="menu-moon-base" />
-              </div>
-              <RocketIcon class="menu-moon-rocket" aria-hidden="true" />
+    <NavigationMenuItem class="pointer-events-auto" @mouseenter="onMenuEnter" @mouseleave="onMenuLeave">
+      <NavigationMenuTrigger
+        Trigger
+        :aria-label="controller.isOperationalRewardsFlowActive ? 'Operational rewards' : 'Operational progress'"
+        class="flex h-[30px] cursor-pointer flex-row items-center justify-center overflow-hidden rounded-md border border-slate-400/50 text-argon-600/70 hover:border-slate-400/50 hover:bg-slate-400/10 focus:outline-none data-[state=open]:border-slate-400/60 data-[state=open]:bg-slate-400/10"
+        :class="[
+          controller.isOperationalRewardsFlowActive ? 'w-[42px]' : 'font-mono text-base font-semibold',
+        ]"
+        @focus="onMenuEnter"
+      >
+        <template v-if="controller.isOperationalRewardsFlowActive">
+          <div class="relative flex h-full w-full items-center justify-center">
+            <div class="menu-moon">
+              <div class="menu-moon-crater left-[3px] top-[5px]" />
+              <div class="menu-moon-crater h-[2.5px] w-[2.5px] right-[4px] bottom-[5px]" />
+              <div v-if="hasInviteMoonBase" class="menu-moon-base" />
             </div>
-          </template>
-
-          <div v-else class="relative flex flex-row items-center pl-2.5 pr-3 pt-px">
-            <RocketIcon class="h-[17px] relative top-[2px] mr-[5px] -rotate-45" aria-hidden="true" />
-            {{ controller.completedCertificationStepCount }}/{{ controller.certificationStepCount }}
+            <RocketIcon class="menu-moon-rocket" aria-hidden="true" />
           </div>
-        </NavigationMenuTrigger>
+        </template>
 
-        <NavigationMenuContent
-          class="data-[motion=from-start]:animate-enterFromLeft data-[motion=from-end]:animate-enterFromRight data-[motion=to-start]:animate-exitToLeft data-[motion=to-end]:animate-exitToRight absolute top-0 left-0 w-full sm:w-auto"
-          @mouseenter="onMenuEnter"
-          @mouseleave="onMenuLeave"
-        >
-            <div class="relative">
-              <div class="w-fit bg-argon-menu-bg flex shrink flex-col rounded p-1 text-gray-900 shadow-lg ring-1 ring-gray-900/20">
-                <div v-if="controller.isOperationalRewardsFlowActive" class="w-[26rem] px-4 pt-4 pb-4">
-                  <div v-if="controller.isOperationalActivationReady" class="space-y-3">
-                    <div class="border-b border-slate-300/50 pb-2.5">
-                      <div class="text-lg font-bold text-slate-700">Claim your Rewards</div>
-                      <div class="mt-0.5 text-sm leading-5 text-slate-500">
-                        You've finished the Argon Operational Certification Process! Open to claim your {{ operationalReferralRewardLabel }} reward.
-                      </div>
-                      <button
-                        type="button"
-                        class="bg-argon-button hover:bg-argon-button-hover mt-3 rounded-lg px-3 py-1.5 text-sm font-semibold text-white"
-                        @click="openRewardsActivation()"
-                      >
-                        Open
-                      </button>
-                    </div>
-                  </div>
+        <div v-else class="relative flex flex-row items-center pl-2.5 pr-3 pt-px">
+          <RocketIcon class="h-[17px] relative top-[2px] mr-[5px] -rotate-45" aria-hidden="true" />
+          {{ controller.completedCertificationStepCount }}/{{ controller.certificationStepCount }}
+        </div>
+      </NavigationMenuTrigger>
 
-                  <template v-else>
-                    <div class="border-b border-slate-300/50 pb-2.5">
-                    <div class="text-lg font-bold text-slate-700">Operator Referrals</div>
-                    <div class="mt-0.5 text-sm text-slate-500">
-                      Earn {{ operationalReferralRewardLabel }} for both you and each referral who completes the operational checklist. Every
-                      {{ controller.rewardConfig.referralBonusEveryXOperationalSponsees }} referred triggers a
-                      {{ referralBonusRewardLabel }} bonus!
-                    </div>
-                  </div>
-
-                  <OperationalInviteSlots
-                    class="mt-3"
-                    mode="menu"
-                    :progress="controller.inviteSlotProgress"
-                    :rewardConfig="controller.rewardConfig"
-                    :invites="controller.operationalInvites"
-                    :inviteStatusesByCode="controller.operationalInviteStatusesByCode"
-                    @select="openInviteHub"
-                  />
-
-                  <div class="mt-4 ">
-                    <div StatsBox box class="mt-2 grid grid-cols-3 overflow-hidden text-center">
-                      <Tooltip
-                        v-for="stat in referralStats"
-                        :key="stat.label"
-                        asChild
-                        side="bottom"
-                        :content="stat.tooltip">
-                        <div StatWrapper class="border-r border-slate-200/70 px-3 py-2.5 last:border-r-0">
-                          <div Stat class="text-2xl! leading-none">{{ stat.value }}</div>
-                          <div class="mt-1.5 text-xs font-semibold tracking-widest text-slate-400 uppercase">{{ stat.label }}</div>
-                        </div>
-                      </Tooltip>
-                    </div>
-                  </div>
-
-                  <div
-                    v-if="hasUnclaimedRewards"
-                    class="mt-3 flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2">
-                    <div class="min-w-0">
-                      <div class="text-sm font-semibold text-slate-800">{{ pendingReferralRewardLabel }} unclaimed</div>
-                      <div class="text-xs text-slate-500">Choose where to send rewards.</div>
+      <NavigationMenuContent
+        class="data-[motion=from-start]:animate-enterFromLeft data-[motion=from-end]:animate-enterFromRight data-[motion=to-start]:animate-exitToLeft data-[motion=to-end]:animate-exitToRight absolute top-0 left-0 w-full sm:w-auto"
+        @mouseenter="onMenuEnter"
+        @mouseleave="onMenuLeave"
+      >
+          <div class="relative">
+            <div class="w-fit bg-argon-menu-bg flex shrink flex-col rounded p-1 text-gray-900 shadow-lg ring-1 ring-gray-900/20">
+              <div v-if="controller.isOperationalRewardsFlowActive" class="w-[26rem] px-4 pt-4 pb-4">
+                <div v-if="controller.isOperationalActivationReady" class="space-y-3">
+                  <div class="border-b border-slate-300/50 pb-2.5">
+                    <div class="text-lg font-bold text-slate-700">Claim your Rewards</div>
+                    <div class="mt-0.5 text-sm leading-5 text-slate-500">
+                      You've finished the Argon Operational Certification Process! Open to claim your {{ operationalReferralRewardLabel }} reward.
                     </div>
                     <button
                       type="button"
-                      class="text-argon-700 shrink-0 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold hover:border-slate-400"
-                      @click="openRewardsClaim()"
+                      class="bg-argon-button hover:bg-argon-button-hover mt-3 rounded-lg px-3 py-1.5 text-sm font-semibold text-white"
+                      @click="openRewardsActivation()"
                     >
-                      Claim
+                      Open
                     </button>
                   </div>
-
-                  <div class="mt-4 flex items-center justify-end border-t border-slate-300/50 pt-3">
-                    <button
-                      type="button"
-                      class="text-argon-700 rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold hover:border-slate-400 hover:bg-white"
-                      @click="openInviteHub()"
-                    >
-                      Manage Referral Codes
-                    </button>
-                  </div>
-                  </template>
                 </div>
 
-                <div v-else class="max-w-160 pt-4 pb-2">
-                  <p class="font-light px-5 ">
-                    Complete the following seven steps, and you'll earn
-                    (along with your sponsor) a {{ operationalReferralRewardLabel }} bonus from the Argon Treasury.
-                  </p>
-                  <ul class="flex flex-col mt-3 mb-1 text-base font-semibold divide-y divide-slate-600/15 whitespace-nowrap">
-                    <li
-                      v-for="[stepId, step] of Object.entries(operationalSteps)"
-                      @click="openOverlay(stepId as OperationalStepId, $event)"
-                      class="flex flex-row items-center gap-x-2 py-3 pl-5 pr-2 cursor-pointer"
-                      :class="controller.isCertificationStepUnlocked(stepId as OperationalStepId) ? 'hover:bg-argon-600/5' : 'bg-slate-50/80 text-slate-500'"
-                    >
-                      <Checkbox
-                        :size="7"
-                        :isChecked="
-                          controller.isCertificationStepComplete(stepId as OperationalStepId) ||
-                          controller.isCertificationStepUnderway(stepId as OperationalStepId)
-                        "
-                        :isPulsing="controller.isCertificationStepUnderway(stepId as OperationalStepId)"
-                      />
-                      <span class="grow">{{ step.title }}</span>
-                      <span
-                        v-if="controller.isCertificationStepUnderway(stepId as OperationalStepId)"
-                        class="rounded-full border border-argon-300 bg-argon-50 px-2 py-1 text-xs font-medium text-argon-700"
-                      >
-                        Underway
-                      </span>
-                      <span
-                        v-if="controller.getCertificationBlocker(stepId as OperationalStepId)"
-                        class="rounded-full border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-500"
-                      >
-                        Requires: {{ controller.getCertificationBlocker(stepId as OperationalStepId)?.title }}
-                      </span>
-                      <a :href="step.documentationLink" target="_blank" class="px-3 text-right text-argon-600 font-light hover:bg-white hover:text-argon-700! rounded-full">Open Docs</a>
-                    </li>
-                  </ul>
-                  <div class="pt-4 pb-2 px-5 border-t border-slate-500/30">
-                    <a href="https://argon.network/docs/operator-certification" target="_blank" class="text-argon-600 hover:text-argon-700! font-light">
-                      Learn more about the Argon's Operator Certification.
-                    </a>
+                <template v-else>
+                  <div class="border-b border-slate-300/50 pb-2.5">
+                  <div class="text-lg font-bold text-slate-700">Operator Referrals</div>
+                  <div class="mt-0.5 text-sm text-slate-500">
+                    Earn {{ operationalReferralRewardLabel }} for both you and each referral who completes the operational checklist. Every
+                    {{ controller.rewardConfig.referralBonusEveryXOperationalSponsees }} referred triggers a
+                    {{ referralBonusRewardLabel }} bonus!
                   </div>
+                </div>
+
+                <OperationalInviteSlots
+                  class="mt-3"
+                  mode="menu"
+                  :progress="controller.inviteSlotProgress"
+                  :rewardConfig="controller.rewardConfig"
+                  :invites="controller.operationalInvites"
+                  :inviteStatusesByCode="controller.operationalInviteStatusesByCode"
+                  @select="openInviteHub"
+                />
+
+                <div class="mt-4 ">
+                  <div StatsBox box class="mt-2 grid grid-cols-3 overflow-hidden text-center">
+                    <Tooltip
+                      v-for="stat in referralStats"
+                      :key="stat.label"
+                      asChild
+                      side="bottom"
+                      :content="stat.tooltip">
+                      <div StatWrapper class="border-r border-slate-200/70 px-3 py-2.5 last:border-r-0">
+                        <div Stat class="text-2xl! leading-none">{{ stat.value }}</div>
+                        <div class="mt-1.5 text-xs font-semibold tracking-widest text-slate-400 uppercase">{{ stat.label }}</div>
+                      </div>
+                    </Tooltip>
+                  </div>
+                </div>
+
+                <div
+                  v-if="hasUnclaimedRewards"
+                  class="mt-3 flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2">
+                  <div class="min-w-0">
+                    <div class="text-sm font-semibold text-slate-800">{{ pendingReferralRewardLabel }} unclaimed</div>
+                    <div class="text-xs text-slate-500">Choose where to send rewards.</div>
+                  </div>
+                  <button
+                    type="button"
+                    class="text-argon-700 shrink-0 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold hover:border-slate-400"
+                    @click="openRewardsClaim()"
+                  >
+                    Claim
+                  </button>
+                </div>
+
+                <div class="mt-4 flex items-center justify-end border-t border-slate-300/50 pt-3">
+                  <button
+                    type="button"
+                    class="text-argon-700 rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-semibold hover:border-slate-400 hover:bg-white"
+                    @click="openInviteHub()"
+                  >
+                    Manage Referral Codes
+                  </button>
+                </div>
+                </template>
+              </div>
+
+              <div v-else class="max-w-160 pt-4 pb-2">
+                <p class="font-light px-5 ">
+                  Complete the following seven steps, and you'll earn
+                  (along with your sponsor) a {{ operationalReferralRewardLabel }} bonus from the Argon Treasury.
+                </p>
+                <ul class="flex flex-col mt-3 mb-1 text-base font-semibold divide-y divide-slate-600/15 whitespace-nowrap">
+                  <li
+                    v-for="[stepId, step] of Object.entries(operationalSteps)"
+                    @click="openOverlay(stepId as OperationalStepId, $event)"
+                    class="flex flex-row items-center gap-x-2 py-3 pl-5 pr-2 cursor-pointer"
+                    :class="controller.isCertificationStepUnlocked(stepId as OperationalStepId) ? 'hover:bg-argon-600/5' : 'bg-slate-50/80 text-slate-500'"
+                  >
+                    <Checkbox
+                      class="shrink-0"
+                      :size="7"
+                      :isChecked="
+                        controller.isCertificationStepComplete(stepId as OperationalStepId) ||
+                        controller.isCertificationStepUnderway(stepId as OperationalStepId)
+                      "
+                      :isPulsing="controller.isCertificationStepUnderway(stepId as OperationalStepId)"
+                    />
+                    <span class="grow">{{ step.title }}</span>
+                    <span
+                      v-if="controller.isCertificationStepUnderway(stepId as OperationalStepId)"
+                      class="rounded-full border border-argon-300 bg-argon-50 px-2 py-1 text-xs font-medium text-argon-700"
+                    >
+                      Underway
+                    </span>
+                    <span
+                      v-if="controller.getCertificationBlocker(stepId as OperationalStepId)"
+                      class="rounded-full border border-slate-300 bg-white px-2 py-1 text-xs font-medium text-slate-500"
+                    >
+                      Requires: {{ controller.getCertificationBlocker(stepId as OperationalStepId)?.title }}
+                    </span>
+                    <a :href="step.documentationLink" target="_blank" class="px-3 text-right text-argon-600 font-light hover:bg-white hover:text-argon-700! rounded-full">Open Docs</a>
+                  </li>
+                </ul>
+                <div class="pt-4 pb-2 px-5 border-t border-slate-500/30">
+                  <a href="https://argon.network/docs/operator-certification" target="_blank" class="text-argon-600 hover:text-argon-700! font-light">
+                    Learn more about the Argon's Operator Certification.
+                  </a>
                 </div>
               </div>
             </div>
-          </NavigationMenuContent>
-      </NavigationMenuItem>
-    </div>
+          </div>
+        </NavigationMenuContent>
+    </NavigationMenuItem>
   </div>
 </template>
 
@@ -249,6 +248,7 @@ const { microgonToArgonNm } = createNumeralHelpers(currency);
 
 const isOpen = Vue.ref(false);
 const rootRef = Vue.ref<HTMLElement>();
+const alertMenuStyle = Vue.ref<Record<string, string>>({});
 const completionNoticeStepId = Vue.computed(() => controller.pendingCompletionNoticeStepId);
 const completionNoticeStepTitle = Vue.computed(() => {
   return completionNoticeStepId.value ? operationalSteps[completionNoticeStepId.value].title : '';
@@ -316,6 +316,17 @@ const hasInviteMoonBase = Vue.computed(() => {
   );
 });
 let mouseLeaveTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
+
+function updateAlertMenuPosition() {
+  const rect = rootRef.value?.getBoundingClientRect();
+  if (!rect) return;
+
+  alertMenuStyle.value = {
+    top: `${Math.round(rect.bottom + 6)}px`,
+    left: `${Math.round(rect.right)}px`,
+    transform: 'translateX(-100%)',
+  };
+}
 
 function dismissCompletionNotice() {
   controller.dismissCompletionNotice();
@@ -390,6 +401,23 @@ Vue.watch(isOpen, value => {
       void controller.loadOperationalInvites().catch(() => undefined);
     }
   }
+});
+
+Vue.watch(
+  () => isShowingCompletionTooltip.value || isShowingBonusTooltip.value,
+  isShowingAlert => {
+    if (!isShowingAlert) return;
+    void Vue.nextTick().then(updateAlertMenuPosition);
+  },
+  { immediate: true },
+);
+
+Vue.onMounted(() => {
+  window.addEventListener('resize', updateAlertMenuPosition);
+});
+
+Vue.onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateAlertMenuPosition);
 });
 
 function formatArgon(amount: bigint) {

--- a/src-vue/app-operations/navigation/TopBar.vue
+++ b/src-vue/app-operations/navigation/TopBar.vue
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <div
-    class="bg-white/95 min-h-14 w-full flex flex-row items-center select-none"
+    class="bg-white/95 relative z-[2500] flex min-h-14 w-full flex-row items-center select-none"
     style="border-radius: 10px 10px 0 0; box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2)"
     data-tauri-drag-region
   >
@@ -22,7 +22,7 @@
 
     <NavigationMenuRoot
       v-if="controller.isLoaded && !controller.isImporting"
-      class="grow pointer-events-none relative mr-3 flex flex-row items-center justify-end w-1/3"
+      class="relative z-[2501] mr-3 flex w-1/3 grow flex-row items-center justify-end pointer-events-none"
       :class="[wallets.isLoaded ? '' : 'opacity-20']"
       :model-value="navigationMenuValue"
       :delay-duration="0"
@@ -39,10 +39,7 @@
         <div :class="[controller.selectedTab === OperationsTab.Mining && bot.isSyncing ? 'pointer-events-none' : 'pointer-events-auto']">
           <PortfolioMenu ref="currencyMenuRef" />
         </div>
-        <div
-          :class="[controller.selectedTab === OperationsTab.Mining && bot.isSyncing ? 'pointer-events-none' : 'pointer-events-auto']"
-          class="relative"
-        >
+        <div :class="[controller.selectedTab === OperationsTab.Mining && bot.isSyncing ? 'pointer-events-none' : 'pointer-events-auto']">
           <AccountMenu ref="accountMenuRef" />
         </div>
       </NavigationMenuList>

--- a/src-vue/app-operations/overlays/OperationalOverlay.vue
+++ b/src-vue/app-operations/overlays/OperationalOverlay.vue
@@ -32,6 +32,7 @@
           :class="controller.isCertificationStepUnlocked(stepId as OperationalStepId) ? 'hover:bg-argon-600/5' : 'bg-slate-50/80 text-slate-500'"
         >
           <Checkbox
+            class="shrink-0"
             :size="7"
             :isChecked="
               controller.isCertificationStepComplete(stepId as OperationalStepId) ||

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -912,6 +912,7 @@ export default class BitcoinLocks {
       }
 
       const typeClient = await genericClient.at(blockHash!);
+      await this.#transactionTracker.ensureStoredEvents(txInfo);
       const { lock, createdAtHeight } = await BitcoinLock.getBitcoinLockFromTxResult(typeClient, txResult);
       const record = await this.finalizePendingRecord(
         { uuid },

--- a/src-vue/lib/BotWsClient.ts
+++ b/src-vue/lib/BotWsClient.ts
@@ -117,8 +117,9 @@ export class BotWsClient {
   }
 
   private async openWebSocket(): Promise<void> {
+    let sessionId: string;
     try {
-      await this.serverApiClient.ensureAdminOperatorSession({ forceVerify: true });
+      sessionId = await this.serverApiClient.getAdminOperatorSessionId({ forceVerify: true });
     } catch (error) {
       if (!this.connectDeferred.isSettled) {
         this.connectDeferred.reject(error);
@@ -130,7 +131,7 @@ export class BotWsClient {
       return;
     }
 
-    this.webSocket = new WebSocket(this.serverApiClient.getGatewayWebsocketUrl('/bot/'));
+    this.webSocket = new WebSocket(this.serverApiClient.getGatewayWebsocketUrl('/bot/', sessionId));
 
     this.webSocket.addEventListener('open', event => {
       this.reconnectAttempt = 0;

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -1,6 +1,7 @@
 import packageJson from '../../package.json';
 import { Db } from './Db';
 import {
+  BootstrapType,
   ConfigSchema,
   IConfig,
   IConfigCertificationDetailsSchema,
@@ -230,6 +231,20 @@ export class Config implements IConfig {
       const isFirstTimeAppLoad = Object.keys(dbRawData).length === 0;
       if (isFirstTimeAppLoad) {
         await this._injectFirstTimeAppData(loadedData, rawData, fieldsToSave);
+      }
+
+      const hasLegacyAccountState =
+        loadedData.isServerInstalled ||
+        loadedData.miningSetupStatus !== MiningSetupStatus.None ||
+        loadedData.vaultingSetupStatus !== VaultingSetupStatus.None;
+
+      if (!loadedData.bootstrapDetails && hasLegacyAccountState) {
+        loadedData.bootstrapDetails = {
+          type: BootstrapType.Public,
+          routerHost: 'LOADING',
+        };
+        fieldsToSave.add(dbFields.bootstrapDetails);
+        rawData[dbFields.bootstrapDetails] = JsonExt.stringify(loadedData.bootstrapDetails, 2);
       }
 
       const isLocalComputer = loadedData.serverDetails.type === ServerType.LocalComputer;
@@ -551,7 +566,12 @@ export class Config implements IConfig {
     fieldsToSave.add(dbFields.walletAccountsHadPreviousLife);
 
     if (walletHadPreviousLife) {
-      // TODO: Need to set bootstrapDetails
+      loadedData.bootstrapDetails = {
+        type: BootstrapType.Public,
+        routerHost: 'LOADING',
+      };
+      stringifiedData[dbFields.bootstrapDetails] = JsonExt.stringify(loadedData.bootstrapDetails, 2);
+      fieldsToSave.add(dbFields.bootstrapDetails);
     }
   }
 

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -464,6 +464,7 @@ export class EthereumOutboundTransferTracker {
     await txInfo.txResult.waitForFinalizedBlock;
     const minimumReadyBlockNumber = txInfo.tx.blockHeight ?? txInfo.tx.finalizedHeadHeight;
 
+    await this.transactionTracker.ensureStoredEvents(txInfo);
     const transferId = await extractTransferId(txInfo);
     const priorTransferId = transfer.transferId;
     const requestFinalizedRecord = await (

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -236,13 +236,19 @@ export default class Installer {
       if (this.remoteFilesNeedUpdating) {
         console.info('Uploading account address');
         await server.uploadAccountAddress(this.walletKeys.miningBotAddress);
+        this.fileUploadProgress = 2;
 
         console.info('Uploading core files');
-        await this.uploadCoreFiles(t => (this.fileUploadProgress += (1 / t) * 49));
+        await this.uploadCoreFiles((totalCount, uploadedCount) => {
+          this.fileUploadProgress = 2 + (uploadedCount / totalCount) * 88;
+        });
       }
 
       console.info('Uploading bot config files');
-      await this.uploadBotConfigFiles(t => (this.fileUploadProgress += (1 / t) * 49));
+      await this.uploadBotConfigFiles((totalCount, uploadedCount) => {
+        const startProgress = this.remoteFilesNeedUpdating ? 90 : 0;
+        this.fileUploadProgress = startProgress + (uploadedCount / totalCount) * (99 - startProgress);
+      });
 
       console.info('Starting remote script');
       await server.createLogsDir();
@@ -578,8 +584,9 @@ export default class Installer {
 
     try {
       console.log(`Uploading server to ${remoteDir}`);
+      const uploadStart = totalProgress;
       await SSH.uploadEmbeddedFile(localServerTar, `${workDir}/${serverTar}`, progress => {
-        totalProgress += progress;
+        totalProgress = uploadStart + progress;
         progressFn?.(totalCount, totalProgress);
       });
 

--- a/src-vue/lib/InstallerCheck.ts
+++ b/src-vue/lib/InstallerCheck.ts
@@ -196,6 +196,14 @@ export class InstallerCheck {
     }
 
     if (stepName === InstallStepKey.ServerConnect) {
+      if (
+        this.installer.serverConnectProgress >= 100 ||
+        this.config.serverInstaller.ServerConnect.progress >= 100 ||
+        this.installer.fileUploadProgress > 0 ||
+        this.config.serverInstaller.FileUpload.progress > 0
+      ) {
+        return InstallStepStatusType.Finished;
+      }
       if (!this.config.isServerAdded) {
         return InstallStepStatusType.Started;
       }

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -1131,6 +1131,7 @@ export class MyVault {
     const { txResult, tx } = txInfo;
     const { vaultId } = tx.metadataJson;
     await txResult.waitForInFirstBlock;
+    await this.#transactionTracker.ensureStoredEvents(txInfo);
     const client = await getMainchainClient(false);
 
     for (const event of txResult.events) {
@@ -1293,6 +1294,7 @@ export class MyVault {
     try {
       const client = await getMainchainClient(true);
       const blockHash = await txResult.waitForFinalizedBlock;
+      await this.#transactionTracker.ensureStoredEvents(txInfo);
       const api = await client.at(blockHash);
       const blockNumber = await api.query.system.number();
       let vaultId: number | undefined;

--- a/src-vue/lib/SSHConnection.ts
+++ b/src-vue/lib/SSHConnection.ts
@@ -1,4 +1,4 @@
-import { invokeWithTimeout } from './tauriApi';
+import { InvokeTimeout, invokeWithTimeout } from './tauriApi';
 import { listen } from '@tauri-apps/api/event';
 import { IConfigServerDetails, ServerType } from '../interfaces/IConfig.ts';
 
@@ -60,9 +60,24 @@ export class SSHConnection {
     return this.isConnectedPromise;
   }
 
-  public async runCommandWithTimeout(command: string, timeout: number): Promise<[string, number]> {
+  public async runCommandWithTimeout(command: string, timeout: number, retries = 1): Promise<[string, number]> {
     const payload = { address: this.address, command };
-    return await invokeWithTimeout('ssh_run_command', payload, timeout);
+
+    try {
+      return await invokeWithTimeout('ssh_run_command', payload, timeout);
+    } catch (error) {
+      const canRetry =
+        retries > 0 &&
+        !this.isDestroyed &&
+        (error instanceof InvokeTimeout || String(error) === 'SSHCommandMissingExitStatus');
+      if (!canRetry) {
+        throw error;
+      }
+
+      await this.close().catch(() => undefined);
+      await this.connect();
+      return await this.runCommandWithTimeout(command, timeout, retries - 1);
+    }
   }
 
   public async uploadFileWithTimeout(contents: string, remotePath: string, timeout: number): Promise<void> {

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -262,11 +262,11 @@ export class ServerAdmin {
   }
 
   public async removeAllLogFiles(): Promise<void> {
-    await this.connection.runCommandWithTimeout(`rm -rf ${this.workDir}/logs/*`, 10e3);
+    await this.connection.runCommandWithTimeout(`rm -rf ${this.workDir}/logs/*`, 60e3);
   }
 
   public async removeLogStep(stepKey: string): Promise<void> {
-    await this.connection.runCommandWithTimeout(`rm -rf ${this.workDir}/logs/step-${stepKey}.*`, 10e3);
+    await this.connection.runCommandWithTimeout(`rm -rf ${this.workDir}/logs/step-${stepKey}.*`, 60e3);
   }
 
   public async startInstallerScript(): Promise<void> {

--- a/src-vue/lib/ServerApiClient.ts
+++ b/src-vue/lib/ServerApiClient.ts
@@ -18,7 +18,12 @@ import type {
   ITreasuryUserInviteCreateRequest,
 } from '@argonprotocol/apps-router';
 import { type IConfigServerDetails, ServerType } from '../interfaces/IConfig.ts';
-import { type ServerAuthClient, type ServerAuthOptions } from './ServerAuthClient.ts';
+import {
+  RequestStatusError,
+  isUnauthenticatedServerAuthError,
+  type ServerAuthClient,
+  type ServerAuthOptions,
+} from './ServerAuthClient.ts';
 
 export type ServerGatewayDetails = Pick<IConfigServerDetails, 'ipAddress' | 'gatewayPort' | 'type'>;
 
@@ -64,29 +69,34 @@ interface IBitcoinLatestBlocks extends ILatestBlocks {
 type RequestOptions = {
   init?: RequestInit;
   timeoutMs?: number;
-  adminOperatorAuth?: ServerAuthClient;
+  sessionId?: string;
 };
 
-type ClientRequestOptions = Omit<RequestOptions, 'adminOperatorAuth'> & {
+type ClientRequestOptions = Omit<RequestOptions, 'sessionId'> & {
   adminOperatorAuth?: boolean;
 };
+
+type AdminOperatorServerAuthClient = Pick<
+  ServerAuthClient,
+  'getAdminOperatorSessionId' | 'invalidateAdminOperatorSessionId'
+>;
 
 export class ServerApiClient {
   constructor(
     private readonly getServerDetails: () => ServerGatewayDetails,
-    private readonly serverAuthClient: ServerAuthClient,
+    private readonly serverAuthClient: AdminOperatorServerAuthClient,
   ) {}
 
-  public getGatewayHttpUrl(path = ''): string {
-    return ServerApiClient.getGatewayHttpUrl(this.getServerDetails(), path);
+  public getGatewayHttpUrl(path = '', sessionId?: string): string {
+    return ServerApiClient.getGatewayHttpUrl(this.getServerDetails(), path, sessionId);
   }
 
-  public getGatewayWebsocketUrl(path: string): string {
-    return ServerApiClient.getGatewayWebsocketUrl(this.getServerDetails(), path);
+  public getGatewayWebsocketUrl(path: string, sessionId?: string): string {
+    return ServerApiClient.getGatewayWebsocketUrl(this.getServerDetails(), path, sessionId);
   }
 
-  public async ensureAdminOperatorSession(options: ServerAuthOptions = {}): Promise<void> {
-    await this.serverAuthClient.ensureAdminOperatorSession(this.getGatewayHttpUrl(), options);
+  public async getAdminOperatorSessionId(options: ServerAuthOptions = {}): Promise<string> {
+    return await this.serverAuthClient.getAdminOperatorSessionId(this.getGatewayHttpUrl(), options);
   }
 
   public async isGatewayReady(): Promise<boolean> {
@@ -158,11 +168,32 @@ export class ServerApiClient {
     return body.invite;
   }
 
-  private request<T>(path: string, options: ClientRequestOptions = {}): Promise<T> {
-    return ServerApiClient.request<T>(this.getServerDetails(), path, {
-      ...options,
-      adminOperatorAuth: options.adminOperatorAuth ? this.serverAuthClient : undefined,
-    });
+  private async request<T>(path: string, options: ClientRequestOptions = {}): Promise<T> {
+    const { adminOperatorAuth, ...requestOptions } = options;
+    if (!adminOperatorAuth) {
+      return await ServerApiClient.request<T>(this.getServerDetails(), path, requestOptions);
+    }
+
+    let sessionId = await this.getAdminOperatorSessionId();
+
+    try {
+      return await ServerApiClient.request<T>(this.getServerDetails(), path, {
+        ...requestOptions,
+        sessionId,
+      });
+    } catch (error) {
+      if (!isUnauthenticatedServerAuthError(error)) {
+        throw error;
+      }
+
+      this.serverAuthClient.invalidateAdminOperatorSessionId(this.getGatewayHttpUrl());
+      sessionId = await this.getAdminOperatorSessionId();
+
+      return await ServerApiClient.request<T>(this.getServerDetails(), path, {
+        ...requestOptions,
+        sessionId,
+      });
+    }
   }
 
   private postJson<T>(path: string, payload: unknown, options: ClientRequestOptions = {}): Promise<T> {
@@ -176,7 +207,7 @@ export class ServerApiClient {
     });
   }
 
-  public static getGatewayHttpUrl(serverDetails: ServerGatewayDetails, path = ''): string {
+  public static getGatewayHttpUrl(serverDetails: ServerGatewayDetails, path = '', sessionId?: string): string {
     if (!serverDetails.ipAddress) {
       throw new Error('No server IP address configured');
     }
@@ -184,11 +215,18 @@ export class ServerApiClient {
     const host = getGatewayHost(serverDetails);
     const port = serverDetails.gatewayPort && serverDetails.gatewayPort !== 443 ? `:${serverDetails.gatewayPort}` : '';
     const normalizedPath = path ? (path.startsWith('/') ? path : `/${path}`) : '';
-    return `https://${host}${port}${normalizedPath}`;
+    const url = `https://${host}${port}${normalizedPath}`;
+    if (!sessionId) {
+      return url;
+    }
+
+    const authenticatedUrl = new URL(url);
+    authenticatedUrl.searchParams.set('sessionId', sessionId);
+    return authenticatedUrl.toString();
   }
 
-  public static getGatewayWebsocketUrl(serverDetails: ServerGatewayDetails, path: string): string {
-    return this.getGatewayHttpUrl(serverDetails, path).replace(/^http/i, 'ws');
+  public static getGatewayWebsocketUrl(serverDetails: ServerGatewayDetails, path: string, sessionId?: string): string {
+    return this.getGatewayHttpUrl(serverDetails, path, sessionId).replace(/^http/i, 'ws');
   }
 
   public static async isGatewayReady(serverDetails: ServerGatewayDetails): Promise<boolean> {
@@ -270,18 +308,13 @@ export class ServerApiClient {
     path: string,
     options: RequestOptions = {},
   ): Promise<T> {
-    const baseUrl = this.getGatewayHttpUrl(serverDetails);
     const abortController = new AbortController();
     const timeoutMs = options.timeoutMs ?? 10e3;
     const timeout = setTimeout(() => abortController.abort(), timeoutMs);
-    if (options.adminOperatorAuth) {
-      await options.adminOperatorAuth.ensureAdminOperatorSession(baseUrl);
-    }
 
     try {
-      const response = await fetch(`${baseUrl}${path}`, {
+      const response = await fetch(this.getGatewayHttpUrl(serverDetails, path, options.sessionId), {
         ...options.init,
-        credentials: options.adminOperatorAuth ? 'include' : options.init?.credentials,
         headers: {
           ...(options.init?.headers as Record<string, string> | undefined),
         },
@@ -304,7 +337,7 @@ export class ServerApiClient {
       }
 
       if (!response.ok) {
-        throw new Error(error ?? `Server API request failed (${response.status}).`);
+        throw new RequestStatusError(error ?? `Server API request failed (${response.status}).`, response.status);
       }
       if (error) {
         throw new Error(error);

--- a/src-vue/lib/ServerAuthClient.ts
+++ b/src-vue/lib/ServerAuthClient.ts
@@ -14,8 +14,8 @@ export type ServerAuthOptions = {
 };
 
 type VerifiedServerSession = {
+  sessionId: string;
   expiresAt: number;
-  verifiedUntil: number;
 };
 
 export type ServerAuthWalletKeys = Pick<
@@ -23,50 +23,86 @@ export type ServerAuthWalletKeys = Pick<
   'operationalAddress' | 'getOperationalKeypair' | 'getUpstreamOperatorAuthKeypair'
 >;
 
+export class RequestStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+export function isUnauthenticatedServerAuthError(error: unknown): boolean {
+  if (!(error instanceof RequestStatusError)) return false;
+  return error.status === 401 || error.status === 403;
+}
+
 const failedAuthRetryMs = 60_000;
-const verifiedSessionTtlMs = 30_000;
 const refreshSessionBeforeExpiryMs = 60_000;
 
 export class ServerAuthClient {
   private failedAuthBySessionKey = new Map<string, { message: string; retryAfter: number }>();
-  private sessionPromisesBySessionKey = new Map<string, Promise<void>>();
+  private sessionPromisesBySessionKey = new Map<string, Promise<VerifiedServerSession>>();
   private verifiedSessionsBySessionKey = new Map<string, VerifiedServerSession>();
 
   constructor(private readonly getWalletKeys: () => ServerAuthWalletKeys) {}
 
-  public async ensureAdminOperatorSession(baseUrl: string, options: ServerAuthOptions = {}): Promise<void> {
+  public async getAdminOperatorSessionId(baseUrl: string, options: ServerAuthOptions = {}): Promise<string> {
     const walletKeys = this.getWalletKeys();
-    await this.ensureSession(
+    const session = await this.ensureSession(
       baseUrl,
       walletKeys.operationalAddress,
       UserRole.AdminOperator,
       () => walletKeys.getOperationalKeypair(),
       options,
     );
+    return session.sessionId;
   }
 
-  public async ensureTreasurySession(baseUrl: string, options: ServerAuthOptions = {}): Promise<void> {
+  public invalidateAdminOperatorSessionId(baseUrl: string): void {
+    const walletKeys = this.getWalletKeys();
+    const cacheKey = getCacheKey(baseUrl, walletKeys.operationalAddress, UserRole.AdminOperator);
+    this.invalidateSession(cacheKey);
+  }
+
+  public async getTreasurySessionId(baseUrl: string, options: ServerAuthOptions = {}): Promise<string> {
     const walletKeys = this.getWalletKeys();
     const authKeypair = await walletKeys.getUpstreamOperatorAuthKeypair();
-    await this.ensureSession(
+    const session = await this.ensureSession(
       baseUrl,
       authKeypair.address,
       UserRole.TreasuryUser,
       () => Promise.resolve(authKeypair),
       options,
     );
+    return session.sessionId;
   }
 
-  public async ensureOperationalSession(baseUrl: string, options: ServerAuthOptions = {}): Promise<void> {
+  public async invalidateTreasurySessionId(baseUrl: string): Promise<void> {
     const walletKeys = this.getWalletKeys();
     const authKeypair = await walletKeys.getUpstreamOperatorAuthKeypair();
-    await this.ensureSession(
+    const cacheKey = getCacheKey(baseUrl, authKeypair.address, UserRole.TreasuryUser);
+    this.invalidateSession(cacheKey);
+  }
+
+  public async getOperationalSessionId(baseUrl: string, options: ServerAuthOptions = {}): Promise<string> {
+    const walletKeys = this.getWalletKeys();
+    const authKeypair = await walletKeys.getUpstreamOperatorAuthKeypair();
+    const session = await this.ensureSession(
       baseUrl,
       authKeypair.address,
       UserRole.OperationalPartner,
       () => Promise.resolve(authKeypair),
       options,
     );
+    return session.sessionId;
+  }
+
+  public async invalidateOperationalSessionId(baseUrl: string): Promise<void> {
+    const walletKeys = this.getWalletKeys();
+    const authKeypair = await walletKeys.getUpstreamOperatorAuthKeypair();
+    const cacheKey = getCacheKey(baseUrl, authKeypair.address, UserRole.OperationalPartner);
+    this.invalidateSession(cacheKey);
   }
 
   private async ensureSession(
@@ -75,7 +111,7 @@ export class ServerAuthClient {
     role: ServerAuthRole,
     getAuthKeypair: () => Promise<KeyringPair>,
     options: ServerAuthOptions,
-  ): Promise<void> {
+  ): Promise<VerifiedServerSession> {
     const cacheKey = getCacheKey(baseUrl, authAccountId, role);
     const existingPromise = this.sessionPromisesBySessionKey.get(cacheKey);
     if (existingPromise) return existingPromise;
@@ -99,7 +135,7 @@ export class ServerAuthClient {
     getAuthKeypair: () => Promise<KeyringPair>,
     options: ServerAuthOptions,
     cacheKey: string,
-  ): Promise<void> {
+  ): Promise<VerifiedServerSession> {
     const failedAuth = this.failedAuthBySessionKey.get(cacheKey);
     if (failedAuth && failedAuth.retryAfter > Date.now()) {
       throw new Error(failedAuth.message);
@@ -108,20 +144,19 @@ export class ServerAuthClient {
 
     const cachedSession = this.verifiedSessionsBySessionKey.get(cacheKey);
     if (cachedSession && cachedSession.expiresAt - refreshSessionBeforeExpiryMs > Date.now()) {
-      if (!options.forceVerify && cachedSession.verifiedUntil > Date.now()) {
-        return;
+      if (!options.forceVerify) {
+        return cachedSession;
       }
 
       try {
-        if (await verifySession(baseUrl, role)) {
-          this.markSessionVerified(cacheKey, cachedSession.expiresAt);
-          return;
+        if (await verifySession(baseUrl, role, cachedSession.sessionId)) {
+          return this.markSessionVerified(cacheKey, cachedSession.sessionId, cachedSession.expiresAt);
         }
       } catch {
         // Fall through to signing a fresh challenge below.
       }
     }
-    this.verifiedSessionsBySessionKey.delete(cacheKey);
+    this.invalidateSession(cacheKey);
 
     try {
       const challenge = await requestAuth<IServerAuthChallenge>(`${baseUrl}/auth/challenge`, {
@@ -141,28 +176,36 @@ export class ServerAuthClient {
         throw new Error('Server auth session was not created.');
       }
 
-      if (!(await verifySession(baseUrl, role))) {
+      if (!(await verifySession(baseUrl, role, session.sessionId))) {
         throw new Error('Server auth session was not accepted.');
       }
 
-      this.markSessionVerified(cacheKey, Date.parse(session.expiresAt));
+      return this.markSessionVerified(cacheKey, session.sessionId, Date.parse(session.expiresAt));
     } catch (error) {
       this.markAuthFailed(cacheKey, error);
       throw error;
     }
   }
 
-  private markSessionVerified(cacheKey: string, expiresAt: number): void {
+  private markSessionVerified(cacheKey: string, sessionId: string, expiresAt: number): VerifiedServerSession {
     this.failedAuthBySessionKey.delete(cacheKey);
-    this.verifiedSessionsBySessionKey.set(cacheKey, {
+    const session = {
+      sessionId,
       expiresAt,
-      verifiedUntil: Date.now() + verifiedSessionTtlMs,
-    });
+    };
+    this.verifiedSessionsBySessionKey.set(cacheKey, session);
+    return session;
   }
 
   private markAuthFailed(cacheKey: string, error: unknown): void {
     const message = error instanceof Error ? error.message : String(error);
     this.failedAuthBySessionKey.set(cacheKey, { message, retryAfter: Date.now() + failedAuthRetryMs });
+  }
+
+  private invalidateSession(cacheKey: string): void {
+    this.failedAuthBySessionKey.delete(cacheKey);
+    this.sessionPromisesBySessionKey.delete(cacheKey);
+    this.verifiedSessionsBySessionKey.delete(cacheKey);
   }
 }
 
@@ -174,7 +217,6 @@ async function requestAuth<T>(url: string, payload: unknown): Promise<T | null> 
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
     body: JsonExt.stringify(payload),
   });
   const rawBody = await response.text();
@@ -188,10 +230,11 @@ async function requestAuth<T>(url: string, payload: unknown): Promise<T | null> 
   return JsonExt.parse<T>(rawBody);
 }
 
-async function verifySession(baseUrl: string, role: ServerAuthRole): Promise<boolean> {
-  const response = await fetch(`${baseUrl}${getVerifyPath(role)}`, {
-    credentials: 'include',
-  });
+async function verifySession(baseUrl: string, role: ServerAuthRole, sessionId: string): Promise<boolean> {
+  const verifyUrl = new URL(`${baseUrl}${getVerifyPath(role)}`);
+  verifyUrl.searchParams.set('sessionId', sessionId);
+
+  const response = await fetch(verifyUrl, { cache: 'no-store' });
 
   return response.ok;
 }

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -1,5 +1,6 @@
 import {
   ExtrinsicError,
+  type GenericEvent,
   hexToU8a,
   ISubmittableOptions,
   type ISubmittableResult,
@@ -96,16 +97,35 @@ export class TransactionTracker {
             events: [],
           });
         }
-        if (tx.blockExtrinsicEventsJson) {
+        if (tx.blockExtrinsicEventsJson?.length) {
+          const decodeStoredEvents = ({ registry }: Pick<typeof client, 'registry'>): GenericEvent[] =>
+            tx.blockExtrinsicEventsJson.map(({ raw }) =>
+              registry.createType<GenericEvent>('GenericEvent', hexToU8a(raw)),
+            );
+
           try {
-            txResult.events = tx.blockExtrinsicEventsJson.map(({ raw }) =>
-              client.createType('GenericEvent', hexToU8a(raw)),
-            );
+            txResult.events = decodeStoredEvents(client);
           } catch (error) {
-            console.error(
-              `[TransactionTracker] Error restoring events for transaction #${tx.id} (${tx.extrinsicType})`,
-              error,
-            );
+            let restoreError = error;
+            if (tx.blockHash && tx.blockHeight != null && this.blockWatch.getApi) {
+              try {
+                const historicalApi = await this.blockWatch.getApi({
+                  blockNumber: tx.blockHeight,
+                  blockHash: tx.blockHash,
+                });
+                txResult.events = decodeStoredEvents(historicalApi);
+                restoreError = undefined;
+              } catch (historicalError) {
+                restoreError = historicalError;
+              }
+            }
+
+            if (restoreError) {
+              console.error(
+                `[TransactionTracker] Error restoring events for transaction #${tx.id} (${tx.extrinsicType})`,
+                restoreError,
+              );
+            }
           }
         }
         if (tx.blockExtrinsicErrorJson) {

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -97,36 +97,12 @@ export class TransactionTracker {
             events: [],
           });
         }
-        if (tx.blockExtrinsicEventsJson?.length) {
-          const decodeStoredEvents = ({ registry }: Pick<typeof client, 'registry'>): GenericEvent[] =>
-            tx.blockExtrinsicEventsJson.map(({ raw }) =>
-              registry.createType<GenericEvent>('GenericEvent', hexToU8a(raw)),
-            );
-
-          try {
-            txResult.events = decodeStoredEvents(client);
-          } catch (error) {
-            let restoreError = error;
-            if (tx.blockHash && tx.blockHeight != null && this.blockWatch.getApi) {
-              try {
-                const historicalApi = await this.blockWatch.getApi({
-                  blockNumber: tx.blockHeight,
-                  blockHash: tx.blockHash,
-                });
-                txResult.events = decodeStoredEvents(historicalApi);
-                restoreError = undefined;
-              } catch (historicalError) {
-                restoreError = historicalError;
-              }
-            }
-
-            if (restoreError) {
-              console.error(
-                `[TransactionTracker] Error restoring events for transaction #${tx.id} (${tx.extrinsicType})`,
-                restoreError,
-              );
-            }
-          }
+        const txInfo = new TransactionInfo({
+          tx,
+          txResult,
+        });
+        if (this.shouldRestoreStoredEventsAtLoad(txInfo)) {
+          await this.ensureStoredEvents(txInfo);
         }
         if (tx.blockExtrinsicErrorJson) {
           txResult.extrinsicError = new ExtrinsicError(
@@ -141,10 +117,6 @@ export class TransactionTracker {
         }
         // Mark txResult as non-reactive to avoid issues with private fields
         Vue.markRaw(txResult);
-        const txInfo = new TransactionInfo({
-          tx,
-          txResult,
-        });
         this.data.txInfos.push(txInfo);
         this.data.txInfosByType[tx.extrinsicType] = txInfo;
       }
@@ -165,6 +137,44 @@ export class TransactionTracker {
       this.#waitForLoad.reject(error as Error);
     }
     return this.#waitForLoad.promise;
+  }
+
+  public async ensureStoredEvents(txInfo: TransactionInfo): Promise<void> {
+    if (txInfo.txResult.events.length || !txInfo.tx.blockExtrinsicEventsJson?.length) {
+      return;
+    }
+
+    const client = await getMainchainClient(false);
+    const decodeStoredEvents = ({ registry }: Pick<typeof client, 'registry'>): GenericEvent[] =>
+      txInfo.tx.blockExtrinsicEventsJson.map(({ raw }) =>
+        registry.createType<GenericEvent>('GenericEvent', hexToU8a(raw)),
+      );
+
+    try {
+      txInfo.txResult.events = decodeStoredEvents(client);
+      return;
+    } catch (error) {
+      let restoreError = error;
+      if (txInfo.tx.blockHash && txInfo.tx.blockHeight != null && this.blockWatch.getApi) {
+        try {
+          const historicalApi = await this.blockWatch.getApi({
+            blockNumber: txInfo.tx.blockHeight,
+            blockHash: txInfo.tx.blockHash,
+          });
+          txInfo.txResult.events = decodeStoredEvents(historicalApi);
+          restoreError = undefined;
+        } catch (historicalError) {
+          restoreError = historicalError;
+        }
+      }
+
+      if (restoreError) {
+        console.error(
+          `[TransactionTracker] Error restoring events for transaction #${txInfo.tx.id} (${txInfo.tx.extrinsicType})`,
+          restoreError,
+        );
+      }
+    }
   }
 
   public async submitAndWatch<T>(
@@ -701,5 +711,9 @@ export class TransactionTracker {
       status === TransactionHistoryStatus.Usurped ||
       status === TransactionHistoryStatus.Invalid
     );
+  }
+
+  private shouldRestoreStoredEventsAtLoad(txInfo: TransactionInfo) {
+    return !!txInfo.tx.blockExtrinsicEventsJson?.length && this.isPendingTxInfoAtLoad(txInfo);
   }
 }

--- a/src-vue/lib/UpstreamOperatorClient.ts
+++ b/src-vue/lib/UpstreamOperatorClient.ts
@@ -21,7 +21,12 @@ import type {
   ITreasuryUserInvite,
 } from '@argonprotocol/apps-router';
 import type { BootstrapType, IConfig, IConfigServerDetails, IOperationalReferral } from '../interfaces/IConfig.ts';
-import type { ServerAuthClient, ServerAuthOptions } from './ServerAuthClient.ts';
+import {
+  RequestStatusError,
+  isUnauthenticatedServerAuthError,
+  type ServerAuthClient,
+  type ServerAuthOptions,
+} from './ServerAuthClient.ts';
 import type { WalletKeys } from './WalletKeys.ts';
 
 type ServerInviteDetails = Pick<IConfigServerDetails, 'ipAddress' | 'gatewayPort'>;
@@ -29,6 +34,10 @@ type UpstreamOperatorInviteWalletKeys = Pick<
   WalletKeys,
   'getLiquidLockingKeypair' | 'getOperationalKeypair' | 'getUpstreamOperatorAuthKeypair'
 >;
+type UpstreamOperatorSessionAuth = {
+  getSessionId: () => Promise<string>;
+  invalidateSessionId: () => Promise<void>;
+};
 
 const BOOTSTRAP_LOADING_HOST = 'loading';
 
@@ -42,26 +51,26 @@ export class UpstreamOperatorClient {
     return this.getOperatorHost();
   }
 
-  public getWebsocketUrl(path: string): string {
-    return `${this.requireOperatorHost()}${path.startsWith('/') ? path : `/${path}`}`.replace(/^http/i, 'ws');
+  public getWebsocketUrl(path: string, sessionId?: string): string {
+    return buildAuthenticatedUrl(this.requireOperatorHost(), path, sessionId).replace(/^http/i, 'ws');
   }
 
-  public async ensureTreasurySession(options: ServerAuthOptions = {}): Promise<void> {
+  public async getTreasurySessionId(options: ServerAuthOptions = {}): Promise<string> {
     const operatorHost = this.requireOperatorHost();
     if (!this.serverAuthClient) {
       throw new Error('No upstream operator auth client configured.');
     }
 
-    await this.serverAuthClient.ensureTreasurySession(operatorHost, options);
+    return await this.serverAuthClient.getTreasurySessionId(operatorHost, options);
   }
 
-  public async ensureOperationalSession(options: ServerAuthOptions = {}): Promise<void> {
+  public async getOperationalSessionId(options: ServerAuthOptions = {}): Promise<string> {
     const operatorHost = this.requireOperatorHost();
     if (!this.serverAuthClient) {
       throw new Error('No upstream operator auth client configured.');
     }
 
-    await this.serverAuthClient.ensureOperationalSession(operatorHost, options);
+    return await this.serverAuthClient.getOperationalSessionId(operatorHost, options);
   }
 
   public static getBootstrapHost(bootstrapDetails: IConfig['bootstrapDetails']): string | undefined {
@@ -148,29 +157,29 @@ export class UpstreamOperatorClient {
     payload: IInitializeBitcoinLockRequest,
   ): Promise<IBitcoinLockCouponStatus & { status: BitcoinLockRelayStatus }> {
     const operatorHost = this.requireOperatorHost();
-    const body = await UpstreamOperatorClient.postJson<IBitcoinLockStatusResponse>(
-      operatorHost,
-      `/bitcoin-lock-coupons/${encodeURIComponent(offerCode)}/initialize`,
-      payload,
-      {
-        serverAuthClient: this.serverAuthClient,
-        treasuryAuth: true,
-      },
+    const body = await this.requestWithSessionRetry(this.getTreasurySessionAuth(operatorHost), sessionId =>
+      UpstreamOperatorClient.postJson<IBitcoinLockStatusResponse>(
+        operatorHost,
+        `/bitcoin-lock-coupons/${encodeURIComponent(offerCode)}/initialize`,
+        payload,
+        sessionId,
+      ),
     );
+
     return body.bitcoinLock as IBitcoinLockCouponStatus & { status: BitcoinLockRelayStatus };
   }
 
   public async getBitcoinLockCoupons(accountId: string): Promise<IBitcoinLockCouponStatus[]> {
     const operatorHost = this.requireOperatorHost();
-    const body = await UpstreamOperatorClient.request<IListBitcoinLockCouponsResponse>(
-      operatorHost,
-      `/treasury-users/${encodeURIComponent(accountId)}/bitcoin-lock-coupons`,
-      undefined,
-      {
-        serverAuthClient: this.serverAuthClient,
-        treasuryAuth: true,
-      },
+    const body = await this.requestWithSessionRetry(this.getTreasurySessionAuth(operatorHost), sessionId =>
+      UpstreamOperatorClient.request<IListBitcoinLockCouponsResponse>(
+        operatorHost,
+        `/treasury-users/${encodeURIComponent(accountId)}/bitcoin-lock-coupons`,
+        undefined,
+        sessionId,
+      ),
     );
+
     return body.bitcoinLockCoupons;
   }
 
@@ -178,25 +187,29 @@ export class UpstreamOperatorClient {
     payload: IEthereumGatewayCatchUpRequest,
   ): Promise<IEthereumGatewayCatchUpResponse> {
     const operatorHost = this.requireOperatorHost();
-    if (!this.serverAuthClient) {
+    const serverAuthClient = this.serverAuthClient;
+    if (!serverAuthClient) {
       throw new Error('No upstream operator auth client configured.');
     }
 
+    let sessionAuth = this.getTreasurySessionAuth(operatorHost);
     try {
-      await this.serverAuthClient.ensureTreasurySession(operatorHost);
+      await sessionAuth.getSessionId();
     } catch {
-      await this.serverAuthClient.ensureOperationalSession(operatorHost);
+      sessionAuth = this.getOperationalSessionAuth(operatorHost);
     }
 
-    return await UpstreamOperatorClient.request<IEthereumGatewayCatchUpResponse>(
-      operatorHost,
-      '/ethereum-relay-request',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JsonExt.stringify(payload),
-        credentials: 'include',
-      },
+    return await this.requestWithSessionRetry(sessionAuth, sessionId =>
+      UpstreamOperatorClient.request<IEthereumGatewayCatchUpResponse>(
+        operatorHost,
+        '/ethereum-relay-request',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JsonExt.stringify(payload),
+        },
+        sessionId,
+      ),
     );
   }
 
@@ -221,16 +234,10 @@ export class UpstreamOperatorClient {
     operatorHost: string,
     path: string,
     init?: RequestInit,
-    options: { serverAuthClient?: ServerAuthClient; treasuryAuth?: boolean } = {},
+    sessionId?: string,
   ): Promise<T> {
-    const shouldAuthenticate = !!options.serverAuthClient && !!options.treasuryAuth;
-    if (options.serverAuthClient && options.treasuryAuth) {
-      await options.serverAuthClient.ensureTreasurySession(operatorHost);
-    }
-
-    const response = await fetch(`${operatorHost}${path}`, {
+    const response = await fetch(buildAuthenticatedUrl(operatorHost, path, sessionId), {
       ...init,
-      credentials: shouldAuthenticate ? 'include' : init?.credentials,
       headers: {
         ...(init?.headers as Record<string, string> | undefined),
       },
@@ -252,7 +259,10 @@ export class UpstreamOperatorClient {
     }
 
     if (!response.ok) {
-      throw new Error(responseError ?? `Upstream operator request failed (${response.status}).`);
+      throw new RequestStatusError(
+        responseError ?? `Upstream operator request failed (${response.status}).`,
+        response.status,
+      );
     }
     if (responseError) {
       throw new Error(responseError);
@@ -261,12 +271,7 @@ export class UpstreamOperatorClient {
     return body as T;
   }
 
-  private static postJson<T>(
-    operatorHost: string,
-    path: string,
-    payload: unknown,
-    options?: { serverAuthClient?: ServerAuthClient; treasuryAuth?: boolean },
-  ): Promise<T> {
+  private static postJson<T>(operatorHost: string, path: string, payload: unknown, sessionId?: string): Promise<T> {
     return this.request<T>(
       operatorHost,
       path,
@@ -275,9 +280,63 @@ export class UpstreamOperatorClient {
         headers: { 'Content-Type': 'application/json' },
         body: JsonExt.stringify(payload),
       },
-      options,
+      sessionId,
     );
   }
+
+  private getTreasurySessionAuth(operatorHost: string): UpstreamOperatorSessionAuth {
+    const serverAuthClient = this.serverAuthClient;
+    if (!serverAuthClient) {
+      throw new Error('No upstream operator auth client configured.');
+    }
+
+    return {
+      getSessionId: () => serverAuthClient.getTreasurySessionId(operatorHost),
+      invalidateSessionId: () => serverAuthClient.invalidateTreasurySessionId(operatorHost),
+    };
+  }
+
+  private getOperationalSessionAuth(operatorHost: string): UpstreamOperatorSessionAuth {
+    const serverAuthClient = this.serverAuthClient;
+    if (!serverAuthClient) {
+      throw new Error('No upstream operator auth client configured.');
+    }
+
+    return {
+      getSessionId: () => serverAuthClient.getOperationalSessionId(operatorHost),
+      invalidateSessionId: () => serverAuthClient.invalidateOperationalSessionId(operatorHost),
+    };
+  }
+
+  private async requestWithSessionRetry<T>(
+    sessionAuth: UpstreamOperatorSessionAuth,
+    request: (sessionId: string) => Promise<T>,
+  ): Promise<T> {
+    let sessionId = await sessionAuth.getSessionId();
+
+    try {
+      return await request(sessionId);
+    } catch (error) {
+      if (!isUnauthenticatedServerAuthError(error)) {
+        throw error;
+      }
+
+      await sessionAuth.invalidateSessionId();
+      sessionId = await sessionAuth.getSessionId();
+      return await request(sessionId);
+    }
+  }
+}
+
+function buildAuthenticatedUrl(operatorHost: string, path: string, sessionId?: string): string {
+  const url = `${operatorHost}${path.startsWith('/') ? path : `/${path}`}`;
+  if (!sessionId) {
+    return url;
+  }
+
+  const authenticatedUrl = new URL(url);
+  authenticatedUrl.searchParams.set('sessionId', sessionId);
+  return authenticatedUrl.toString();
 }
 
 function stripScheme(value: string): string {

--- a/src-vue/stores/mainchain.ts
+++ b/src-vue/stores/mainchain.ts
@@ -213,8 +213,8 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
     }
 
     try {
-      await serverApiClient.ensureAdminOperatorSession({ forceVerify: true });
-      await mainchainClients.setPrunedClient(serverApiClient.getGatewayWebsocketUrl('/substrate'));
+      const sessionId = await serverApiClient.getAdminOperatorSessionId({ forceVerify: true });
+      await mainchainClients.setPrunedClient(serverApiClient.getGatewayWebsocketUrl('/substrate', sessionId));
     } catch (error) {
       mainchainClients.clearPrunedClient();
       throw error;
@@ -225,15 +225,16 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
 
   const upstreamOperatorClient = getUpstreamOperatorClient();
   if (upstreamOperatorClient.operatorHost && config.upstreamOperator) {
+    let sessionId: string | undefined;
     if (IS_TREASURY_APP) {
-      await upstreamOperatorClient.ensureTreasurySession({ forceVerify: true });
+      sessionId = await upstreamOperatorClient.getTreasurySessionId({ forceVerify: true });
     } else if (IS_OPERATIONS_APP) {
-      await upstreamOperatorClient.ensureOperationalSession({
+      sessionId = await upstreamOperatorClient.getOperationalSessionId({
         forceVerify: true,
       });
     }
 
-    await mainchainClients.setPrunedClient(upstreamOperatorClient.getWebsocketUrl('/substrate'));
+    await mainchainClients.setPrunedClient(upstreamOperatorClient.getWebsocketUrl('/substrate', sessionId));
     return;
   }
 


### PR DESCRIPTION
- wait for DB migrations before the app finishes startup so schema gaps fail early instead of surfacing later during wallet or bitcoin-lock loading
- backfill bootstrapDetails with the same Public / LOADING placeholder used by mnemonic import when a legacy account already has durable setup state but is missing that onboarding marker
- retry stored transaction event decoding with block-specific historical metadata when current metadata can no longer decode older saved event bytes
- fix ssh escape characters breaking during upload 