### PR TITLE
fix(troubleshooting): improve support package diagnostics

### DIFF
--- a/core/src/fetch.ts
+++ b/core/src/fetch.ts
@@ -1,14 +1,247 @@
 export type FetchImplementation = (...args: Parameters<typeof globalThis.fetch>) => ReturnType<typeof globalThis.fetch>;
 
 let fetchImplementation: FetchImplementation | undefined;
+let fetchImplementationLabel = 'globalThis.fetch';
+const standardErrorKeys = new Set(['name', 'message', 'stack', 'cause', 'code', 'status']);
 
-export function setFetchImplementation(next?: FetchImplementation): void {
+export function setFetchImplementation(next?: FetchImplementation, label?: string): void {
   fetchImplementation = next;
+  fetchImplementationLabel = next ? (label ?? 'custom fetch implementation') : 'globalThis.fetch';
 }
 
-export function fetch(...args: Parameters<FetchImplementation>): ReturnType<FetchImplementation> {
-  if (fetchImplementation) return fetchImplementation(...args);
-  if (typeof globalThis.fetch === 'function') return globalThis.fetch(...args);
+export async function fetch(...args: Parameters<FetchImplementation>): ReturnType<FetchImplementation> {
+  const implementation = fetchImplementation ?? globalThis.fetch;
+  if (typeof implementation !== 'function') {
+    throw new Error('Fetch API is not available in this runtime');
+  }
 
-  throw new Error('Fetch API is not available in this runtime');
+  const startedAt = Date.now();
+  const shouldLog = Boolean(fetchImplementation);
+  const implementationLabel = fetchImplementation ? fetchImplementationLabel : 'globalThis.fetch';
+
+  try {
+    const response = await implementation(...args);
+
+    if (shouldLog && !response.ok) {
+      console.warn('[fetch] HTTP response', {
+        implementation: implementationLabel,
+        elapsedMs: Date.now() - startedAt,
+        request: summarizeRequest(...args),
+        response: summarizeResponse(response),
+      });
+    }
+
+    return response;
+  } catch (error) {
+    if (shouldLog) {
+      console.error('[fetch] HTTP request failed', {
+        implementation: implementationLabel,
+        elapsedMs: Date.now() - startedAt,
+        request: summarizeRequest(...args),
+        runtime: getRuntimeDiagnostics(),
+        error: getErrorDiagnostics(error),
+      });
+    }
+    throw error;
+  }
+}
+
+function summarizeRequest(...args: Parameters<FetchImplementation>) {
+  const [input, init] = args;
+  const request = getRequestFromInput(input);
+
+  return {
+    method: init?.method ?? request?.method ?? 'GET',
+    url: summarizeUrl(
+      typeof input === 'string' || input instanceof URL ? String(input) : (request?.url ?? String(input)),
+    ),
+    hasQuery: hasQueryString(typeof input === 'string' || input instanceof URL ? String(input) : request?.url),
+    hasAuthorization: hasAuthorizationHeader(init?.headers) || Boolean(request?.headers?.has('authorization')),
+  };
+}
+
+function summarizeResponse(response: Response) {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    url: summarizeUrl(response.url),
+    contentType: response.headers.get('content-type') ?? undefined,
+  };
+}
+
+export function getErrorDiagnostics(error: unknown) {
+  if (!(error instanceof Error)) {
+    const message = sanitizeDiagnosticText(String(error));
+
+    return {
+      type: typeof error,
+      message,
+      classification: classifyError(message),
+      keys: getDiagnosticKeys(error),
+    };
+  }
+
+  const errorRecord = error as Error & Record<string, unknown>;
+  const message = sanitizeDiagnosticText(error.message || String(error));
+
+  return {
+    name: error.name,
+    message,
+    code: typeof errorRecord.code === 'string' ? errorRecord.code : undefined,
+    status: typeof errorRecord.status === 'number' ? errorRecord.status : undefined,
+    classification: classifyError(message),
+    keys: getDiagnosticKeys(errorRecord),
+    cause: getErrorCauseDiagnostics(errorRecord.cause),
+  };
+}
+
+export function getRuntimeDiagnostics() {
+  const navigatorWithDiagnostics =
+    typeof navigator !== 'undefined'
+      ? (navigator as Navigator & { onLine?: boolean; userAgentData?: { platform?: string } })
+      : undefined;
+
+  return {
+    online: navigatorWithDiagnostics?.onLine,
+    platform: getPlatformHint(navigatorWithDiagnostics),
+  };
+}
+
+function classifyError(message: string): string {
+  const text = message.toLowerCase();
+
+  if (text.includes('certificate') || text.includes('tls') || text.includes('ssl')) {
+    return 'tls';
+  }
+  if (text.includes('proxy')) {
+    return 'proxy';
+  }
+  if (
+    text.includes('dns') ||
+    text.includes('name or service not known') ||
+    text.includes('could not resolve host') ||
+    text.includes('lookup')
+  ) {
+    return 'dns';
+  }
+  if (text.includes('timed out') || text.includes('timeout')) {
+    return 'timeout';
+  }
+  if (
+    text.includes('connection refused') ||
+    text.includes('connection reset') ||
+    text.includes('connection aborted') ||
+    text.includes('socket')
+  ) {
+    return 'connection';
+  }
+  if (text.includes('error sending request for url')) {
+    return 'transport';
+  }
+  if (text.includes('authenticate') || text.includes('unauthorized') || text.includes('forbidden')) {
+    return 'auth';
+  }
+
+  return 'unknown';
+}
+
+function summarizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+function sanitizeDiagnosticText(text: string): string {
+  return text.replace(/https?:\/\/[^\s)]+/g, url => summarizeUrl(url));
+}
+
+function hasQueryString(url?: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    return new URL(url).search.length > 0;
+  } catch {
+    return url.includes('?');
+  }
+}
+
+function getRequestFromInput(input: Parameters<FetchImplementation>[0]): Request | undefined {
+  if (typeof Request === 'undefined') {
+    return undefined;
+  }
+
+  return input instanceof Request ? input : undefined;
+}
+
+function getErrorCauseDiagnostics(cause: unknown) {
+  if (cause == null) {
+    return undefined;
+  }
+
+  if (cause instanceof Error) {
+    const causeRecord = cause as Error & Record<string, unknown>;
+    const message = sanitizeDiagnosticText(cause.message || String(cause));
+
+    return {
+      name: cause.name,
+      message,
+      code: typeof causeRecord.code === 'string' ? causeRecord.code : undefined,
+      classification: classifyError(message),
+      keys: getDiagnosticKeys(causeRecord),
+    };
+  }
+
+  const message = sanitizeDiagnosticText(String(cause));
+
+  return {
+    type: typeof cause,
+    message,
+    keys: getDiagnosticKeys(cause),
+  };
+}
+
+function getDiagnosticKeys(value: unknown): string[] | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const keys = Object.keys(value).filter(key => !standardErrorKeys.has(key) && !isSensitiveDiagnosticKey(key));
+  return keys.length ? keys.slice(0, 8) : undefined;
+}
+
+function isSensitiveDiagnosticKey(key: string): boolean {
+  return /auth|token|secret|password|cookie|session|header|body/i.test(key);
+}
+
+function getPlatformHint(
+  navigatorWithDiagnostics?: Navigator & { onLine?: boolean; userAgentData?: { platform?: string } },
+): string | undefined {
+  if (navigatorWithDiagnostics) {
+    return navigatorWithDiagnostics.userAgentData?.platform ?? navigatorWithDiagnostics.platform;
+  }
+
+  if (typeof process !== 'undefined') {
+    return process.platform;
+  }
+}
+
+function hasAuthorizationHeader(headers: RequestInit['headers']): boolean {
+  if (!headers) {
+    return false;
+  }
+
+  if (headers instanceof Headers) {
+    return headers.has('authorization');
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.some(([key]) => key.toLowerCase() === 'authorization');
+  }
+
+  return Object.keys(headers).some(key => key.toLowerCase() === 'authorization');
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod security;
 mod ssh;
 mod ssh_access;
 mod ssh_pool;
+mod troubleshooting;
 mod utils;
 mod vm;
 
@@ -380,54 +381,95 @@ async fn toggle_nosleep(
 
 #[tauri::command]
 async fn create_zip(
+    app: AppHandle,
     paths_with_prefixes: Vec<(PathBuf, PathBuf)>,
     zip_name: PathBuf,
+    event_progress_key: Option<String>,
 ) -> Result<PathBuf, String> {
-    let file = fs::File::create(&zip_name).map_err(|e| e.to_string())?;
-    let mut zip = zip::ZipWriter::new(file);
-    let opts = zip::write::SimpleFileOptions::default();
+    tauri::async_runtime::spawn_blocking(move || {
+        let file = fs::File::create(&zip_name).map_err(|e| e.to_string())?;
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = zip::write::SimpleFileOptions::default();
 
-    for (prefix, p) in paths_with_prefixes {
-        // Walk children and prefix entries with the root directory name
-        for entry in walkdir::WalkDir::new(&p).into_iter().flatten() {
-            if entry.file_type().is_dir() {
-                continue;
-            }
-            let path = entry.path();
-            let rel = if p.is_file() {
-                // If the path is a file, we need to strip the parent directory
-                path.strip_prefix(p.parent().unwrap_or(&PathBuf::from("")))
-            } else {
-                path.strip_prefix(&p)
-            }
-            .unwrap_or(path);
+        let total_bytes = paths_with_prefixes
+            .iter()
+            .flat_map(|(_, path)| walkdir::WalkDir::new(path).into_iter().flatten())
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.metadata().map(|metadata| metadata.len()).unwrap_or(0))
+            .sum::<u64>();
 
-            println!(
-                "Processing entry: {} {}",
-                rel.display(),
-                path.to_string_lossy()
-            );
+        let mut copied_bytes = 0u64;
+        let mut last_percent = u8::MAX;
 
-            // Skip the directory itself; it"s already added
-            if rel.as_os_str().is_empty() {
-                continue;
-            }
+        for (prefix, path_root) in paths_with_prefixes {
+            for entry in walkdir::WalkDir::new(&path_root).into_iter().flatten() {
+                if entry.file_type().is_dir() {
+                    continue;
+                }
+                let path = entry.path();
+                let rel = if path_root.is_file() {
+                    path.strip_prefix(path_root.parent().unwrap_or(&PathBuf::from("")))
+                } else {
+                    path.strip_prefix(&path_root)
+                }
+                .unwrap_or(path);
 
-            let name = prefix.join(rel).to_string_lossy().replace("\\", "/");
-            let mut file_opts = opts;
-            if let Ok(mtime) = entry.metadata().map_err(|e| e.to_string())?.modified() {
-                if let Ok(zdt) = DateTime::try_from(OffsetDateTime::from(mtime)) {
-                    file_opts = file_opts.last_modified_time(zdt);
+                if rel.as_os_str().is_empty() {
+                    continue;
+                }
+
+                let name = prefix.join(rel).to_string_lossy().replace("\\", "/");
+                let mut file_opts = opts;
+                if let Ok(mtime) = entry.metadata().map_err(|e| e.to_string())?.modified() {
+                    if let Ok(zdt) = DateTime::try_from(OffsetDateTime::from(mtime)) {
+                        file_opts = file_opts.last_modified_time(zdt);
+                    }
+                }
+                zip.start_file(name, file_opts).map_err(|e| e.to_string())?;
+
+                let mut source = fs::File::open(path).map_err(|e| e.to_string())?;
+                let mut buffer = [0u8; 64 * 1024];
+
+                loop {
+                    let read =
+                        std::io::Read::read(&mut source, &mut buffer).map_err(|e| e.to_string())?;
+                    if read == 0 {
+                        break;
+                    }
+
+                    std::io::Write::write_all(&mut zip, &buffer[..read])
+                        .map_err(|e| e.to_string())?;
+                    copied_bytes += read as u64;
+
+                    if total_bytes > 0 {
+                        let percent =
+                            ((copied_bytes.saturating_mul(100)) / total_bytes).min(100) as u8;
+                        if percent != last_percent {
+                            last_percent = percent;
+                            if let Some(event_key) = &event_progress_key {
+                                app.emit(event_key, percent).map_err(|e| e.to_string())?;
+                            }
+                        }
+                    }
                 }
             }
-            zip.start_file(name, file_opts).map_err(|e| e.to_string())?;
-            let mut f = fs::File::open(path).map_err(|e| e.to_string())?;
-            std::io::copy(&mut f, &mut zip).map_err(|e| e.to_string())?;
         }
-    }
 
-    zip.finish().map_err(|e| e.to_string())?;
-    Ok(zip_name)
+        zip.finish().map_err(|e| e.to_string())?;
+
+        if let Some(event_key) = &event_progress_key {
+            app.emit(event_key, 100u8).map_err(|e| e.to_string())?;
+        }
+
+        Ok(zip_name)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+async fn collect_troubleshooting_os_profile(app: AppHandle) -> Result<String, String> {
+    troubleshooting::collect_os_profile(&app)
 }
 
 #[tauri::command]
@@ -797,6 +839,7 @@ pub fn run() {
             read_embedded_file,
             run_db_migrations,
             create_zip,
+            collect_troubleshooting_os_profile,
             ssh_access::ssh_access_status,
             ssh_access::ssh_access_activate,
             ssh_access::ssh_access_deactivate,

--- a/src-tauri/src/troubleshooting.rs
+++ b/src-tauri/src/troubleshooting.rs
@@ -1,0 +1,316 @@
+use crate::utils::Utils;
+use reqwest::Url;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tauri::AppHandle;
+use time::OffsetDateTime;
+
+pub fn collect_os_profile(app: &AppHandle) -> Result<String, String> {
+    let config_instance_dir = Utils::get_absolute_config_instance_dir(app);
+    let temp_dir = std::env::temp_dir();
+
+    let profile = json!({
+        "collectedAtUnixSeconds": OffsetDateTime::now_utc().unix_timestamp(),
+        "app": {
+            "identifier": app.config().identifier.clone(),
+            "version": app.package_info().version.to_string(),
+        },
+        "system": collect_system_profile(),
+        "storage": {
+            "configInstanceDir": collect_path_status(&config_instance_dir),
+            "tempDir": collect_path_status(&temp_dir),
+        },
+        "networkEnvironment": collect_network_environment(),
+        "windowsSecurity": collect_windows_security_profile(),
+        "windowsNetwork": collect_windows_network_profile(),
+    });
+
+    serde_json::to_string_pretty(&profile).map_err(|e| e.to_string())
+}
+
+fn collect_path_status(path: &Path) -> Value {
+    let metadata = fs::metadata(path);
+    let exists = metadata.is_ok();
+    let is_directory = metadata.as_ref().is_ok_and(|x| x.is_dir());
+    let metadata_error = metadata.err().map(|e| e.to_string());
+    let available_space_bytes = fs2::available_space(path).ok();
+    let write_check_error = if is_directory {
+        test_directory_write(path).err()
+    } else if exists {
+        Some("Path is not a directory".to_string())
+    } else {
+        Some("Path does not exist".to_string())
+    };
+
+    json!({
+        "exists": exists,
+        "isDirectory": is_directory,
+        "availableSpaceBytes": available_space_bytes,
+        "writable": write_check_error.is_none(),
+        "metadataError": metadata_error,
+        "writeCheckError": write_check_error,
+    })
+}
+
+fn test_directory_write(path: &Path) -> Result<(), String> {
+    let test_file = path.join(format!(
+        ".argon-troubleshooting-write-check-{}-{}",
+        std::process::id(),
+        OffsetDateTime::now_utc().unix_timestamp_nanos()
+    ));
+
+    fs::write(&test_file, []).map_err(|e| e.to_string())?;
+    fs::remove_file(&test_file).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn collect_system_profile() -> Value {
+    json!({
+        "platform": std::env::consts::OS,
+        "family": std::env::consts::FAMILY,
+        "arch": std::env::consts::ARCH,
+        "version": collect_system_version(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn collect_system_version() -> Value {
+    json!({
+        "productName": run_command_text("sw_vers", &["-productName"]).ok(),
+        "productVersion": run_command_text("sw_vers", &["-productVersion"]).ok(),
+        "buildVersion": run_command_text("sw_vers", &["-buildVersion"]).ok(),
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn collect_system_version() -> Value {
+    Value::Null
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn collect_system_version() -> Value {
+    json!({
+        "kernelRelease": run_command_text("uname", &["-r"]).ok(),
+    })
+}
+
+fn collect_network_environment() -> Value {
+    json!({
+        "proxyVars": {
+            "http_proxy": summarize_proxy_env_var("HTTP_PROXY"),
+            "https_proxy": summarize_proxy_env_var("HTTPS_PROXY"),
+            "all_proxy": summarize_proxy_env_var("ALL_PROXY"),
+            "no_proxy": summarize_present_env_var("NO_PROXY"),
+        },
+        "certificateVars": {
+            "ssl_cert_file": summarize_present_env_var("SSL_CERT_FILE"),
+            "ssl_cert_dir": summarize_present_env_var("SSL_CERT_DIR"),
+            "curl_ca_bundle": summarize_present_env_var("CURL_CA_BUNDLE"),
+            "requests_ca_bundle": summarize_present_env_var("REQUESTS_CA_BUNDLE"),
+        },
+    })
+}
+
+fn summarize_proxy_env_var(key: &str) -> Value {
+    let Ok(raw) = std::env::var(key) else {
+        return Value::String("absent".to_string());
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Value::String("absent".to_string());
+    }
+
+    if let Ok(url) = Url::parse(raw) {
+        let value = if !url.username().is_empty() || url.password().is_some() {
+            "configured_with_credentials"
+        } else {
+            "configured"
+        };
+        return Value::String(value.to_string());
+    }
+
+    Value::String("configured_unparsed".to_string())
+}
+
+fn summarize_present_env_var(key: &str) -> Value {
+    let present = std::env::var(key)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty());
+
+    Value::String(if present { "configured" } else { "absent" }.to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn collect_windows_security_profile() -> Value {
+    json!({
+        "os": result_or_error(run_powershell_json(
+            "Get-CimInstance Win32_OperatingSystem | Select-Object Caption,Version,BuildNumber,OSArchitecture,LastBootUpTime",
+        )),
+        "firewallProfiles": result_or_error(run_powershell_json(
+            "Get-NetFirewallProfile | Select-Object Name,Enabled,DefaultInboundAction,DefaultOutboundAction,AllowInboundRules,NotifyOnListen",
+        )),
+        "antivirusProducts": result_or_error(run_powershell_json(
+            "Get-CimInstance -Namespace root/SecurityCenter2 -ClassName AntivirusProduct | Select-Object displayName,productState,timestamp",
+        )),
+        "defenderStatus": result_or_error(run_powershell_json(
+            "Get-MpComputerStatus | Select-Object AMRunningMode,AMServiceEnabled,AntispywareEnabled,AntivirusEnabled,BehaviorMonitorEnabled,DefenderSignaturesOutOfDate,IoavProtectionEnabled,IsTamperProtected,NISEnabled,OnAccessProtectionEnabled,QuickScanAge,RealTimeProtectionEnabled,AntivirusSignatureVersion,AntivirusSignatureLastUpdated",
+        )),
+        "defenderPreferences": result_or_error(run_powershell_json(
+            "Get-MpPreference | Select-Object EnableControlledFolderAccess,DisableRealtimeMonitoring",
+        )),
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+fn collect_windows_security_profile() -> Value {
+    Value::Null
+}
+
+#[cfg(target_os = "windows")]
+fn collect_windows_network_profile() -> Value {
+    json!({
+        "connectionProfiles": result_or_error(run_powershell_json(
+            "Get-NetConnectionProfile | Select-Object NetworkCategory,IPv4Connectivity,IPv6Connectivity",
+        )),
+        "internetSettingsProxy": result_or_error(
+            run_powershell_json(
+                "Get-ItemProperty 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings' | Select-Object ProxyEnable,ProxyServer,AutoConfigURL,AutoDetect",
+            )
+            .map(summarize_windows_proxy_settings)
+        ),
+        "winHttpProxy": result_or_error(run_powershell_text(
+            "netsh winhttp show proxy",
+        ).map(summarize_winhttp_proxy)),
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+fn collect_windows_network_profile() -> Value {
+    Value::Null
+}
+
+#[cfg(target_os = "windows")]
+fn result_or_error(result: Result<Value, String>) -> Value {
+    match result {
+        Ok(value) => value,
+        Err(error) => json!({ "error": error }),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn run_powershell_json(script: &str) -> Result<Value, String> {
+    let command = format!("{script} | ConvertTo-Json -Depth 6 -Compress");
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &command])
+        .output()
+        .map_err(|e| format!("Failed to launch PowerShell: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!(
+            "PowerShell exited with {}{}",
+            output.status,
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return Ok(Value::Null);
+    }
+
+    serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse PowerShell JSON: {e}"))
+}
+
+#[cfg(target_os = "windows")]
+fn run_powershell_text(script: &str) -> Result<Value, String> {
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .output()
+        .map_err(|e| format!("Failed to launch PowerShell: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!(
+            "PowerShell exited with {}{}",
+            output.status,
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        ));
+    }
+
+    Ok(json!({
+        "text": String::from_utf8_lossy(&output.stdout).trim(),
+    }))
+}
+
+#[cfg(target_os = "windows")]
+fn summarize_windows_proxy_settings(value: Value) -> Value {
+    let object = match value {
+        Value::Object(object) => object,
+        other => return other,
+    };
+
+    json!({
+        "proxyEnabled": object.get("ProxyEnable").and_then(Value::as_i64).is_some_and(|x| x != 0),
+        "autoDetect": object.get("AutoDetect").and_then(Value::as_i64).is_some_and(|x| x != 0),
+        "proxyConfigured": object
+            .get("ProxyServer")
+            .and_then(Value::as_str)
+            .is_some_and(|x| !x.trim().is_empty()),
+        "autoConfigConfigured": object
+            .get("AutoConfigURL")
+            .and_then(Value::as_str)
+            .is_some_and(|x| !x.trim().is_empty()),
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn summarize_winhttp_proxy(value: Value) -> Value {
+    let Some(text) = value.get("text").and_then(Value::as_str) else {
+        return value;
+    };
+
+    let normalized = text.to_ascii_lowercase();
+    json!({
+        "configured": !normalized.contains("direct access"),
+        "hasBypassList": normalized.contains("bypass list"),
+    })
+}
+
+fn run_command_text(command: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(command)
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to launch {command}: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(format!(
+            "{command} exited with {}{}",
+            output.status,
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/src-vue/__test__/FetchDiagnostics.test.ts
+++ b/src-vue/__test__/FetchDiagnostics.test.ts
@@ -1,0 +1,90 @@
+import { fetch, setFetchImplementation, type FetchImplementation } from '@argonprotocol/apps-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtimeFetchMock = vi.fn();
+
+describe('fetch diagnostics', () => {
+  beforeEach(() => {
+    runtimeFetchMock.mockReset();
+    setFetchImplementation(runtimeFetchMock as unknown as FetchImplementation, 'tauri-plugin-http');
+  });
+
+  afterEach(() => {
+    setFetchImplementation();
+    vi.restoreAllMocks();
+  });
+
+  it('logs non-ok HTTP responses with sanitized request details', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    runtimeFetchMock.mockResolvedValue(
+      new Response('Unauthorized', {
+        status: 401,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+      }),
+    );
+
+    await fetch('https://api.digitalocean.com/v2/account/keys?tag_name=wallet', {
+      headers: {
+        Authorization: 'Bearer secret',
+      },
+    });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[fetch] HTTP response',
+      expect.objectContaining({
+        implementation: 'tauri-plugin-http',
+        request: expect.objectContaining({
+          url: 'https://api.digitalocean.com/v2/account/keys',
+          hasAuthorization: true,
+        }),
+        response: expect.objectContaining({
+          status: 401,
+        }),
+      }),
+    );
+  });
+
+  it('logs classified transport failures', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const cause = Object.assign(new Error('TLS handshake failed'), {
+      code: 'CERT_E_UNTRUSTEDROOT',
+      sessionId: 'secret',
+    });
+    const error = Object.assign(
+      new Error('error sending request for url (https://raw.githubusercontent.com/path/file.json?sessionId=secret)'),
+      {
+        cause,
+        proxyDetected: false,
+        sessionId: 'secret',
+      },
+    );
+    runtimeFetchMock.mockRejectedValue(error);
+
+    await expect(fetch('https://raw.githubusercontent.com/argonprotocol/apps/main/file.json')).rejects.toThrow(
+      'error sending request for url',
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[fetch] HTTP request failed',
+      expect.objectContaining({
+        implementation: 'tauri-plugin-http',
+        runtime: expect.any(Object),
+        request: expect.objectContaining({
+          url: 'https://raw.githubusercontent.com/argonprotocol/apps/main/file.json',
+        }),
+        error: expect.objectContaining({
+          classification: 'transport',
+          message: 'error sending request for url (https://raw.githubusercontent.com/path/file.json)',
+          keys: ['proxyDetected'],
+          cause: expect.objectContaining({
+            classification: 'tls',
+            code: 'CERT_E_UNTRUSTEDROOT',
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src-vue/app-shared/overlays/troubleshooting/DataAndLogFiles.vue
+++ b/src-vue/app-shared/overlays/troubleshooting/DataAndLogFiles.vue
@@ -54,13 +54,16 @@
         >
           Download
         </button>
-        <div
-          class="pointer-events-none ml-2 flex cursor-pointer flex-row items-center space-x-2 whitespace-nowrap text-gray-800"
+        <button
+          @click="includeWalletMnemonics = !includeWalletMnemonics"
+          type="button"
+          class="ml-2 flex cursor-pointer flex-row items-center space-x-2 whitespace-nowrap text-gray-800"
         >
-          <Checkbox :isChecked="true" :size="5" class="opacity-50" />
+          <Checkbox :isChecked="includeWalletMnemonics" :size="5" />
           <span class="text-sm font-bold">Include Wallet Mnemonics</span>
-        </div>
+        </button>
       </div>
+      <p class="mt-2 text-xs text-slate-500">Wallet mnemonic files are excluded unless you opt in.</p>
     </li>
   </ul>
   <!-- <div class="flex my-3 mx-4 border-t border-black/20 pt-3">
@@ -72,16 +75,17 @@
 import * as Vue from 'vue';
 import { Db } from '../../../lib/Db.ts';
 import { appConfigDir, appLogDir, join, tempDir } from '@tauri-apps/api/path';
+import { listen } from '@tauri-apps/api/event';
 import { openPath, revealItemInDir } from '@tauri-apps/plugin-opener';
 import Checkbox from '../../../components/Checkbox.vue';
 import { Config, getConfig } from '../../../stores/config.ts';
 import { Diagnostics } from '../../../lib/Diagnostics.ts';
 import ProgressBar from '../../../components/ProgressBar.vue';
 import { invokeWithTimeout } from '../../../lib/tauriApi.ts';
-import { remove } from '@tauri-apps/plugin-fs';
-import { getInstanceConfigDir } from '../../../lib/Utils.ts';
+import { copyFile, mkdir, readDir, remove, writeTextFile } from '@tauri-apps/plugin-fs';
 import { getWalletKeys } from '../../../stores/wallets.ts';
 import { INSTANCE_NAME } from '../../../lib/Env.ts';
+import { getInstanceConfigDir } from '../../../lib/Utils.ts';
 
 const config = getConfig();
 const walletKeys = getWalletKeys();
@@ -92,6 +96,7 @@ const localLogDir = Vue.ref('');
 const troubleshootingProgress = Vue.ref(0);
 const isCreatingTroubleshootingPackage = Vue.ref(false);
 const troubleshootingError = Vue.ref('');
+const includeWalletMnemonics = Vue.ref(false);
 
 async function openLogDir() {
   await openPath(localLogDir.value);
@@ -101,55 +106,114 @@ async function openDataDir() {
   await openPath(localDataDir.value);
 }
 
-async function createZipFile() {
-  // TODO: Create zip file
-}
-
 async function downloadTroubleshooting() {
   isCreatingTroubleshootingPackage.value = true;
   troubleshootingProgress.value = 0;
   troubleshootingError.value = '';
+  const removeOnFinish: { path: string; recursive?: boolean }[] = [];
+  let unsubZipProgress: (() => void) | undefined;
+
   try {
-    const removeOnFinish: string[] = [];
-    const config = await getInstanceConfigDir();
-    const logDir = await appLogDir();
-    const pathsWithPrefixes: [string, string][] = [
-      ['logs', logDir],
-      ['data', config],
-    ];
     let zipPath = `argon_${INSTANCE_NAME}_troubleshooting_${Date.now()}.zip`;
+    let serverPackagePath: string | undefined;
+
     if (diagnostics.hasServer()) {
       await diagnostics.load();
       const downloadPath = await diagnostics.downloadTroubleshootingPackage(x => {
-        troubleshootingProgress.value = Math.min(90, x);
+        troubleshootingProgress.value = Math.min(60, x);
       });
-      pathsWithPrefixes.push(['server', downloadPath]);
-      removeOnFinish.push(downloadPath);
+      serverPackagePath = downloadPath;
+      removeOnFinish.push({ path: downloadPath });
       zipPath = downloadPath.replace('.tar.gz', '.zip');
     } else {
       zipPath = await join(await tempDir(), zipPath);
+      troubleshootingProgress.value = 15;
     }
 
-    troubleshootingProgress.value = 90;
+    const troubleshootingRoot = await join(await tempDir(), `argon_${INSTANCE_NAME}_troubleshooting_${Date.now()}`);
+    const dataSnapshotDir = await join(troubleshootingRoot, 'data');
+    const osProfilePath = await join(troubleshootingRoot, 'os-profile.json');
+
+    removeOnFinish.push({ path: troubleshootingRoot, recursive: true });
+
+    await mkdir(dataSnapshotDir, { recursive: true });
+    await copyDirectorySnapshot(await getInstanceConfigDir(), dataSnapshotDir, includeWalletMnemonics.value);
+    troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 75);
+
+    const osProfile = await invokeWithTimeout<string>('collect_troubleshooting_os_profile', {}, 15e3);
+    await writeTextFile(osProfilePath, osProfile);
+    troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 85);
+
+    const pathsWithPrefixes: [string, string][] = [
+      ['logs', localLogDir.value],
+      ['data', dataSnapshotDir],
+      ['profile', osProfilePath],
+    ];
+
+    if (serverPackagePath) {
+      pathsWithPrefixes.push(['server', serverPackagePath]);
+    }
+
+    const zipProgressEventKey = `troubleshooting_zip_progress_${Date.now()}`;
+    unsubZipProgress = await listen<number>(zipProgressEventKey, event => {
+      const zipProgress = 85 + (event.payload / 100) * 14;
+      troubleshootingProgress.value = Math.max(troubleshootingProgress.value, Math.min(99, zipProgress));
+      if (event.payload === 100) {
+        unsubZipProgress?.();
+        unsubZipProgress = undefined;
+      }
+    });
+
     await invokeWithTimeout(
       'create_zip',
       {
-        zipName: zipPath,
+        eventProgressKey: zipProgressEventKey,
         pathsWithPrefixes,
+        zipName: zipPath,
       },
-      60e3,
+      300e3,
     );
-    for (const path of removeOnFinish) {
-      await remove(path);
-    }
+
+    troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 99);
     await revealItemInDir(zipPath);
     troubleshootingProgress.value = 100;
   } catch (err) {
     console.error('Error downloading troubleshooting package:', err);
     troubleshootingError.value = `Error downloading troubleshooting package: ${err}`;
   } finally {
+    unsubZipProgress?.();
+
+    for (const { path, recursive } of removeOnFinish) {
+      await remove(path, recursive ? { recursive } : undefined).catch(error => {
+        console.warn(`Unable to remove troubleshooting temp path ${path}:`, error);
+      });
+    }
     isCreatingTroubleshootingPackage.value = false;
     troubleshootingProgress.value = 0;
+  }
+}
+
+async function copyDirectorySnapshot(sourceDir: string, destinationDir: string, includeMnemonic: boolean) {
+  await mkdir(destinationDir, { recursive: true });
+
+  for (const entry of await readDir(sourceDir)) {
+    if (!entry.name) {
+      continue;
+    }
+    if (!includeMnemonic && entry.name === 'mnemonic') {
+      continue;
+    }
+
+    const sourcePath = await join(sourceDir, entry.name);
+    const destinationPath = await join(destinationDir, entry.name);
+
+    if (entry.isDirectory) {
+      await copyDirectorySnapshot(sourcePath, destinationPath, includeMnemonic);
+      continue;
+    }
+    if (entry.isFile) {
+      await copyFile(sourcePath, destinationPath);
+    }
   }
 }
 

--- a/src-vue/configureFetch.ts
+++ b/src-vue/configureFetch.ts
@@ -2,5 +2,5 @@ import { setFetchImplementation } from '@argonprotocol/apps-core';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 
 if ('__TAURI_INTERNALS__' in window) {
-  setFetchImplementation(tauriFetch);
+  setFetchImplementation(tauriFetch, 'tauri-plugin-http');
 }

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -11,7 +11,7 @@ import { InstallerCheck } from './InstallerCheck';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { ensureOnlyOneInstance, resetOnlyOneInstance } from './Utils';
-import { createDeferred, type IDeferred } from '@argonprotocol/apps-core';
+import { createDeferred, getErrorDiagnostics, getRuntimeDiagnostics, type IDeferred } from '@argonprotocol/apps-core';
 import { ask as tauriAsk, message as tauriMessage } from '@tauri-apps/plugin-dialog';
 import { exit as tauriExit } from '@tauri-apps/plugin-process';
 import { ServerAdmin } from './ServerAdmin';
@@ -289,7 +289,14 @@ export default class Installer {
       this.remoteFilesNeedUpdating = false;
       console.info('Installer finished');
     } catch (e: any) {
-      console.error(`Installation failed: `, e);
+      console.error('Installation failed', {
+        installPhase,
+        serverType: this.config.serverDetails.type,
+        hasServerIpAddress: Boolean(this.config.serverDetails.ipAddress),
+        remoteFilesNeedUpdating: this.remoteFilesNeedUpdating,
+        runtime: getRuntimeDiagnostics(),
+        error: getErrorDiagnostics(e),
+      });
       this.config.serverInstaller.errorType = installPhase ?? InstallStepErrorType.Unknown;
       this.config.serverInstaller.errorMessage = e.message ?? `Installation failed - ${String(e)}`;
       this.config.serverInstaller = this.config.serverInstaller;

--- a/src-vue/stores/appUpdater.ts
+++ b/src-vue/stores/appUpdater.ts
@@ -4,6 +4,7 @@ import { toRaw } from 'vue';
 import { app } from '@tauri-apps/api';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { check } from '@tauri-apps/plugin-updater';
+import { getErrorDiagnostics, getRuntimeDiagnostics } from '@argonprotocol/apps-core';
 import { ENABLE_AUTO_UPDATE } from '../lib/Env.ts';
 
 type AppUpdate = Awaited<ReturnType<typeof check>>;
@@ -50,7 +51,10 @@ export const useAppUpdater = defineStore('appUpdater', () => {
         return version;
       })
       .catch(error => {
-        console.error('Error loading app version', error);
+        console.error('Error loading app version', {
+          runtime: getRuntimeDiagnostics(),
+          error: getErrorDiagnostics(error),
+        });
         installedVersion.value = 'unknown';
         return installedVersion.value;
       });
@@ -82,7 +86,11 @@ export const useAppUpdater = defineStore('appUpdater', () => {
 
         return nextUpdate;
       } catch (error) {
-        console.error('Error checking for updates', error);
+        console.error('Error checking for updates', {
+          installedVersion: installedVersion.value,
+          runtime: getRuntimeDiagnostics(),
+          error: getErrorDiagnostics(error),
+        });
         errorMessage.value = 'Error checking for updates. Please try again later.';
         return update.value as AppUpdate;
       } finally {
@@ -127,7 +135,12 @@ export const useAppUpdater = defineStore('appUpdater', () => {
 
       isReadyToInstall.value = true;
     } catch (error) {
-      console.error('Error during download', error);
+      console.error('Error during download', {
+        installedVersion: installedVersion.value,
+        updateVersion: update.value?.version,
+        runtime: getRuntimeDiagnostics(),
+        error: getErrorDiagnostics(error),
+      });
       errorMessage.value = 'Error downloading update. Please try again later.';
     } finally {
       isDownloading.value = false;
@@ -140,7 +153,11 @@ export const useAppUpdater = defineStore('appUpdater', () => {
       isDownloading.value = false;
       await relaunch();
     } catch (error) {
-      console.error('Error during relaunch', error);
+      console.error('Error during relaunch', {
+        updateVersion: update.value?.version,
+        runtime: getRuntimeDiagnostics(),
+        error: getErrorDiagnostics(error),
+      });
     }
   }
 

--- a/src-vue/stores/runtimeCompatibility.ts
+++ b/src-vue/stores/runtimeCompatibility.ts
@@ -1,11 +1,10 @@
 import * as Vue from 'vue';
 import { defineStore } from 'pinia';
+import { fetch, SingleFileQueue } from '@argonprotocol/apps-core';
 import type { ArgonClient } from '@argonprotocol/mainchain';
-import { fetch } from '@tauri-apps/plugin-http';
 import { ENABLE_AUTO_UPDATE, IS_EXPERIMENTAL_BUILD, IS_TREASURY_APP } from '../lib/Env.ts';
 import { getMainchainClients } from './mainchain.ts';
 import { useAppUpdater } from './appUpdater.ts';
-import { SingleFileQueue } from '@argonprotocol/apps-core';
 
 export type RuntimeCompatibilityPhase = 'disabled' | 'loading' | 'compatible' | 'paused' | 'upgrade-required';
 


### PR DESCRIPTION
## Summary
- make the troubleshooting package checkbox functional and exclude the plaintext mnemonic file by default
- move troubleshooting package assembly back into the renderer and keep Rust focused on OS/profile collection
- add passive OS and network diagnostics with reduced sensitivity
- stream zip progress so large troubleshooting packages no longer appear stuck at 85%

## Notes
- encrypted wallet metadata in wallet.json remains included in the package
- the branch does not include the current local unstaged formatting-only change in src-tauri/src/lib.rs