### PR TITLE
fix(vault): recover collect processing after reload

### DIFF
--- a/src-vue/__test__/Alerts.test.ts
+++ b/src-vue/__test__/Alerts.test.ts
@@ -35,7 +35,6 @@ describe('VaultCollectBuilder.getNotice', () => {
 
     expect(notice).toEqual({
       isProcessing: true,
-      isCollectProcessing: false,
       collectRevenue: 42n,
       expiringCollectAmount: 7n,
       nextCollectDueDate: 1234,
@@ -50,6 +49,12 @@ describe('VaultCollectBuilder.getNotice', () => {
       earningsAmountMicrogons: 42n,
       amountAtRiskMicrogons: 57n,
       transactionCount: 4,
+      processing: {
+        actionType: 'approveCouncil',
+        collectRevenue: 0n,
+        signatureCount: 0,
+        councilApprovalCount: 0,
+      },
     });
   });
 
@@ -63,7 +68,6 @@ describe('VaultCollectBuilder.getNotice', () => {
 
     expect(notice).toEqual({
       isProcessing: false,
-      isCollectProcessing: false,
       collectRevenue: 0n,
       expiringCollectAmount: 0n,
       nextCollectDueDate: 0,
@@ -78,6 +82,7 @@ describe('VaultCollectBuilder.getNotice', () => {
       earningsAmountMicrogons: 0n,
       amountAtRiskMicrogons: 0n,
       transactionCount: 2,
+      processing: undefined,
     });
   });
 
@@ -96,7 +101,12 @@ describe('VaultCollectBuilder.getNotice', () => {
     ).getNotice();
 
     expect(notice?.isProcessing).toBe(true);
-    expect(notice?.isCollectProcessing).toBe(true);
+    expect(notice?.processing).toEqual({
+      actionType: 'collectRevenue',
+      collectRevenue: 42n,
+      signatureCount: 0,
+      councilApprovalCount: 0,
+    });
   });
 });
 

--- a/src-vue/app-shared/alerts/VaultAlert.vue
+++ b/src-vue/app-shared/alerts/VaultAlert.vue
@@ -7,21 +7,17 @@
     <template #icon>
       <div class="flex items-center gap-x-1.5 text-argon-700/70">
         <MoneyIcon
-          v-if="
-            notice.collectRevenue > 0n ||
-            notice.authorizedTransferRewardAmount > 0n ||
-            notice.pendingAuthorizedTransferRewardAmount > 0n
-          "
+          v-if="showMoneyIcon(notice)"
           class="relative h-6 w-6 top-0.5 text-white/85" />
         <SigningIcon
-          v-if="notice.signatureCount > 0 || hasVaultSecurityWork(notice)"
+          v-if="showSigningIcon(notice)"
           class="h-5 w-5 text-white/85" />
       </div>
     </template>
 
     <div class="min-w-0 leading-tight text-white">
-      <template v-if="notice.isCollectProcessing && notice.collectRevenue">
-        <strong>{{ formatMoney(notice.collectRevenue) }} is being collected</strong>
+      <template v-if="isProcessingCollect(notice)">
+        <strong>{{ formatMoney(notice.processing?.collectRevenue ?? 0n) }} is being collected</strong>
       </template>
 
       <template v-else-if="notice.isProcessing">
@@ -34,13 +30,17 @@
             is processing
           </strong>
         </template>
-        <template v-else-if="hasVaultSecurityWork(notice)">
+        <template v-else-if="isProcessingApprovals(notice)">
           <strong>
             Vault approvals are processing
           </strong>
         </template>
-        <template v-else>
-          <strong>{{ notice.signatureCount }} co-signature{{ notice.signatureCount === 1 ? ' is' : 's are' }} processing.</strong>
+        <template v-else-if="notice.processing">
+          <strong>
+            {{ notice.processing.signatureCount }} co-signature{{
+              notice.processing.signatureCount === 1 ? ' is' : 's are'
+            }} processing.
+          </strong>
         </template>
       </template>
 
@@ -124,12 +124,7 @@
 
     <template #action>
       <button @click="$emit('open')">
-        <template v-if="notice.isProcessing">View Progress</template>
-        <template v-else-if="hasVaultSecurityWork(notice) || (notice.collectRevenue > 0n && notice.signatureCount > 0)">
-          Open Details
-        </template>
-        <template v-else-if="notice.collectRevenue > 0n">Collect Revenue</template>
-        <template v-else>Sign Bitcoin Transactions</template>
+        {{ getButtonLabel(notice) }}
       </button>
     </template>
   </AlertBarRow>
@@ -146,20 +141,16 @@
     <template #icon>
       <div class="flex items-center gap-x-1.5">
         <MoneyIcon
-          v-if="
-            notice.collectRevenue > 0n ||
-            notice.authorizedTransferRewardAmount > 0n ||
-            notice.pendingAuthorizedTransferRewardAmount > 0n
-          "
+          v-if="showMoneyIcon(notice)"
           class="relative top-0.5 h-9 w-9 text-argon-700/70" />
         <SigningIcon
-          v-if="notice.signatureCount > 0 || hasVaultSecurityWork(notice)"
+          v-if="showSigningIcon(notice)"
           class="h-8 w-8 text-argon-700/70" />
       </div>
     </template>
 
     <template #subline>
-      <template v-if="notice.isProcessing && notice.collectRevenue">
+      <template v-if="isProcessingCollect(notice)">
         Waiting for collect to finalize.
       </template>
 
@@ -167,7 +158,7 @@
         <template v-if="notice.pendingAuthorizedTransferCount > 0">
           Waiting for crosschain authorization to finalize.
         </template>
-        <template v-else-if="hasVaultSecurityWork(notice)">
+        <template v-else-if="isProcessingApprovals(notice)">
           Waiting for vault approvals to finalize.
         </template>
         <template v-else>Waiting for signatures to finalize.</template>
@@ -290,6 +281,32 @@ function hasAvailableAuthorizationWork(notice: IVaultCollectNotice): boolean {
   return notice.authorizedTransferCount > 0;
 }
 
+function showMoneyIcon(notice: IVaultCollectNotice): boolean {
+  return (
+    notice.collectRevenue > 0n ||
+    (notice.processing?.collectRevenue ?? 0n) > 0n ||
+    notice.authorizedTransferRewardAmount > 0n ||
+    notice.pendingAuthorizedTransferRewardAmount > 0n
+  );
+}
+
+function showSigningIcon(notice: IVaultCollectNotice): boolean {
+  return (
+    notice.signatureCount > 0 ||
+    hasVaultSecurityWork(notice) ||
+    (notice.processing?.signatureCount ?? 0) > 0 ||
+    (notice.processing?.councilApprovalCount ?? 0) > 0
+  );
+}
+
+function isProcessingCollect(notice: IVaultCollectNotice): boolean {
+  return notice.processing?.actionType === 'collectRevenue';
+}
+
+function isProcessingApprovals(notice: IVaultCollectNotice): boolean {
+  return notice.processing?.actionType === 'approveCouncil';
+}
+
 function getButtonLabel(notice: IVaultCollectNotice): string {
   if (notice.isProcessing) {
     return 'View Progress';
@@ -307,8 +324,8 @@ function getButtonLabel(notice: IVaultCollectNotice): string {
 }
 
 function getCardTitle(notice: IVaultCollectNotice): string {
-  if (notice.isCollectProcessing && notice.collectRevenue > 0n) {
-    return `${formatMoney(notice.collectRevenue)} is being collected`;
+  if (isProcessingCollect(notice)) {
+    return `${formatMoney(notice.processing?.collectRevenue ?? 0n)} is being collected`;
   }
 
   if (notice.isProcessing) {
@@ -318,11 +335,12 @@ function getCardTitle(notice: IVaultCollectNotice): string {
         : 'Crosschain transfer authorization is processing';
     }
 
-    if (hasVaultSecurityWork(notice)) {
+    if (isProcessingApprovals(notice)) {
       return 'Vault approvals are processing';
     }
 
-    return `${notice.signatureCount} co-signature${notice.signatureCount === 1 ? ' is' : 's are'} processing`;
+    const processingSignatureCount = notice.processing?.signatureCount ?? 0;
+    return `${processingSignatureCount} co-signature${processingSignatureCount === 1 ? ' is' : 's are'} processing`;
   }
 
   if (hasVaultSecurityWork(notice)) {
@@ -353,7 +371,7 @@ function getCardTooltipContent(notice: IVaultCollectNotice): string {
     return 'Crosschain transfer authorization is pending.';
   }
 
-  if (hasVaultSecurityWork(notice) && notice.isProcessing) {
+  if (isProcessingApprovals(notice)) {
     return 'Vault approvals are pending.';
   }
 
@@ -369,7 +387,7 @@ function getCardTooltipContent(notice: IVaultCollectNotice): string {
     return 'Review pending vault actions.';
   }
 
-  if (notice.isProcessing && notice.collectRevenue > 0n) {
+  if (isProcessingCollect(notice)) {
     return 'Revenue collection is pending.';
   }
 

--- a/src-vue/lib/VaultCollectBuilder.ts
+++ b/src-vue/lib/VaultCollectBuilder.ts
@@ -30,7 +30,6 @@ export type IVaultCollectSubmission = {
 
 export type IVaultCollectNotice = {
   isProcessing: boolean;
-  isCollectProcessing: boolean;
   collectRevenue: bigint;
   expiringCollectAmount: bigint;
   nextCollectDueDate: number;
@@ -45,6 +44,14 @@ export type IVaultCollectNotice = {
   earningsAmountMicrogons: bigint;
   amountAtRiskMicrogons: bigint;
   transactionCount: number;
+  processing:
+    | {
+        actionType: IVaultCollectMetadata['actionType'];
+        collectRevenue: bigint;
+        signatureCount: number;
+        councilApprovalCount: number;
+      }
+    | undefined;
 };
 
 export class VaultCollectBuilder {
@@ -59,6 +66,8 @@ export class VaultCollectBuilder {
     }
 
     const manualPendingCosignEntries = getManualPendingCosignEntries(myVault, ownPendingLockUtxoIds);
+    const pendingCollectMetadata = myVault.data.pendingCollectTxInfo?.tx.metadataJson;
+    const processing = getPendingCollectProcessing(pendingCollectMetadata);
 
     const signaturePenalty = bigIntMin(
       manualPendingCosignEntries.reduce((sum, [, entry]) => sum + entry.targetValue, 0n),
@@ -68,6 +77,7 @@ export class VaultCollectBuilder {
     const collectRevenue = myVault.data.pendingCollectRevenue;
     const signatureCount = manualPendingCosignEntries.length;
     const councilApprovalCount = myVault.globalCouncil.data.pendingApprovals.length;
+
     const pendingMintingAuthorizations = myVault.mintingAuthorities.data.pendingMintingAuthorizations;
     const authorizedTransferCount = pendingMintingAuthorizations.length;
     const authorizedTransferRewardAmount = pendingMintingAuthorizations.reduce(
@@ -92,8 +102,7 @@ export class VaultCollectBuilder {
 
     const earningsAmountMicrogons = collectRevenue;
     const amountAtRiskMicrogons = myVault.data.expiringCollectAmount + signaturePenalty;
-    const isCollectProcessing = myVault.data.pendingCollectTxInfo?.tx.metadataJson.actionType === 'collectRevenue';
-    const isProcessing = Boolean(myVault.data.pendingCollectTxInfo || pendingAuthorizedTransferCount > 0);
+    const isProcessing = Boolean(processing || pendingAuthorizedTransferCount > 0);
 
     if (
       collectRevenue <= 0n &&
@@ -109,7 +118,6 @@ export class VaultCollectBuilder {
 
     return {
       isProcessing,
-      isCollectProcessing,
       collectRevenue,
       expiringCollectAmount: myVault.data.expiringCollectAmount,
       nextCollectDueDate: myVault.data.nextCollectDueDate,
@@ -124,6 +132,7 @@ export class VaultCollectBuilder {
       earningsAmountMicrogons,
       amountAtRiskMicrogons,
       transactionCount: Number(hasCollectWork || councilApprovalCount > 0 || isProcessing) + authorizedTransferCount,
+      processing,
     };
   }
 
@@ -203,6 +212,25 @@ function getManualPendingCosignEntries(myVault: MyVault, ownPendingLockUtxoIds: 
     if (ownPendingLockUtxoIds.has(utxoId)) return false;
     return !myVault.data.myPendingBitcoinCosignTxInfosByUtxoId.has(utxoId);
   });
+}
+
+function getPendingCollectProcessing(metadata?: IVaultCollectMetadata | null) {
+  if (!metadata) {
+    return;
+  }
+
+  return {
+    actionType: metadata.actionType,
+    collectRevenue: metadata.actionType === 'collectRevenue' ? metadata.expectedCollectRevenue : 0n,
+    signatureCount: metadata.actionType === 'approveCouncil' ? 0 : getStoredCosignCount(metadata),
+    councilApprovalCount: metadata.councilApprovalCount ?? 0,
+  };
+}
+
+function getStoredCosignCount(
+  metadata?: Pick<IVaultCollectMetadata, 'cosignedUtxoIds' | 'cosignedOrphanUtxos'> | null,
+): number {
+  return (metadata?.cosignedUtxoIds?.length ?? 0) + (metadata?.cosignedOrphanUtxos?.length ?? 0);
 }
 
 async function buildCollectBitcoinTxs(args: {


### PR DESCRIPTION
## Summary
Reloaded vault alerts now recover the pending collect action from the stored transaction metadata, so the app can still tell whether a vault is collecting revenue, waiting on approvals, or waiting on cosignatures.

Before this, reopening the app could drop that context and fall back to "0 co-signatures are processing" even when a different collect step was already in flight.

The alert copy now follows the persisted processing state instead of guessing from whichever live counters happen to be present after startup.
