### PR TITLE
fix: reject empty-history account imports

### DIFF
--- a/src-vue/app-operations/overlays/import-account/FromMnemonic.vue
+++ b/src-vue/app-operations/overlays/import-account/FromMnemonic.vue
@@ -143,13 +143,18 @@ async function importAccount() {
   }
 
   isImporting.value = true;
-
-  await controller.importFromMnemonic(mnemonic.value.join(' '));
-
-  isImporting.value = false;
-  mnemonic.value.fill('');
-  emit('close');
-  return true;
+  try {
+    await controller.importFromMnemonic(mnemonic.value.join(' '));
+    mnemonic.value.fill('');
+    emit('close');
+    return true;
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error && error.message ? error.message : 'Unable to import that account right now.';
+    return false;
+  } finally {
+    isImporting.value = false;
+  }
 }
 
 Vue.onUnmounted(() => {

--- a/src-vue/app-operations/stores/controller.ts
+++ b/src-vue/app-operations/stores/controller.ts
@@ -416,8 +416,11 @@ export const useOperationsController = defineStore('operationsController', () =>
   async function importFromMnemonic(mnemonic: string) {
     isImporting.value = true;
     const importer = new Importer(config as Config, walletKeys, dbPromise);
-    await importer.importFromMnemonic(mnemonic);
-    isImporting.value = false;
+    try {
+      await importer.importFromMnemonic(mnemonic);
+    } finally {
+      isImporting.value = false;
+    }
   }
 
   async function loadOperationalInvites() {

--- a/src-vue/app-treasury/stores/controller.ts
+++ b/src-vue/app-treasury/stores/controller.ts
@@ -70,8 +70,11 @@ export const useTreasuryController = defineStore('treasuryController', () => {
   async function importFromMnemonic(mnemonic: string) {
     isImporting.value = true;
     const importer = new Importer(config as Config, walletKeys, dbPromise);
-    await importer.importFromMnemonic(mnemonic);
-    isImporting.value = false;
+    try {
+      await importer.importFromMnemonic(mnemonic);
+    } finally {
+      isImporting.value = false;
+    }
   }
 
   Vue.watch(

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -4,10 +4,13 @@ import { Db } from './Db';
 import { invokeWithTimeout } from './tauriApi';
 import { ITryServerData, SSH } from './SSH';
 import { BootstrapType, IConfigServerDetails } from '../interfaces/IConfig';
-import { SECURITY } from './Env.ts';
+import { NETWORK_NAME, SECURITY } from './Env.ts';
+import { hasArgonWalletValue } from './WalletForArgon.ts';
 import { WalletKeys } from './WalletKeys.ts';
+import { MemoryWalletKeys } from './MemoryWalletKeys.ts';
+import { readArgonWalletBalanceValues } from './WalletsForArgon.ts';
 import { getWalletsForArgon } from '../stores/wallets.ts';
-import { getBlockWatch } from '../stores/mainchain.ts';
+import { getBlockWatch, getFinalizedClient } from '../stores/mainchain.ts';
 
 export default class Importer {
   private readonly config: Config;
@@ -25,6 +28,30 @@ export default class Importer {
   }
 
   public async importFromMnemonic(mnemonic: string) {
+    if (NETWORK_NAME !== 'dev-docker') {
+      const importWalletKeys = new MemoryWalletKeys({
+        substrateSuri: mnemonic,
+        masterMnemonic: mnemonic,
+      });
+      const finalizedApi = await getFinalizedClient();
+      const addresses = [
+        importWalletKeys.miningHoldAddress,
+        importWalletKeys.miningBotAddress,
+        importWalletKeys.vaultingAddress,
+        importWalletKeys.operationalAddress,
+        importWalletKeys.investmentAddress,
+      ];
+      const balances = await readArgonWalletBalanceValues(finalizedApi, addresses);
+
+      const hasExistingWalletValue = balances.some(balance => {
+        return hasArgonWalletValue(balance);
+      });
+
+      if (!hasExistingWalletValue) {
+        throw new Error('No existing wallet value was found for that mnemonic on this network.');
+      }
+    }
+
     await this.shutdownBackgroundSync();
     const restarter = new Restarter(this.dbPromise, this.config);
     await restarter.deleteAndCreateLocalDatabase();

--- a/src-vue/lib/WalletForArgon.ts
+++ b/src-vue/lib/WalletForArgon.ts
@@ -31,6 +31,19 @@ export function getSpendableMiningHoldMicrogons(availableMicrogons: bigint): big
 export type IWalletType = keyof typeof WalletType;
 export type IArgonWalletType = Exclude<IWalletType, 'ethereum'>;
 
+export function hasArgonWalletValue(balance: {
+  availableMicrogons: bigint;
+  availableMicronots: bigint;
+  reservedMicrogons: bigint;
+  reservedMicronots: bigint;
+}): boolean {
+  if (balance.availableMicrogons > 0n) return true;
+  if (balance.availableMicronots > 0n) return true;
+  if (balance.reservedMicronots > 0n) return true;
+  if (balance.reservedMicrogons > 0n) return true;
+  return false;
+}
+
 export class WalletForArgon implements IWallet {
   public balanceHistory: IBalanceChange[];
   public fetchErrorMsg = '';
@@ -77,11 +90,7 @@ export class WalletForArgon implements IWallet {
   }
 
   public hasValue(): boolean {
-    if (this.availableMicrogons > 0n) return true;
-    if (this.availableMicronots > 0n) return true;
-    if (this.reservedMicronots > 0n) return true;
-    if (this.reservedMicrogons > 0n) return true;
-    return false;
+    return hasArgonWalletValue(this);
   }
 
   public trimToFinalizedBlock(finalizedBlock: { blockNumber: number; blockHash: string }) {

--- a/src-vue/lib/WalletsForArgon.ts
+++ b/src-vue/lib/WalletsForArgon.ts
@@ -36,6 +36,23 @@ export interface IWalletEvents {
 type IWalletEventKeys = keyof IWalletEvents;
 type IWalletFlatList<T extends IWalletEventKeys = IWalletEventKeys> = Parameters<IWalletEvents[T]>;
 
+export async function readArgonWalletBalanceValues(
+  api: ApiDecoration<'promise'>,
+  addresses: string[],
+): Promise<
+  Pick<IBalanceChange, 'availableMicrogons' | 'reservedMicrogons' | 'availableMicronots' | 'reservedMicronots'>[]
+> {
+  const microgons = await api.query.system.account.multi(addresses).then(x => x.map(acc => acc.data));
+  const micronots = await api.query.ownership.account.multi(addresses);
+
+  return addresses.map((_, i) => ({
+    availableMicrogons: microgons[i]?.free.toBigInt() ?? 0n,
+    reservedMicrogons: microgons[i]?.reserved.toBigInt() ?? 0n,
+    availableMicronots: micronots[i]?.free.toBigInt() ?? 0n,
+    reservedMicronots: micronots[i]?.reserved.toBigInt() ?? 0n,
+  }));
+}
+
 export class WalletsForArgon {
   public deferredLoading = createDeferred<void>(false);
   public events = createTypedEventEmitter<IWalletEvents>();
@@ -444,15 +461,11 @@ export class WalletsForArgon {
   }> {
     const client = await this.blockWatch.getRpcClient(block.blockNumber);
     const api = await this.blockWatch.getApi(block);
-    const microgons = await api.query.system.account.multi(addresses).then(x => x.map(acc => acc.data));
-    const micronots = await api.query.ownership.account.multi(addresses);
+    const balanceValues = await readArgonWalletBalanceValues(api, addresses);
 
-    const balances = addresses.map((_, i) => ({
+    const balances = balanceValues.map(balance => ({
       block: { ...block },
-      availableMicrogons: microgons[i]?.free.toBigInt() ?? 0n,
-      reservedMicrogons: microgons[i]?.reserved.toBigInt() ?? 0n,
-      availableMicronots: micronots[i]?.free.toBigInt() ?? 0n,
-      reservedMicronots: micronots[i]?.reserved.toBigInt() ?? 0n,
+      ...balance,
       microgonsAdded: 0n,
       micronotsAdded: 0n,
       vaultRevenueEvents: [],


### PR DESCRIPTION
Importing a brand-new mnemonic used to replace the active wallet and restart into an empty account as if it were recoverable. Now non-`dev-docker` imports stop before the mnemonic is overwritten unless one of the derived Argon wallets already has on-chain balance history.

`dev-docker` keeps the empty-history escape hatch for local workflows. Rejected imports also flow back to the existing import UI cleanly instead of leaving the import state stuck.
