### PR TITLE
Fix mining bid recovery and SSH reconnect handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Trust local gateway CA for Linux e2e
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          yarn dev:gateway-certs
+          sudo cp "$HOME/.argon/dev-gateway-ca/rootCA.pem" /usr/local/share/ca-certificates/argon-dev-gateway-ca.crt
+          sudo update-ca-certificates
+
       - name: Build
         run: yarn build:indexer
 

--- a/core/__test__/BiddingCalculatorData.test.ts
+++ b/core/__test__/BiddingCalculatorData.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/Currency.js', () => ({
+  Currency: class {
+    public async fetchMicrogonsInCirculation(): Promise<bigint> {
+      return 1_000n;
+    }
+
+    public async fetchMainchainRates(): Promise<{ USD: bigint; ARGNOT: bigint }> {
+      return { USD: 2n, ARGNOT: 3n };
+    }
+  },
+}));
+
+import BiddingCalculatorData from '../src/BiddingCalculatorData.ts';
+import { NetworkConfig } from '../src/NetworkConfig.ts';
+import type { IBlockHeaderInfo } from '../src/BlockWatch.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BiddingCalculatorData best-block recovery', () => {
+  it('retries with the finalized block when the latest head cannot be decorated', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = createHeaderInfo(155, '0xbest', '0x154', false);
+    const finalizedHeader = createHeaderInfo(154, '0xfinalized', '0x153', true);
+    const finalizedApi = {
+      consts: {
+        miningSlot: {
+          bidIncrements: {
+            toBigInt: () => 10_000n,
+          },
+        },
+      },
+    };
+    const clientAt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Unable to retrieve header and parent from supplied hash'))
+      .mockResolvedValueOnce(finalizedApi);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const calculatorData = new BiddingCalculatorData(
+      {
+        clients: {},
+        fetchNextFrameId: vi.fn().mockResolvedValue(16),
+        fetchTickAtStartOfNextCohort: vi.fn().mockResolvedValue(1_000),
+        fetchNextCohortSize: vi.fn().mockResolvedValue(25),
+        getNextEpochMaxMiners: vi.fn().mockResolvedValue(50),
+        fetchPreviousDayWinningBidAmounts: vi.fn().mockResolvedValue([10n, 20n]),
+        fetchMicrogonsMinedPerBlockDuringNextCohort: vi.fn().mockResolvedValue(500n),
+        fetchCurrentMicronotsForBid: vi.fn().mockResolvedValue(30n),
+        fetchMaximumMicronotsForEndOfEpochBid: vi.fn().mockResolvedValue(40n),
+        minimumMicronotsMinedDuringTickRange: vi.fn().mockResolvedValue(250n),
+      } as any,
+      {
+        waitForFrameId: vi.fn().mockResolvedValue(undefined),
+        clientAt,
+        blockWatch: {
+          bestBlockHeader: latestHeader,
+          finalizedBlockHeader: finalizedHeader,
+        },
+        framesById: {},
+      } as any,
+    );
+
+    await expect(calculatorData.load(15)).resolves.toBeUndefined();
+
+    expect(clientAt.mock.calls).toEqual([[latestHeader], [finalizedHeader]]);
+    expect(calculatorData.microgonsInCirculation).toBe(1_000n);
+    expect(calculatorData.allowedBidIncrementMicrogons).toBe(10_000n);
+  });
+});
+
+function createHeaderInfo(
+  blockNumber: number,
+  blockHash: string,
+  parentHash: string,
+  isFinalized: boolean,
+): IBlockHeaderInfo {
+  return {
+    isFinalized,
+    blockNumber,
+    blockHash,
+    blockTime: blockNumber * 1_000,
+    parentHash,
+    author: 'author',
+    tick: blockNumber,
+  };
+}

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { Mining } from './Mining.js';
 import { Currency } from './Currency.js';
 import { bigIntMax, bigIntMin, bigNumberToBigInt } from './utils.js';
-import { type ArgonClient, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
+import { type ApiDecoration, type ArgonClient, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { type IBiddingRules, SeatGoalInterval, SeatGoalType } from './interfaces/index.js';
 import { NetworkConfig } from './NetworkConfig.js';
 import type { MiningFrames } from './MiningFrames.ts';
@@ -72,27 +72,44 @@ export default class BiddingCalculatorData {
       // wait for any previous load to finish
       void (await this.loadedFrameIdPromise);
       this.loadedFrameIdPromise = new Promise<number>(async (resolve, reject) => {
-        const mining = this.mining;
-        await this.miningFrames.waitForFrameId(biddingFrameId);
-        const latestHeader = this.miningFrames.blockWatch.bestBlockHeader;
-        let api = await this.miningFrames.clientAt(latestHeader);
-        const nextFrameId = await this.mining.fetchNextFrameId(api);
-        if (biddingFrameId !== nextFrameId - 1) {
-          // need to go back to the start of the bidding frame
-          const frame = this.miningFrames.framesById[biddingFrameId];
-          const frameStartBlockHash = frame.firstBlockHash;
-          const frameStartBlockNumber = frame.firstBlockNumber;
-          if (!frameStartBlockHash || frameStartBlockNumber == null) {
-            return reject(new Error(`No starting block for frame ${biddingFrameId}`));
-          }
-          api = await this.miningFrames.clientAt({
-            blockHash: frameStartBlockHash,
-            blockNumber: frameStartBlockNumber,
-          });
-        }
-
-        const currency = new Currency(mining.clients);
         try {
+          const mining = this.mining;
+          await this.miningFrames.waitForFrameId(biddingFrameId);
+
+          const latestHeader = this.miningFrames.blockWatch.bestBlockHeader;
+          let api: ApiDecoration<'promise'>;
+          try {
+            api = await this.miningFrames.clientAt(latestHeader);
+          } catch (error) {
+            if (latestHeader.isFinalized) {
+              throw error;
+            }
+
+            const finalizedHeader = this.miningFrames.blockWatch.finalizedBlockHeader;
+            console.warn('[BiddingCalculatorData] Failed to decorate best block, retrying with finalized block', {
+              bestBlockNumber: latestHeader.blockNumber,
+              finalizedBlockNumber: finalizedHeader.blockNumber,
+              error: String(error),
+            });
+            api = await this.miningFrames.clientAt(finalizedHeader);
+          }
+
+          const nextFrameId = await this.mining.fetchNextFrameId(api);
+          if (biddingFrameId !== nextFrameId - 1) {
+            // need to go back to the start of the bidding frame
+            const frame = this.miningFrames.framesById[biddingFrameId];
+            const frameStartBlockHash = frame.firstBlockHash;
+            const frameStartBlockNumber = frame.firstBlockNumber;
+            if (!frameStartBlockHash || frameStartBlockNumber == null) {
+              throw new Error(`No starting block for frame ${biddingFrameId}`);
+            }
+            api = await this.miningFrames.clientAt({
+              blockHash: frameStartBlockHash,
+              blockNumber: frameStartBlockNumber,
+            });
+          }
+
+          const currency = new Currency(mining.clients);
           const tickAtStartOfNextCohort = await mining.fetchTickAtStartOfNextCohort(api);
           const tickAtEndOfNextCohort = tickAtStartOfNextCohort + NetworkConfig.ticksPerCohort;
 

--- a/e2e/flows/operations/Mining.op.completeChecklist.ts
+++ b/e2e/flows/operations/Mining.op.completeChecklist.ts
@@ -70,6 +70,12 @@ async function applyCustomBid(
 ): Promise<void> {
   await flow.click(`BotSettings.openEditBoxOverlay('${bidType}')`);
   const formulaTestId = bidType === 'startingBid' ? 'startingBidFormulaType' : 'maximumBidFormulaType';
+  const formulaState = await flow.isVisible(formulaTestId);
+  if (!formulaState.clickable) {
+    throw new Error(
+      `${bidType} formula type is not clickable (visible=${formulaState.visible}, enabled=${formulaState.enabled}, clickable=${formulaState.clickable}, pointerReason=${formulaState.pointerReason ?? 'none'}, pointerBlocker=${formulaState.pointerBlocker ?? 'none'}).`,
+    );
+  }
   await flow.click(formulaTestId);
   await flow.click('Custom Amount');
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3985,6 +3985,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5222,7 +5223,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -5994,6 +5995,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -7334,6 +7341,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7735,6 +7743,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
-tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
+tauri-plugin-http = { version = "2", features = ["unsafe-headers", "rustls-tls-native-roots"] }
 tauri-plugin-clipboard-manager = "2.3.0"
 tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"

--- a/src-vue/__test__/SSHConnection.test.ts
+++ b/src-vue/__test__/SSHConnection.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServerType } from '../interfaces/IConfig.ts';
+import { SSHConnection } from '../lib/SSHConnection.ts';
+import { InvokeTimeout } from '../lib/tauriApi.ts';
+
+const { invokeWithTimeout, MockInvokeTimeout } = vi.hoisted(() => {
+  class MockInvokeTimeout extends Error {}
+
+  return {
+    invokeWithTimeout: vi.fn(),
+    MockInvokeTimeout,
+  };
+});
+
+vi.mock('../lib/tauriApi.ts', () => {
+  return {
+    InvokeTimeout: MockInvokeTimeout,
+    invokeWithTimeout,
+  };
+});
+
+vi.mock('@tauri-apps/api/event', () => {
+  return {
+    listen: vi.fn(),
+  };
+});
+
+describe('SSHConnection', () => {
+  beforeEach(() => {
+    invokeWithTimeout.mockReset();
+  });
+
+  it('reconnects after a command timeout even if close times out', async () => {
+    invokeWithTimeout
+      .mockResolvedValueOnce('success')
+      .mockRejectedValueOnce(new InvokeTimeout('command timed out'))
+      .mockRejectedValueOnce(new InvokeTimeout('close timed out'))
+      .mockResolvedValueOnce('success')
+      .mockResolvedValueOnce(['ok', 0]);
+
+    const connection = new SSHConnection({
+      type: ServerType.LocalComputer,
+      ipAddress: '127.0.0.1',
+      sshPort: 55404,
+      sshUser: 'root',
+      workDir: '/app',
+    });
+
+    await connection.connect(0);
+
+    await expect(connection.runCommandWithTimeout('pwd', 10_000)).resolves.toEqual(['ok', 0]);
+
+    expect(invokeWithTimeout.mock.calls.map(call => call[0] as string)).toEqual([
+      'open_ssh_connection',
+      'ssh_run_command',
+      'close_ssh_connection',
+      'open_ssh_connection',
+      'ssh_run_command',
+    ]);
+  });
+
+  it('reconnects when the SSH pool no longer has the connection', async () => {
+    invokeWithTimeout
+      .mockResolvedValueOnce('success')
+      .mockRejectedValueOnce('No SSH connection')
+      .mockResolvedValueOnce('success')
+      .mockResolvedValueOnce('success')
+      .mockResolvedValueOnce(['ok', 0]);
+
+    const connection = new SSHConnection({
+      type: ServerType.LocalComputer,
+      ipAddress: '127.0.0.1',
+      sshPort: 55404,
+      sshUser: 'root',
+      workDir: '/app',
+    });
+
+    await connection.connect(0);
+
+    await expect(connection.runCommandWithTimeout('ls /app/logs', 10_000)).resolves.toEqual(['ok', 0]);
+
+    expect(invokeWithTimeout.mock.calls.map(call => call[0] as string)).toEqual([
+      'open_ssh_connection',
+      'ssh_run_command',
+      'close_ssh_connection',
+      'open_ssh_connection',
+      'ssh_run_command',
+    ]);
+  });
+});

--- a/src-vue/app-operations/overlays/EditBoxOverlay.vue
+++ b/src-vue/app-operations/overlays/EditBoxOverlay.vue
@@ -2,7 +2,7 @@
 <template>
   <div
     ref="modalElem"
-    class="absolute bg-white border border-slate-500/60 rounded-md shadow-lg z-100 text-base"
+    class="absolute bg-white border border-slate-500/60 rounded-md shadow-lg z-200 text-base"
     :style="[positionStyle, { cursor: isDragging ? 'grabbing' : 'default' }]"
   >
     <div class="flex flex-col">

--- a/src-vue/lib/SSHConnection.ts
+++ b/src-vue/lib/SSHConnection.ts
@@ -82,11 +82,16 @@ export class SSHConnection {
     try {
       return await invokeWithTimeout('ssh_run_command', payload, timeout);
     } catch (error) {
-      const canRetry =
-        retries > 0 &&
-        !this.isDestroyed &&
-        (error instanceof InvokeTimeout || String(error) === 'SSHCommandMissingExitStatus');
-      if (!canRetry) {
+      if (retries <= 0 || this.isDestroyed) {
+        throw error;
+      }
+
+      const errorMessage = String(error);
+      const isReconnectableError =
+        error instanceof InvokeTimeout ||
+        errorMessage === 'SSHCommandMissingExitStatus' ||
+        errorMessage === 'No SSH connection';
+      if (!isReconnectableError) {
         throw error;
       }
 
@@ -147,11 +152,14 @@ export class SSHConnection {
 
   public async close(destroy = false): Promise<void> {
     const payload = { address: this.address };
-    await invokeWithTimeout('close_ssh_connection', payload, 5_000);
-    this.isConnectedPromise = undefined;
-    this.isConnected = false;
-    if (destroy) {
-      this.isDestroyed = true;
+    try {
+      await invokeWithTimeout('close_ssh_connection', payload, 5_000);
+    } finally {
+      this.isConnectedPromise = undefined;
+      this.isConnected = false;
+      if (destroy) {
+        this.isDestroyed = true;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Retry mining data loading against the finalized block when the best block cannot be decorated, so bidding can still recover on transient head lookup failures.
- Surface clearer clickable-state failures in the mining checklist flow when the bid formula selector is not interactable.
- Make SSH command execution recover from pool disconnects and preserve connection cleanup even when close times out.
- Raise the edit overlay stacking order so the bidding controls stay reachable.

## Testing
- Added targeted unit coverage for mining best-block recovery and SSH reconnect behavior.
- Updated the mining flow to fail fast with actionable visibility details when the formula selector is blocked.