### PR TITLE
Tauri Permissions

### DIFF
--- a/src-tauri/capabilities/dev.json
+++ b/src-tauri/capabilities/dev.json
@@ -11,7 +11,13 @@
           "url": "http://localhost:*/*"
         },
         {
+          "url": "https://localhost:*/*"
+        },
+        {
           "url": "http://127.0.0.1:*/*"
+        },
+        {
+          "url": "https://127.0.0.1:*/*"
         }
       ]
     }


### PR DESCRIPTION
Tauri permissions need to allow https for localhost dev mode. Otherwise, it's failing to connect to dev-docker network.