### PR TITLE
fix: restore ethereum RPCs and relay setup guidance

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -36,10 +36,7 @@
       "identifier": "http:default",
       "allow": [
         {
-          "url": "https://indexer.testnet.argonprotocol.org/*"
-        },
-        {
-          "url": "https://indexer.testnet.argon.network/*"
+          "url": "https://*"
         }
       ],
       "deny": []

--- a/src-tauri/capabilities/dev.json
+++ b/src-tauri/capabilities/dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "dev",
-  "description": "Dev-only localhost access",
+  "description": "Dev-only HTTP access",
   "windows": [
     "main"
   ],
@@ -10,10 +10,7 @@
       "identifier": "http:default",
       "allow": [
         {
-          "url": "http://localhost:*/*"
-        },
-        {
-          "url": "http://127.0.0.1:*/*"
+          "url": "http://*"
         }
       ]
     }

--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -1,8 +1,38 @@
-import { describe, expect, it } from 'vitest';
-import { getEthereumUserErrorMessage, submitEthereumTransaction } from '../lib/EthereumClient.ts';
+import { NetworkConfig } from '@argonprotocol/apps-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { keccak256, TransactionNotFoundError, TransactionReceiptNotFoundError } from 'viem';
+import {
+  createEthereumPublicClient,
+  getEthereumUserErrorMessage,
+  submitEthereumTransaction,
+} from '../lib/EthereumClient.ts';
+
+const { tauriFetchMock } = vi.hoisted(() => {
+  return {
+    tauriFetchMock: vi.fn(),
+  };
+});
+
+vi.mock('@tauri-apps/plugin-http', () => {
+  return {
+    fetch: tauriFetchMock,
+  };
+});
 
 describe('EthereumClient', () => {
+  beforeEach(() => {
+    tauriFetchMock.mockReset();
+    NetworkConfig.setRuntimeOverride('dev-docker', {
+      ethereumNetwork: {
+        executionRpcUrl: 'https://ethereum.test',
+      },
+    });
+  });
+
+  afterEach(() => {
+    NetworkConfig.clearRuntimeOverride('dev-docker');
+  });
+
   it('prefers the short viem error message over raw RPC request details', () => {
     const error = Object.assign(
       new Error(
@@ -79,5 +109,24 @@ describe('EthereumClient', () => {
         fallbackErrorMessage: 'fallback',
       }),
     ).rejects.toThrow('Missing or invalid parameters. Double check you have provided the correct parameters.');
+  });
+
+  it('routes Ethereum balance requests through plugin-http', async () => {
+    tauriFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x2a' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    const publicClient = createEthereumPublicClient();
+
+    await expect(publicClient.getBalance({ address: '0x0000000000000000000000000000000000000001' })).resolves.toBe(42n);
+    expect(String(tauriFetchMock.mock.calls[0][0])).toBe('https://ethereum.test/');
+    const requestBody = JSON.parse(String(tauriFetchMock.mock.calls[0][1]?.body));
+    expect(requestBody.method).toBe('eth_getBalance');
+    expect(requestBody.params).toEqual(['0x0000000000000000000000000000000000000001', 'latest']);
   });
 });

--- a/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../lib/db/CrosschainInboundTransfersTable.ts';
 import type { TransactionTracker } from '../lib/TransactionTracker.ts';
 import { WalletType } from '../lib/Wallet.ts';
+import { convertEthereumTokenBaseUnitsToRuntimeAmount } from '../lib/WalletForEthereum.ts';
 
 type IWaitForTransactionFinalityArgs = Parameters<EthereumClient['waitForTransactionFinality']>[0];
 
@@ -73,6 +74,7 @@ describe('EthereumInboundTransferTracker integration', () => {
       amountBaseUnits: 5_000_000_000_000n,
       targetWalletType: WalletType.investment,
     });
+    expect(activeTransfer?.transferState.amount).toBe(convertEthereumTokenBaseUnitsToRuntimeAmount(5_000_000_000_000n));
 
     await vi.waitFor(() => {
       expect(upstreamCatchUp).toHaveBeenCalledWith({
@@ -164,6 +166,7 @@ describe('EthereumInboundTransferTracker integration', () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
     let provenNonce = 6n;
+    const delegateAddress = await walletKeys.getVaultDelegateKeypair().then(x => x.address);
     const mainchainClient = createMainchainClient({
       getProvenNonce: () => provenNonce,
     });
@@ -197,6 +200,11 @@ describe('EthereumInboundTransferTracker integration', () => {
         operatorHost: 'https://upstream.example',
         requestEthereumGatewayCatchUp: upstreamCatchUp,
       },
+      {
+        createdVault: {
+          bitcoinLockDelegateAccount: delegateAddress,
+        } as any,
+      },
     );
 
     const activeTransfer = await tracker.startMove({
@@ -217,6 +225,157 @@ describe('EthereumInboundTransferTracker integration', () => {
       const persisted = await db.crosschainInboundTransfersTable.get(activeTransfer!.id);
       expect(persisted?.status).toBe(CrosschainInboundTransferStatus.ArgonFinalized);
     });
+  });
+
+  it('surfaces a generic relay-readiness error when no upstream fallback is available', async () => {
+    const db = await createTestDb();
+    const walletKeys = createMockWalletKeys();
+    const mainchainClient = createMainchainClient({
+      getProvenNonce: () => 6n,
+    });
+    getMainchainClientMock.mockResolvedValue(mainchainClient);
+
+    const requestEthereumGatewayCatchUp = vi.fn();
+    const tracker = new EthereumInboundTransferTracker(
+      Promise.resolve(db),
+      createTransactionTracker(),
+      walletKeys,
+      createEthereumClient({
+        sourceAddress: walletKeys.ethereumAddress,
+        destinationAddress: walletKeys.investmentAddress,
+        sourceTxHash: `0x${'39'.repeat(32)}`,
+        sourceBlockNumber: 42,
+        sourceBlockHash: `0x${'4a'.repeat(32)}`,
+        sourceLogIndex: 8,
+        gatewayActivityNonce: 7n,
+        waitEstimateMs: 60_000,
+      }),
+      {
+        getEthereumRelayStatus: vi.fn(async () => ({
+          isReady: false,
+          reason: 'Vault delegate needs more funds before Ethereum relays can run.',
+        })),
+        requestEthereumGatewayCatchUp,
+      },
+      {
+        operatorHost: undefined,
+        requestEthereumGatewayCatchUp: vi.fn(),
+      },
+      {
+        createdVault: {
+          bitcoinLockDelegateAccount: undefined,
+        } as any,
+      },
+    );
+
+    const activeTransfer = await tracker.startMove({
+      moveToken: MoveToken.ARGN,
+      amountBaseUnits: 5_000_000_000_000n,
+      targetWalletType: WalletType.investment,
+    });
+
+    await vi.waitFor(() => {
+      expect(activeTransfer?.transferState.error).toBe(
+        "Your server isn't set up to send this transfer yet, so this transfer is waiting for the Argon network to pick it up.",
+      );
+    });
+    expect(requestEthereumGatewayCatchUp).not.toHaveBeenCalled();
+  });
+
+  it('explains when the Argon network is taking over after the server runs out of relay funds', async () => {
+    const db = await createTestDb();
+    const walletKeys = createMockWalletKeys();
+    const delegateAddress = await walletKeys.getVaultDelegateKeypair().then(x => x.address);
+    const mainchainClient = createMainchainClient({
+      getProvenNonce: () => 6n,
+    });
+    getMainchainClientMock.mockResolvedValue(mainchainClient);
+
+    const upstreamCatchUp = vi.fn(async () => ({ outcome: 'Noop' as const, throughGatewayActivityNonce: 7n }));
+    const tracker = new EthereumInboundTransferTracker(
+      Promise.resolve(db),
+      createTransactionTracker(),
+      walletKeys,
+      createEthereumClient({
+        sourceAddress: walletKeys.ethereumAddress,
+        destinationAddress: walletKeys.investmentAddress,
+        sourceTxHash: `0x${'3a'.repeat(32)}`,
+        sourceBlockNumber: 42,
+        sourceBlockHash: `0x${'4b'.repeat(32)}`,
+        sourceLogIndex: 8,
+        gatewayActivityNonce: 7n,
+        waitEstimateMs: 60_000,
+      }),
+      {
+        getEthereumRelayStatus: vi.fn(async () => ({
+          isReady: false,
+          reason: 'Vault delegate cannot afford Ethereum gateway relay.',
+        })),
+        requestEthereumGatewayCatchUp: vi.fn(),
+      },
+      {
+        operatorHost: 'https://upstream.example',
+        requestEthereumGatewayCatchUp: upstreamCatchUp,
+      },
+      {
+        createdVault: {
+          bitcoinLockDelegateAccount: delegateAddress,
+        } as any,
+      },
+    );
+
+    const persistedRecord = await insertTransferRecord(db, walletKeys.ethereumAddress, {
+      id: nanoid(),
+      token: MoveToken.ARGN,
+      argonDestinationAddress: walletKeys.investmentAddress,
+      sourceTxHash: `0x${'3a'.repeat(32)}`,
+      sourceBlockNumber: 42,
+      sourceBlockHash: `0x${'4b'.repeat(32)}`,
+      sourceLogIndex: 8,
+      gatewayActivityNonce: 7n,
+      status: CrosschainInboundTransferStatus.SourceFinalized,
+    });
+    const progress = setInboundRelayStepProgress(createCrosschainTransferProgress(INBOUND_TRANSFER_STEP_TITLES), {
+      progressPct: 0,
+      detail: 'Waiting for Argon to receive finalized Ethereum state...',
+    });
+    const activeTransfer = {
+      id: persistedRecord.id,
+      moveToken: MoveToken.ARGN,
+      persistedRecord,
+      transferState: {
+        ...tracker.getTransferStateForToken(MoveToken.ARGN),
+        hasPersistedTransfer: true,
+        isSubmitting: true,
+        targetWalletType: WalletType.investment,
+        progress,
+      },
+    };
+    (
+      tracker as unknown as {
+        data: {
+          transfersById: Record<string, unknown>;
+          latestTransferIdByToken: Partial<Record<MoveToken.ARGN | MoveToken.ARGNOT, string>>;
+        };
+      }
+    ).data.transfersById[persistedRecord.id] = activeTransfer;
+
+    const requestBackendCatchUp = (
+      tracker as unknown as {
+        requestBackendCatchUp: (transfer: typeof activeTransfer) => Promise<void>;
+      }
+    ).requestBackendCatchUp.bind(tracker);
+
+    await requestBackendCatchUp(activeTransfer);
+
+    expect(upstreamCatchUp).toHaveBeenCalledWith({
+      sourceChain: 'Ethereum',
+      throughGatewayActivityNonce: 7n,
+    });
+    expect(activeTransfer.transferState.error).toBe('');
+    expect(activeTransfer.transferState.progress.currentStepHint).toBe(
+      "Your server doesn't have enough relay funds, so this transfer is waiting for the Argon network to pick it up.",
+    );
   });
 
   it('retries inbound catch-up only after relay progress stays stalled for the full wait estimate', async () => {
@@ -423,6 +582,7 @@ describe('EthereumInboundTransferTracker integration', () => {
 
     const transferState = tracker.getTransferStateForToken(MoveToken.ARGNOT);
     expect(transferState).toMatchObject({
+      amount: convertEthereumTokenBaseUnitsToRuntimeAmount(persistedRecord.amountBaseUnits),
       isSubmitting: false,
       hasPersistedTransfer: false,
       targetWalletType: WalletType.vaulting,

--- a/src-vue/app-operations/overlays/MintingAuthorityRequestOverlay.vue
+++ b/src-vue/app-operations/overlays/MintingAuthorityRequestOverlay.vue
@@ -74,6 +74,99 @@
           Argonots you have explicitly committed for minting-authority work.
         </p>
 
+        <div
+          v-if="relayDelegateNeedsSetup"
+          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
+          <div class="flex items-start justify-between gap-4">
+            <div class="grow">
+              <div class="text-sm font-semibold text-amber-900">Relay Delegate Needs Setup</div>
+              <div class="mt-1 text-sm leading-6 text-amber-800">
+                Your server can't send Ethereum relays for this vault yet because the relay delegate isn't set up.
+              </div>
+
+              <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Current Balance</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Minimum Balance</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Setup Funding</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(targetVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              :disabled="isSubmitting || isUpdatingRelayDelegate"
+              data-testid="MintingAuthorityRequestOverlay.updateRelayDelegate()"
+              class="bg-argon-button hover:bg-argon-button-hover shrink-0 rounded px-4 py-2 text-sm font-semibold text-white disabled:cursor-default disabled:opacity-40"
+              @click="updateRelayDelegate">
+              <template v-if="isUpdatingRelayDelegate">Setting Up...</template>
+              <template v-else>Set Up Relay Delegate</template>
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-else-if="relayDelegateTopUpAmount > 0n"
+          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
+          <div class="flex items-start justify-between gap-4">
+            <div class="grow">
+              <div class="text-sm font-semibold text-amber-900">Relay Delegate Needs Funds</div>
+              <div class="mt-1 text-sm leading-6 text-amber-800">
+                Your server's relay delegate is low on funds. Top it up here so your server can keep sending Ethereum
+                relays for this vault.
+              </div>
+
+              <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Current Balance</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Minimum Balance</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+
+                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Top-Up Needed</div>
+                  <div class="mt-1 font-semibold text-amber-950">
+                    {{ microgonToArgonNm(relayDelegateTopUpAmount).format('0,0.[000000]') }} ARGN
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              :disabled="isSubmitting || isUpdatingRelayDelegate"
+              data-testid="MintingAuthorityRequestOverlay.updateRelayDelegate()"
+              class="bg-argon-button hover:bg-argon-button-hover shrink-0 rounded px-4 py-2 text-sm font-semibold text-white disabled:cursor-default disabled:opacity-40"
+              @click="updateRelayDelegate">
+              <template v-if="isUpdatingRelayDelegate">Topping Up...</template>
+              <template v-else>Top Up Relay Delegate</template>
+            </button>
+          </div>
+        </div>
+
         <div class="grid grid-cols-2 gap-3">
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Council signing key</div>
@@ -152,7 +245,7 @@
 
         <div class="grid grid-cols-2 gap-3">
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-            <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Council value</div>
+            <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Epoch Argonot Conversion</div>
             <div class="mt-1 text-lg font-semibold text-slate-800">
               {{ microgonToArgonNm(epochMicrogonsPerArgonot).format('0,0.[000000]') }} ARGN / ARGNOT
             </div>
@@ -252,7 +345,7 @@
           </button>
           <button
             type="button"
-            :disabled="isSubmitting || !!validationMessage"
+            :disabled="isSubmitting || isUpdatingRelayDelegate || !!validationMessage"
             data-testid="MintingAuthorityRequestOverlay.submit()"
             class="bg-argon-button hover:bg-argon-button-hover rounded px-5 py-2 text-sm font-semibold text-white disabled:cursor-default disabled:opacity-40"
             @click="submit">
@@ -266,7 +359,12 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import { BondLot, TreasuryBonds } from '@argonprotocol/apps-core';
+import {
+  BondLot,
+  minimumVaultDelegateBalance,
+  targetVaultDelegateBalance,
+  TreasuryBonds,
+} from '@argonprotocol/apps-core';
 import { MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import InputToken from '../../components/InputToken.vue';
 import ProgressBar from '../../components/ProgressBar.vue';
@@ -293,6 +391,7 @@ const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency
 const isOpen = Vue.ref(false);
 const isLoading = Vue.ref(false);
 const isSubmitting = Vue.ref(false);
+const isUpdatingRelayDelegate = Vue.ref(false);
 const loadError = Vue.ref('');
 const submitError = Vue.ref('');
 const vaultId = Vue.ref<number>();
@@ -301,6 +400,9 @@ const remainingBondMicrogons = Vue.ref(0n);
 const remainingCommittedMicronots = Vue.ref(0n);
 const minimumRequiredMicrogons = Vue.ref(MINIMUM_REQUEST_VALUE_MICROGONS);
 const epochMicrogonsPerArgonot = Vue.ref(0n);
+const relayDelegateAddress = Vue.ref('');
+const relayDelegateBalance = Vue.ref(0n);
+const relayDelegateTopUpAmount = Vue.ref(0n);
 
 const microgonCollateral = Vue.ref(0n);
 const micronotCollateral = Vue.ref(0n);
@@ -336,6 +438,12 @@ const maximumRequestValueMicrogons = Vue.computed(() => {
 
 const requestValueMicrogons = Vue.computed(() => {
   return microgonCollateral.value + (micronotCollateral.value * epochMicrogonsPerArgonot.value) / ONE_TOKEN;
+});
+
+const relayDelegateNeedsSetup = Vue.computed(() => {
+  if (!relayDelegateAddress.value) return false;
+
+  return myVault.createdVault?.bitcoinLockDelegateAccount !== relayDelegateAddress.value;
 });
 
 const validationMessage = Vue.computed(() => {
@@ -392,6 +500,9 @@ async function loadState() {
   remainingCommittedMicronots.value = 0n;
   minimumRequiredMicrogons.value = MINIMUM_REQUEST_VALUE_MICROGONS;
   epochMicrogonsPerArgonot.value = 0n;
+  relayDelegateAddress.value = '';
+  relayDelegateBalance.value = 0n;
+  relayDelegateTopUpAmount.value = 0n;
   microgonCollateral.value = 0n;
   micronotCollateral.value = 0n;
 
@@ -404,22 +515,31 @@ async function loadState() {
 
     vaultId.value = myVault.vaultId;
 
-    const [[localCouncilSigner], finalizedClient] = await Promise.all([
+    const [[localCouncilSigner], delegateKeypair, finalizedClient] = await Promise.all([
       walletKeys.getEthereumAddresses([walletKeys.councilSignerEthereumHdPath]),
+      walletKeys.getVaultDelegateKeypair(),
       getFinalizedClient(),
     ]);
+    relayDelegateAddress.value = delegateKeypair.address;
     await Promise.all([
       myVault.mintingAuthorities.refresh(finalizedClient),
       myVault.globalCouncil.refresh(finalizedClient),
     ]);
-    const [commitmentOption, bondLots, encumberedBondMicrogons, activeCouncilHashOption, minimumMintingAuthorityValue] =
-      await Promise.all([
-        finalizedClient.query.vaults.argonotCommitmentByVaultId(vaultId.value),
-        TreasuryBonds.getBondLots(finalizedClient, vaultId.value, walletKeys.vaultingAddress),
-        finalizedClient.query.treasury.encumberedBondMicrogonsByAccount(walletKeys.vaultingAddress),
-        finalizedClient.query.crosschainTransfer.activeGlobalIssuanceCouncilByDestinationChain('Ethereum'),
-        finalizedClient.query.crosschainTransfer.minimumMintingAuthorityValueByDestinationChain('Ethereum'),
-      ]);
+    const [
+      commitmentOption,
+      bondLots,
+      encumberedBondMicrogons,
+      activeCouncilHashOption,
+      minimumMintingAuthorityValue,
+      relayDelegateAccount,
+    ] = await Promise.all([
+      finalizedClient.query.vaults.argonotCommitmentByVaultId(vaultId.value),
+      TreasuryBonds.getBondLots(finalizedClient, vaultId.value, walletKeys.vaultingAddress),
+      finalizedClient.query.treasury.encumberedBondMicrogonsByAccount(walletKeys.vaultingAddress),
+      finalizedClient.query.crosschainTransfer.activeGlobalIssuanceCouncilByDestinationChain('Ethereum'),
+      finalizedClient.query.crosschainTransfer.minimumMintingAuthorityValueByDestinationChain('Ethereum'),
+      finalizedClient.query.system.account(delegateKeypair.address),
+    ]);
 
     if (commitmentOption.isSome) {
       const commitment = commitmentOption.unwrap();
@@ -432,6 +552,11 @@ async function loadState() {
     remainingBondMicrogons.value = bigintMax(bondTotals.activeBondMicrogons - encumberedBondMicrogons.toBigInt(), 0n);
 
     minimumRequiredMicrogons.value = minimumMintingAuthorityValue.toBigInt();
+    relayDelegateBalance.value = relayDelegateAccount.data.free.toBigInt();
+    relayDelegateTopUpAmount.value =
+      relayDelegateBalance.value >= minimumVaultDelegateBalance
+        ? 0n
+        : targetVaultDelegateBalance - relayDelegateBalance.value;
 
     councilSigner.value = myVault.globalCouncil.data.councilSigner ?? localCouncilSigner;
 
@@ -513,6 +638,25 @@ async function submit() {
   } catch (error) {
     submitError.value = error instanceof Error ? error.message : 'Unable to create a minting authority request.';
     isSubmitting.value = false;
+  }
+}
+
+async function updateRelayDelegate() {
+  if (isUpdatingRelayDelegate.value || isSubmitting.value || !vaultId.value) {
+    return;
+  }
+
+  submitError.value = '';
+  isUpdatingRelayDelegate.value = true;
+
+  try {
+    const relaySetupTx = await myVault.ensureDelegatedBitcoinSigner();
+    await relaySetupTx?.waitForPostProcessing;
+    await loadState();
+  } catch (error) {
+    submitError.value = error instanceof Error ? error.message : 'Unable to update the relay delegate.';
+  } finally {
+    isUpdatingRelayDelegate.value = false;
   }
 }
 

--- a/src-vue/app-shared/overlays/wallet/CrosschainMoveButton.vue
+++ b/src-vue/app-shared/overlays/wallet/CrosschainMoveButton.vue
@@ -46,7 +46,7 @@
 
           <p v-else-if="inboundTransfer" class="font-light text-slate-700">
             Moving
-            <strong>{{ props.moveToken }}</strong>
+            <strong>{{ formatTokenAmount(inboundTransfer.transferState.amount) }} {{ props.moveToken }}</strong>
             from your
             <strong>{{ props.networkName }}</strong>
             wallet into your

--- a/src-vue/app-shared/overlays/wallet/WalletTransferOverlay.vue
+++ b/src-vue/app-shared/overlays/wallet/WalletTransferOverlay.vue
@@ -26,7 +26,7 @@
 
       <p v-else-if="transferToArgon" class="font-light text-slate-700">
         Moving
-        <strong>{{ props.request?.moveToken }}</strong>
+        <strong>{{ formatTokenAmount(transferToArgon.transferState.amount) }} {{ props.request?.moveToken }}</strong>
         from your
         <strong>{{ props.request?.networkName }}</strong>
         wallet into your

--- a/src-vue/interfaces/IEthereumInboundTransferTracker.ts
+++ b/src-vue/interfaces/IEthereumInboundTransferTracker.ts
@@ -10,6 +10,7 @@ export interface IEthereumInboundTransferState {
   isSubmitting: boolean;
   hasPersistedTransfer: boolean;
   needsAcknowledgement: boolean;
+  amount: bigint;
   targetWalletType?: IArgonWalletType;
   progress: ICrosschainTransferProgress;
   error: string;

--- a/src-vue/lib/ChartOptions.ts
+++ b/src-vue/lib/ChartOptions.ts
@@ -39,7 +39,7 @@ export function createChartOptions(
           pointHoverRadius: 0,
           pointHoverBackgroundColor: '#F8E7FB',
           pointRadius: 0,
-          lineTension: 1,
+          lineTension: 0.2,
         },
         {
           data: chartPoints,
@@ -51,7 +51,7 @@ export function createChartOptions(
           pointHoverRadius: 0,
           pointHoverBackgroundColor: '#A600D4',
           pointRadius: pointRadius,
-          lineTension: 1,
+          lineTension: 0.2,
         },
       ],
     },

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -32,6 +32,7 @@ import {
   type TransactionSerializableEIP1559,
   toHex,
 } from 'viem';
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import type { IEthereumMoveToken } from '../interfaces/IEthereumInboundTransferTracker.ts';
 import { sleep } from './Utils.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
@@ -93,7 +94,6 @@ type IEthereumGatewayUpdate = {
   payload: Hex;
   signatures: Hex[];
 };
-const ETHEREUM_PUBLIC_CLIENT_OPTIONS = { retryCount: 1, timeout: 15_000 } as const;
 const ethereumChainConfigPromises = new Map<string, Promise<IEthereumChainConfig | undefined>>();
 type EthereumExecutionReceipt = Awaited<ReturnType<PublicClient['getTransactionReceipt']>>;
 type MintingGatewayTransferOutOfArgonAuthorization = {
@@ -794,7 +794,11 @@ function createEthereumPublicClientForRpc(
 ): PublicClient {
   return createPublicClient({
     ...(chain ? { chain } : {}),
-    transport: http(executionRpcUrl, ETHEREUM_PUBLIC_CLIENT_OPTIONS),
+    transport: http(executionRpcUrl, {
+      retryCount: 1,
+      timeout: 15_000,
+      fetchFn: tauriFetch,
+    }),
   });
 }
 

--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -19,12 +19,18 @@ import {
   type ICrosschainInboundTransferRecord,
 } from './db/CrosschainInboundTransfersTable.ts';
 import type { Db } from './Db.ts';
-import { requestEthereumGatewayCatchUpThroughOperator, type ServerApiClient } from './ServerApiClient.ts';
+import {
+  requestEthereumGatewayCatchUpDispatch,
+  type IEthereumGatewayRelaySource,
+  type ServerApiClient,
+} from './ServerApiClient.ts';
 import { getEthereumGatewayPauseReason, getMainchainClient } from '../stores/mainchain.ts';
 import { TransactionTracker } from './TransactionTracker.ts';
 import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
 import { WalletType } from './Wallet.ts';
+import { convertEthereumTokenBaseUnitsToRuntimeAmount } from './WalletForEthereum.ts';
 import type { WalletKeys } from './WalletKeys.ts';
+import type { MyVault } from './MyVault.ts';
 
 export type {
   IArgonWalletType,
@@ -81,6 +87,7 @@ export class EthereumInboundTransferTracker {
       UpstreamOperatorClient,
       'operatorHost' | 'requestEthereumGatewayCatchUp'
     >,
+    private readonly myVault?: Pick<MyVault, 'createdVault'>,
   ) {}
 
   public async load(): Promise<void> {
@@ -157,6 +164,7 @@ export class EthereumInboundTransferTracker {
     this.data.latestTransferIdByToken[moveToken] = id;
     transfer.transferState = {
       ...createEmptyTransferState(),
+      amount: convertEthereumTokenBaseUnitsToRuntimeAmount(amountBaseUnits),
       isSubmitting: true,
       needsAcknowledgement: false,
       targetWalletType,
@@ -283,6 +291,7 @@ export class EthereumInboundTransferTracker {
     this.data.latestTransferIdByToken[moveToken] ??= record.id;
     transfer.transferState = {
       ...createEmptyTransferState(),
+      amount: convertEthereumTokenBaseUnitsToRuntimeAmount(record.amountBaseUnits),
       isSubmitting: !hasUnacknowledgedFailure(record),
       hasPersistedTransfer: true,
       needsAcknowledgement: hasUnacknowledgedFailure(record),
@@ -415,7 +424,7 @@ export class EthereumInboundTransferTracker {
         transferState.error = '';
         transferState.progress = setInboundEthereumStepProgress(transferState.progress, {
           progressPct: Math.max(txProgress?.progressPct ?? transferState.progress.steps[0]?.progressPct ?? 0, 1),
-          detail: 'Submitted to Ethereum. Waiting for the RPC to confirm the transfer...',
+          detail: 'Submitted to Ethereum. Waiting for confirmation...',
         });
       },
     });
@@ -516,7 +525,7 @@ export class EthereumInboundTransferTracker {
         const relayedBlocks = Math.max(0, latestRetainedBlockNumber - relayStartBlockNumber);
         transferState.progress = setInboundRelayStepProgress(transferState.progress, {
           progressPct: Math.min(99, Math.round((Math.min(relayedBlocks, totalRelayBlocks) / totalRelayBlocks) * 100)),
-          detail: `Waiting for ${remainingRelayBlocks.toLocaleString()} Ethereum blocks to sync`,
+          detail: `Waiting for Argon proof of ${remainingRelayBlocks.toLocaleString()} Ethereum blocks`,
         });
       } else {
         const argonStartHeight =
@@ -530,7 +539,7 @@ export class EthereumInboundTransferTracker {
             Math.round((Math.min(finalizedArgonBlocks, expectedArgonBlocks) / expectedArgonBlocks) * 100),
           ),
           detail: `Argon block ${Math.min(expectedArgonBlocks, finalizedArgonBlocks) + 1} of ${expectedArgonBlocks}`,
-          hint: 'Waiting for the relay to finalize on Argon.',
+          hint: 'Argon is finalizing this transfer now.',
         });
       }
 
@@ -603,13 +612,46 @@ export class EthereumInboundTransferTracker {
     const upstreamOperatorHost = this.upstreamOperatorClient.operatorHost;
     if (this.serverApiClient || upstreamOperatorHost) {
       this.#lastCatchUpRequestAt.set(record.id, now);
-      const relayError = await requestEthereumGatewayCatchUpThroughOperator({
+      const relayDispatch = await requestEthereumGatewayCatchUpDispatch({
         throughGatewayActivityNonce,
         serverApiClient: this.serverApiClient,
         upstreamOperatorClient: upstreamOperatorHost ? this.upstreamOperatorClient : undefined,
       });
-      transfer.transferState.error = shouldSurfaceRelayError(relayError ?? '', hasExceededWaitEstimate)
-        ? (relayError ?? '')
+      let isLocalRelaySetupComplete: boolean | undefined;
+      if (isRelayFundingError(relayDispatch.localRelayError ?? '')) {
+        const delegateAddress = await this.walletKeys.getVaultDelegateKeypair().then(x => x.address);
+        if (this.myVault?.createdVault) {
+          isLocalRelaySetupComplete = this.myVault.createdVault.bitcoinLockDelegateAccount === delegateAddress;
+        }
+      }
+      const relayHint = getRelayProgressHint({
+        relaySource: relayDispatch.relaySource,
+        localRelayError: relayDispatch.localRelayError,
+        isLocalRelaySetupComplete,
+        isFinalizingOnArgon: transfer.transferState.progress.currentStep >= 3,
+      });
+      if (relayHint) {
+        const activeStepIndex = Math.max(0, transfer.transferState.progress.currentStep - 1);
+        const nextSteps = transfer.transferState.progress.steps.map((step, index) => {
+          if (index !== activeStepIndex) {
+            return { ...step };
+          }
+
+          return {
+            ...step,
+            hint: relayHint,
+          };
+        });
+        transfer.transferState.progress = hydrateCrosschainTransferProgress(nextSteps);
+      }
+
+      transfer.transferState.error = shouldSurfaceRelayError(relayDispatch.relayError ?? '', hasExceededWaitEstimate)
+        ? getRelayErrorMessage({
+            relayError: relayDispatch.relayError ?? '',
+            relaySource: relayDispatch.relaySource,
+            localRelayError: relayDispatch.localRelayError,
+            isLocalRelaySetupComplete,
+          })
         : '';
     }
   }
@@ -658,6 +700,7 @@ function createEmptyTransferState(): IEthereumInboundTransferState {
     isSubmitting: false,
     hasPersistedTransfer: false,
     needsAcknowledgement: false,
+    amount: 0n,
     progress: createCrosschainTransferProgress(INBOUND_TRANSFER_STEP_TITLES),
     error: '',
   };
@@ -695,14 +738,81 @@ function getMoveToken(record: ICrosschainInboundTransferRecord): IEthereumMoveTo
 }
 
 function shouldSurfaceRelayError(reason: string, hasExceededWaitEstimate: boolean): boolean {
-  return hasExceededWaitEstimate && !shouldWaitForRelay(reason);
+  if (!reason) {
+    return false;
+  }
+
+  if (isRelayFundingError(reason)) {
+    return true;
+  }
+
+  return hasExceededWaitEstimate;
 }
 
-function shouldWaitForRelay(reason: string): boolean {
+function isRelayFundingError(reason: string): boolean {
   return (
     reason.includes('Vault delegate needs more funds before Ethereum relays can run.') ||
     reason.includes('Vault delegate cannot afford Ethereum gateway relay.')
   );
+}
+
+function getRelayErrorMessage(args: {
+  relayError: string;
+  relaySource?: IEthereumGatewayRelaySource;
+  localRelayError?: string;
+  isLocalRelaySetupComplete?: boolean;
+}): string {
+  const { relayError, relaySource, localRelayError, isLocalRelaySetupComplete } = args;
+  const serverOutOfRelayFunds = isRelayFundingError(localRelayError ?? '');
+  const relayRejectedForFunding = isRelayFundingError(relayError);
+
+  if (!serverOutOfRelayFunds && !relayRejectedForFunding) {
+    return relayError;
+  }
+
+  if (serverOutOfRelayFunds) {
+    return getLocalRelayFundingMessage(isLocalRelaySetupComplete);
+  }
+
+  if (relaySource === 'upstreamOperator') {
+    return 'This transfer has not been picked up on Argon yet.';
+  }
+
+  return relayError;
+}
+
+function getRelayProgressHint(args: {
+  relaySource?: IEthereumGatewayRelaySource;
+  localRelayError?: string;
+  isLocalRelaySetupComplete?: boolean;
+  isFinalizingOnArgon: boolean;
+}): string | undefined {
+  const { relaySource, localRelayError, isLocalRelaySetupComplete, isFinalizingOnArgon } = args;
+  if (relaySource === 'localServer') {
+    return isFinalizingOnArgon
+      ? 'Argon is finalizing this transfer now.'
+      : 'Your server is sending this transfer to Argon.';
+  }
+
+  if (relaySource === 'upstreamOperator') {
+    if (isFinalizingOnArgon) {
+      return 'Argon is finalizing this transfer now.';
+    }
+
+    if (isRelayFundingError(localRelayError ?? '')) {
+      return getLocalRelayFundingMessage(isLocalRelaySetupComplete);
+    }
+
+    return 'The Argon network is sending this transfer now.';
+  }
+}
+
+function getLocalRelayFundingMessage(isLocalRelaySetupComplete?: boolean): string {
+  if (isLocalRelaySetupComplete === false) {
+    return "Your server isn't set up to send this transfer yet, so this transfer is waiting for the Argon network to pick it up.";
+  }
+
+  return "Your server doesn't have enough relay funds, so this transfer is waiting for the Argon network to pick it up.";
 }
 
 function hasUnacknowledgedFailure(record: ICrosschainInboundTransferRecord | undefined): boolean {

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -800,32 +800,26 @@ export class EthereumOutboundTransferTracker {
       blockNumber: activeRecord.targetBlockNumber,
       blockHash: activeRecord.targetBlockHash,
       onProgress: txProgress => {
-        const visibleConfirmationGoal = 4;
-        const visibleConfirmationCount =
-          txProgress.confirmations < 0 ? 0 : Math.min(visibleConfirmationGoal, txProgress.confirmations + 1);
-
         let progressPct = 1;
         let detail = 'Submitted to Ethereum. Waiting for confirmation...';
         let hint: string | undefined;
 
-        if (visibleConfirmationCount > 0) {
-          progressPct = Math.round((visibleConfirmationCount / visibleConfirmationGoal) * 100);
-          detail =
-            visibleConfirmationCount === visibleConfirmationGoal
-              ? 'Submitted to Ethereum.'
-              : `Ethereum confirmation ${visibleConfirmationCount} of ${visibleConfirmationGoal}`;
-          hint =
-            visibleConfirmationCount === visibleConfirmationGoal
-              ? 'You can close this and check back later.'
-              : undefined;
+        if (txProgress.confirmations >= 0) {
+          progressPct = Math.max(1, txProgress.progressPct);
+          detail = formatCrosschainBlockStepDetail({
+            blockType: 'Ethereum',
+            confirmations: txProgress.confirmations,
+            expectedConfirmations: txProgress.expectedConfirmations,
+          });
+          hint = 'You can close this and check back later.';
         }
 
         transfer.transferState.progress = setOutboundEthereumStepProgress(transfer.transferState.progress, {
           progressPct,
           detail,
           hint,
-          confirmations: visibleConfirmationCount,
-          expectedConfirmations: visibleConfirmationGoal,
+          confirmations: txProgress.confirmations,
+          expectedConfirmations: txProgress.expectedConfirmations,
         });
       },
       onRpcDelay: txProgress => {
@@ -836,8 +830,10 @@ export class EthereumOutboundTransferTracker {
             txProgress?.progressPct ?? transfer.transferState.progress.steps[2]?.progressPct ?? 0,
             1,
           ),
-          detail: 'Submitted to Ethereum. Waiting for the RPC to confirm the transfer...',
+          detail: 'Submitted to Ethereum. Waiting for confirmation...',
           hint: 'You can close this and check back later.',
+          confirmations: txProgress?.confirmations,
+          expectedConfirmations: txProgress?.expectedConfirmations,
         });
       },
     });

--- a/src-vue/lib/ServerApiClient.ts
+++ b/src-vue/lib/ServerApiClient.ts
@@ -27,6 +27,12 @@ import {
 import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
 
 export type ServerGatewayDetails = Pick<IConfigServerDetails, 'ipAddress' | 'gatewayPort' | 'type'>;
+export type IEthereumGatewayRelaySource = 'localServer' | 'upstreamOperator';
+export type IEthereumGatewayCatchUpDispatchResult = {
+  relayError?: string;
+  relaySource?: IEthereumGatewayRelaySource;
+  localRelayError?: string;
+};
 
 export interface IBitcoinBlockChainInfo {
   chain: string;
@@ -368,6 +374,15 @@ export async function requestEthereumGatewayCatchUpThroughOperator(args: {
   serverApiClient?: Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
   upstreamOperatorClient?: Pick<UpstreamOperatorClient, 'operatorHost' | 'requestEthereumGatewayCatchUp'>;
 }): Promise<string | undefined> {
+  const result = await requestEthereumGatewayCatchUpDispatch(args);
+  return result.relayError;
+}
+
+export async function requestEthereumGatewayCatchUpDispatch(args: {
+  throughGatewayActivityNonce: bigint;
+  serverApiClient?: Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
+  upstreamOperatorClient?: Pick<UpstreamOperatorClient, 'operatorHost' | 'requestEthereumGatewayCatchUp'>;
+}): Promise<IEthereumGatewayCatchUpDispatchResult> {
   const { throughGatewayActivityNonce, serverApiClient, upstreamOperatorClient } = args;
   let localRelayError = '';
 
@@ -380,7 +395,9 @@ export async function requestEthereumGatewayCatchUpThroughOperator(args: {
           throughGatewayActivityNonce,
         });
         if (response.outcome !== 'Rejected') {
-          return;
+          return {
+            relaySource: 'localServer',
+          };
         }
 
         localRelayError = response.reason;
@@ -392,12 +409,15 @@ export async function requestEthereumGatewayCatchUpThroughOperator(args: {
     }
 
     if (!upstreamOperatorClient?.operatorHost) {
-      return localRelayError;
+      return {
+        relayError: localRelayError,
+        localRelayError,
+      };
     }
   }
 
   if (!upstreamOperatorClient?.operatorHost) {
-    return;
+    return {};
   }
 
   try {
@@ -405,8 +425,21 @@ export async function requestEthereumGatewayCatchUpThroughOperator(args: {
       sourceChain: 'Ethereum',
       throughGatewayActivityNonce,
     });
-    return response.outcome === 'Rejected' ? response.reason : undefined;
+    if (response.outcome === 'Rejected') {
+      return {
+        relayError: response.reason,
+        localRelayError: localRelayError || undefined,
+      };
+    }
+
+    return {
+      relaySource: 'upstreamOperator',
+      localRelayError: localRelayError || undefined,
+    };
   } catch (error) {
-    return error instanceof Error ? error.message : String(error);
+    return {
+      relayError: error instanceof Error ? error.message : String(error),
+      localRelayError: localRelayError || undefined,
+    };
   }
 }

--- a/src-vue/stores/moveFromEthereum.ts
+++ b/src-vue/stores/moveFromEthereum.ts
@@ -8,6 +8,7 @@ import { getTransactionTracker } from './transactions.ts';
 import { getUpstreamOperatorClient } from './upstreamOperator.ts';
 import { getWalletKeys } from './wallets.ts';
 import { getDbPromise } from './helpers/dbPromise.ts';
+import { getMyVault } from './vaults.ts';
 
 let ethereumMoveTracker: EthereumInboundTransferTracker;
 
@@ -23,6 +24,7 @@ export function getEthereumMoveTracker(): EthereumInboundTransferTracker {
     const ethereumClient = new EthereumClient(walletKeys, executionRpcUrl);
     const serverApiClient = getConfig().serverDetails.ipAddress ? getServerApiClient() : undefined;
     const upstreamOperatorClient = getUpstreamOperatorClient();
+    const myVault = getMyVault();
 
     ethereumMoveTracker = new EthereumInboundTransferTracker(
       dbPromise,
@@ -31,6 +33,7 @@ export function getEthereumMoveTracker(): EthereumInboundTransferTracker {
       ethereumClient,
       serverApiClient,
       upstreamOperatorClient,
+      myVault,
     );
     ethereumMoveTracker.data = reactive(ethereumMoveTracker.data) as any;
     ethereumMoveTracker.load().catch(handleFatalError.bind(ethereumMoveTracker));


### PR DESCRIPTION
## Summary
Ethereum RPC calls from the desktop app now go through Tauri's HTTP plugin, so balance checks and transfer polling on `v1.4.0` can reach the configured RPC host instead of failing in the renderer.

Minting authority setup now shows when the relay delegate still needs to be created or topped up, and lets the operator fix that directly from the request overlay before submitting.

Inbound and outbound Ethereum transfer progress now keep the moved amount visible, distinguish whether the local server or the Argon network is relaying, and use clearer proof and confirmation messaging while the transfer finalizes.

## Testing
- `yarn lint:check`
- `yarn typecheck`
- `yarn vitest --run src-vue/__test__/EthereumClient.test.ts`
- `yarn vitest --run src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts`
