### PR TITLE
fix: recover beacon submissions and mining setup stalls

### DIFF
--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -54,10 +54,7 @@ import {
   EthereumBeaconSyncService,
   waitForFinalizedBeaconExecutionAtOrAbove,
 } from '../src/EthereumBeaconSyncService.ts';
-import {
-  SubmissionStatusError,
-  SubmissionStatusErrorCode,
-} from '../src/submitWithTerminalStatusWatch.ts';
+import { SubmissionStatusError, SubmissionStatusErrorCode } from '../src/submitWithTerminalStatusWatch.ts';
 
 const syncKeypair = { address: 'sync-account' } as any;
 
@@ -503,14 +500,12 @@ describe('EthereumBeaconSyncService', () => {
         headerInterval: 32n,
       });
     mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
-    submissionMock.submitWithTerminalStatusWatch
-      .mockRejectedValueOnce(droppedError)
-      .mockResolvedValueOnce({
-        result: {
-          extrinsic: { signedHash: 'tx-2-hash' },
-          waitForInFirstBlock: Promise.resolve(),
-        },
-      });
+    submissionMock.submitWithTerminalStatusWatch.mockRejectedValueOnce(droppedError).mockResolvedValueOnce({
+      result: {
+        extrinsic: { signedHash: 'tx-2-hash' },
+        waitForInFirstBlock: Promise.resolve(),
+      },
+    });
 
     const service = new EthereumBeaconSyncService(client, {
       beaconApiUrl: 'https://beacon.example',

--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -85,6 +85,9 @@ describe('EthereumBeaconSyncService', () => {
         },
       },
       rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => []),
+        },
         system: {
           accountNextIndex: vi.fn(async () => ({
             toNumber: () => startingNonce,
@@ -98,6 +101,7 @@ describe('EthereumBeaconSyncService', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -135,6 +139,7 @@ describe('EthereumBeaconSyncService', () => {
       latestSyncCommitteeUpdatePeriod: 11n,
       mode: 'needsBootstrap',
     });
+    expect(service.state().lastUpdatedAt).toBeInstanceOf(Date);
   });
 
   it('stays idle until the Ethereum transfer gateway is configured on-chain', async () => {
@@ -218,6 +223,116 @@ describe('EthereumBeaconSyncService', () => {
       lastSubmittedTxHash: 'tx-2-hash',
       mode: 'idle',
     });
+    expect(service.state().lastUpdatedAt).toBeInstanceOf(Date);
+  });
+
+  it('rechecks timed-out submitted beacon sync txs before retrying them', async () => {
+    vi.useFakeTimers();
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const txs: IMockTx[] = [{ id: 'tx-1' }];
+    const client = createClient(12);
+
+    (client.rpc.author.pendingExtrinsics as any) = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          hash: {
+            toHex: () => 'tx-1-hash',
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    mainchainMock.getEthereumBeaconSyncState
+      .mockResolvedValueOnce({
+        isBootstrapped: true,
+        hasNextSyncCommittee: true,
+        latestFinalizedBlockRoot: '0xabc',
+        latestFinalizedSlot: 800n,
+        nextRecommendedFinalizedSlot: 832n,
+        latestSyncCommitteeUpdatePeriod: 12n,
+        headerInterval: 32n,
+      })
+      .mockResolvedValueOnce({
+        isBootstrapped: true,
+        hasNextSyncCommittee: true,
+        latestFinalizedBlockRoot: '0xabc',
+        latestFinalizedSlot: 800n,
+        nextRecommendedFinalizedSlot: 832n,
+        latestSyncCommitteeUpdatePeriod: 12n,
+        headerInterval: 32n,
+      })
+      .mockResolvedValueOnce({
+        isBootstrapped: true,
+        hasNextSyncCommittee: true,
+        latestFinalizedBlockRoot: '0xabc',
+        latestFinalizedSlot: 800n,
+        nextRecommendedFinalizedSlot: 832n,
+        latestSyncCommitteeUpdatePeriod: 12n,
+        headerInterval: 32n,
+      })
+      .mockResolvedValueOnce({
+        isBootstrapped: true,
+        hasNextSyncCommittee: true,
+        latestFinalizedBlockRoot: '0xdef',
+        latestFinalizedSlot: 832n,
+        nextRecommendedFinalizedSlot: 864n,
+        latestSyncCommitteeUpdatePeriod: 13n,
+        headerInterval: 32n,
+      });
+    mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
+    mainchainMock.submitTx
+      .mockResolvedValueOnce({
+        extrinsic: { signedHash: 'tx-1-hash' },
+        waitForInFirstBlock: new Promise<void>(() => undefined),
+      })
+      .mockResolvedValueOnce({
+        extrinsic: { signedHash: 'tx-1-retry-hash' },
+        waitForInFirstBlock: Promise.resolve(),
+      });
+
+    const service = new EthereumBeaconSyncService(client, {
+      beaconApiUrl: 'https://beacon.example',
+      submitLane: createSubmitLane(client),
+    });
+
+    const firstRunPromise = service.runOnce();
+    await vi.waitFor(() => {
+      expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    await firstRunPromise;
+
+    expect(service.state()).toMatchObject({
+      lastSubmittedTxHash: 'tx-1-hash',
+      latestFinalizedSlot: 800n,
+      latestSyncCommitteeUpdatePeriod: 12n,
+      mode: 'submitting',
+    });
+
+    await service.runOnce();
+
+    expect(mainchainMock.getNextEthereumBeaconSyncTxs).toHaveBeenCalledTimes(1);
+    expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+    expect(service.state()).toMatchObject({
+      lastSubmittedTxHash: 'tx-1-hash',
+      latestFinalizedSlot: 800n,
+      latestSyncCommitteeUpdatePeriod: 12n,
+      mode: 'submitting',
+    });
+
+    await service.runOnce();
+
+    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(2, txs[0], syncKeypair, {
+      nonce: 12,
+    });
+    expect(service.state()).toMatchObject({
+      latestFinalizedSlot: 832n,
+      latestSyncCommitteeUpdatePeriod: 13n,
+      lastSubmittedTxHash: 'tx-1-retry-hash',
+      mode: 'idle',
+    });
+    expect(consoleWarnSpy).toHaveBeenCalled();
   });
 
   it('records errors and recovers on the next pass', async () => {

--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -1,42 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-type IMockSubmitResult = {
-  extrinsic: { signedHash: string };
-  waitForInFirstBlock: Promise<void>;
-};
+import { NetworkConfig } from '@argonprotocol/apps-core';
 
 type IMockTx = { id: string };
-type IMockSubmitOptions = { nonce?: number };
 
 const mainchainMock = vi.hoisted(() => {
   const dispatchErrorToString = vi.fn();
   const getEthereumBeaconSyncBootstrapTx = vi.fn();
   const getEthereumBeaconSyncState = vi.fn();
   const getNextEthereumBeaconSyncTxs = vi.fn();
-  const submitTx =
-    vi.fn<(tx: IMockTx, syncKeypair: unknown, options?: IMockSubmitOptions) => Promise<IMockSubmitResult>>();
-
-  class TxSubmitter {
-    private readonly tx: unknown;
-    private readonly syncKeypair: unknown;
-
-    constructor(_client: unknown, tx: unknown, syncKeypair: unknown) {
-      this.tx = tx;
-      this.syncKeypair = syncKeypair;
-    }
-
-    public submit(options?: IMockSubmitOptions): Promise<IMockSubmitResult> {
-      return submitTx(this.tx as IMockTx, this.syncKeypair, options);
-    }
-  }
 
   return {
     dispatchErrorToString,
     getEthereumBeaconSyncBootstrapTx,
     getEthereumBeaconSyncState,
     getNextEthereumBeaconSyncTxs,
-    submitTx,
-    TxSubmitter,
+  };
+});
+
+const submissionMock = vi.hoisted(() => {
+  const submitWithTerminalStatusWatch = vi.fn();
+
+  return {
+    submitWithTerminalStatusWatch,
   };
 });
 
@@ -49,16 +34,30 @@ vi.mock('@argonprotocol/mainchain', async () => {
     getEthereumBeaconSyncBootstrapTx: mainchainMock.getEthereumBeaconSyncBootstrapTx,
     getEthereumBeaconSyncState: mainchainMock.getEthereumBeaconSyncState,
     getNextEthereumBeaconSyncTxs: mainchainMock.getNextEthereumBeaconSyncTxs,
-    TxSubmitter: mainchainMock.TxSubmitter,
   };
 });
 
-import type { ArgonClient } from '@argonprotocol/mainchain';
+vi.mock('../src/submitWithTerminalStatusWatch.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/submitWithTerminalStatusWatch.ts')>(
+    '../src/submitWithTerminalStatusWatch.ts',
+  );
+
+  return {
+    ...actual,
+    submitWithTerminalStatusWatch: submissionMock.submitWithTerminalStatusWatch,
+  };
+});
+
+import { ExtrinsicError, type ArgonClient } from '@argonprotocol/mainchain';
 import { DelegateSubmitLane } from '../src/DelegateSubmitLane.ts';
 import {
   EthereumBeaconSyncService,
   waitForFinalizedBeaconExecutionAtOrAbove,
 } from '../src/EthereumBeaconSyncService.ts';
+import {
+  SubmissionStatusError,
+  SubmissionStatusErrorCode,
+} from '../src/submitWithTerminalStatusWatch.ts';
 
 const syncKeypair = { address: 'sync-account' } as any;
 
@@ -98,6 +97,7 @@ describe('EthereumBeaconSyncService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    NetworkConfig.setNetwork('mainnet');
   });
 
   afterEach(() => {
@@ -186,10 +186,12 @@ describe('EthereumBeaconSyncService', () => {
         headerInterval: 32n,
       });
     mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
-    mainchainMock.submitTx.mockImplementation(async (tx: IMockTx) => {
+    submissionMock.submitWithTerminalStatusWatch.mockImplementation(async (submitter: { tx: IMockTx }) => {
       return {
-        extrinsic: { signedHash: `${tx.id}-hash` },
-        waitForInFirstBlock: tx.id === 'tx-1' ? firstInBlock : Promise.resolve(),
+        result: {
+          extrinsic: { signedHash: `${submitter.tx.id}-hash` },
+          waitForInFirstBlock: submitter.tx.id === 'tx-1' ? firstInBlock : Promise.resolve(),
+        },
       };
     });
 
@@ -200,21 +202,35 @@ describe('EthereumBeaconSyncService', () => {
 
     const runOncePromise = service.runOnce();
     await vi.waitFor(() => {
-      expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+      expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
     });
 
-    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(1, txs[0], syncKeypair, {
-      nonce: 12,
-    });
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        account: syncKeypair,
+        address: syncKeypair.address,
+        client,
+        tx: txs[0],
+      }),
+      { nonce: 12 },
+    );
 
     resolveFirstInBlock();
     await vi.waitFor(() => {
-      expect(mainchainMock.submitTx).toHaveBeenCalledTimes(2);
+      expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);
     });
 
-    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(2, txs[1], syncKeypair, {
-      nonce: 13,
-    });
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        account: syncKeypair,
+        address: syncKeypair.address,
+        client,
+        tx: txs[1],
+      }),
+      { nonce: 13 },
+    );
     await runOncePromise;
 
     expect(service.state()).toMatchObject({
@@ -281,14 +297,18 @@ describe('EthereumBeaconSyncService', () => {
         headerInterval: 32n,
       });
     mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
-    mainchainMock.submitTx
+    submissionMock.submitWithTerminalStatusWatch
       .mockResolvedValueOnce({
-        extrinsic: { signedHash: 'tx-1-hash' },
-        waitForInFirstBlock: new Promise<void>(() => undefined),
+        result: {
+          extrinsic: { signedHash: 'tx-1-hash' },
+          waitForInFirstBlock: new Promise<void>(() => undefined),
+        },
       })
       .mockResolvedValueOnce({
-        extrinsic: { signedHash: 'tx-1-retry-hash' },
-        waitForInFirstBlock: Promise.resolve(),
+        result: {
+          extrinsic: { signedHash: 'tx-1-retry-hash' },
+          waitForInFirstBlock: Promise.resolve(),
+        },
       });
 
     const service = new EthereumBeaconSyncService(client, {
@@ -298,9 +318,9 @@ describe('EthereumBeaconSyncService', () => {
 
     const firstRunPromise = service.runOnce();
     await vi.waitFor(() => {
-      expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+      expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
     });
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(600_000);
     await firstRunPromise;
 
     expect(service.state()).toMatchObject({
@@ -313,7 +333,7 @@ describe('EthereumBeaconSyncService', () => {
     await service.runOnce();
 
     expect(mainchainMock.getNextEthereumBeaconSyncTxs).toHaveBeenCalledTimes(1);
-    expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
     expect(service.state()).toMatchObject({
       lastSubmittedTxHash: 'tx-1-hash',
       latestFinalizedSlot: 800n,
@@ -323,9 +343,16 @@ describe('EthereumBeaconSyncService', () => {
 
     await service.runOnce();
 
-    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(2, txs[0], syncKeypair, {
-      nonce: 12,
-    });
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        account: syncKeypair,
+        address: syncKeypair.address,
+        client,
+        tx: txs[0],
+      }),
+      { nonce: 12 },
+    );
     expect(service.state()).toMatchObject({
       latestFinalizedSlot: 832n,
       latestSyncCommitteeUpdatePeriod: 13n,
@@ -448,9 +475,12 @@ describe('EthereumBeaconSyncService', () => {
     expect(service.state().lastError).toBeUndefined();
   });
 
-  it('continues when the submit error is classified as outdated', async () => {
+  it('continues when the submit error is retryable after the node drops it', async () => {
     const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
-    const outdatedError = new Error('Invalid Transaction: Transaction is outdated');
+    const droppedError = new SubmissionStatusError(
+      SubmissionStatusErrorCode.Dropped,
+      'Transaction was dropped before it was included in a block.',
+    );
     const client = createClient(12);
 
     mainchainMock.getEthereumBeaconSyncState
@@ -473,10 +503,14 @@ describe('EthereumBeaconSyncService', () => {
         headerInterval: 32n,
       });
     mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
-    mainchainMock.submitTx.mockRejectedValueOnce(outdatedError).mockResolvedValueOnce({
-      extrinsic: { signedHash: 'tx-2-hash' },
-      waitForInFirstBlock: Promise.resolve(),
-    });
+    submissionMock.submitWithTerminalStatusWatch
+      .mockRejectedValueOnce(droppedError)
+      .mockResolvedValueOnce({
+        result: {
+          extrinsic: { signedHash: 'tx-2-hash' },
+          waitForInFirstBlock: Promise.resolve(),
+        },
+      });
 
     const service = new EthereumBeaconSyncService(client, {
       beaconApiUrl: 'https://beacon.example',
@@ -485,12 +519,26 @@ describe('EthereumBeaconSyncService', () => {
 
     await service.runOnce();
 
-    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(1, txs[0], syncKeypair, {
-      nonce: 12,
-    });
-    expect(mainchainMock.submitTx).toHaveBeenNthCalledWith(2, txs[1], syncKeypair, {
-      nonce: 12,
-    });
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        account: syncKeypair,
+        address: syncKeypair.address,
+        client,
+        tx: txs[0],
+      }),
+      { nonce: 12 },
+    );
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        account: syncKeypair,
+        address: syncKeypair.address,
+        client,
+        tx: txs[1],
+      }),
+      { nonce: 12 },
+    );
     expect(service.state()).toMatchObject({
       latestFinalizedSlot: 832n,
       latestSyncCommitteeUpdatePeriod: 13n,
@@ -512,8 +560,8 @@ describe('EthereumBeaconSyncService', () => {
       headerInterval: 32n,
     });
     mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue([{ id: 'tx-1' }]);
-    mainchainMock.submitTx.mockRejectedValue(
-      new Error('ExtrinsicError: ethereumVerifier.ExpectedFinalizedHeaderNotStored'),
+    submissionMock.submitWithTerminalStatusWatch.mockRejectedValue(
+      new ExtrinsicError('ethereumVerifier.ExpectedFinalizedHeaderNotStored'),
     );
 
     const service = new EthereumBeaconSyncService(client, {
@@ -523,7 +571,7 @@ describe('EthereumBeaconSyncService', () => {
 
     await service.runOnce();
 
-    expect(mainchainMock.submitTx).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
     expect(service.state()).toMatchObject({
       latestFinalizedSlot: 800n,
       latestSyncCommitteeUpdatePeriod: 12n,

--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NetworkConfig } from '@argonprotocol/apps-core';
-import {
-  SubmissionStatusError,
-  SubmissionStatusErrorCode,
-} from '../src/submitWithTerminalStatusWatch.ts';
+import { SubmissionStatusError, SubmissionStatusErrorCode } from '../src/submitWithTerminalStatusWatch.ts';
 
 const gatewayProofMock = vi.hoisted(() => {
   return {
@@ -210,45 +207,49 @@ describe('EthereumGatewayProverService', () => {
         gatewayActivityNonceRange: { start: 7n, end: 7n },
         activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
       });
-    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => {
-      const droppedSubmission = Promise.reject(
-        new SubmissionStatusError(
-          SubmissionStatusErrorCode.Dropped,
-          'Transaction was dropped before it was included in a block.',
-        ),
-      );
-      droppedSubmission.catch(() => undefined);
+    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(
+      async (_submitter, options?: { nonce?: number }) => {
+        const droppedSubmission = Promise.reject(
+          new SubmissionStatusError(
+            SubmissionStatusErrorCode.Dropped,
+            'Transaction was dropped before it was included in a block.',
+          ),
+        );
+        droppedSubmission.catch(() => undefined);
 
-      return {
+        return {
+          signedTx: {
+            method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+            nonce: { toNumber: () => options?.nonce ?? 0 },
+          },
+          result: {
+            extrinsic: {
+              signedHash: '0xstale',
+              submittedAtBlockNumber: 321,
+              submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+            },
+            waitForInFirstBlock: droppedSubmission,
+          },
+        };
+      },
+    );
+    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(
+      async (_submitter, options?: { nonce?: number }) => ({
         signedTx: {
           method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
           nonce: { toNumber: () => options?.nonce ?? 0 },
         },
         result: {
           extrinsic: {
-            signedHash: '0xstale',
-            submittedAtBlockNumber: 321,
-            submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+            signedHash: '0xrelaytx',
+            submittedAtBlockNumber: 322,
+            submittedTime: new Date('2026-05-13T16:00:01.000Z'),
           },
-          waitForInFirstBlock: droppedSubmission,
+          blockNumber: 322,
+          waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
         },
-      };
-    });
-    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
-      signedTx: {
-        method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
-        nonce: { toNumber: () => options?.nonce ?? 0 },
-      },
-      result: {
-        extrinsic: {
-          signedHash: '0xrelaytx',
-          submittedAtBlockNumber: 322,
-          submittedTime: new Date('2026-05-13T16:00:01.000Z'),
-        },
-        blockNumber: 322,
-        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
-      },
-    }));
+      }),
+    );
 
     await expect(
       service.runToCheckpoint({ sourceChain: 'Ethereum', throughGatewayActivityNonce: 7n }),

--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NetworkConfig } from '@argonprotocol/apps-core';
+import {
+  SubmissionStatusError,
+  SubmissionStatusErrorCode,
+} from '../src/submitWithTerminalStatusWatch.ts';
 
 const gatewayProofMock = vi.hoisted(() => {
   return {
@@ -16,23 +20,17 @@ const viemMock = vi.hoisted(() => {
 });
 
 const mainchainMock = vi.hoisted(() => {
-  const sign = vi.fn();
-  const submitSigned = vi.fn();
+  return {
+    buildGatewayActivityProofPayload: gatewayProofMock.buildGatewayActivityProofPayload,
+    getLatestArgonFinalizedExecutionHeader: gatewayProofMock.getLatestArgonFinalizedExecutionHeader,
+  };
+});
 
-  class TxSubmitter {
-    public async sign(options?: { nonce?: number }): Promise<unknown> {
-      return (await sign(options)) as unknown;
-    }
-
-    public async submitSigned(signedTx: unknown): Promise<unknown> {
-      return (await submitSigned(signedTx)) as unknown;
-    }
-  }
+const submissionMock = vi.hoisted(() => {
+  const submitWithTerminalStatusWatch = vi.fn();
 
   return {
-    sign,
-    submitSigned,
-    TxSubmitter,
+    submitWithTerminalStatusWatch,
   };
 });
 
@@ -48,9 +46,19 @@ vi.mock('@argonprotocol/mainchain', async () => {
   const actual = await vi.importActual<typeof import('@argonprotocol/mainchain')>('@argonprotocol/mainchain');
   return {
     ...actual,
-    TxSubmitter: mainchainMock.TxSubmitter,
-    buildGatewayActivityProofPayload: gatewayProofMock.buildGatewayActivityProofPayload,
-    getLatestArgonFinalizedExecutionHeader: gatewayProofMock.getLatestArgonFinalizedExecutionHeader,
+    buildGatewayActivityProofPayload: mainchainMock.buildGatewayActivityProofPayload,
+    getLatestArgonFinalizedExecutionHeader: mainchainMock.getLatestArgonFinalizedExecutionHeader,
+  };
+});
+
+vi.mock('../src/submitWithTerminalStatusWatch.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/submitWithTerminalStatusWatch.ts')>(
+    '../src/submitWithTerminalStatusWatch.ts',
+  );
+
+  return {
+    ...actual,
+    submitWithTerminalStatusWatch: submissionMock.submitWithTerminalStatusWatch,
   };
 });
 
@@ -154,15 +162,17 @@ describe('EthereumGatewayProverService', () => {
         gatewayActivityNonceRange: { start: 8n, end: 9n },
         activities: [{ gatewayState: { gatewayActivityNonce: 9n } }],
       });
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     await expect(
@@ -178,10 +188,10 @@ describe('EthereumGatewayProverService', () => {
       estimatedFee: 11n,
       throughGatewayActivityNonce: 9n,
     });
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(2);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);
   });
 
-  it('retries with a refreshed nonce when the delegate submit comes back stale', async () => {
+  it('retries with a refreshed nonce when the node drops the delegate submission', async () => {
     const client = createClient();
     const service = new EthereumGatewayProverService(createSubmitLane(client));
     const accountNextIndex = client.rpc.system.accountNextIndex as ReturnType<typeof vi.fn>;
@@ -200,22 +210,36 @@ describe('EthereumGatewayProverService', () => {
         gatewayActivityNonceRange: { start: 7n, end: 7n },
         activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
       });
-    mainchainMock.sign.mockImplementation(async (options?: { nonce?: number }) => ({
-      method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
-      nonce: { toNumber: () => options?.nonce ?? 0 },
-    }));
-    const staleSubmission = Promise.reject(new Error('Invalid Transaction: Stale'));
-    staleSubmission.catch(() => undefined);
-    mainchainMock.submitSigned
-      .mockResolvedValueOnce({
-        extrinsic: {
-          signedHash: '0xstale',
-          submittedAtBlockNumber: 321,
-          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => {
+      const droppedSubmission = Promise.reject(
+        new SubmissionStatusError(
+          SubmissionStatusErrorCode.Dropped,
+          'Transaction was dropped before it was included in a block.',
+        ),
+      );
+      droppedSubmission.catch(() => undefined);
+
+      return {
+        signedTx: {
+          method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+          nonce: { toNumber: () => options?.nonce ?? 0 },
         },
-        waitForInFirstBlock: staleSubmission,
-      })
-      .mockResolvedValueOnce({
+        result: {
+          extrinsic: {
+            signedHash: '0xstale',
+            submittedAtBlockNumber: 321,
+            submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+          },
+          waitForInFirstBlock: droppedSubmission,
+        },
+      };
+    });
+    submissionMock.submitWithTerminalStatusWatch.mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
+      signedTx: {
+        method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+        nonce: { toNumber: () => options?.nonce ?? 0 },
+      },
+      result: {
         extrinsic: {
           signedHash: '0xrelaytx',
           submittedAtBlockNumber: 322,
@@ -223,7 +247,8 @@ describe('EthereumGatewayProverService', () => {
         },
         blockNumber: 322,
         waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
-      });
+      },
+    }));
 
     await expect(
       service.runToCheckpoint({ sourceChain: 'Ethereum', throughGatewayActivityNonce: 7n }),
@@ -238,7 +263,7 @@ describe('EthereumGatewayProverService', () => {
       estimatedFee: 7n,
       throughGatewayActivityNonce: 7n,
     });
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(2);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);
   });
 
   it('releases a timed-out first-block wait so a later catch-up can run', async () => {
@@ -246,35 +271,43 @@ describe('EthereumGatewayProverService', () => {
 
     const client = createClient();
     const service = new EthereumGatewayProverService(createSubmitLane(client));
-    mainchainMock.sign.mockImplementation(async (options?: { nonce?: number }) => ({
-      method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
-      nonce: { toNumber: () => options?.nonce ?? 0 },
-    }));
     gatewayProofMock.buildGatewayActivityProofPayload.mockResolvedValue({
       previousGatewayActivityNonce: 6n,
       proof: { batch: 'proof' },
       gatewayActivityNonceRange: { start: 7n, end: 7n },
       activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
     });
-    mainchainMock.submitSigned
-      .mockResolvedValueOnce({
-        extrinsic: {
-          signedHash: '0xtimeout',
-          submittedAtBlockNumber: 321,
-          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch
+      .mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
+        signedTx: {
+          method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+          nonce: { toNumber: () => options?.nonce ?? 0 },
         },
-        blockNumber: 321,
-        waitForInFirstBlock: new Promise(() => undefined),
-      })
-      .mockResolvedValueOnce({
-        extrinsic: {
-          signedHash: '0xretry',
-          submittedAtBlockNumber: 322,
-          submittedTime: new Date('2026-05-13T16:01:00.000Z'),
+        result: {
+          extrinsic: {
+            signedHash: '0xtimeout',
+            submittedAtBlockNumber: 321,
+            submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+          },
+          blockNumber: 321,
+          waitForInFirstBlock: new Promise(() => undefined),
         },
-        blockNumber: 322,
-        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
-      });
+      }))
+      .mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
+        signedTx: {
+          method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+          nonce: { toNumber: () => options?.nonce ?? 0 },
+        },
+        result: {
+          extrinsic: {
+            signedHash: '0xretry',
+            submittedAtBlockNumber: 322,
+            submittedTime: new Date('2026-05-13T16:01:00.000Z'),
+          },
+          blockNumber: 322,
+          waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
+        },
+      }));
 
     const firstCatchUp = service.runToCheckpoint({
       sourceChain: 'Ethereum',
@@ -306,7 +339,7 @@ describe('EthereumGatewayProverService', () => {
       estimatedFee: 7n,
       throughGatewayActivityNonce: 7n,
     });
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(2);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);
   });
 
   it('rejects when the delegate cannot afford the relay reserve', async () => {
@@ -339,7 +372,7 @@ describe('EthereumGatewayProverService', () => {
       estimatedFee: 5n,
       throughGatewayActivityNonce: 7n,
     });
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
   });
 
   it('reports relay readiness without submitting work', async () => {
@@ -371,7 +404,7 @@ describe('EthereumGatewayProverService', () => {
     });
 
     await service.start();
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
 
     await service.shutdown();
   });
@@ -431,15 +464,17 @@ describe('EthereumGatewayProverService', () => {
     });
 
     gatewayProofMock.buildGatewayActivityProofPayload.mockReturnValueOnce(buildProofPlan);
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     const first = service.runToCheckpoint({ sourceChain: 'Ethereum', throughGatewayActivityNonce: 7n });
@@ -477,7 +512,7 @@ describe('EthereumGatewayProverService', () => {
       },
     ]);
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledTimes(1);
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
   });
 
   it('does not bypass staggered relay scheduling on startup', async () => {
@@ -497,20 +532,22 @@ describe('EthereumGatewayProverService', () => {
       gatewayActivityNonceRange: { start: 7n, end: 7n },
       activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
     });
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     await service.start();
 
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
 
     await service.shutdown();
   });
@@ -532,23 +569,25 @@ describe('EthereumGatewayProverService', () => {
       gatewayActivityNonceRange: { start: 7n, end: 7n },
       activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
     });
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     await service.start();
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(72_000);
 
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
 
     await service.shutdown();
   });
@@ -582,30 +621,32 @@ describe('EthereumGatewayProverService', () => {
         },
       ],
     });
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     await runBackgroundSweep();
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledTimes(1);
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
 
     vi.setSystemTime(new Date('2026-05-13T16:00:23.000Z'));
     await runBackgroundSweep();
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledTimes(2);
-    expect(mainchainMock.sign).not.toHaveBeenCalled();
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
 
     vi.setSystemTime(new Date('2026-05-13T16:01:11.000Z'));
     await runBackgroundSweep();
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledTimes(4);
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
   });
 
   it('prioritizes owned outbound relay work without waiting for a stagger window', async () => {
@@ -643,21 +684,23 @@ describe('EthereumGatewayProverService', () => {
         },
       ],
     });
-    mainchainMock.sign.mockResolvedValue(signedTx);
-    mainchainMock.submitSigned.mockResolvedValue({
-      extrinsic: {
-        signedHash: '0xrelaytx',
-        submittedAtBlockNumber: 321,
-        submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
       },
-      blockNumber: 321,
-      waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
     });
 
     await runBackgroundSweep();
 
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledTimes(1);
-    expect(mainchainMock.sign).toHaveBeenCalledTimes(1);
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/bot/__test__/submitWithTerminalStatusWatch.test.ts
+++ b/bot/__test__/submitWithTerminalStatusWatch.test.ts
@@ -1,49 +1,17 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  SubmissionStatusErrorCode,
-  submitWithTerminalStatusWatch,
-} from '../src/submitWithTerminalStatusWatch.ts';
+import { SubmissionStatusErrorCode, submitWithTerminalStatusWatch } from '../src/submitWithTerminalStatusWatch.ts';
 
 describe('submitWithTerminalStatusWatch', () => {
   it('rejects the tx result when the node drops the transaction before inclusion', async () => {
-    let onResult!: (result: unknown) => void;
-    const signedTx = {
-      hash: {
-        toHex: () => '0xdropped',
-      },
-      method: {
-        toHuman: () => ({ section: 'ethereumVerifier', method: 'submit' }),
-      },
-      nonce: {
-        toNumber: () => 7,
-      },
-      send: vi.fn(async callback => {
-        onResult = callback as (result: unknown) => void;
-      }),
-    };
-    const submitter = {
-      address: '5SyncAccount',
-      client: {
-        rpc: {
-          chain: {
-            getHeader: vi.fn(async () => ({
-              number: {
-                toNumber: () => 123,
-              },
-            })),
-          },
-        },
-      },
-      sign: vi.fn(async () => signedTx),
-    } as any;
+    const harness = createSubmissionHarness();
 
-    const { result, signedTx: returnedSignedTx } = await submitWithTerminalStatusWatch(submitter, {
+    const { result, signedTx: returnedSignedTx } = await submitWithTerminalStatusWatch(harness.submitter, {
       nonce: 7,
     });
 
-    expect(returnedSignedTx).toBe(signedTx);
+    expect(returnedSignedTx).toBe(harness.signedTx);
 
-    onResult({
+    harness.emitResult({
       events: [],
       isFinalized: false,
       status: {
@@ -62,5 +30,110 @@ describe('submitWithTerminalStatusWatch', () => {
     await expect(result.waitForFinalizedBlock).rejects.toMatchObject({
       code: SubmissionStatusErrorCode.Dropped,
     });
+    expect(harness.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes after the transaction is finalized', async () => {
+    const harness = createSubmissionHarness();
+
+    const { result } = await submitWithTerminalStatusWatch(harness.submitter, {
+      nonce: 7,
+    });
+
+    harness.emitResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: true,
+        isInvalid: false,
+        isUsurped: false,
+        asInBlock: new Uint8Array([1, 2, 3]),
+      },
+      txIndex: 0,
+    });
+
+    await expect(result.waitForInFirstBlock).resolves.toEqual(Uint8Array.from([1, 2, 3]));
+    expect(harness.unsubscribe).not.toHaveBeenCalled();
+
+    harness.emitResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 0,
+    });
+
+    await expect(result.waitForFinalizedBlock).resolves.toEqual(Uint8Array.from([1, 2, 3]));
+    expect(harness.unsubscribe).toHaveBeenCalledOnce();
   });
 });
+
+function createSubmissionHarness() {
+  let onResult!: (result: unknown) => void;
+  const unsubscribe = vi.fn();
+
+  const blockNumber = {
+    toNumber: () => 123,
+  };
+  const blockNumberAtInclusion = {
+    toNumber: () => 124,
+  };
+
+  const client = {
+    rpc: {
+      chain: {
+        getHeader: vi.fn(async (_blockHash?: Uint8Array) => ({
+          number: _blockHash ? blockNumberAtInclusion : blockNumber,
+        })),
+      },
+    },
+    events: {
+      system: {
+        ExtrinsicFailed: { is: () => false },
+      },
+      utility: {
+        BatchInterrupted: { is: () => false },
+      },
+      transactionPayment: {
+        TransactionFeePaid: { is: () => false },
+      },
+    },
+  };
+
+  const signedTx = {
+    hash: {
+      toHex: () => '0xdropped',
+    },
+    method: {
+      toHuman: () => ({ section: 'ethereumVerifier', method: 'submit' }),
+    },
+    nonce: {
+      toNumber: () => 7,
+    },
+    send: vi.fn(async callback => {
+      onResult = callback as (result: unknown) => void;
+      return unsubscribe;
+    }),
+  };
+  const submitter = {
+    address: '5SyncAccount',
+    client,
+    sign: vi.fn(async () => signedTx),
+  } as any;
+
+  return {
+    emitResult(result: unknown) {
+      onResult(result);
+    },
+    signedTx,
+    submitter,
+    unsubscribe,
+  };
+}

--- a/bot/__test__/submitWithTerminalStatusWatch.test.ts
+++ b/bot/__test__/submitWithTerminalStatusWatch.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SubmissionStatusErrorCode,
+  submitWithTerminalStatusWatch,
+} from '../src/submitWithTerminalStatusWatch.ts';
+
+describe('submitWithTerminalStatusWatch', () => {
+  it('rejects the tx result when the node drops the transaction before inclusion', async () => {
+    let onResult!: (result: unknown) => void;
+    const signedTx = {
+      hash: {
+        toHex: () => '0xdropped',
+      },
+      method: {
+        toHuman: () => ({ section: 'ethereumVerifier', method: 'submit' }),
+      },
+      nonce: {
+        toNumber: () => 7,
+      },
+      send: vi.fn(async callback => {
+        onResult = callback as (result: unknown) => void;
+      }),
+    };
+    const submitter = {
+      address: '5SyncAccount',
+      client: {
+        rpc: {
+          chain: {
+            getHeader: vi.fn(async () => ({
+              number: {
+                toNumber: () => 123,
+              },
+            })),
+          },
+        },
+      },
+      sign: vi.fn(async () => signedTx),
+    } as any;
+
+    const { result, signedTx: returnedSignedTx } = await submitWithTerminalStatusWatch(submitter, {
+      nonce: 7,
+    });
+
+    expect(returnedSignedTx).toBe(signedTx);
+
+    onResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: true,
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: undefined,
+    });
+
+    await expect(result.waitForInFirstBlock).rejects.toMatchObject({
+      code: SubmissionStatusErrorCode.Dropped,
+    });
+    await expect(result.waitForFinalizedBlock).rejects.toMatchObject({
+      code: SubmissionStatusErrorCode.Dropped,
+    });
+  });
+});

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -1,5 +1,5 @@
-import { setTimeout } from 'node:timers/promises';
-import { NetworkConfig, SingleFileQueue, type IEthereumSyncStatus } from '@argonprotocol/apps-core';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { NetworkConfig, raceWithTimeout, SingleFileQueue, type IEthereumSyncStatus } from '@argonprotocol/apps-core';
 import {
   dispatchErrorToString,
   type ArgonClient,
@@ -29,6 +29,7 @@ type IEthereumBeaconBootstrapOptions = {
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_BOOTSTRAP_POLL_MS = 1_000;
 const DEFAULT_BEACON_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_SUBMISSION_INCLUSION_TIMEOUT_MS = 60_000;
 
 export class EthereumBeaconSyncService {
   private loopPromise?: Promise<void>;
@@ -80,6 +81,8 @@ export class EthereumBeaconSyncService {
         await this.runOnceInner();
       } catch (error) {
         this.recordError(error);
+      } finally {
+        this.stateData.lastUpdatedAt = new Date();
       }
     }).promise;
   }
@@ -133,7 +136,7 @@ export class EthereumBeaconSyncService {
         if (!isBootstrapEndpointNotReady(error.message)) {
           throw error;
         }
-        await setTimeout(pollMs);
+        await sleep(pollMs);
       }
     }
 
@@ -169,7 +172,7 @@ export class EthereumBeaconSyncService {
 
   private async loop(): Promise<void> {
     while (!this.shouldStop) {
-      await setTimeout(this.pollMs);
+      await sleep(this.pollMs);
       if (this.shouldStop) break;
       await this.runOnce();
     }
@@ -208,6 +211,25 @@ export class EthereumBeaconSyncService {
     this.stateData.latestFinalizedSlot = syncState.latestFinalizedSlot;
     await this.updateExecutionLag();
 
+    if (this.stateData.mode === 'submitting' && this.stateData.lastSubmittedTxHash) {
+      const pendingExtrinsics = await this.client.rpc.author.pendingExtrinsics();
+      const isSubmittedTxStillPending = pendingExtrinsics.some(
+        pendingExtrinsic => pendingExtrinsic.hash.toHex() === this.stateData.lastSubmittedTxHash,
+      );
+
+      if (isSubmittedTxStillPending) {
+        return;
+      }
+
+      console.warn(
+        `[EthereumBeaconSyncService] Submitted beacon sync tx ${this.stateData.lastSubmittedTxHash} ` +
+          'is no longer pending before inclusion was observed; retrying',
+      );
+      submitLane.invalidateNonce();
+      this.stateData.mode = 'idle';
+      delete this.stateData.lastSubmittedTxHash;
+    }
+
     let txs;
     try {
       txs = await getNextEthereumBeaconSyncTxs(this.client, beaconApiUrl);
@@ -235,7 +257,20 @@ export class EthereumBeaconSyncService {
           });
         });
         this.stateData.lastSubmittedTxHash = result.extrinsic.signedHash;
-        await result.waitForInFirstBlock;
+        const inclusionTimeoutMs = Math.max(this.pollMs * 2, DEFAULT_SUBMISSION_INCLUSION_TIMEOUT_MS);
+        const observedInFirstBlock = await raceWithTimeout(
+          result.waitForInFirstBlock.then(() => true),
+          inclusionTimeoutMs,
+          () => false,
+        );
+
+        if (!observedInFirstBlock) {
+          console.warn(
+            `[EthereumBeaconSyncService] Submitted beacon sync tx ${result.extrinsic.signedHash} ` +
+              `but did not observe its first block within ${inclusionTimeoutMs}ms; will re-check next sweep`,
+          );
+          return;
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (isOutdatedBeaconSyncSubmitError(error) || message.includes('Priority is too low')) {
@@ -379,7 +414,7 @@ export async function waitForFinalizedBeaconExecutionAtOrAbove(
       }
     }
 
-    await setTimeout(pollMs);
+    await sleep(pollMs);
   }
 
   const lastErrorSuffix = lastError ? ` (${lastError.message})` : '';

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -14,10 +14,7 @@ import {
 } from '@argonprotocol/mainchain';
 import { createPublicClient, http } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
-import {
-  isSubmissionStatusError,
-  submitWithTerminalStatusWatch,
-} from './submitWithTerminalStatusWatch.ts';
+import { isSubmissionStatusError, submitWithTerminalStatusWatch } from './submitWithTerminalStatusWatch.ts';
 
 type IEthereumBeaconSyncServiceOptions = {
   beaconApiUrl?: string;
@@ -284,7 +281,10 @@ export class EthereumBeaconSyncService {
           submitLane.invalidateNonce();
           continue;
         }
-        if (error instanceof ExtrinsicError && error.errorCode === 'ethereumVerifier.ExpectedFinalizedHeaderNotStored') {
+        if (
+          error instanceof ExtrinsicError &&
+          error.errorCode === 'ethereumVerifier.ExpectedFinalizedHeaderNotStored'
+        ) {
           this.stateData.mode = 'idle';
           return;
         }

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -3,15 +3,21 @@ import { NetworkConfig, raceWithTimeout, SingleFileQueue, type IEthereumSyncStat
 import {
   dispatchErrorToString,
   type ArgonClient,
+  ExtrinsicError,
   getEthereumBeaconSyncBootstrapTx,
   getEthereumBeaconSyncState,
   getLatestArgonFinalizedExecutionHeader,
   getNextEthereumBeaconSyncTxs,
+  isOutdatedTransactionError,
   type KeyringPair,
   TxSubmitter,
 } from '@argonprotocol/mainchain';
 import { createPublicClient, http } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
+import {
+  isSubmissionStatusError,
+  submitWithTerminalStatusWatch,
+} from './submitWithTerminalStatusWatch.ts';
 
 type IEthereumBeaconSyncServiceOptions = {
   beaconApiUrl?: string;
@@ -29,7 +35,7 @@ type IEthereumBeaconBootstrapOptions = {
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_BOOTSTRAP_POLL_MS = 1_000;
 const DEFAULT_BEACON_REQUEST_TIMEOUT_MS = 10_000;
-const DEFAULT_SUBMISSION_INCLUSION_TIMEOUT_MS = 60_000;
+const SUBMISSION_INCLUSION_BLOCKS = 10;
 
 export class EthereumBeaconSyncService {
   private loopPromise?: Promise<void>;
@@ -252,12 +258,14 @@ export class EthereumBeaconSyncService {
 
       try {
         const result = await submitLane.runExclusive(async (client, getNonce) => {
-          return await new TxSubmitter(client, tx, submitLane.keypair).submit({
-            nonce: await getNonce(),
-          });
+          return (
+            await submitWithTerminalStatusWatch(new TxSubmitter(client, tx, submitLane.keypair), {
+              nonce: await getNonce(),
+            })
+          ).result;
         });
         this.stateData.lastSubmittedTxHash = result.extrinsic.signedHash;
-        const inclusionTimeoutMs = Math.max(this.pollMs * 2, DEFAULT_SUBMISSION_INCLUSION_TIMEOUT_MS);
+        const inclusionTimeoutMs = NetworkConfig.tickMillis * SUBMISSION_INCLUSION_BLOCKS;
         const observedInFirstBlock = await raceWithTimeout(
           result.waitForInFirstBlock.then(() => true),
           inclusionTimeoutMs,
@@ -272,12 +280,11 @@ export class EthereumBeaconSyncService {
           return;
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (isOutdatedBeaconSyncSubmitError(error) || message.includes('Priority is too low')) {
+        if (isRetryableBeaconSyncSubmitError(error)) {
           submitLane.invalidateNonce();
           continue;
         }
-        if (message.includes('ethereumVerifier.ExpectedFinalizedHeaderNotStored')) {
+        if (error instanceof ExtrinsicError && error.errorCode === 'ethereumVerifier.ExpectedFinalizedHeaderNotStored') {
           this.stateData.mode = 'idle';
           return;
         }
@@ -436,11 +443,8 @@ function isLightClientFinalityUpdateNotReady(error: unknown): boolean {
   );
 }
 
-function isOutdatedBeaconSyncSubmitError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes('Invalid Transaction: Transaction is outdated') || message.includes('InvalidTransaction::Stale')
-  );
+function isRetryableBeaconSyncSubmitError(error: unknown): boolean {
+  return isOutdatedTransactionError(error) || isSubmissionStatusError(error);
 }
 
 async function getBeaconJson<T>(

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -21,6 +21,10 @@ import { createHash } from 'node:crypto';
 import { createPublicClient, http, type Hex } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
 import { HttpError } from './HttpError.ts';
+import {
+  isSubmissionStatusError,
+  submitWithTerminalStatusWatch,
+} from './submitWithTerminalStatusWatch.ts';
 
 export class EthereumGatewayProverService {
   private startPromise?: Promise<void>;
@@ -460,8 +464,9 @@ export class EthereumGatewayProverService {
                 `estimated fee ${estimatedFee}`,
             );
             const submitter = new TxSubmitter(lockedClient, tx, this.submitLane.keypair);
-            const signedTx = await submitter.sign({ nonce: await getNonce() });
-            const submitted = await submitter.submitSigned(signedTx);
+            const { signedTx, result: submitted } = await submitWithTerminalStatusWatch(submitter, {
+              nonce: await getNonce(),
+            });
 
             const txSubmittedAtBlockHeight = submitted.blockNumber ?? submitted.extrinsic.submittedAtBlockNumber;
             const inclusionTimeoutMs = Math.max(NetworkConfig.tickMillis * 2, 60_000);
@@ -696,8 +701,7 @@ function isRedundantCatchUpError(reason: string): boolean {
 }
 
 function isNonceRefreshableCatchUpError(error: unknown): boolean {
-  const reason = error instanceof Error ? error.message : String(error);
-  return isOutdatedTransactionError(error) || reason.includes('Invalid Transaction: Stale');
+  return isOutdatedTransactionError(error) || isSubmissionStatusError(error);
 }
 
 function isCheckpointSatisfied(

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -1,6 +1,7 @@
 import {
   minimumVaultDelegateBalance,
   NetworkConfig,
+  raceWithTimeout,
   type IEthereumGatewayCatchUpRequest,
   type IEthereumGatewayCatchUpResponse,
   type IEthereumGatewayRelayStatus,
@@ -464,16 +465,11 @@ export class EthereumGatewayProverService {
 
             const txSubmittedAtBlockHeight = submitted.blockNumber ?? submitted.extrinsic.submittedAtBlockNumber;
             const inclusionTimeoutMs = Math.max(NetworkConfig.tickMillis * 2, 60_000);
-            let timeoutId: ReturnType<typeof setTimeout> | undefined;
-            const observedInFirstBlock = await Promise.race([
+            const observedInFirstBlock = await raceWithTimeout(
               submitted.waitForInFirstBlock.then(() => true),
-              new Promise<false>(resolve => {
-                timeoutId = setTimeout(() => resolve(false), inclusionTimeoutMs);
-              }),
-            ]);
-            if (timeoutId) {
-              clearTimeout(timeoutId);
-            }
+              inclusionTimeoutMs,
+              () => false,
+            );
             const resolvedThroughGatewayActivityNonce =
               proofPayload.activities.at(-1)?.gatewayState.gatewayActivityNonce ?? throughGatewayActivityNonce;
 

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -21,10 +21,7 @@ import { createHash } from 'node:crypto';
 import { createPublicClient, http, type Hex } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
 import { HttpError } from './HttpError.ts';
-import {
-  isSubmissionStatusError,
-  submitWithTerminalStatusWatch,
-} from './submitWithTerminalStatusWatch.ts';
+import { isSubmissionStatusError, submitWithTerminalStatusWatch } from './submitWithTerminalStatusWatch.ts';
 
 export class EthereumGatewayProverService {
   private startPromise?: Promise<void>;

--- a/bot/src/submitWithTerminalStatusWatch.ts
+++ b/bot/src/submitWithTerminalStatusWatch.ts
@@ -1,0 +1,79 @@
+import { TxResult, TxSubmitter } from '@argonprotocol/mainchain';
+
+export const SubmissionStatusErrorCode = {
+  Dropped: 'SubmissionStatus.Dropped',
+  Invalid: 'SubmissionStatus.Invalid',
+  Usurped: 'SubmissionStatus.Usurped',
+} as const;
+
+export type SubmissionStatusErrorCode = (typeof SubmissionStatusErrorCode)[keyof typeof SubmissionStatusErrorCode];
+
+export class SubmissionStatusError extends Error {
+  constructor(
+    public readonly code: SubmissionStatusErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function isSubmissionStatusError(
+  error: unknown,
+  ...codes: SubmissionStatusErrorCode[]
+): error is SubmissionStatusError {
+  if (!(error instanceof SubmissionStatusError)) {
+    return false;
+  }
+
+  return codes.length === 0 || codes.includes(error.code);
+}
+
+export type IWatchedSubmission = {
+  signedTx: Awaited<ReturnType<TxSubmitter['sign']>>;
+  result: TxResult;
+};
+
+export async function submitWithTerminalStatusWatch(
+  submitter: TxSubmitter,
+  options: {
+    nonce: number;
+  },
+): Promise<IWatchedSubmission> {
+  const signedTx = await submitter.sign(options);
+  const submittedAtBlockNumber = await submitter.client.rpc.chain.getHeader().then(header => header.number.toNumber());
+  const result = new TxResult(submitter.client, {
+    signedHash: signedTx.hash.toHex(),
+    method: signedTx.method.toHuman(),
+    accountAddress: submitter.address,
+    submittedTime: new Date(),
+    submittedAtBlockNumber,
+    nonce: signedTx.nonce.toNumber(),
+  });
+
+  await signedTx.send(subscriptionResult => {
+    result.onSubscriptionResult(subscriptionResult);
+    const status = subscriptionResult.status;
+    if (status.isUsurped) {
+      result.submissionError = new SubmissionStatusError(
+        SubmissionStatusErrorCode.Usurped,
+        `Transaction was usurped by ${status.asUsurped.toHex()}.`,
+      );
+      return;
+    }
+    if (status.isDropped) {
+      result.submissionError = new SubmissionStatusError(
+        SubmissionStatusErrorCode.Dropped,
+        'Transaction was dropped before it was included in a block.',
+      );
+      return;
+    }
+    if (status.isInvalid) {
+      result.submissionError = new SubmissionStatusError(
+        SubmissionStatusErrorCode.Invalid,
+        'Transaction was rejected as invalid by the node.',
+      );
+    }
+  });
+
+  return { signedTx, result };
+}

--- a/bot/src/submitWithTerminalStatusWatch.ts
+++ b/bot/src/submitWithTerminalStatusWatch.ts
@@ -50,7 +50,20 @@ export async function submitWithTerminalStatusWatch(
     nonce: signedTx.nonce.toNumber(),
   });
 
-  await signedTx.send(subscriptionResult => {
+  let unsubscribe: (() => void) | undefined;
+  let shouldUnsubscribe = false;
+
+  const stopWatching = () => {
+    if (!unsubscribe) {
+      shouldUnsubscribe = true;
+      return;
+    }
+
+    unsubscribe();
+    unsubscribe = undefined;
+  };
+
+  unsubscribe = await signedTx.send(subscriptionResult => {
     result.onSubscriptionResult(subscriptionResult);
     const status = subscriptionResult.status;
     if (status.isUsurped) {
@@ -58,6 +71,7 @@ export async function submitWithTerminalStatusWatch(
         SubmissionStatusErrorCode.Usurped,
         `Transaction was usurped by ${status.asUsurped.toHex()}.`,
       );
+      stopWatching();
       return;
     }
     if (status.isDropped) {
@@ -65,6 +79,7 @@ export async function submitWithTerminalStatusWatch(
         SubmissionStatusErrorCode.Dropped,
         'Transaction was dropped before it was included in a block.',
       );
+      stopWatching();
       return;
     }
     if (status.isInvalid) {
@@ -72,8 +87,18 @@ export async function submitWithTerminalStatusWatch(
         SubmissionStatusErrorCode.Invalid,
         'Transaction was rejected as invalid by the node.',
       );
+      stopWatching();
+      return;
+    }
+    if (subscriptionResult.isFinalized) {
+      stopWatching();
     }
   });
+
+  if (shouldUnsubscribe) {
+    unsubscribe();
+    unsubscribe = undefined;
+  }
 
   return { signedTx, result };
 }

--- a/core/__test__/MiningFrames.test.ts
+++ b/core/__test__/MiningFrames.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MiningFrames, NetworkConfig } from '../src/index.ts';
+import type { IBlockHeaderInfo } from '../src/BlockWatch.ts';
+
+describe('MiningFrames frame refresh recovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses cached block APIs for latest and historical frame reads', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = createHeaderInfo(182, '0xlatest', '0x181', undefined, 1_820);
+    const frameHeader = createHeaderInfo(181, '0xframe', '0x180', 18, 1_810);
+    const currentApi = {
+      query: {
+        miningSlot: {
+          frameStartBlockNumbers: vi.fn().mockResolvedValue([createNumberLike(181)]),
+        },
+      },
+    };
+    const frameApi = {
+      query: {
+        miningSlot: {
+          nextFrameId: vi.fn().mockResolvedValue(createNumberLike(19)),
+          frameStartBlockNumbers: vi.fn().mockResolvedValue([createNumberLike(181)]),
+        },
+      },
+      runtimeVersion: {
+        specVersion: createNumberLike(153),
+      },
+    };
+    const getApi = vi.fn().mockResolvedValueOnce(currentApi).mockResolvedValueOnce(frameApi);
+    const blockWatch = {
+      getApi,
+      getHeader: vi.fn().mockResolvedValue(frameHeader),
+      events: { on: vi.fn() },
+    };
+    const clients = {};
+    Object.defineProperty(clients, 'prunedClientOrArchivePromise', {
+      get() {
+        throw new Error('should use BlockWatch.getApi instead');
+      },
+    });
+
+    const miningFrames = new MiningFrames(clients as any, blockWatch as any);
+    const checkForFrameChange = getCheckForFrameChange(miningFrames);
+
+    await checkForFrameChange.call(miningFrames, [latestHeader]);
+
+    expect(getApi).toHaveBeenNthCalledWith(1, latestHeader);
+    expect(getApi).toHaveBeenNthCalledWith(2, frameHeader);
+    expect(miningFrames.framesById[18]).toMatchObject({
+      frameId: 18,
+      firstBlockNumber: 181,
+      firstBlockHash: '0xframe',
+      firstBlockTick: 1_810,
+      firstBlockSpecVersion: 153,
+    });
+  });
+
+  it('does not reject higher callers when frame refresh hits a retryable API miss', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = createHeaderInfo(182, '0xlatest', '0x181', undefined, 1_820);
+    const frameHeader = createHeaderInfo(181, '0xframe', '0x180', 18, 1_810);
+    const currentApi = {
+      query: {
+        miningSlot: {
+          frameStartBlockNumbers: vi.fn().mockResolvedValue([createNumberLike(181)]),
+        },
+      },
+    };
+    const blockWatch = {
+      getApi: vi
+        .fn()
+        .mockResolvedValueOnce(currentApi)
+        .mockRejectedValueOnce(new Error('Unable to retrieve header and parent from supplied hash')),
+      getHeader: vi.fn().mockResolvedValue(frameHeader),
+      events: { on: vi.fn() },
+    };
+    const miningFrames = new MiningFrames({} as any, blockWatch as any);
+    const checkForFrameChange = getCheckForFrameChange(miningFrames);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(checkForFrameChange.call(miningFrames, [latestHeader])).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Mining Frames] Failed to refresh frame history, will retry on the next block',
+      expect.any(Error),
+    );
+    expect(miningFrames.framesById[18]).toBeUndefined();
+  });
+});
+
+function createHeaderInfo(
+  blockNumber: number,
+  blockHash: string,
+  parentHash: string,
+  frameId?: number,
+  tick = blockNumber,
+): IBlockHeaderInfo {
+  return {
+    isFinalized: blockNumber <= 100,
+    blockNumber,
+    blockHash,
+    blockTime: blockNumber * 1_000,
+    parentHash,
+    author: 'author',
+    tick,
+    frameId,
+  };
+}
+
+function createNumberLike(value: number) {
+  return {
+    toNumber: () => value,
+  };
+}
+
+function getCheckForFrameChange(miningFrames: MiningFrames): (headers: IBlockHeaderInfo[]) => Promise<void> {
+  return Reflect.get(miningFrames, 'checkForFrameChange') as (headers: IBlockHeaderInfo[]) => Promise<void>;
+}

--- a/core/__test__/utils.test.ts
+++ b/core/__test__/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { raceWithTimeout } from '../src/utils.ts';
+
+describe('raceWithTimeout', () => {
+  it('returns the original promise result when it resolves before the timeout', async () => {
+    await expect(raceWithTimeout(Promise.resolve('ready'), 100, () => 'timed-out')).resolves.toBe('ready');
+  });
+
+  it('returns the timeout result when the promise does not settle in time', async () => {
+    vi.useFakeTimers();
+
+    const resultPromise = raceWithTimeout(new Promise<string>(() => undefined), 100, () => 'timed-out');
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toBe('timed-out');
+    vi.useRealTimers();
+  });
+
+  it('rejects when the original promise rejects before the timeout', async () => {
+    await expect(raceWithTimeout(Promise.reject(new Error('boom')), 100, () => 'timed-out')).rejects.toThrow('boom');
+  });
+});

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -74,17 +74,21 @@ export default class BiddingCalculatorData {
       this.loadedFrameIdPromise = new Promise<number>(async (resolve, reject) => {
         const mining = this.mining;
         await this.miningFrames.waitForFrameId(biddingFrameId);
-        const client = await mining.clients.prunedClientOrArchivePromise;
-        const currentBlockHash = await client.rpc.chain.getBlockHash();
-        let api = await client.at(currentBlockHash);
+        const latestHeader = this.miningFrames.blockWatch.bestBlockHeader;
+        let api = await this.miningFrames.clientAt(latestHeader);
         const nextFrameId = await this.mining.fetchNextFrameId(api);
         if (biddingFrameId !== nextFrameId - 1) {
           // need to go back to the start of the bidding frame
-          const frameStartBlockHash = this.miningFrames.framesById[biddingFrameId].firstBlockHash;
-          if (!frameStartBlockHash) {
+          const frame = this.miningFrames.framesById[biddingFrameId];
+          const frameStartBlockHash = frame.firstBlockHash;
+          const frameStartBlockNumber = frame.firstBlockNumber;
+          if (!frameStartBlockHash || frameStartBlockNumber == null) {
             return reject(new Error(`No starting block for frame ${biddingFrameId}`));
           }
-          api = await client.at(frameStartBlockHash);
+          api = await this.miningFrames.clientAt({
+            blockHash: frameStartBlockHash,
+            blockNumber: frameStartBlockNumber,
+          });
         }
 
         const currency = new Currency(mining.clients);
@@ -119,7 +123,7 @@ export default class BiddingCalculatorData {
 
           this.microgonExchangeRateTo = await currency.fetchMainchainRates(api);
           this.maxPossibleMiningSeatCount = maxPossibleMinersInNextEpoch;
-          this.allowedBidIncrementMicrogons = client.consts.miningSlot.bidIncrements.toBigInt();
+          this.allowedBidIncrementMicrogons = api.consts.miningSlot.bidIncrements.toBigInt();
           resolve(biddingFrameId);
         } catch (error) {
           console.error('Error initializing BiddingCalculatorData', error);

--- a/core/src/MiningFrames.ts
+++ b/core/src/MiningFrames.ts
@@ -429,7 +429,8 @@ export class MiningFrames {
         const header = await this.blockWatch.getHeader(blockNumber);
         const blockHash = header.blockHash;
         const api = await this.clientAt(header);
-        const frameId: number = header.frameId ?? (await api.query.miningSlot.nextFrameId().then(x => x.toNumber() - 1));
+        const frameId: number =
+          header.frameId ?? (await api.query.miningSlot.nextFrameId().then(x => x.toNumber() - 1));
 
         const existing = this.framesById[frameId];
         if (existing && existing.firstBlockHash === blockHash) {
@@ -461,7 +462,6 @@ export class MiningFrames {
             }
           }
         }
-
       } while (queue.length > 0);
 
       if (hasChanges) {

--- a/core/src/MiningFrames.ts
+++ b/core/src/MiningFrames.ts
@@ -409,57 +409,66 @@ export class MiningFrames {
       return;
     }
 
-    const localOrArchive = await this.clients.prunedClientOrArchivePromise;
-    const rawFrameStartBlocks = await localOrArchive.query.miningSlot.frameStartBlockNumbers();
-
-    const queue = rawFrameStartBlocks.map(x => x.toNumber());
-    if (!queue.length) {
-      console.warn('[Mining Frames] No frame start block numbers found');
+    const latestHeader = headers.at(-1);
+    if (!latestHeader) {
       return;
     }
-    let hasChanges = false;
-    do {
-      const blockNumber = queue.shift()!;
-      const blockClient = await this.blockWatch.getRpcClient(blockNumber);
-      const header = await this.blockWatch.getHeader(blockNumber);
-      const blockHash = header.blockHash;
-      const api = await blockClient.at(header.blockHash);
-      const frameId: number = header.frameId ?? (await api.query.miningSlot.nextFrameId().then(x => x.toNumber() - 1));
 
-      const existing = this.framesById[frameId];
-      if (existing && existing.firstBlockHash === blockHash) {
-        break;
+    try {
+      const latestApi = await this.clientAt(latestHeader);
+      const rawFrameStartBlocks = await latestApi.query.miningSlot.frameStartBlockNumbers();
+
+      const queue = rawFrameStartBlocks.map(x => x.toNumber());
+      if (!queue.length) {
+        console.warn('[Mining Frames] No frame start block numbers found');
+        return;
       }
+      let hasChanges = false;
+      do {
+        const blockNumber = queue.shift()!;
+        const header = await this.blockWatch.getHeader(blockNumber);
+        const blockHash = header.blockHash;
+        const api = await this.clientAt(header);
+        const frameId: number = header.frameId ?? (await api.query.miningSlot.nextFrameId().then(x => x.toNumber() - 1));
 
-      const startingTick = header.tick;
-      const isChanged = this.setFrameHistory({
-        frameId,
-        frameStartTick: startingTick,
-        dateStart: MiningFrames.getTickDate(startingTick),
-        firstBlockNumber: blockNumber,
-        firstBlockHash: blockHash,
-        firstBlockTick: startingTick,
-        firstBlockSpecVersion: api.runtimeVersion.specVersion.toNumber(),
-      });
-      if (isChanged) {
-        this.events.emit('on-frame', { frameId, blockNumber, blockHash });
-        this.events.emit('on-tick', startingTick);
-        hasChanges = true;
-      }
+        const existing = this.framesById[frameId];
+        if (existing && existing.firstBlockHash === blockHash) {
+          break;
+        }
 
-      if (queue.length === 0) {
-        const frameStartBlockNumbers = await api.query.miningSlot.frameStartBlockNumbers();
-        for (const bn of frameStartBlockNumbers) {
-          const bnNumber = bn.toNumber();
-          if (bnNumber < blockNumber) {
-            queue.push(bnNumber);
+        const startingTick = header.tick;
+        const isChanged = this.setFrameHistory({
+          frameId,
+          frameStartTick: startingTick,
+          dateStart: MiningFrames.getTickDate(startingTick),
+          firstBlockNumber: blockNumber,
+          firstBlockHash: blockHash,
+          firstBlockTick: startingTick,
+          firstBlockSpecVersion: api.runtimeVersion.specVersion.toNumber(),
+        });
+        if (isChanged) {
+          this.events.emit('on-frame', { frameId, blockNumber, blockHash });
+          this.events.emit('on-tick', startingTick);
+          hasChanges = true;
+        }
+
+        if (queue.length === 0) {
+          const frameStartBlockNumbers = await api.query.miningSlot.frameStartBlockNumbers();
+          for (const bn of frameStartBlockNumbers) {
+            const bnNumber = bn.toNumber();
+            if (bnNumber < blockNumber) {
+              queue.push(bnNumber);
+            }
           }
         }
-      }
-    } while (queue.length > 0);
 
-    if (hasChanges) {
-      await this.safeSaveUpdates();
+      } while (queue.length > 0);
+
+      if (hasChanges) {
+        await this.safeSaveUpdates();
+      }
+    } catch (error) {
+      console.warn('[Mining Frames] Failed to refresh frame history, will retry on the next block', error);
     }
   }
 

--- a/core/src/interfaces/IBotStateFile.ts
+++ b/core/src/interfaces/IBotStateFile.ts
@@ -6,6 +6,7 @@ export type IEthereumSyncMode = 'disabled' | 'needsBootstrap' | 'idle' | 'submit
 export interface IEthereumSyncStatus {
   mode: IEthereumSyncMode;
   syncAccountAddress: string;
+  lastUpdatedAt?: Date;
   latestFinalizedSlot?: bigint;
   latestExecutionAnchorBlockNumber?: bigint;
   latestEthereumBlockNumber?: bigint;

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -92,6 +92,40 @@ export async function waitAtLeast<T>(timeoutMs: number, promise: Promise<T>): Pr
   return result;
 }
 
+export function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => T | Promise<T>,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+
+  return new Promise((resolve, reject) => {
+    let isSettled = false;
+    const settle = (fn: () => void) => {
+      if (isSettled) return;
+      isSettled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      void Promise.resolve()
+        .then(onTimeout)
+        .then(
+          value => settle(() => resolve(value)),
+          error => settle(() => reject(error)),
+        );
+    }, timeoutMs);
+
+    promise.then(
+      value => settle(() => resolve(value)),
+      error => settle(() => reject(error)),
+    );
+  });
+}
+
 export function convertBigIntStringToNumber(bigIntStr: string | undefined): bigint | undefined {
   if (bigIntStr === undefined) return undefined;
   if (!bigIntStr) return 0n;

--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -172,7 +172,7 @@ describe('MoveCapital', () => {
       },
     });
     expect(buildOperatorAccountRegistrationTx).toHaveBeenCalledOnce();
-    expect(result).toBe(txInfo);
+    expect(result).toEqual({ kind: 'submitted', txInfo });
   });
 
   it('retries the fee calculation without argons when only argonots should move', async () => {
@@ -288,7 +288,33 @@ describe('MoveCapital', () => {
 
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
-    expect(result).toBeUndefined();
+    expect(result).toEqual({
+      kind: 'blocked',
+      error: 'Your wallet has insufficient funds for this transaction.',
+    });
+  });
+
+  it('reports a transaction error when the sweep fee exceeds the mining hold balance', async () => {
+    const { moveCapital } = createMoveCapital();
+    vi.spyOn(moveCapital, 'buildTransaction').mockResolvedValue({
+      tx: createMockFeeTx(12n) as any,
+      metadata: {
+        moveFrom: MoveFrom.MiningHold,
+        moveTo: MoveTo.MiningBot,
+        assetsToMove: { ARGNOT: 4n },
+      },
+    });
+
+    const fee = await moveCapital.calculateFee(
+      MoveFrom.MiningHold,
+      MoveTo.MiningBot,
+      { ARGNOT: 4n },
+      createWallet({ availableMicrogons: 10n, availableMicronots: 4n }),
+      'mining-bot-address',
+    );
+
+    expect(fee).toBe(0n);
+    expect(moveCapital.transactionError).toBe('Your wallet has insufficient funds for this transaction.');
   });
 
   it('skips the sweep when fee calculation fails', async () => {
@@ -307,7 +333,10 @@ describe('MoveCapital', () => {
 
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
-    expect(result).toBeUndefined();
+    expect(result).toEqual({
+      kind: 'blocked',
+      error: 'Unable to calculate transaction fee.',
+    });
   });
 
   it('skips the sweep when there is nothing available to move', async () => {
@@ -324,7 +353,8 @@ describe('MoveCapital', () => {
     expect(feeSpy).not.toHaveBeenCalled();
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ kind: 'noSpendableFundsToSweep' });
+    expect(moveCapital.transactionError).toBe('');
   });
 
   it('reuses an in-flight mining hold sweep instead of submitting a duplicate move', async () => {
@@ -367,8 +397,8 @@ describe('MoveCapital', () => {
 
     resolveSubmit?.(txInfo);
 
-    await expect(firstSweep).resolves.toBe(txInfo);
-    await expect(secondSweep).resolves.toBe(txInfo);
+    await expect(firstSweep).resolves.toEqual({ kind: 'submitted', txInfo });
+    await expect(secondSweep).resolves.toEqual({ kind: 'submitted', txInfo });
   });
 
   it('follows an existing tracked mining hold sweep after reload', async () => {
@@ -395,7 +425,10 @@ describe('MoveCapital', () => {
     );
 
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
-    expect(result).toBe(existingTxInfo);
+    expect(result).toEqual({
+      kind: 'trackingExisting',
+      txInfo: existingTxInfo,
+    });
   });
 
   it('submits a new sweep after a prior mining hold sweep finalized', async () => {
@@ -434,7 +467,7 @@ describe('MoveCapital', () => {
     );
 
     expect(transactionTracker.submitAndWatch).toHaveBeenCalledOnce();
-    expect(result).toBe(newTxInfo);
+    expect(result).toEqual({ kind: 'submitted', txInfo: newTxInfo });
   });
 });
 

--- a/src-vue/app-operations/overlays/ServerOverlay.vue
+++ b/src-vue/app-operations/overlays/ServerOverlay.vue
@@ -148,6 +148,15 @@
             <div class="font-semibold font-mono">
               {{ beaconSyncStatusLabel }}
             </div>
+            <div v-if="ethereumSyncLastUpdatedAt" class="pt-1 text-xs font-light text-slate-500">
+              Status updated
+              <CountupClock as="span" :time="ethereumSyncLastUpdatedAt" v-slot="{ hours, minutes, seconds, isNull }">
+                <template v-if="hours">{{ hours }}h, </template>
+                <template v-if="minutes || hours">{{ minutes }}m{{ !isNull && !hours ? ', ' : '' }}</template>
+                <template v-if="!isNull && !hours">{{ seconds }}s ago</template>
+                <template v-else-if="isNull">-- ----</template>
+              </CountupClock>
+            </div>
             <div v-if="ethereumSyncState?.lastSubmittedTxHash" class="pt-1 text-xs font-light text-slate-500 break-all">
               Last tx: {{ ethereumSyncState.lastSubmittedTxHash }}
             </div>
@@ -161,7 +170,7 @@
               Ethereum block: {{ ethereumSyncState.latestEthereumBlockNumber.toString() }}
             </div>
             <div v-if="ethereumExecutionBlockLag !== undefined" class="pt-1 text-xs font-light text-slate-500">
-              Blocks behind: {{ ethereumExecutionBlockLag.toString() }}
+              Execution anchor gap: {{ ethereumExecutionBlockLag.toString() }}
             </div>
             <div
               v-if="ethereumSyncState?.latestSyncCommitteeUpdatePeriod !== undefined"
@@ -171,6 +180,9 @@
             </div>
             <div v-if="ethereumSyncState?.gatewayActivityNonceGap !== undefined" class="pt-1 text-xs font-light text-slate-500">
               Gateway nonce gap: {{ ethereumSyncState.gatewayActivityNonceGap.toString() }}
+            </div>
+            <div v-if="beaconSyncStatusHint" class="pt-2 text-xs font-medium text-amber-700">
+              {{ beaconSyncStatusHint }}
             </div>
             <div v-if="beaconSyncActionError" class="pt-2 text-sm font-medium text-red-600">
               {{ beaconSyncActionError }}
@@ -262,6 +274,11 @@ const ethereumSyncState = Vue.computed(() => {
   return bot.state?.ethereumSync;
 });
 
+const ethereumSyncLastUpdatedAt = Vue.computed(() => {
+  const lastUpdatedAt = ethereumSyncState.value?.lastUpdatedAt;
+  return lastUpdatedAt ? dayjs(lastUpdatedAt) : null;
+});
+
 const ethereumExecutionBlockLag = Vue.computed(() => {
   const latestExecutionAnchorBlockNumber = ethereumSyncState.value?.latestExecutionAnchorBlockNumber;
   const latestEthereumBlockNumber = ethereumSyncState.value?.latestEthereumBlockNumber;
@@ -276,6 +293,14 @@ const ethereumExecutionBlockLag = Vue.computed(() => {
 
 const beaconSyncStatusLabel = Vue.computed(() => {
   return formatBeaconSyncStatus(ethereumSyncState.value?.mode, ethereumSyncState.value?.lastError);
+});
+
+const beaconSyncStatusHint = Vue.computed(() => {
+  if (ethereumSyncState.value?.mode !== 'submitting') {
+    return '';
+  }
+
+  return 'Execution anchor and sync period values are the latest observed snapshot while the verifier tx is still being checked.';
 });
 
 const isBeaconSyncSaveDisabled = Vue.computed(() => {

--- a/src-vue/app-operations/overlays/WalletFundingReceivedOverlay.vue
+++ b/src-vue/app-operations/overlays/WalletFundingReceivedOverlay.vue
@@ -124,11 +124,13 @@ async function queueMiningHoldAutoTransfer(wallet: IWallet) {
     // after the in-flight transfer settles instead of submitting a second transfer in parallel.
     do {
       shouldRetryAutoTransfer = false;
-      const sweepTxInfo = await moveCapital.moveAvailableMiningHoldToBot(wallet, walletKeys, config as Config);
-      if (sweepTxInfo) {
-        await sweepTxInfo.waitForPostProcessing.catch(error => {
+      const sweepResult = await moveCapital.moveAvailableMiningHoldToBot(wallet, walletKeys, config as Config);
+      if (sweepResult.kind === 'submitted' || sweepResult.kind === 'trackingExisting') {
+        await sweepResult.txInfo.waitForPostProcessing.catch(error => {
           console.error('[WalletFundingReceivedOverlay] Mining hold sweep failed while waiting to retry', error);
         });
+      } else if (sweepResult.kind === 'blocked') {
+        console.error('[WalletFundingReceivedOverlay] Mining hold auto-transfer was blocked', sweepResult.error);
       }
     } while (shouldRetryAutoTransfer);
   } finally {

--- a/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
@@ -203,14 +203,12 @@
 import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { MICROGONS_PER_ARGON } from '@argonprotocol/apps-core';
 import basicEmitter from '../../../emitters/basicEmitter.ts';
-import { Config, getConfig } from '../../../stores/config.ts';
-import { getWalletKeys, useWallets } from '../../../stores/wallets.ts';
+import { getConfig } from '../../../stores/config.ts';
+import { useWallets } from '../../../stores/wallets.ts';
 import { getCurrency } from '../../../stores/currency.ts';
 import Checkbox from '../../../components/Checkbox.vue';
 import numeral, { createNumeralHelpers } from '../../../lib/numeral.ts';
-import { bigIntMax } from '@argonprotocol/apps-core/src/utils.ts';
 import { ArrowLeftIcon } from '@heroicons/vue/24/outline';
 import { getBiddingCalculator } from '../../../stores/mainchain.ts';
 import BotReturns from '../../overlays/bot/BotReturns.vue';
@@ -220,12 +218,10 @@ import { OperationalStepId, OperationsTab, useOperationsController } from '../..
 import BotCreatePriceChangeOverlay from '../../overlays/BotCreatePriceChangeOverlay.vue';
 import { UnitOfMeasurement } from '../../../lib/Currency.ts';
 import { WalletType } from '../../../lib/Wallet.ts';
-import { MoveCapital } from '../../../lib/MoveCapital.ts';
-import { getMyVault } from '../../../stores/vaults.ts';
-import { getTransactionTracker } from '../../../stores/transactions.ts';
 import { MiningSetupStatus } from '../../../interfaces/IConfig.ts';
 import ArrowCalloutButton from '../../../components/ArrowCalloutButton.vue';
 import { useBasics } from '../../../stores/basics.ts';
+import { getMiningFundingState } from './miningFunding.ts';
 
 dayjs.extend(utc);
 
@@ -235,8 +231,6 @@ const wallets = useWallets();
 const currency = getCurrency();
 const controller = useOperationsController();
 const calculator = getBiddingCalculator();
-const walletKeys = getWalletKeys();
-const transactionTracker = getTransactionTracker();
 
 const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 
@@ -246,8 +240,6 @@ const alignOffsetForBotReturns = Vue.ref(0);
 const alignOffsetForBotCapital = Vue.ref(0);
 
 const capitalCommitment = Vue.ref(0n);
-const futureTransactionFeeBudgetMicrogons = 2n * BigInt(MICROGONS_PER_ARGON);
-
 const isLaunchingMiningBot = Vue.ref(false);
 const averageAPY = Vue.ref(0);
 
@@ -281,50 +273,42 @@ const availableMicronots = Vue.computed(() => {
   return wallets.miningHoldWallet.availableMicronots + wallets.miningBotWallet.availableMicronots;
 });
 
+const miningMicronotsOnHand = Vue.computed(() => {
+  return availableMicronots.value + reservedMicronots.value;
+});
+
+const fundingState = Vue.computed(() => {
+  return getMiningFundingState({
+    hasSavedBiddingRules: config.hasSavedBiddingRules,
+    miningSetupStatus: config.miningSetupStatus,
+    miningMicrogonsOnHand: wallets.totalMiningMicrogons,
+    miningMicronotsOnHand: miningMicronotsOnHand.value,
+    initialMicrogonRequirement: config.biddingRules.initialMicrogonRequirement,
+    initialMicronotRequirement: config.biddingRules.initialMicronotRequirement,
+  });
+});
+
 const walletIsPartiallyFunded = Vue.computed(() => {
   if (!config.hasSavedBiddingRules) {
     return false;
   }
-  return (wallets.totalMiningMicrogons || availableMicronots.value) > 0n;
-});
-
-const onboardingAdditionalMicrogons = Vue.computed(() => {
-  if (config.miningSetupStatus === MiningSetupStatus.Finished) {
-    return 0n;
-  }
-
-  return futureTransactionFeeBudgetMicrogons;
+  return wallets.totalMiningMicrogons > 0n || availableMicronots.value > 0n;
 });
 
 const minimumMicrogonsNeeded = Vue.computed(() => {
-  return (config.biddingRules.initialMicrogonRequirement ?? 0n) + onboardingAdditionalMicrogons.value;
+  return fundingState.value.requiredMicrogons;
 });
 
 const additionalMicrogonsNeeded = Vue.computed(() => {
-  return bigIntMax(minimumMicrogonsNeeded.value - wallets.totalMiningMicrogons, 0n);
+  return fundingState.value.additionalMicrogonsNeeded;
 });
 
 const additionalMicronotsNeeded = Vue.computed(() => {
-  return bigIntMax(
-    config.biddingRules.initialMicronotRequirement - (availableMicronots.value + reservedMicronots.value),
-    0n,
-  );
+  return fundingState.value.additionalMicronotsNeeded;
 });
 
 const walletIsFullyFunded = Vue.computed(() => {
-  if (!config.hasSavedBiddingRules) {
-    return false;
-  }
-
-  if (additionalMicrogonsNeeded.value > 0n) {
-    return false;
-  }
-
-  if (additionalMicronotsNeeded.value > 0n) {
-    return false;
-  }
-
-  return true;
+  return fundingState.value.isFullyFunded;
 });
 
 const hasMiningMachine = Vue.computed(() => {
@@ -389,24 +373,9 @@ async function launchMiningBot() {
 
   biddingRules.initialCapitalCommitment = availableMicrogons.value + micronotsAsMicrogons;
 
-  const myVault = getMyVault();
-  const moveCapital = new MoveCapital(walletKeys, transactionTracker, myVault);
-
   try {
     config.biddingRules = biddingRules;
     config.miningSetupStatus = MiningSetupStatus.Installing;
-    await config.save();
-
-    const miningHoldWallet = wallets.miningHoldWallet;
-    const miningHoldSweepTxInfo = await moveCapital.moveAvailableMiningHoldToBot(
-      miningHoldWallet,
-      walletKeys,
-      config as Config,
-    );
-    if (miningHoldSweepTxInfo) return;
-
-    // If no sweep tx was queued, the bot still cannot move forward with setup.
-    config.miningSetupStatus = MiningSetupStatus.Checklist;
     await config.save();
   } catch (error) {
     if (config.miningSetupStatus === MiningSetupStatus.Installing) {

--- a/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
@@ -24,6 +24,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
+import { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
 import { getConfig } from '../../../stores/config.ts';
 import { stepLabels, type IStepLabel } from '../../../lib/InstallerStep.ts';
 import { InstallStepStatus, MiningSetupStatus } from '../../../interfaces/IConfig.ts';
@@ -31,12 +32,12 @@ import ProgressBar from '../../../components/ProgressBar.vue';
 import MiningIcon from '../../../assets/mining.svg?component';
 import { useWallets, getWalletKeys } from '../../../stores/wallets.ts';
 import { getTransactionTracker } from '../../../stores/transactions.ts';
-import { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
 import { MoveCapital, type ITransactionMoveMetadata } from '../../../lib/MoveCapital.ts';
 import { ExtrinsicType } from '../../../lib/db/TransactionsTable.ts';
 import type { TransactionInfo } from '../../../lib/TransactionInfo.ts';
 import { getMyVault } from '../../../stores/vaults.ts';
 import type { Config } from '../../../lib/Config.ts';
+import { getMiningFundingState } from './miningFunding.ts';
 
 const config = getConfig();
 const wallets = useWallets();
@@ -76,6 +77,24 @@ const transactionProgressScaled = Vue.computed(() => 80 + txProgressPct.value * 
 const targetProgressPct = Vue.computed(() =>
   hasEnteredTransactionPhase.value ? transactionProgressScaled.value : installerProgressScaled.value,
 );
+const miningMicronotsOnHand = Vue.computed(() => {
+  return (
+    wallets.miningHoldWallet.availableMicronots +
+    wallets.miningHoldWallet.reservedMicronots +
+    wallets.miningBotWallet.availableMicronots +
+    wallets.miningBotWallet.reservedMicronots
+  );
+});
+const fundingState = Vue.computed(() => {
+  return getMiningFundingState({
+    hasSavedBiddingRules: config.hasSavedBiddingRules,
+    miningSetupStatus: config.miningSetupStatus,
+    miningMicrogonsOnHand: wallets.totalMiningMicrogons,
+    miningMicronotsOnHand: miningMicronotsOnHand.value,
+    initialMicrogonRequirement: config.biddingRules.initialMicrogonRequirement,
+    initialMicronotRequirement: config.biddingRules.initialMicronotRequirement,
+  });
+});
 
 const progressLabel = Vue.computed(() => {
   if (hasEnteredTransactionPhase.value) {
@@ -186,14 +205,32 @@ async function ensureTrackedSetupTransfer(force = false) {
   lastEnsureSetupTransferAt = now;
 
   try {
-    const ensuredTxInfo = await moveCapital.moveAvailableMiningHoldToBot(
+    const sweepResult = await moveCapital.moveAvailableMiningHoldToBot(
       wallets.miningHoldWallet,
       walletKeys,
       config as Config,
     );
-    if (ensuredTxInfo) {
-      trackTxInfo(ensuredTxInfo);
+    if (sweepResult.kind === 'submitted' || sweepResult.kind === 'trackingExisting') {
+      trackTxInfo(sweepResult.txInfo);
+      return;
     }
+    if (sweepResult.kind === 'noSpendableFundsToSweep') {
+      if (fundingState.value.isFullyFunded) {
+        transactionErrorMessage.value = '';
+        txProgressLabel.value = 'Mining capital is ready.';
+        txProgressPct.value = 100;
+        return;
+      }
+
+      txProgressPct.value = 0;
+      txProgressLabel.value = 'Mining capital needs attention.';
+      transactionErrorMessage.value = 'This miner is not fully funded yet.';
+      return;
+    }
+
+    txProgressPct.value = 0;
+    txProgressLabel.value = 'Mining capital needs attention.';
+    transactionErrorMessage.value = sweepResult.error;
   } finally {
     isEnsuringSetupTransfer.value = false;
   }

--- a/src-vue/app-operations/screens/mining-screen/miningFunding.ts
+++ b/src-vue/app-operations/screens/mining-screen/miningFunding.ts
@@ -1,0 +1,47 @@
+import { MICROGONS_PER_ARGON } from '@argonprotocol/apps-core';
+import { bigIntMax } from '@argonprotocol/apps-core/src/utils.ts';
+import { MiningSetupStatus } from '../../../interfaces/IConfig.ts';
+
+const FUTURE_TRANSACTION_FEE_BUDGET_MICROGONS = 2n * BigInt(MICROGONS_PER_ARGON);
+
+export interface IMiningFundingState {
+  isFullyFunded: boolean;
+  requiredMicrogons: bigint;
+  requiredMicronots: bigint;
+  additionalMicrogonsNeeded: bigint;
+  additionalMicronotsNeeded: bigint;
+}
+
+export function getMiningFundingState(args: {
+  hasSavedBiddingRules: boolean;
+  miningSetupStatus: MiningSetupStatus;
+  miningMicrogonsOnHand: bigint;
+  miningMicronotsOnHand: bigint;
+  initialMicrogonRequirement?: bigint;
+  initialMicronotRequirement?: bigint;
+}): IMiningFundingState {
+  if (!args.hasSavedBiddingRules) {
+    return {
+      isFullyFunded: false,
+      requiredMicrogons: 0n,
+      requiredMicronots: 0n,
+      additionalMicrogonsNeeded: 0n,
+      additionalMicronotsNeeded: 0n,
+    };
+  }
+
+  const requiredMicrogons =
+    (args.initialMicrogonRequirement ?? 0n) +
+    (args.miningSetupStatus === MiningSetupStatus.Finished ? 0n : FUTURE_TRANSACTION_FEE_BUDGET_MICROGONS);
+  const requiredMicronots = args.initialMicronotRequirement ?? 0n;
+  const additionalMicrogonsNeeded = bigIntMax(requiredMicrogons - args.miningMicrogonsOnHand, 0n);
+  const additionalMicronotsNeeded = bigIntMax(requiredMicronots - args.miningMicronotsOnHand, 0n);
+
+  return {
+    isFullyFunded: additionalMicrogonsNeeded === 0n && additionalMicronotsNeeded === 0n,
+    requiredMicrogons,
+    requiredMicronots,
+    additionalMicrogonsNeeded,
+    additionalMicronotsNeeded,
+  };
+}

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -2607,88 +2607,96 @@ export default class BitcoinLocks {
     if (newestHeader.blockNumber === 0) {
       return;
     }
-    // We look at the previous block to give more time for blocks to settle so we don't bounce data around, but don't
-    // wait for finality because of how long it can take. We might need to revisit this for anything where finality is
-    // important.
-    const generalClient = await this.blockWatch.getRpcClient(newestHeader.blockNumber);
-    const header = await this.blockWatch.getHeader(newestHeader.blockNumber);
 
-    if (header.blockNumber <= this.data.latestArgonBlockHeight) {
-      return;
-    }
-    const table = await this.getTable();
-    const archivedBitcoinBlockHeight = this.data.oracleBitcoinBlockHeight;
-    this.data.latestArgonBlockHeight = header.blockNumber;
+    try {
+      // We look at the previous block to give more time for blocks to settle so we don't bounce data around, but don't
+      // wait for finality because of how long it can take. We might need to revisit this for anything where finality is
+      // important.
+      const header = await this.blockWatch.getHeader(newestHeader.blockNumber);
 
-    const clientAt = await generalClient.at(header.blockHash);
+      if (header.blockNumber <= this.data.latestArgonBlockHeight) {
+        return;
+      }
+      const table = await this.getTable();
+      const archivedBitcoinBlockHeight = this.data.oracleBitcoinBlockHeight;
+      this.data.latestArgonBlockHeight = header.blockNumber;
 
-    this.data.oracleBitcoinBlockHeight = await clientAt.query.bitcoinUtxos
-      .confirmedBitcoinBlockTip()
-      .then(x => (x.isSome ? (x.value?.blockHeight.toNumber() ?? 0) : 0));
+      const clientAt = await this.blockWatch.getApi(header);
 
-    const hasNewOracleBitcoinBlockHeight = archivedBitcoinBlockHeight !== this.data.oracleBitcoinBlockHeight;
+      this.data.oracleBitcoinBlockHeight = await clientAt.query.bitcoinUtxos
+        .confirmedBitcoinBlockTip()
+        .then(x => (x.isSome ? (x.value?.blockHeight.toNumber() ?? 0) : 0));
 
-    const promises = Object.values(this.data.locksByUtxoId)
-      .map(lockRecord => {
-        if (lockRecord.status === BitcoinLockStatus.LockIsProcessingOnArgon) {
-          // waiting for a utxo to be found
-          return undefined;
-        }
-        return this.runInQueueForUtxo(lockRecord, 30e3, async () => {
-          const isPendingFunding = lockRecord.status === BitcoinLockStatus.LockPendingFunding;
-          const shouldTrackFundingSignals = this.isFundingSignalTrackingStatus(lockRecord.status);
-          const shouldSyncLockingState = this.isLockedStatus(lockRecord) || isPendingFunding;
+      const hasNewOracleBitcoinBlockHeight = archivedBitcoinBlockHeight !== this.data.oracleBitcoinBlockHeight;
 
-          // Phase 1: lock sync.
-          if (shouldSyncLockingState) {
-            await this.updateLockingStatus(lockRecord, clientAt).catch(err =>
-              console.warn(`[BitcoinLocks] Error updating locking status for utxo ${lockRecord.uuid}`, err),
-            );
+      const promises = Object.values(this.data.locksByUtxoId)
+        .map(lockRecord => {
+          if (lockRecord.status === BitcoinLockStatus.LockIsProcessingOnArgon) {
+            // waiting for a utxo to be found
+            return undefined;
           }
+          return this.runInQueueForUtxo(lockRecord, 30e3, async () => {
+            const isPendingFunding = lockRecord.status === BitcoinLockStatus.LockPendingFunding;
+            const shouldTrackFundingSignals = this.isFundingSignalTrackingStatus(lockRecord.status);
+            const shouldSyncLockingState = this.isLockedStatus(lockRecord) || isPendingFunding;
 
-          // Phase 2: funding sync.
-          if (!lockRecord.fundingUtxoRecordId) {
-            await this.ensureFundingUtxoRecordPointer(lockRecord).catch(err =>
-              console.warn(`[BitcoinLocks] Error linking funding UTXO record for utxo ${lockRecord.uuid}`, err),
-            );
-          }
-          if (shouldTrackFundingSignals && hasNewOracleBitcoinBlockHeight) {
-            await this.utxoTracking.updateFundingLastConfirmationCheck(lockRecord).catch(err => {
-              console.warn(`[BitcoinLocks] Error updating funding confirmation check for utxo ${lockRecord.uuid}`, err);
+            // Phase 1: lock sync.
+            if (shouldSyncLockingState) {
+              await this.updateLockingStatus(lockRecord, clientAt).catch(err =>
+                console.warn(`[BitcoinLocks] Error updating locking status for utxo ${lockRecord.uuid}`, err),
+              );
+            }
+
+            // Phase 2: funding sync.
+            if (!lockRecord.fundingUtxoRecordId) {
+              await this.ensureFundingUtxoRecordPointer(lockRecord).catch(err =>
+                console.warn(`[BitcoinLocks] Error linking funding UTXO record for utxo ${lockRecord.uuid}`, err),
+              );
+            }
+            if (shouldTrackFundingSignals && hasNewOracleBitcoinBlockHeight) {
+              await this.utxoTracking.updateFundingLastConfirmationCheck(lockRecord).catch(err => {
+                console.warn(`[BitcoinLocks] Error updating funding confirmation check for utxo ${lockRecord.uuid}`, err);
+              });
+            }
+            if (shouldTrackFundingSignals) {
+              await this.syncPendingFundingSignals(lockRecord, clientAt).catch(err => {
+                console.warn(`[BitcoinLocks] Error syncing funding signals for utxo ${lockRecord.uuid}`, err);
+              });
+            }
+
+            // Phase 3: mismatch sync.
+            await this.reconcileMismatchState(lockRecord).catch(err => {
+              console.warn(`[BitcoinLocks] Error reconciling mismatch state for utxo ${lockRecord.uuid}`, err);
             });
-          }
-          if (shouldTrackFundingSignals) {
-            await this.syncPendingFundingSignals(lockRecord, clientAt).catch(err => {
-              console.warn(`[BitcoinLocks] Error syncing funding signals for utxo ${lockRecord.uuid}`, err);
+
+            // Phase 4: mismatch return sync.
+            await this.reconcileMismatchReturnOnBlock(lockRecord).catch(err => {
+              console.warn(`[BitcoinLocks] Error reconciling mismatch return for utxo ${lockRecord.uuid}`, err);
             });
-          }
 
-          // Phase 3: mismatch sync.
-          await this.reconcileMismatchState(lockRecord).catch(err => {
-            console.warn(`[BitcoinLocks] Error reconciling mismatch state for utxo ${lockRecord.uuid}`, err);
+            // Phase 5: accepted funding release sync.
+            await this.reconcileAcceptedFundingReleaseOnBlock(lockRecord, hasNewOracleBitcoinBlockHeight).catch(err => {
+              console.warn(`[BitcoinLocks] Error reconciling accepted release for utxo ${lockRecord.uuid}`, err);
+            });
+
+            // Phase 6: mint sync.
+            await this.syncMintPendingState(lockRecord, table, clientAt);
+          }).catch(err => {
+            console.warn(`[BitcoinLocks] Error processing lock for utxo ${lockRecord.uuid}`, err);
           });
-
-          // Phase 4: mismatch return sync.
-          await this.reconcileMismatchReturnOnBlock(lockRecord).catch(err => {
-            console.warn(`[BitcoinLocks] Error reconciling mismatch return for utxo ${lockRecord.uuid}`, err);
-          });
-
-          // Phase 5: accepted funding release sync.
-          await this.reconcileAcceptedFundingReleaseOnBlock(lockRecord, hasNewOracleBitcoinBlockHeight).catch(err => {
-            console.warn(`[BitcoinLocks] Error reconciling accepted release for utxo ${lockRecord.uuid}`, err);
-          });
-
-          // Phase 6: mint sync.
-          await this.syncMintPendingState(lockRecord, table, clientAt);
-        }).catch(err => {
-          console.warn(`[BitcoinLocks] Error processing lock for utxo ${lockRecord.uuid}`, err);
-        });
-      })
-      .filter(x => x !== undefined);
-    if (hasNewOracleBitcoinBlockHeight) {
-      await this.syncOrphanReturnBitcoinProcessing(this.data.oracleBitcoinBlockHeight);
+        })
+        .filter(x => x !== undefined);
+      if (hasNewOracleBitcoinBlockHeight) {
+        await this.syncOrphanReturnBitcoinProcessing(this.data.oracleBitcoinBlockHeight);
+      }
+      await Promise.allSettled(promises);
+    } catch (error) {
+      console.warn('[BitcoinLocks] Failed to process incoming Argon block, will retry on the next block', {
+        blockNumber: newestHeader.blockNumber,
+        blockHash: newestHeader.blockHash,
+        error,
+      });
     }
-    await Promise.allSettled(promises);
   }
 
   private async syncMintPendingState(

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -2655,7 +2655,10 @@ export default class BitcoinLocks {
             }
             if (shouldTrackFundingSignals && hasNewOracleBitcoinBlockHeight) {
               await this.utxoTracking.updateFundingLastConfirmationCheck(lockRecord).catch(err => {
-                console.warn(`[BitcoinLocks] Error updating funding confirmation check for utxo ${lockRecord.uuid}`, err);
+                console.warn(
+                  `[BitcoinLocks] Error updating funding confirmation check for utxo ${lockRecord.uuid}`,
+                  err,
+                );
               });
             }
             if (shouldTrackFundingSignals) {
@@ -2687,7 +2690,9 @@ export default class BitcoinLocks {
         })
         .filter(x => x !== undefined);
       if (hasNewOracleBitcoinBlockHeight) {
-        await this.syncOrphanReturnBitcoinProcessing(this.data.oracleBitcoinBlockHeight);
+        await this.syncOrphanReturnBitcoinProcessing(this.data.oracleBitcoinBlockHeight).catch(err => {
+          console.warn('[BitcoinLocks] Error syncing orphan return processing', err);
+        });
       }
       await Promise.allSettled(promises);
     } catch (error) {

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -16,7 +16,7 @@ export interface IAssetsToMove {
   [MoveToken.ARGNOT]?: bigint;
 }
 
-let pendingMiningHoldSweepPromise: Promise<TransactionInfo | undefined> | undefined;
+let pendingMiningHoldSweepPromise: Promise<MiningHoldSweepResult> | undefined;
 const MINING_HOLD_SWEEP_FOLLOW_WINDOW_FINALIZED_BLOCKS = 2;
 
 export class MoveCapital {
@@ -98,7 +98,7 @@ export class MoveCapital {
     wallet: IWallet,
     walletKeys: WalletKeys,
     config: Config,
-  ): Promise<TransactionInfo | undefined> {
+  ): Promise<MiningHoldSweepResult> {
     if (pendingMiningHoldSweepPromise) {
       return await pendingMiningHoldSweepPromise;
     }
@@ -119,8 +119,9 @@ export class MoveCapital {
     wallet: IWallet,
     walletKeys: WalletKeys,
     config: Config,
-  ): Promise<TransactionInfo | undefined> {
+  ): Promise<MiningHoldSweepResult> {
     await this.transactionTracker.load();
+    this.transactionError = '';
 
     const latestMiningHoldSweepTxInfo = this.transactionTracker.findLatestTxInfo<ITransactionMoveMetadata>(txInfo => {
       const metadata = txInfo.tx.metadataJson;
@@ -142,7 +143,10 @@ export class MoveCapital {
       : undefined;
 
     if (latestMiningHoldSweepAttempt?.txAttemptState === TxAttemptState.Follow) {
-      return latestMiningHoldSweepAttempt.txInfo;
+      return {
+        kind: 'trackingExisting',
+        txInfo: latestMiningHoldSweepAttempt.txInfo,
+      };
     }
 
     const assetsToMove: IAssetsToMove = {};
@@ -154,7 +158,9 @@ export class MoveCapital {
     if (wallet.availableMicronots > 0n) {
       assetsToMove[MoveToken.ARGNOT] = wallet.availableMicronots;
     }
-    if (!assetsToMove[MoveToken.ARGN] && !assetsToMove[MoveToken.ARGNOT]) return;
+    if (!assetsToMove[MoveToken.ARGN] && !assetsToMove[MoveToken.ARGNOT]) {
+      return { kind: 'noSpendableFundsToSweep' };
+    }
 
     const client = await getMainchainClient(false);
     const prependedTxs: SubmittableExtrinsic[] = [];
@@ -182,14 +188,10 @@ export class MoveCapital {
         availableMicrogons: wallet.availableMicrogons,
         assetsToMove,
       });
-      return;
-    }
-    if (fee > wallet.availableMicrogons) {
-      console.info('[MoveCapital] Skipping mining hold auto-transfer, not enough argons to cover fee', {
-        availableMicrogons: wallet.availableMicrogons,
-        fee,
-      });
-      return;
+      return {
+        kind: 'blocked',
+        error: this.transactionError,
+      };
     }
 
     let finalAssetsToMove: IAssetsToMove = {};
@@ -217,21 +219,19 @@ export class MoveCapital {
             availableMicrogons: wallet.availableMicrogons,
             assetsToMove: finalAssetsToMove,
           });
-          return;
-        }
-        if (fee > wallet.availableMicrogons) {
-          console.info('[MoveCapital] Skipping mining hold auto-transfer, not enough argons to cover fee', {
-            availableMicrogons: wallet.availableMicrogons,
-            fee,
-          });
-          return;
+          return {
+            kind: 'blocked',
+            error: this.transactionError,
+          };
         }
       } else {
         finalAssetsToMove[MoveToken.ARGNOT] = assetsToMove[MoveToken.ARGNOT];
       }
     }
 
-    if (!finalAssetsToMove[MoveToken.ARGN] && !finalAssetsToMove[MoveToken.ARGNOT]) return;
+    if (!finalAssetsToMove[MoveToken.ARGN] && !finalAssetsToMove[MoveToken.ARGNOT]) {
+      return { kind: 'noSpendableFundsToSweep' };
+    }
 
     const { tx, metadata } = await this.buildTransaction(
       MoveFrom.MiningHold,
@@ -258,7 +258,10 @@ export class MoveCapital {
         metadata,
       });
       followOnTx?.resolve(txInfo);
-      return txInfo;
+      return {
+        kind: 'submitted',
+        txInfo,
+      };
     } catch (error) {
       followOnTx?.reject(error);
       throw error;
@@ -417,3 +420,20 @@ export interface ITransactionMoveMetadata {
   externalAddress?: string;
   assetsToMove: IAssetsToMove;
 }
+
+export type MiningHoldSweepResult =
+  | {
+      kind: 'submitted';
+      txInfo: TransactionInfo;
+    }
+  | {
+      kind: 'trackingExisting';
+      txInfo: TransactionInfo;
+    }
+  | {
+      kind: 'noSpendableFundsToSweep';
+    }
+  | {
+      kind: 'blocked';
+      error: string;
+    };

--- a/src-vue/stores/blockchain.ts
+++ b/src-vue/stores/blockchain.ts
@@ -45,35 +45,43 @@ export const useBlockchainStore = defineStore('blockchain', () => {
     cachedBlockLoading,
   ]);
 
-  async function fetchBlock(header: IBlockHeaderInfo) {
+  async function fetchBlock(header: IBlockHeaderInfo): Promise<IBlock | undefined> {
     await blockWatch.start();
     const { author, blockNumber, blockHash, blockTime } = header;
-    const client = await blockWatch.getRpcClient(header.blockNumber);
-    const clientAt = await client.at(blockHash);
-    const events = await clientAt.query.system.events();
-    let microgons = 0n;
-    let micronots = 0n;
-    events.find(({ event }: { event: any }) => {
-      if (client.events.blockRewards.RewardCreated.is(event)) {
-        for (const x of event.data.rewards) {
-          if (x.rewardType.isMiner) {
-            microgons += x.argons.toBigInt();
-            micronots += x.ownership.toBigInt();
-          }
-        }
-        return true;
-      }
-    });
-    const newBlock: IBlock = {
-      number: blockNumber,
-      hash: blockHash,
-      author: author ?? '',
-      microgons,
-      micronots,
-      timestamp: dayjs.utc(blockTime),
-    };
 
-    return newBlock;
+    try {
+      const clientAt = await blockWatch.getApi(header);
+      const events = await clientAt.query.system.events();
+      let microgons = 0n;
+      let micronots = 0n;
+      events.find(({ event }: { event: any }) => {
+        if (clientAt.events.blockRewards.RewardCreated.is(event)) {
+          for (const x of event.data.rewards) {
+            if (x.rewardType.isMiner) {
+              microgons += x.argons.toBigInt();
+              micronots += x.ownership.toBigInt();
+            }
+          }
+          return true;
+        }
+      });
+
+      return {
+        number: blockNumber,
+        hash: blockHash,
+        author: author ?? '',
+        microgons,
+        micronots,
+        timestamp: dayjs.utc(blockTime),
+      };
+    } catch (error) {
+      console.warn('[BlockchainStore] Failed to fetch block details, skipping block update', {
+        blockNumber,
+        blockHash,
+        error,
+      });
+      return;
+    }
   }
 
   async function fetchBlocks(lastBlockNumber: number | null, maxBlockCount: number) {
@@ -84,7 +92,9 @@ export const useBlockchainStore = defineStore('blockchain', () => {
     while (blocks.length < maxBlockCount && blockNumber >= 0) {
       const headerInfo = await blockWatch.getHeader(blockNumber);
       const block = await fetchBlock(headerInfo);
-      blocks.push(block);
+      if (block) {
+        blocks.push(block);
+      }
       blockNumber--;
     }
 
@@ -97,13 +107,22 @@ export const useBlockchainStore = defineStore('blockchain', () => {
     // Subscribe to new blocks
     for (const header of blockWatch.latestHeaders) {
       const block = await fetchBlock(header);
-      onBlock(block);
-    }
-    return blockWatch.events.on('best-blocks', async headers => {
-      for (const header of headers) {
-        const block = await fetchBlock(header);
+      if (block) {
         onBlock(block);
       }
+    }
+
+    return blockWatch.events.on('best-blocks', headers => {
+      void (async () => {
+        for (const header of headers) {
+          const block = await fetchBlock(header);
+          if (block) {
+            onBlock(block);
+          }
+        }
+      })().catch(error => {
+        console.warn('[BlockchainStore] Failed to process best block update', error);
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

Beacon sync and gateway proving now recover when a submitted transaction leaves the pool before its first inclusion instead of stalling until an outer timeout notices. Mining onboarding and block-driven refreshes now route historical reads through the archive-backed `BlockWatch` path, so pruned hashes and transient history misses stop crashing frame, bitcoin lock, and block detail updates. Mining-hold sweeps also return explicit submitted, existing, blocked, and no-funds outcomes, which lets the setup and wallet overlays surface recoverable funding problems instead of silently spinning.

## Validation

- `yarn vitest --run bot/__test__/EthereumBeaconSyncService.test.ts bot/__test__/EthereumGatewayProverService.test.ts bot/__test__/submitWithTerminalStatusWatch.test.ts core/__test__/MiningFrames.test.ts core/__test__/BlockWatch.test.ts src-vue/__test__/MoveCapital.test.ts`
- `ARGON_E2E_HEADLESS=1 E2E_FLOW_APP_LOGS=quiet E2E_FLOWS=Mining.flow.onboarding yarn e2e:docker`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000?logoColor=white)
