### PR TITLE
fix: stabilize ethereum transfer-out readiness

### DIFF
--- a/e2e/__test__/ethereumTransferOut.e2e.test.ts
+++ b/e2e/__test__/ethereumTransferOut.e2e.test.ts
@@ -8,7 +8,7 @@ describe.skipIf(skipE2E).sequential('Ethereum transfer-out flow', () => {
     'preseeds a same-user authority and transfers ARGN to Ethereum',
     async () => {
       const session = await createFlowSession({
-        useTestNetwork: false,
+        useTestNetwork: true,
         sessionName: 'ethereum-transfer-out-spec',
         appEnv: {
           ARGON_DEV_ETHEREUM: '1',

--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -81,6 +81,7 @@ export interface IDevEthereumRuntimeState {
   serverExecutionRpcUrl: string;
   serverBeaconApiUrl: string;
   usdcTokenAddress: Address;
+  setupStatus: 'starting' | 'ready';
   updatedAt: string;
 }
 
@@ -142,7 +143,10 @@ export async function startDevEthereum(config: IDevEthereumConfig): Promise<ISta
     serverBeaconApiUrl: rewriteLocalUrlHost(endpoints.beaconApiUrl, 'host.docker.internal'),
     usdcTokenAddress,
   };
-  await writeDevEthereumRuntimeState(result);
+  await writeDevEthereumRuntimeState({
+    ...result,
+    setupStatus: 'starting',
+  });
   return result;
 }
 
@@ -200,7 +204,7 @@ export function createDevEthereumSetup(
 
         setupStep = 'starting the local Ethereum relayer';
         console.log(`[tauri-dev] ${setupStep}`);
-        return await startDevEthereumRelayer({
+        const runtime = await startDevEthereumRelayer({
           archiveUrl,
           beaconApiUrl: devEthereum.beaconApiUrl,
           executionRpcUrl: devEthereum.executionRpcUrl,
@@ -210,6 +214,11 @@ export function createDevEthereumSetup(
           relayerPollMs: config.relayerPollMs,
           syncKeypair: relayer,
         });
+        await writeDevEthereumRuntimeState({
+          ...devEthereum,
+          setupStatus: 'ready',
+        });
+        return runtime;
       } catch (error) {
         throw new Error(`Failed while ${setupStep}: ${(error as Error).message}`);
       }
@@ -269,9 +278,11 @@ export async function sendDevEthereumAdminTransaction(args: {
   };
 }
 
-export async function readDevEthereumRuntimeState(): Promise<IDevEthereumRuntimeState | undefined> {
+export async function readDevEthereumRuntimeState(
+  executionRpcUrl?: string,
+): Promise<IDevEthereumRuntimeState | undefined> {
   try {
-    const raw = await fs.readFile(getDevEthereumRuntimeStatePath(), 'utf8');
+    const raw = await fs.readFile(getDevEthereumRuntimeStatePath(executionRpcUrl), 'utf8');
     return JSON.parse(raw) as IDevEthereumRuntimeState;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -288,22 +299,28 @@ export async function resolveDevEthereumRpcUrl(args: { rpcUrl?: string; logPrefi
   if (explicitRpc) return explicitRpc;
   if (envRpc) return envRpc;
 
-  const candidates = await detectExecutionRpcUrls();
-  if (!candidates.length) {
-    throw new Error(
-      'Unable to detect a local Ethereum execution RPC. Pass --rpc http://127.0.0.1:<port>, set ETH_RPC or ETHEREUM_EXECUTION_RPC_URL, or start the local Kurtosis devnet first.',
-    );
+  const runtimeState = await readDevEthereumRuntimeState();
+  const runtimeRpc = readNonEmpty(runtimeState?.executionRpcUrl);
+  if (runtimeRpc) {
+    try {
+      const chainId = await rpcCall<string>(runtimeRpc, 'eth_chainId', []);
+      if (!runtimeState?.chainId || chainId === runtimeState.chainId) {
+        return runtimeRpc;
+      }
+
+      console.warn(
+        `[${logPrefix}] Ignoring dev Ethereum runtime state at ${runtimeRpc} because it reported chainId ${chainId}, expected ${runtimeState.chainId}.`,
+      );
+    } catch (error) {
+      console.warn(
+        `[${logPrefix}] Ignoring unreadable dev Ethereum runtime state at ${runtimeRpc}: ${(error as Error).message}`,
+      );
+    }
   }
 
-  if (candidates.length > 1) {
-    const selected = candidates.at(-1)!;
-    console.warn(
-      `[${logPrefix}] Multiple execution RPC endpoints detected (${candidates.join(', ')}). Using newest ${selected}. Override with --rpc if needed.`,
-    );
-    return selected;
-  }
-
-  return candidates[0];
+  throw new Error(
+    'Unable to resolve a local Ethereum execution RPC. Pass --rpc http://127.0.0.1:<port>, set ETH_RPC or ETHEREUM_EXECUTION_RPC_URL, or start the local Kurtosis devnet first.',
+  );
 }
 
 async function ensureDevEthereumBeaconBootstrap(
@@ -504,24 +521,36 @@ function createDevEthereumChain(chainId: number, rpcUrl: string) {
 }
 
 async function writeDevEthereumRuntimeState(state: Omit<IDevEthereumRuntimeState, 'updatedAt'>): Promise<void> {
-  const statePath = getDevEthereumRuntimeStatePath();
-  await fs.mkdir(path.dirname(statePath), { recursive: true });
-  await fs.writeFile(
-    statePath,
-    `${JSON.stringify(
-      {
-        ...state,
-        updatedAt: new Date().toISOString(),
-      } satisfies IDevEthereumRuntimeState,
-      null,
-      2,
-    )}\n`,
-    'utf8',
-  );
+  const runtimeState = {
+    ...state,
+    updatedAt: new Date().toISOString(),
+  } satisfies IDevEthereumRuntimeState;
+  const latestStatePath = getDevEthereumRuntimeStatePath();
+  const scopedStatePath = getDevEthereumRuntimeStatePath(state.executionRpcUrl);
+  const serialized = `${JSON.stringify(runtimeState, null, 2)}\n`;
+
+  await Promise.all([
+    fs.mkdir(path.dirname(latestStatePath), { recursive: true }),
+    fs.mkdir(path.dirname(scopedStatePath), { recursive: true }),
+  ]);
+  await Promise.all([
+    fs.writeFile(latestStatePath, serialized, 'utf8'),
+    fs.writeFile(scopedStatePath, serialized, 'utf8'),
+  ]);
 }
 
-function getDevEthereumRuntimeStatePath(): string {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'artifacts', 'dev-ethereum.json');
+function getDevEthereumRuntimeStatePath(executionRpcUrl?: string): string {
+  if (!executionRpcUrl) {
+    return path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'artifacts', 'dev-ethereum.json');
+  }
+
+  const safeExecutionRpcUrl = executionRpcUrl.replace(/[^a-zA-Z0-9_.-]+/g, '_');
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'artifacts',
+    'dev-ethereum',
+    `${safeExecutionRpcUrl}.json`,
+  );
 }
 
 async function ensureDevEthereumChainConfig(
@@ -672,32 +701,6 @@ async function ensureDevEthereumGatewayActiveCouncil(
   } finally {
     await client.disconnect().catch(() => undefined);
   }
-}
-
-async function detectExecutionRpcUrls(): Promise<string[]> {
-  const candidates: string[] = [];
-  const portRangeSize = 32;
-  const portStart = 32_000;
-  const portScanLimit = 1_024;
-
-  // Mirror TestEthereum.launch() in @argonprotocol/testing, which allocates the
-  // first free 32-port execution block starting near 32000 for each devnet.
-  for (let rangeStart = portStart; rangeStart < portStart + portScanLimit; rangeStart += portRangeSize) {
-    for (let port = rangeStart; port < rangeStart + portRangeSize; port += 1) {
-      const rpcUrl = `http://127.0.0.1:${port}`;
-      try {
-        const chainId = await rpcCall<string>(rpcUrl, 'eth_chainId', []);
-        if (typeof chainId === 'string') {
-          candidates.push(rpcUrl);
-          break;
-        }
-      } catch {
-        continue;
-      }
-    }
-  }
-
-  return candidates;
 }
 
 async function loadLocalGatewayCouncilFloorMicrogonsPerArgonot(archiveUrl: string): Promise<bigint> {

--- a/e2e/flows/operations/Vaulting.flow.transferOutThroughEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutThroughEthereum.ts
@@ -1,5 +1,6 @@
 import { createVaultingFlowContext, type IVaultingFlowContext } from '../contexts/vaultingContext.ts';
 import { startDevEthereumMintingAuthority } from '../../helpers/startDevEthereumMintingAuthority.ts';
+import { fundDevEthereumAccount } from '../../scripts/fundDevEthereumAccount.ts';
 import { clickIfVisible } from '../helpers/utils.ts';
 import vaultingOnboarding from './Vaulting.flow.onboarding.ts';
 import vaultingActivateTab from './Vaulting.op.activateTab.ts';
@@ -10,6 +11,8 @@ import type { IE2EOperationInspectState } from '../types.ts';
 type ITransferOutThroughEthereumUiState = {
   transferComplete: boolean;
 };
+
+const DEV_ETHEREUM_TRANSFER_GAS_BUFFER_WEI = 1_000_000_000_000_000_000n;
 
 type ITransferOutThroughEthereumState = IE2EOperationInspectState<
   Record<string, never>,
@@ -42,12 +45,34 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutThroughEthe
     await flow.run(vaultingOnboarding);
     const archiveUrl = flow.getData<string>('sessionArchiveUrl') as string;
 
+    const { ethereumAddress, executionRpcUrl } = (await flow.queryApp(
+      async refs => {
+        await refs.wallets.load().catch(() => undefined);
+        const tracker = refs.getEthereumOutboundTransferTracker() as any;
+
+        return {
+          ethereumAddress: refs.wallets.ethereumWallet.address,
+          executionRpcUrl: tracker.ethereumClient.executionRpcUrl,
+        };
+      },
+      {
+        timeoutMs: 15_000,
+      },
+    )) as { ethereumAddress: string; executionRpcUrl: string };
+
     const mintingAuthorityRuntime = await startDevEthereumMintingAuthority({
       archiveUrl,
+      executionRpcUrl,
       logPrefix: context.flowName,
     });
 
     try {
+      await fundDevEthereumAccount({
+        to: ethereumAddress,
+        rpcUrl: executionRpcUrl,
+        amountBaseUnits: DEV_ETHEREUM_TRANSFER_GAS_BUFFER_WEI,
+      });
+
       await clickIfVisible(flow, 'WalletFundingReceivedOverlay.closeOverlay()', { timeoutMs: 5_000 });
 
       if (!(await flow.isVisible('VaultingScreen')).visible) {

--- a/e2e/flows/operations/Vaulting.op.transferOutThroughEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutThroughEthereum.ts
@@ -38,12 +38,14 @@ export default new Operation<IVaultingFlowContext, ITransferOutThroughEthereumSt
       flow.isVisible('WalletOverlay'),
       readOutboundTransferState(flow),
     ]);
+    const transferCompleted = flow.getData<boolean>('Vaulting.op.transferOutThroughEthereum.completed') ?? false;
 
     const isComplete =
-      transferState.phase === 'confirmedOnEthereum' &&
-      !transferState.isSubmitting &&
-      !transferState.hasPersistedTransfer &&
-      !transferState.error;
+      transferCompleted ||
+      (transferState.phase === 'confirmedOnEthereum' &&
+        !transferState.isSubmitting &&
+        !transferState.hasPersistedTransfer &&
+        !transferState.error);
 
     let operationState: 'complete' | 'runnable' | 'processing' = 'processing';
     if (isComplete) {
@@ -73,6 +75,8 @@ export default new Operation<IVaultingFlowContext, ITransferOutThroughEthereumSt
   },
 
   async run({ flow, flowName }, state) {
+    flow.setData('Vaulting.op.transferOutThroughEthereum.completed', false);
+
     if (state.chainState.error) {
       throw new Error(state.chainState.error);
     }
@@ -131,6 +135,13 @@ export default new Operation<IVaultingFlowContext, ITransferOutThroughEthereumSt
     if ((await flow.isVisible('WalletTransferOverlay.close()')).clickable) {
       await flow.click('WalletTransferOverlay.close()', { timeoutMs: 15_000 });
     }
+
+    const overlayCloseButton = await flow.isVisible('OverlayBase.clickClose()');
+    if (overlayCloseButton.clickable) {
+      await flow.click('OverlayBase.clickClose()', { timeoutMs: 8_000 });
+    }
+
+    flow.setData('Vaulting.op.transferOutThroughEthereum.completed', true);
   },
 });
 

--- a/e2e/helpers/startDevEthereumMintingAuthority.ts
+++ b/e2e/helpers/startDevEthereumMintingAuthority.ts
@@ -1,11 +1,11 @@
 import { MainchainClients, minimumVaultDelegateBalance, NetworkConfig } from '@argonprotocol/apps-core';
 import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
 import type { ArgonClient } from '@argonprotocol/mainchain';
-import { getEthereumBeaconSyncState, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
+import { EvmContracts, getClient, getEthereumBeaconSyncState, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { createPublicClient, getAddress, http } from 'viem';
 import { sudoSubmitAndFinalize } from '../../core/__test__/helpers/mainchain.ts';
 import type { IEthereumMintingAuthorityStatus, VaultActor } from '../actors/VaultActor.ts';
-import { resolveDevEthereumRpcUrl } from '../devEthereum.ts';
+import { readDevEthereumRuntimeState, resolveDevEthereumRpcUrl } from '../devEthereum.ts';
 import {
   collectVaultOperatorsByEffectiveCouncilSigner,
   forceUpdateGlobalIssuanceCouncil,
@@ -23,6 +23,7 @@ export type IDevEthereumMintingAuthorityRuntime = {
 export async function startDevEthereumMintingAuthority(args: {
   archiveUrl: string;
   logPrefix?: string;
+  executionRpcUrl?: string;
   virtualEnv?: {
     app?: string;
     appInstance?: string;
@@ -30,7 +31,26 @@ export async function startDevEthereumMintingAuthority(args: {
     serverEnvVars?: NodeJS.ProcessEnv;
   };
 }): Promise<IDevEthereumMintingAuthorityRuntime> {
-  seedVirtualFrontendGlobals(args.virtualEnv);
+  const executionRpcUrl = await resolveDevEthereumRpcUrl({
+    rpcUrl: args.executionRpcUrl,
+    logPrefix: args.logPrefix,
+  });
+  NetworkConfig.setNetwork('dev-docker');
+  NetworkConfig.setRuntimeOverride('dev-docker', {
+    ethereumNetwork: {
+      executionRpcUrl,
+      finalityBlocks: 16,
+    },
+  });
+  seedVirtualFrontendGlobals({
+    ...args.virtualEnv,
+    network: args.virtualEnv?.network ?? 'dev-docker',
+  });
+  await waitForDevEthereumGatewayReady({
+    archiveUrl: args.archiveUrl,
+    executionRpcUrl,
+    logPrefix: args.logPrefix ?? 'dev-ethereum-minting-authority',
+  });
   const { VaultActor } = await import('../actors/VaultActor.ts');
   const clients = new MainchainClients(args.archiveUrl, () => false);
   const actor = await VaultActor.load({
@@ -58,6 +78,7 @@ export async function startDevEthereumMintingAuthority(args: {
       actor,
       archiveUrl: args.archiveUrl,
       client: await getClient(),
+      executionRpcUrl,
       logPrefix: args.logPrefix ?? 'dev-ethereum-minting-authority',
     });
 
@@ -93,10 +114,10 @@ async function activateDevEthereumMintingAuthority(args: {
   actor: VaultActor;
   archiveUrl: string;
   client: ArgonClient;
+  executionRpcUrl: string;
   logPrefix: string;
 }) {
-  const { actor, archiveUrl, client, logPrefix } = args;
-  const executionRpcUrl = await resolveDevEthereumRpcUrl({ logPrefix });
+  const { actor, archiveUrl, client, executionRpcUrl, logPrefix } = args;
   const ethereumClient = createPublicClient({
     transport: http(executionRpcUrl, { retryCount: 1, timeout: 15_000 }),
   });
@@ -430,4 +451,60 @@ function seedVirtualFrontendGlobals(args?: {
 
   Object.assign(virtualWindow, globals);
   Object.assign(globalThis as Record<string, unknown>, globals);
+}
+
+async function waitForDevEthereumGatewayReady(args: {
+  archiveUrl: string;
+  executionRpcUrl: string;
+  logPrefix: string;
+}) {
+  const publicClient = createPublicClient({
+    transport: http(args.executionRpcUrl, { retryCount: 1, timeout: 15_000 }),
+  });
+  const client = await getClient(args.archiveUrl);
+
+  try {
+    await waitFor(
+      2 * 60_000,
+      `${args.logPrefix}: dev Ethereum gateway readiness`,
+      async () => {
+        const runtimeState = await readDevEthereumRuntimeState(args.executionRpcUrl);
+        if (runtimeState?.setupStatus !== 'ready' || runtimeState.executionRpcUrl !== args.executionRpcUrl) {
+          return;
+        }
+
+        const finalizedClient = await client.at(await client.rpc.chain.getFinalizedHead());
+        const [beaconSyncState, chainConfig] = await Promise.all([
+          getEthereumBeaconSyncState(client),
+          finalizedClient.query.crosschainTransfer.chainConfigBySourceChain('Ethereum'),
+        ]);
+        if (!beaconSyncState.isBootstrapped || chainConfig.isNone || !chainConfig.unwrap().isEvm) {
+          return;
+        }
+
+        const ethereumConfig = chainConfig.unwrap().asEvm;
+        const gatewayAddress = getAddress(ethereumConfig.gateway.toHex());
+        if ((await publicClient.getChainId()) !== Number(ethereumConfig.chainId.toString())) {
+          return;
+        }
+
+        try {
+          await publicClient.readContract({
+            address: gatewayAddress,
+            abi: EvmContracts.mintingGatewayAbi,
+            functionName: 'argonApprovalsNonce',
+          });
+          return gatewayAddress;
+        } catch {
+          return;
+        }
+      },
+      {
+        pollMs: 1_000,
+        timeoutMessage: `${args.logPrefix}: local Ethereum gateway never became readable on ${args.executionRpcUrl}.`,
+      },
+    );
+  } finally {
+    await client.disconnect().catch(() => undefined);
+  }
 }

--- a/e2e/scripts/fundDevEthereumAccount.ts
+++ b/e2e/scripts/fundDevEthereumAccount.ts
@@ -235,7 +235,7 @@ Notes:
   - Sends USDC from the local dev mock USDC contract when --token USDC is provided.
   - USDC uses 6-decimal base units.
   - Reads the mock USDC address from e2e/artifacts/dev-ethereum.json, DEV_ETHEREUM_USDC_ADDRESS, or --token-address.
-  - Uses ETH_RPC or ETHEREUM_EXECUTION_RPC_URL if set, otherwise probes local Kurtosis execution RPC ports.
+  - Uses --rpc, ETH_RPC, ETHEREUM_EXECUTION_RPC_URL, or the latest dev Ethereum runtime state.
   - Waits for the funding transaction receipt before returning.
 `);
 }

--- a/e2e/scripts/mintDevEthereumTokens.ts
+++ b/e2e/scripts/mintDevEthereumTokens.ts
@@ -421,7 +421,7 @@ Notes:
   - Migration seeding is one-time per dev chain; restart the dev Ethereum fixture to seed different balances later.
   - Also sudo-bumps the Argon crosschain burn-account liquidity for the seeded assets.
   - Resolves gateway, ARGN, and ARGNOT addresses from Argon runtime Ethereum chain config.
-  - Uses ETH_RPC or ETHEREUM_EXECUTION_RPC_URL if set, otherwise probes local Kurtosis execution RPC ports.
+  - Uses --rpc, ETH_RPC, ETHEREUM_EXECUTION_RPC_URL, or the latest dev Ethereum runtime state.
   - Uses ARGON_ARCHIVE_URL if set, otherwise defaults to ws://127.0.0.1:9944.
   - Uses the built-in local dev admin account if --from is omitted.
   - --amount is a 6-decimal Argon runtime amount for the token selected by the package script.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tauri:dev:local": "NODE_ENV=localnet yarn tauri:dev",
     "tauri:dev:docker:treasury": "ARGON_DEV_ETHEREUM=0 ARGON_APP=treasury yarn tauri:dev:docker",
     "tauri:dev:docker": "RUST_BACKTRACE=full ARGON_APP_INSTANCE=${ARGON_APP_INSTANCE:-e2e} ARGON_NETWORK_NAME=dev-docker yarn tauri:dev",
-    "tauri:dev:docker:ops2": "JOIN_COMPOSE_NETWORK=${JOIN_COMPOSE_NETWORK:-dev-docker-e2e} ARGON_APP_INSTANCE=${ARGON_APP_INSTANCE:-ops2:1421} yarn tauri:dev:docker",
+    "tauri:dev:docker:ops2": "JOIN_COMPOSE_NETWORK=${JOIN_COMPOSE_NETWORK:-dev-docker-e2e} ARGON_DEV_ETHEREUM=0 ARGON_APP_INSTANCE=${ARGON_APP_INSTANCE:-ops2:1421} yarn tauri:dev:docker",
     "lint": "prettier -w bot core src-vue cli e2e",
     "lint:check": "prettier --check bot core cli src-vue e2e && eslint bot core cli src-vue e2e --ext .ts --cache --max-warnings=0 && yarn check:operation-rules",
     "check:operation-rules": "yarn workspace @argonprotocol/apps-e2e run check:operation-rules",

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -56,6 +56,7 @@ async function main(): Promise<void> {
   let devEthereumMintingAuthorityPromise: Promise<void> | undefined;
   let devEthereumSetup: IDevEthereumSetup | undefined;
   let devDockerArchiveUrl: string | undefined;
+  let devEthereumExecutionRpcUrl: string | undefined;
   let isShuttingDown = false;
   if (network === 'dev-docker') {
     shouldStartDevEthereumMintingAuthority = ['1', 'true', 'yes', 'on'].includes(
@@ -63,10 +64,21 @@ async function main(): Promise<void> {
     );
     await ensureDevGatewayCerts({ app, appInstance: argonAppInstance, network });
 
+    console.log('[tauri-dev] Resolving dev-docker compose ports');
     const composePorts = await resolveDevDockerComposePorts();
-    const devEthereum = devEthereumConfig ? await startDevEthereum(devEthereumConfig) : undefined;
+    const devEthereum = devEthereumConfig
+      ? await (async () => {
+          console.log(
+            `[tauri-dev] Launching local dev Ethereum (preset=${devEthereumConfig.beaconPreset}, secondsPerSlot=${devEthereumConfig.secondsPerSlot})`,
+          );
+          return await startDevEthereum(devEthereumConfig);
+        })()
+      : undefined;
     if (composePorts) {
       devDockerArchiveUrl = `ws://127.0.0.1:${composePorts.archivePort}`;
+      console.log(
+        `[tauri-dev] Resolved compose ports archive=${composePorts.archivePort} archiveP2p=${composePorts.archiveP2pPort} bitcoinP2p=${composePorts.bitcoinP2pPort} esplora=${composePorts.esploraPort}${composePorts.indexerPort ? ` indexer=${composePorts.indexerPort}` : ''} notary=${composePorts.notaryAliasContainerId}`,
+      );
       Object.assign(tauriEnv, getDevDockerServerEnvVars(composePorts));
       if (devEthereum && devEthereumConfig) {
         devEthereumSetup = createDevEthereumSetup(devDockerArchiveUrl, devEthereum, devEthereumConfig);
@@ -81,7 +93,9 @@ async function main(): Promise<void> {
       ? JSON.parse(inheritedOverride)
       : undefined;
     const ethereumExecutionRpcUrl = await resolveRuntimeEthereumExecutionRpcUrl(devEthereum, inheritedRuntimeOverride);
+    devEthereumExecutionRpcUrl = ethereumExecutionRpcUrl;
     const ethereumUsdcTokenAddress = await resolveRuntimeEthereumUsdcTokenAddress(
+      ethereumExecutionRpcUrl,
       devEthereum,
       inheritedRuntimeOverride,
     );
@@ -124,11 +138,7 @@ async function main(): Promise<void> {
         throw error;
       });
 
-    if (isE2EAppRun) {
-      await devEthereumSetupPromise;
-    } else {
-      void devEthereumSetupPromise;
-    }
+    void devEthereumSetupPromise.catch(() => undefined);
   }
 
   const child = spawn('yarn', tauriArgs, {
@@ -149,6 +159,7 @@ async function main(): Promise<void> {
       console.log('[tauri-dev] Starting local Ethereum minting authority');
       devEthereumMintingAuthorityRuntime = await startDevEthereumMintingAuthority({
         archiveUrl: devDockerArchiveUrl!,
+        executionRpcUrl: devEthereumExecutionRpcUrl,
         logPrefix: 'tauri-dev',
         virtualEnv: {
           app,
@@ -266,7 +277,13 @@ async function resolveDevDockerComposePorts(): Promise<DevDockerComposePorts | n
     ))!;
     const notaryPort = (await readComposePortWithRetry(composeDir, composeEnv, joinComposeNetwork, 'notary', 9925))!;
     // then after resolving ports:
+    console.log(
+      `[tauri-dev] Resolving notary archive host via ws://127.0.0.1:${notaryPort} with MinIO port ${notebookArchivePort}`,
+    );
     notaryArchiveHost = await resolveNotaryArchiveHost(notaryPort, notebookArchivePort);
+    console.log(
+      `[tauri-dev] Resolved notary archive host${notaryArchiveHost ? ` ${notaryArchiveHost}` : ' unavailable'}`,
+    );
   } catch (error) {
     console.warn(`[tauri-dev] Failed to resolve compose ports: ${(error as Error).message}`);
     return null;
@@ -329,6 +346,7 @@ async function resolveDevDockerNetworkConfigOverride(
   const archiveUrl = `ws://127.0.0.1:${ports.archivePort}`;
   let runtimeConfig: RuntimeChainConfig;
   try {
+    console.log(`[tauri-dev] Loading runtime chain config from ${archiveUrl}`);
     runtimeConfig = await loadRuntimeConfig(archiveUrl);
   } catch (error) {
     console.warn(`[tauri-dev] Failed to load runtime chain config: ${(error as Error).message}`);
@@ -379,6 +397,7 @@ async function resolveRuntimeEthereumExecutionRpcUrl(
 }
 
 async function resolveRuntimeEthereumUsdcTokenAddress(
+  executionRpcUrl: string | undefined,
   devEthereum?: IStartDevEthereumResult,
   inheritedOverride?: RuntimeNetworkConfigOverride,
 ): Promise<string | undefined> {
@@ -393,7 +412,8 @@ async function resolveRuntimeEthereumUsdcTokenAddress(
   }
 
   try {
-    return readNonEmpty((await readDevEthereumRuntimeState())?.usdcTokenAddress);
+    const runtimeState = await readDevEthereumRuntimeState(executionRpcUrl);
+    return readNonEmpty(runtimeState?.usdcTokenAddress);
   } catch (error) {
     console.warn(`[tauri-dev] Dev Ethereum USDC address unavailable: ${(error as Error).message}`);
     return undefined;


### PR DESCRIPTION
## Summary
- stabilize the Ethereum transfer-out flow so the background minting authority waits for the active runtime Ethereum RPC before it starts
- pass the app's execution RPC through the transfer-out flow instead of rediscovering arbitrary local Ethereum endpoints
- keep attached ops2 sessions on the shared dev-docker environment instead of relaunching local Ethereum

## Testing
- yarn typecheck
- ARGON_E2E_HEADLESS=1 E2E_FLOW_APP_LOGS=quiet yarn vitest --run --project e2e e2e/__test__/ethereumTransferOut.e2e.test.ts