### PR TITLE
fix: improve wallet and vault recovery flows

### DIFF
--- a/core/src/TransactionEvents.ts
+++ b/core/src/TransactionEvents.ts
@@ -188,11 +188,12 @@ export class TransactionEvents {
   > {
     const { blockWatch, extrinsicHash, block, blockCache } = args;
     const client = await blockWatch.getRpcClient(block.blockNumber);
-    const rawHeader = await client.rpc.chain.getHeader(block.blockHash);
-    const header = BlockWatch.readHeader(rawHeader, block.blockNumber <= blockWatch.finalizedBlockHeader.blockNumber);
-
-    const signedBlock = blockCache?.get(block.blockHash) ?? (await blockWatch.getBlock(header));
+    const signedBlock = blockCache?.get(block.blockHash) ?? (await blockWatch.getBlock(block));
     blockCache?.set(block.blockHash, signedBlock);
+    const header = BlockWatch.readHeader(
+      signedBlock.block.header,
+      block.blockNumber <= blockWatch.finalizedBlockHeader.blockNumber,
+    );
 
     for (const [index, extrinsic] of signedBlock.block.extrinsics.entries()) {
       if (u8aToHex(extrinsic.hash) !== extrinsicHash) continue;

--- a/core/src/TransactionEvents.ts
+++ b/core/src/TransactionEvents.ts
@@ -8,7 +8,7 @@ import {
   type SpRuntimeDispatchError,
   u8aToHex,
 } from '@argonprotocol/mainchain';
-import type { BlockWatch } from './BlockWatch.js';
+import { BlockWatch, type IBlockHeaderInfo } from './BlockWatch.js';
 
 type IsMatchingEventFn = (
   event: GenericEvent,
@@ -154,32 +154,66 @@ export class TransactionEvents {
       });
       if (!header) continue;
 
-      const client = await blockWatch.getRpcClient(blockHeight);
-
-      const block = blockCache?.get(header.blockHash) ?? (await blockWatch.getBlock(header));
-      blockCache?.set(header.blockHash, block);
-
-      for (const [index, extrinsic] of block.block.extrinsics.entries()) {
-        if (u8aToHex(extrinsic.hash) !== extrinsicHash) continue;
-
-        const events = await blockWatch.getEvents(header);
-        const txEvents = await this.getErrorAndFeeForTransaction({
-          client,
-          extrinsicIndex: index,
-          events,
-        });
-
-        return {
-          blockNumber: blockHeight,
-          blockHash: header.blockHash,
-          blockTime: header.blockTime,
-          extrinsicIndex: index,
-          fee: txEvents.fee,
-          tip: txEvents.tip,
-          error: txEvents.error,
-          extrinsicEvents: txEvents.extrinsicEvents,
-        };
+      const found = await this.findByExtrinsicHashInBlock({
+        blockWatch,
+        extrinsicHash,
+        block: header,
+        blockCache,
+      });
+      if (found) {
+        return found;
       }
+    }
+
+    return undefined;
+  }
+
+  public static async findByExtrinsicHashInBlock(args: {
+    blockWatch: BlockWatch;
+    extrinsicHash: string;
+    block: Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>;
+    blockCache?: IBlockCache;
+  }): Promise<
+    | {
+        blockNumber: number;
+        blockHash: string;
+        blockTime: number;
+        extrinsicIndex: number;
+        fee: bigint;
+        tip: bigint;
+        error?: ExtrinsicError;
+        extrinsicEvents: GenericEvent[];
+      }
+    | undefined
+  > {
+    const { blockWatch, extrinsicHash, block, blockCache } = args;
+    const client = await blockWatch.getRpcClient(block.blockNumber);
+    const rawHeader = await client.rpc.chain.getHeader(block.blockHash);
+    const header = BlockWatch.readHeader(rawHeader, block.blockNumber <= blockWatch.finalizedBlockHeader.blockNumber);
+
+    const signedBlock = blockCache?.get(block.blockHash) ?? (await blockWatch.getBlock(header));
+    blockCache?.set(block.blockHash, signedBlock);
+
+    for (const [index, extrinsic] of signedBlock.block.extrinsics.entries()) {
+      if (u8aToHex(extrinsic.hash) !== extrinsicHash) continue;
+
+      const events = await blockWatch.getEvents(header);
+      const txEvents = await this.getErrorAndFeeForTransaction({
+        client,
+        extrinsicIndex: index,
+        events,
+      });
+
+      return {
+        blockNumber: header.blockNumber,
+        blockHash: header.blockHash,
+        blockTime: header.blockTime,
+        extrinsicIndex: index,
+        fee: txEvents.fee,
+        tip: txEvents.tip,
+        error: txEvents.error,
+        extrinsicEvents: txEvents.extrinsicEvents,
+      };
     }
 
     return undefined;

--- a/src-vue/__test__/Bot.test.ts
+++ b/src-vue/__test__/Bot.test.ts
@@ -1,0 +1,101 @@
+import './helpers/mocks.ts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Bot } from '../lib/Bot.ts';
+import { ServerAdmin } from '../lib/ServerAdmin.ts';
+import { MiningSetupStatus } from '../interfaces/IConfig.ts';
+
+describe('Bot', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists downloaded bidding rules through the dedicated config save path', async () => {
+    const remoteRules = {
+      seatGoal: {
+        type: 'static',
+        seats: 1,
+      },
+    };
+    vi.spyOn(ServerAdmin.prototype, 'downloadConfigState').mockResolvedValue({
+      biddingRules: remoteRules as any,
+      oldestFrameIdToSync: 42,
+      ethereumBeaconApiUrl: 'https://beacon.example',
+      ethereumExecutionRpcUrl: 'https://execution.example',
+    });
+    const config = createConfigStub();
+    const bot = new Bot(config as any, Promise.resolve({} as any), {} as any);
+
+    await bot.loadServerConfig();
+
+    expect(config.biddingRules).toEqual(remoteRules);
+    expect(config.oldestFrameIdToSync).toBe(42);
+    expect(config.ethereumBeaconApiUrl).toBe('https://beacon.example');
+    expect(config.ethereumExecutionRpcUrl).toBe('https://execution.example');
+    expect(config.saveBiddingRules).toHaveBeenCalledTimes(1);
+    expect(config.save).not.toHaveBeenCalled();
+  });
+
+  it('preserves local config when the server omits optional env state fields', async () => {
+    vi.spyOn(ServerAdmin.prototype, 'downloadConfigState').mockResolvedValue({
+      biddingRules: undefined,
+      oldestFrameIdToSync: undefined,
+      ethereumBeaconApiUrl: undefined,
+      ethereumExecutionRpcUrl: undefined,
+    });
+    const config = createConfigStub({
+      oldestFrameIdToSync: 88,
+      ethereumBeaconApiUrl: 'https://local-beacon.example',
+      ethereumExecutionRpcUrl: 'https://local-execution.example',
+    });
+    const bot = new Bot(config as any, Promise.resolve({} as any), {} as any);
+
+    await bot.loadServerConfig();
+
+    expect(config.oldestFrameIdToSync).toBe(88);
+    expect(config.ethereumBeaconApiUrl).toBe('https://local-beacon.example');
+    expect(config.ethereumExecutionRpcUrl).toBe('https://local-execution.example');
+    expect(config.saveBiddingRules).not.toHaveBeenCalled();
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies an explicitly empty beacon api url from server state', async () => {
+    vi.spyOn(ServerAdmin.prototype, 'downloadConfigState').mockResolvedValue({
+      biddingRules: undefined,
+      oldestFrameIdToSync: undefined,
+      ethereumBeaconApiUrl: '',
+      ethereumExecutionRpcUrl: undefined,
+    });
+    const config = createConfigStub({
+      ethereumBeaconApiUrl: 'https://local-beacon.example',
+    });
+    const bot = new Bot(config as any, Promise.resolve({} as any), {} as any);
+
+    await bot.loadServerConfig();
+
+    expect(config.ethereumBeaconApiUrl).toBe('');
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createConfigStub(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    miningSetupStatus: MiningSetupStatus.Finished,
+    serverDetails: {
+      ipAddress: '127.0.0.1',
+      sshUser: 'root',
+      workDir: '~',
+    },
+    biddingRules: {
+      seatGoal: {
+        type: 'static',
+        seats: 2,
+      },
+    },
+    oldestFrameIdToSync: 12,
+    ethereumBeaconApiUrl: 'https://default-beacon.example',
+    ethereumExecutionRpcUrl: 'https://default-execution.example',
+    saveBiddingRules: vi.fn(),
+    save: vi.fn(),
+    ...overrides,
+  };
+}

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -303,10 +303,7 @@ describe('TransactionTracker', () => {
       tracker as unknown as {
         recordWatchStatus: (tx: ITransactionRecord, result: any) => Promise<void>;
       }
-    ).recordWatchStatus.bind(tracker) as (
-      tx: ITransactionRecord,
-      result: any,
-    ) => Promise<void>;
+    ).recordWatchStatus.bind(tracker) as (tx: ITransactionRecord, result: any) => Promise<void>;
     const findSpy = vi.spyOn(TransactionEvents, 'findByExtrinsicHashInBlock').mockResolvedValueOnce({
       blockNumber: 130,
       blockHash: '0xwatched-block',

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -288,6 +288,69 @@ describe('TransactionTracker', () => {
     expect(tx.finalizedHeadHeight).toBe(101);
   });
 
+  it('records finalized watch updates using the watched block hash', async () => {
+    const tx = createTransaction({
+      id: 10,
+      blockHeight: 130,
+      blockHash: '0xold-block',
+      finalizedHeadHeight: 129,
+    });
+    const { tracker, table } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 130,
+    });
+    const recordWatchStatus = (
+      tracker as unknown as {
+        recordWatchStatus: (tx: ITransactionRecord, result: any) => Promise<void>;
+      }
+    ).recordWatchStatus.bind(tracker) as (
+      tx: ITransactionRecord,
+      result: any,
+    ) => Promise<void>;
+    const findSpy = vi.spyOn(TransactionEvents, 'findByExtrinsicHashInBlock').mockResolvedValueOnce({
+      blockNumber: 130,
+      blockHash: '0xwatched-block',
+      blockTime: new Date('2026-03-20T20:10:00Z').getTime(),
+      extrinsicIndex: 2,
+      fee: 1n,
+      tip: 0n,
+      extrinsicEvents: [],
+    });
+
+    await recordWatchStatus(tx, {
+      blockNumber: 130,
+      status: {
+        isBroadcast: false,
+        isInBlock: false,
+        isFinalized: true,
+        isRetracted: false,
+        isUsurped: false,
+        isDropped: false,
+        isInvalid: false,
+        asFinalized: { toHex: () => '0xwatched-block' },
+      },
+    });
+
+    expect(findSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extrinsicHash: tx.extrinsicHash,
+        block: {
+          blockNumber: 130,
+          blockHash: '0xwatched-block',
+        },
+      }),
+    );
+    expect(table.recordInBlock).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        blockNumber: 130,
+        blockHash: '0xwatched-block',
+        extrinsicIndex: 2,
+      }),
+    );
+    expect(table.markFinalized).toHaveBeenCalledWith(tx, expect.objectContaining({ blockNumber: 130 }));
+  });
+
   it('reserves local nonces above restored pending submissions for concurrent same-account work', async () => {
     vi.mocked(getMainchainClient).mockResolvedValue({
       rpc: {
@@ -404,6 +467,14 @@ async function createTracker(args: {
       },
     ),
   };
+  const historyTable = {
+    fetchLatestByTransactionIds: vi.fn().mockResolvedValue(args.latestHistoryByTxId ?? new Map()),
+    record: vi.fn(async (entry: Record<string, unknown>) => ({
+      id: 1,
+      createdAt: new Date('2026-03-20T20:05:00Z'),
+      ...entry,
+    })),
+  };
   const blockWatch = {
     start: vi.fn().mockResolvedValue(undefined),
     bestBlockHeader: { blockNumber: args.finalizedHeight },
@@ -424,9 +495,7 @@ async function createTracker(args: {
   const tracker = new TransactionTracker(
     Promise.resolve({
       transactionsTable: table,
-      transactionStatusHistoryTable: {
-        fetchLatestByTransactionIds: vi.fn().mockResolvedValue(args.latestHistoryByTxId ?? new Map()),
-      },
+      transactionStatusHistoryTable: historyTable,
     } as any),
     blockWatch as any,
   );

--- a/src-vue/__test__/WalletBalances.integration.test.ts
+++ b/src-vue/__test__/WalletBalances.integration.test.ts
@@ -256,6 +256,50 @@ describe
       }
     });
 
+    it.sequential('should keep the current wallet balance visible while catching up history', async () => {
+      const db = await createTestDb();
+      const blockWatch = new BlockWatch(clients);
+      const walletsForArgon = new WalletsForArgon(walletKeys, Promise.resolve(db), blockWatch, undefined);
+      try {
+        const spy = vi
+          .spyOn(walletsForArgon, 'lookupTransferOrClaimBlocks')
+          .mockImplementation(async (address, blocks) => {
+            const mostRecentBlock = Math.max(...transferBlocks);
+            for (const block of transferBlocks) {
+              if (address === walletKeys.miningBotAddress) {
+                blocks.add(block);
+              }
+            }
+            return { asOfBlock: mostRecentBlock };
+          });
+        const visibleMiningBotBalances: bigint[] = [];
+        walletsForArgon.events.on('balance-change', (balanceChange, type) => {
+          if (type === 'miningBot') {
+            visibleMiningBotBalances.push(balanceChange.availableMicrogons);
+          }
+        });
+
+        // @ts-expect-error set a small backlog to force using indexer
+        walletsForArgon.blockBacklogBeforeUsingIndexer = 10;
+        await walletsForArgon.load();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(visibleMiningBotBalances).toEqual([15_000_000n]);
+
+        const replayedMiningBotBalances = walletsForArgon
+          .getLoadEvents('balance-change')
+          .filter(([, type]) => type === 'miningBot')
+          .map(([balanceChange]) => balanceChange.availableMicrogons);
+        expect(replayedMiningBotBalances.length).toBeGreaterThan(1);
+        expect(replayedMiningBotBalances).toContain(5_000_000n);
+        expect(walletsForArgon.miningBotWallet.totalMicrogons).toBe(15_000_000n);
+      } finally {
+        await walletsForArgon.close();
+        blockWatch.stop();
+        await db.close();
+      }
+    });
+
     it.sequential('should recover wallet balances on restart without indexer', async () => {
       // 1. Test that it will fill gap from last synced to latest block
       const db = await createTestDb();

--- a/src-vue/app-operations/overlays/BotEditOverlay.vue
+++ b/src-vue/app-operations/overlays/BotEditOverlay.vue
@@ -146,7 +146,7 @@ basicEmitter.on('openBotEditOverlay', async () => {
   if (isOpen.value) return;
   isLoaded.value = false;
 
-  await bot.loadServerBiddingRules();
+  await bot.loadServerConfig();
   await calculator.load(rules.value);
   previousVaultingRules = JsonExt.stringify(config.vaultingRules);
 

--- a/src-vue/app-operations/overlays/VaultCollectOverlay.vue
+++ b/src-vue/app-operations/overlays/VaultCollectOverlay.vue
@@ -202,6 +202,7 @@ import InputMenu from '../../components/InputMenu.vue';
 import { MoveTo } from '@argonprotocol/apps-core';
 import { TransactionInfo } from '../../lib/TransactionInfo.ts';
 import type { IMintingAuthorityAuthorizeMetadata } from '../../lib/MintingAuthorities.ts';
+import type { IVaultCollectMetadata } from '../../lib/VaultCollectBuilder.ts';
 
 dayjs.extend(utc);
 
@@ -266,6 +267,18 @@ const activeMintingAuthorizeTxInfos = Vue.computed(() => {
   ]) as TransactionInfo<IMintingAuthorityAuthorizeMetadata>[];
 });
 
+const activeCollectActionType = Vue.computed<IVaultCollectMetadata['actionType'] | undefined>(() => {
+  const pendingCollectTxInfo = myVault.data.pendingCollectTxInfo;
+  if (pendingCollectTxInfo && !pendingCollectTxInfo.isPostProcessed) {
+    return pendingCollectTxInfo.tx.metadataJson.actionType;
+  }
+
+  const pendingBitcoinCosignTxInfo = latestMyPendingBitcoinCosignTxInfo.value;
+  if (pendingBitcoinCosignTxInfo && !pendingBitcoinCosignTxInfo.isPostProcessed) {
+    return 'cosignBitcoin';
+  }
+});
+
 const hasCollectWork = Vue.computed(() => {
   return collectRevenue.value > 0n || manualPendingCosignCount.value > 0 || councilApprovalCount.value > 0;
 });
@@ -309,6 +322,9 @@ const mintingAuthorizeRewardAmount = Vue.computed(() => {
 });
 
 const overlayTitle = Vue.computed(() => {
+  if (isCollectBusy.value) {
+    return getCollectActionTitle(activeCollectActionType.value);
+  }
   if (collectRevenue.value > 0n && manualPendingCosignCount.value > 0) {
     return 'Collect Revenue and Cosign';
   }
@@ -320,7 +336,7 @@ const overlayTitle = Vue.computed(() => {
 
 const collectButtonLabel = Vue.computed(() => {
   if (isCollectBusy.value) {
-    return 'Submitting...';
+    return getCollectBusyLabel(activeCollectActionType.value);
   }
   if (collectRevenue.value > 0n && manualPendingCosignCount.value === 0 && councilApprovalCount.value === 0) {
     return 'Collect Revenue';
@@ -562,6 +578,29 @@ function getUniqueTransactionInfos(txInfos: TransactionInfo[]) {
   }
 
   return [...uniqueTxInfos.values()].sort((left, right) => left.tx.createdAt.getTime() - right.tx.createdAt.getTime());
+}
+
+function getCollectActionTitle(actionType?: IVaultCollectMetadata['actionType']) {
+  if (actionType === 'collectRevenue') {
+    return 'Collect Revenue';
+  }
+  if (actionType === 'cosignBitcoin') {
+    return 'Sign Bitcoin Transactions';
+  }
+  return 'Vault Approvals';
+}
+
+function getCollectBusyLabel(actionType?: IVaultCollectMetadata['actionType']) {
+  if (actionType === 'collectRevenue') {
+    return 'Collecting Revenue...';
+  }
+  if (actionType === 'cosignBitcoin') {
+    return 'Signing Bitcoin Transactions...';
+  }
+  if (actionType === 'approveCouncil') {
+    return 'Approving Council Updates...';
+  }
+  return 'Submitting...';
 }
 
 function getMintingAuthorizeCompletionMessage(txInfos: TransactionInfo[]) {

--- a/src-vue/app-shared/overlays/troubleshooting/FindMissingData.vue
+++ b/src-vue/app-shared/overlays/troubleshooting/FindMissingData.vue
@@ -36,6 +36,20 @@
       </success>
       <failure>No bitcoins were found.</failure>
     </DiagnosticStep>
+
+    <DiagnosticStep ref="step4" :run="() => checkMintingAuthorities()">
+      <heading>Searching for Missing Minting Authorities</heading>
+      <success v-slot="{ data }">
+        <template v-if="data.isNotFound">No Ethereum minting authorities were found for this vault operator.</template>
+        <template v-else-if="data.isUnchanged">Your minting authorities are already up to date.</template>
+        <template v-else>
+          We were able to recover {{ data.recoveredAuthorities }} missing minting authorit{{
+            data.recoveredAuthorities === 1 ? 'y' : 'ies'
+          }}.
+        </template>
+      </success>
+      <failure>Unable to recover minting authorities.</failure>
+    </DiagnosticStep>
   </div>
 </template>
 
@@ -50,7 +64,7 @@ import { getMyVault } from '../../../stores/vaults.ts';
 import { getDbPromise } from '../../../stores/helpers/dbPromise.ts';
 import { getBitcoinLocks } from '../../../stores/bitcoin.ts';
 import { MyVaultRecovery } from '../../../lib/MyVaultRecovery.ts';
-import { getMainchainClients } from '../../../stores/mainchain.ts';
+import { getFinalizedClient, getMainchainClients } from '../../../stores/mainchain.ts';
 
 const walletsForArgon = getWalletsForArgon();
 const walletKeys = getWalletKeys();
@@ -63,6 +77,7 @@ const containerRef = Vue.ref<HTMLElement>();
 const step1 = Vue.ref<InstanceType<typeof DiagnosticStep>>();
 const step2 = Vue.ref<InstanceType<typeof DiagnosticStep>>();
 const step3 = Vue.ref<InstanceType<typeof DiagnosticStep>>();
+const step4 = Vue.ref<InstanceType<typeof DiagnosticStep>>();
 
 function scrollToBottom() {
   if (containerRef.value) {
@@ -144,11 +159,43 @@ async function checkBitcoins() {
   };
 }
 
+async function checkMintingAuthorities() {
+  await myVault.load();
+  const recoveredAuthorityCountOnLoad = myVault.mintingAuthorities.recoveredAuthorityCountOnLoad;
+  if (recoveredAuthorityCountOnLoad > 0) {
+    return {
+      isUnchanged: false,
+      isNotFound: false,
+      recoveredAuthorities: recoveredAuthorityCountOnLoad,
+    };
+  }
+
+  const previousAuthorityKeys = new Set(
+    myVault.mintingAuthorities.data.authorities.map(authority => {
+      return `${authority.authorityIndex ?? 'missing'}:${authority.signer.toLowerCase()}`;
+    }),
+  );
+  const finalizedClient = await getFinalizedClient();
+  const restoredAuthorities = await myVault.mintingAuthorities.restoreSignerIndexes(finalizedClient);
+
+  await myVault.mintingAuthorities.refresh(finalizedClient);
+
+  const recoveredAuthorities = restoredAuthorities.filter(authority => {
+    return !previousAuthorityKeys.has(`${authority.authorityIndex ?? 'missing'}:${authority.signer.toLowerCase()}`);
+  }).length;
+
+  return {
+    isUnchanged: recoveredAuthorities === 0,
+    isNotFound: restoredAuthorities.length === 0,
+    recoveredAuthorities,
+  };
+}
+
 async function findMissingData() {
   await myVault.load();
   await Vue.nextTick();
 
-  const steps = [step1.value, step2.value, step3.value].filter(Boolean);
+  const steps = [step1.value, step2.value, step3.value, step4.value].filter(Boolean);
   for (const step of steps) {
     if (step && typeof step.run === 'function') {
       await step.run();

--- a/src-vue/lib/Bot.ts
+++ b/src-vue/lib/Bot.ts
@@ -64,6 +64,7 @@ export class Bot {
     }
     this.loadDeferred.setIsRunning(true);
     try {
+      await this.config.isLoadedPromise;
       const db = await this.dbPromise;
       this.botSyncer = new BotSyncer(this.config, db, installer, this.serverApiClient, mining, miningFrames, {
         onEvent: (type, payload) => botEmitter.emit(type, payload),
@@ -77,10 +78,10 @@ export class Bot {
         setDbSyncProgress: x => (this.syncProgress = 90 + x * 0.1),
       });
 
-      await this.botSyncer.load();
-      await this.loadServerBiddingRules().catch(err => {
-        console.error('Error loading server bidding rules:', err);
+      await this.loadServerConfig().catch(err => {
+        console.error('Error loading server config:', err);
       });
+      await this.botSyncer.load();
       this.loadDeferred.resolve();
     } catch (err) {
       this.loadDeferred.reject(err);
@@ -101,13 +102,31 @@ export class Bot {
     this.botSyncer.isPaused = false;
   }
 
-  public async loadServerBiddingRules(): Promise<void> {
+  public async loadServerConfig(): Promise<void> {
     if (this.config.miningSetupStatus !== MiningSetupStatus.Finished) return;
     const server = new ServerAdmin(await SSH.getOrCreateConnection(), this.config.serverDetails);
-    const remoteRules = await server.downloadBiddingRules();
-    if (!remoteRules) return;
-    this.config.biddingRules = remoteRules;
-    await this.config.saveBiddingRules();
+    const { biddingRules, oldestFrameIdToSync, ethereumBeaconApiUrl, ethereumExecutionRpcUrl } =
+      await server.downloadConfigState();
+
+    if (biddingRules) {
+      this.config.biddingRules = biddingRules;
+    }
+
+    if (oldestFrameIdToSync !== undefined) {
+      this.config.oldestFrameIdToSync = oldestFrameIdToSync;
+    }
+    if (ethereumBeaconApiUrl !== undefined) {
+      this.config.ethereumBeaconApiUrl = ethereumBeaconApiUrl;
+    }
+    if (ethereumExecutionRpcUrl !== undefined) {
+      this.config.ethereumExecutionRpcUrl = ethereumExecutionRpcUrl;
+    }
+
+    if (biddingRules) {
+      await this.config.saveBiddingRules();
+      return;
+    }
+    await this.config.save();
   }
 
   public async resyncBiddingRules(): Promise<void> {

--- a/src-vue/lib/MintingAuthorities.ts
+++ b/src-vue/lib/MintingAuthorities.ts
@@ -70,6 +70,7 @@ export class MintingAuthorities {
     pendingMintingAuthorizations: IMintingAuthorityAuthorization[];
     pendingMintingAuthorizeTxInfosByTransferId: Map<string, TransactionInfo<IMintingAuthorityAuthorizeMetadata>>;
   };
+  public recoveredAuthorityCountOnLoad = 0;
 
   #subscriptions: VoidFunction[] = [];
   #isSubscribing = false;
@@ -102,8 +103,17 @@ export class MintingAuthorities {
 
     this.#waitForLoad = createDeferred();
     try {
+      this.recoveredAuthorityCountOnLoad = 0;
       await this.miningFrames.blockWatch.start();
-      await this.refresh(await this.miningFrames.blockWatch.getFinalizedApi());
+      const finalizedClient = await this.miningFrames.blockWatch.getFinalizedApi();
+      await this.refresh(finalizedClient);
+      if (!this.data.authorities.length) {
+        const restoredAuthorities = await this.restoreSignerIndexes(finalizedClient);
+        this.recoveredAuthorityCountOnLoad = restoredAuthorities.length;
+        if (restoredAuthorities.length) {
+          await this.refresh(finalizedClient);
+        }
+      }
       for (const txInfo of this.transactionTracker.pendingBlockTxInfosAtLoad) {
         if (txInfo.tx.extrinsicType === ExtrinsicType.CrosschainTransferAuthorize) {
           void this.onAuthorize(txInfo as TransactionInfo<IMintingAuthorityAuthorizeMetadata>);

--- a/src-vue/lib/SSH.ts
+++ b/src-vue/lib/SSH.ts
@@ -64,8 +64,8 @@ export class SSH {
         ethereumExecutionRpcUrl: undefined,
       };
 
-    const biddingRules = await server.downloadBiddingRules();
-    const { oldestFrameIdToSync, ethereumBeaconApiUrl, ethereumExecutionRpcUrl } = await server.downloadEnvState();
+    const { biddingRules, oldestFrameIdToSync, ethereumBeaconApiUrl, ethereumExecutionRpcUrl } =
+      await server.downloadConfigState();
 
     return {
       walletAddress,

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -130,6 +130,19 @@ export class ServerAdmin {
     return biddingRulesRaw ? JsonExt.parse(biddingRulesRaw) : undefined;
   }
 
+  public async downloadConfigState(): Promise<{
+    biddingRules: IBiddingRules | undefined;
+    oldestFrameIdToSync?: number;
+    ethereumBeaconApiUrl?: string;
+    ethereumExecutionRpcUrl?: string;
+  }> {
+    const [biddingRules, envState] = await Promise.all([this.downloadBiddingRules(), this.downloadEnvState()]);
+    return {
+      biddingRules,
+      ...envState,
+    };
+  }
+
   public async uploadEnvState(envState: {
     oldestFrameIdToSync: number;
     vaultOperatorAddress: string;
@@ -159,7 +172,7 @@ export class ServerAdmin {
   }
 
   public async downloadEnvState(): Promise<{
-    oldestFrameIdToSync: number;
+    oldestFrameIdToSync?: number;
     ethereumBeaconApiUrl?: string;
     ethereumExecutionRpcUrl?: string;
   }> {
@@ -169,8 +182,9 @@ export class ServerAdmin {
     );
     const envState = envStateRaw ? parseEnv(envStateRaw) : {};
     const hasBeaconApiUrl = 'ETHEREUM_BEACON_API_URL' in envState;
+    const hasOldestFrameIdToSync = 'OLDEST_FRAME_ID_TO_SYNC' in envState;
     return {
-      oldestFrameIdToSync: Number(envState.OLDEST_FRAME_ID_TO_SYNC || '0'),
+      oldestFrameIdToSync: hasOldestFrameIdToSync ? Number(envState.OLDEST_FRAME_ID_TO_SYNC || '0') : undefined,
       ethereumBeaconApiUrl: hasBeaconApiUrl ? (envState.ETHEREUM_BEACON_API_URL?.trim() ?? '') : undefined,
       ethereumExecutionRpcUrl: envState.ETHEREUM_EXECUTION_RPC_URL?.trim() || undefined,
     };

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -605,6 +605,7 @@ export class TransactionTracker {
 
   private async recordWatchStatus(record: ITransactionRecord, result: IWatchedTxResult) {
     const { blockNumber, status } = result;
+    const watchBlockHash = status.isInBlock ? status.asInBlock?.toHex() : status.asFinalized?.toHex();
 
     if (status.isBroadcast) {
       await this.recordHistoryStatus({
@@ -634,15 +635,15 @@ export class TransactionTracker {
       });
     }
 
-    if ((status.isInBlock || status.isFinalized) && blockNumber != null) {
-      const findTransactionResult = await TransactionEvents.findByExtrinsicHash({
+    if ((status.isInBlock || status.isFinalized) && blockNumber != null && watchBlockHash) {
+      const findTransactionResult = await TransactionEvents.findByExtrinsicHashInBlock({
         blockWatch: this.blockWatch,
         extrinsicHash: record.extrinsicHash,
-        searchStartBlockHeight: blockNumber,
-        bestBlockHeight: blockNumber,
-        maxBlocksToCheck: 0,
+        block: {
+          blockNumber,
+          blockHash: watchBlockHash,
+        },
         blockCache: this.#blockCache,
-        ignoreHeaderErrors: true,
       });
 
       if (findTransactionResult) {

--- a/src-vue/lib/WalletsForArgon.ts
+++ b/src-vue/lib/WalletsForArgon.ts
@@ -65,6 +65,7 @@ export class WalletsForArgon {
   private blockQueue = new SingleFileQueue();
   private blockWatch: BlockWatch;
   private myVault?: MyVault;
+  private shouldSuppressLoadBalanceEvents = false;
   private unsubscribe?: () => void;
 
   public get wallets(): WalletForArgon[] {
@@ -114,6 +115,7 @@ export class WalletsForArgon {
     const loadStartedAt = Date.now();
     let stage: string | undefined;
     try {
+      this.shouldSuppressLoadBalanceEvents = false;
       stage = 'blockWatch.start';
       await this.blockWatch.start();
 
@@ -122,6 +124,7 @@ export class WalletsForArgon {
 
       stage = 'loadBalancesAt';
       await this.loadBalancesAt(this.blockWatch.bestBlockHeader);
+      this.shouldSuppressLoadBalanceEvents = false;
       this.unsubscribe = this.blockWatch.events.on('best-blocks', (blocks: IBlockHeaderInfo[]) => {
         const latestBlock = blocks[blocks.length - 1];
         void this.loadBalancesAt(latestBlock).catch(error => {
@@ -133,6 +136,7 @@ export class WalletsForArgon {
       });
       this.deferredLoading.resolve();
     } catch (err) {
+      this.shouldSuppressLoadBalanceEvents = false;
       console.error(
         `[WalletsForArgon] Initial load failed at ${stage ?? 'start'} after ${Date.now() - loadStartedAt}ms`,
         err,
@@ -320,8 +324,11 @@ export class WalletsForArgon {
 
     let latestBlockNumberSynced = lastSyncedBlockNumber;
     const latestFinalizedNumber = this.blockWatch.finalizedBlockHeader.blockNumber;
+    let shouldShowCurrentBalancesWhileLoading = false;
     // if we're far behind, recover history from indexer instead of going block-by-block
     if (bestBlockNumber - lastSyncedBlockNumber > this.blockBacklogBeforeUsingIndexer) {
+      shouldShowCurrentBalancesWhileLoading = true;
+      this.shouldSuppressLoadBalanceEvents = true;
       const addresses = this.addresses;
       const { balances } = await this.readBalances(addresses, this.blockWatch.finalizedBlockHeader);
       const neededBlockNumbers = new Set<number>();
@@ -392,6 +399,18 @@ export class WalletsForArgon {
         isProcessed: true,
       },
     ];
+
+    if (!shouldShowCurrentBalancesWhileLoading) {
+      return;
+    }
+
+    const currentBlock = this.blockWatch.bestBlockHeader;
+    const { balances: currentBalances } = await this.readBalances(this.addresses, currentBlock);
+    for (let i = 0; i < currentBalances.length; i++) {
+      const wallet = this.wallets[i];
+      if (!wallet) continue;
+      this.events.emit('balance-change', currentBalances[i], wallet.type);
+    }
   }
 
   private async rollbackBlock(block: IBlockToProcess) {
@@ -470,7 +489,9 @@ export class WalletsForArgon {
         prices ??= await new CurrencyBase(this.blockWatch.clients).fetchMainchainRates(api);
         const changed = await wallet.onBalanceChange(entry, prices);
         if (changed) {
-          this.events.emit('balance-change', entry, wallet.type);
+          if (!this.shouldSuppressLoadBalanceEvents || this.deferredLoading.isSettled) {
+            this.events.emit('balance-change', entry, wallet.type);
+          }
           if (!this.deferredLoading.isSettled) {
             this.loadEvents['balance-change'].push([entry, wallet.type]);
           }

--- a/src-vue/stores/wallets.ts
+++ b/src-vue/stores/wallets.ts
@@ -247,13 +247,17 @@ export const useWallets = defineStore('wallets', () => {
 
   //////////////////////////////////////////////////////////////////////////////
   walletsForArgon.events.on('balance-change', (entry, type) => {
-    totalWalletMicrogons.value = walletsForArgon.totalWalletMicrogons;
-    totalWalletMicronots.value = walletsForArgon.totalWalletMicronots;
     const wallet = walletMapping[type];
     Object.assign(wallet, entry);
-    const walletEntry = walletsForArgon[`${type}Wallet`];
-    wallet.totalMicrogons = walletEntry.totalMicrogons;
-    wallet.totalMicronots = walletEntry.totalMicronots;
+    wallet.totalMicrogons = wallet.availableMicrogons + wallet.reservedMicrogons;
+    wallet.totalMicronots = wallet.availableMicronots + wallet.reservedMicronots;
+
+    totalWalletMicrogons.value = 0n;
+    totalWalletMicronots.value = 0n;
+    for (const currentWallet of Object.values(walletMapping)) {
+      totalWalletMicrogons.value += currentWallet.totalMicrogons;
+      totalWalletMicronots.value += currentWallet.totalMicronots;
+    }
   });
 
   async function load() {


### PR DESCRIPTION
## Summary
- keep current wallet balances visible while backfilling older history
- recover and report missing minting authorities more reliably
- refresh bot config from server without wiping local values when remote state is partial
- use the watched block hash when resolving finalized transaction events