### PR TITLE
Use a restricted proxy account for mining bids

### DIFF
--- a/bot/__test__/AutoBidder.test.ts
+++ b/bot/__test__/AutoBidder.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AutoBidder } from '../src/AutoBidder.ts';
+
+describe('AutoBidder', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('holds off bidding until the mining bid proxy is ready', async () => {
+    vi.useFakeTimers();
+
+    const autoBidder = new AutoBidder(
+      {
+        planMiningBidProxySetup: vi.fn().mockResolvedValue({ kind: 'tx' }),
+      } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+    const createBidderParams = vi.spyOn(autoBidder as any, 'createBidderParams');
+    const reloadActiveCohort = vi.spyOn(autoBidder as any, 'reloadActiveCohort').mockResolvedValue(undefined);
+
+    await (autoBidder as any).onBiddingStart(12);
+
+    expect(createBidderParams).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(reloadActiveCohort).toHaveBeenCalledOnce();
+  });
+});

--- a/bot/__test__/AutoBidder.test.ts
+++ b/bot/__test__/AutoBidder.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AutoBidder } from '../src/AutoBidder.ts';
 
+const onBiddingStart = Object.getOwnPropertyDescriptor(AutoBidder.prototype, 'onBiddingStart')!.value as (
+  this: AutoBidder,
+  cohortActivationFrameId: number,
+) => Promise<void>;
+
 describe('AutoBidder', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -20,15 +25,54 @@ describe('AutoBidder', () => {
       {} as any,
       {} as any,
     );
-    const createBidderParams = vi.spyOn(autoBidder as any, 'createBidderParams');
-    const reloadActiveCohort = vi.spyOn(autoBidder as any, 'reloadActiveCohort').mockResolvedValue(undefined);
+    const createBidderParams = vi.fn();
+    const reloadActiveCohort = vi.fn().mockResolvedValue(undefined);
+    Object.assign(autoBidder, {
+      createBidderParams,
+      reloadActiveCohort,
+    });
 
-    await (autoBidder as any).onBiddingStart(12);
+    await onBiddingStart.call(autoBidder, 12);
 
     expect(createBidderParams).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(reloadActiveCohort).toHaveBeenCalledOnce();
+  });
+
+  it('clears a pending proxy retry once bidding can start', async () => {
+    vi.useFakeTimers();
+
+    const autoBidder = new AutoBidder(
+      {
+        planMiningBidProxySetup: vi.fn().mockResolvedValueOnce({ kind: 'tx' }).mockResolvedValueOnce({ kind: 'ready' }),
+      } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+    const reloadActiveCohort = vi.fn().mockResolvedValue(undefined);
+    const createBidderParams = vi.fn().mockResolvedValue({
+      minBid: 0n,
+      maxBid: 0n,
+      maxSeats: 0,
+      bidDelay: 0,
+      bidIncrement: 1n,
+      sidelinedWalletMicrogons: 0n,
+      sidelinedWalletMicronots: 0n,
+    });
+    Object.assign(autoBidder, {
+      createBidderParams,
+      reloadActiveCohort,
+    });
+
+    await onBiddingStart.call(autoBidder, 12);
+    await onBiddingStart.call(autoBidder, 12);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(reloadActiveCohort).not.toHaveBeenCalled();
   });
 });

--- a/bot/__test__/bot.integration.test.ts
+++ b/bot/__test__/bot.integration.test.ts
@@ -9,6 +9,7 @@ import {
   BidAmountAdjustmentType,
   BidAmountFormulaType,
   type IBiddingRules,
+  MINING_BID_PROXY_FEE_FLOAT,
   NetworkConfig,
 } from '@argonprotocol/apps-core';
 import { DockerStatus } from '../src/DockerStatus.js';
@@ -112,10 +113,24 @@ it.skipIf(skipE2E)(
 
     const db = new Db(botDataDir);
     db.migrate();
+    const fundingAccount = sudo();
+    const proxyKeypair = new Keyring({ type: 'sr25519' }).addFromUri('//Ferdie//mining-proxy');
+    const proxySetup = await new TxSubmitter(
+      client,
+      client.tx.utility.batchAll([
+        client.tx.sudo.sudo(client.tx.ownership.forceSetBalance(fundingAccount.address, 500_000)),
+        client.tx.proxy.addProxy(proxyKeypair.address, 'MiningBidRealPaysFee', 0),
+        client.tx.balances.transferAllowDeath(proxyKeypair.address, MINING_BID_PROXY_FEE_FLOAT),
+      ]),
+      fundingAccount,
+    ).submit();
+    await proxySetup.waitForInFirstBlock;
+
     const bot = new Bot({
       db,
       bitcoinInitializerDelegateKeypair: sudo(),
-      bidderKeypair: sudo(),
+      fundingAccountId: fundingAccount.address,
+      proxyKeypair,
       archiveRpcUrl: clientAddress,
       localRpcUrl: clientAddress,
       biddingRulesPath: Path.resolve(botDataDir, 'rules.json'),
@@ -244,7 +259,8 @@ it.skipIf(skipE2E)(
     const botRestart = new Bot({
       db: restartDb,
       bitcoinInitializerDelegateKeypair: sudo(),
-      bidderKeypair: sudo(),
+      fundingAccountId: fundingAccount.address,
+      proxyKeypair,
       archiveRpcUrl: clientAddress,
       localRpcUrl: clientAddress,
       biddingRulesPath: Path.resolve(botDataDir, 'rules.json'),

--- a/bot/src/AutoBidder.ts
+++ b/bot/src/AutoBidder.ts
@@ -36,7 +36,7 @@ export class AutoBidder {
   private localRpcUrl?: string;
   private hasRegisteredKeys = false;
   private lifecycleQueue = Promise.resolve();
-  private pendingProxyRetry?: ReturnType<typeof setTimeout>;
+  private pendingProxyRetryTimeout?: ReturnType<typeof setTimeout>;
 
   constructor(
     private readonly accountset: Accountset,
@@ -92,9 +92,9 @@ export class AutoBidder {
     console.log('AUTOBIDDER STOPPING');
     this.unsubscribe?.();
     this.unsubscribe = undefined;
-    if (this.pendingProxyRetry) {
-      clearTimeout(this.pendingProxyRetry);
-      this.pendingProxyRetry = undefined;
+    if (this.pendingProxyRetryTimeout) {
+      clearTimeout(this.pendingProxyRetryTimeout);
+      this.pendingProxyRetryTimeout = undefined;
     }
     await this.lifecycleQueue;
     await this.stopActiveBidders(false);
@@ -184,13 +184,17 @@ export class AutoBidder {
           cohortActivationFrameId,
           proxySetup: proxySetup.kind,
         });
-        if (!this.pendingProxyRetry) {
-          this.pendingProxyRetry = setTimeout(() => {
-            this.pendingProxyRetry = undefined;
+        if (!this.pendingProxyRetryTimeout) {
+          this.pendingProxyRetryTimeout = setTimeout(() => {
+            this.pendingProxyRetryTimeout = undefined;
             void this.queueLifecycle(() => this.reloadActiveCohort());
           }, 1_000);
         }
         return;
+      }
+      if (this.pendingProxyRetryTimeout) {
+        clearTimeout(this.pendingProxyRetryTimeout);
+        this.pendingProxyRetryTimeout = undefined;
       }
 
       const params = await this.createBidderParams(cohortActivationFrameId);

--- a/bot/src/AutoBidder.ts
+++ b/bot/src/AutoBidder.ts
@@ -36,6 +36,7 @@ export class AutoBidder {
   private localRpcUrl?: string;
   private hasRegisteredKeys = false;
   private lifecycleQueue = Promise.resolve();
+  private pendingProxyRetry?: ReturnType<typeof setTimeout>;
 
   constructor(
     private readonly accountset: Accountset,
@@ -91,6 +92,10 @@ export class AutoBidder {
     console.log('AUTOBIDDER STOPPING');
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    if (this.pendingProxyRetry) {
+      clearTimeout(this.pendingProxyRetry);
+      this.pendingProxyRetry = undefined;
+    }
     await this.lifecycleQueue;
     await this.stopActiveBidders(false);
     this.biddingCalculator?.unload();
@@ -173,6 +178,21 @@ export class AutoBidder {
     if (this.isStopped || !this.biddingRules || !this.biddingCalculator) return;
 
     try {
+      const proxySetup = await this.accountset.planMiningBidProxySetup();
+      if (proxySetup.kind !== 'ready') {
+        console.log('Holding off bidding until mining bid proxy is ready', {
+          cohortActivationFrameId,
+          proxySetup: proxySetup.kind,
+        });
+        if (!this.pendingProxyRetry) {
+          this.pendingProxyRetry = setTimeout(() => {
+            this.pendingProxyRetry = undefined;
+            void this.queueLifecycle(() => this.reloadActiveCohort());
+          }, 1_000);
+        }
+        return;
+      }
+
       const params = await this.createBidderParams(cohortActivationFrameId);
       if (this.isStopped) return;
 

--- a/bot/src/Bot.ts
+++ b/bot/src/Bot.ts
@@ -33,7 +33,8 @@ import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
 interface IBotOptions {
   datadir: string;
   db: Db;
-  bidderKeypair: KeyringPair;
+  fundingAccountId: string;
+  proxyKeypair: KeyringPair;
   vaultOperatorAddress: string;
   localRpcUrl: string;
   archiveRpcUrl: string;
@@ -250,9 +251,11 @@ export default class Bot {
       this.biddingRulesJson = this.biddingRules ? JsonExt.stringify(this.biddingRules) : null;
       this.accountset = new Accountset({
         client: this.localClient,
-        seedAccount: this.options.bidderKeypair,
+        fundingAccountId: this.options.fundingAccountId,
+        isProxy: true,
         sessionMiniSecretOrMnemonic: this.options.sessionMiniSecret,
         subaccountRange: getRange(0, 144),
+        txSubmitter: this.options.proxyKeypair,
       });
       const miningFramesPath = this.storage.getPath('miningFrames.json');
       this.miningFrames = new MiningFrames(this.mainchainClients, this.blockWatch, {

--- a/bot/src/MiningFrameHistory.ts
+++ b/bot/src/MiningFrameHistory.ts
@@ -50,7 +50,7 @@ export class MiningFrameHistory {
 
     const [rawWinningBids, slots, totalBidCount, expectedAuctionCloseTick] = await Promise.all([
       Mining.fetchWinningBids(api),
-      Mining.fetchMiningSeats(this.accountset.seedAddress, api),
+      Mining.fetchMiningSeats(this.accountset.fundingAccountId, api),
       api.query.miningSlot.historicalBidsPerSlot().then(h => h[0]?.bidsCount.toNumber() ?? 0),
       mining.fetchTickAtStartOfAuctionClosing(api),
     ]);
@@ -111,7 +111,7 @@ export class MiningFrameHistory {
         return {
           address,
           subAccountIndex:
-            managedBy === this.accountset.seedAddress
+            managedBy === this.accountset.fundingAccountId
               ? this.accountset.subAccountsByAddress[address]?.index
               : undefined,
           bidPosition: i,
@@ -146,7 +146,7 @@ export class MiningFrameHistory {
           blockHash: frame.firstBlockHash,
           blockNumber: frame.firstBlockNumber,
         });
-        slots = await Mining.fetchMiningSeats(this.accountset.seedAddress, frameApi);
+        slots = await Mining.fetchMiningSeats(this.accountset.fundingAccountId, frameApi);
       }
     }
 

--- a/bot/src/env.d.ts
+++ b/bot/src/env.d.ts
@@ -3,6 +3,7 @@ declare global {
     interface ProcessEnv {
       PORT: string;
       BIDDER_KEYPAIR_PATH: string;
+      MINING_FUNDING_ACCOUNT_ID: string;
       KEYPAIR_PASSPHRASE?: string;
       LOCAL_RPC_URL: string;
       ARCHIVE_NODE_URL: string;

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -17,7 +17,7 @@ await waitForLoad();
 
 const datadir = requireEnv('DATADIR');
 const archiveRpcUrl = requireEnv('ARCHIVE_NODE_URL');
-const bidderKeypair = await loadKeypair(requireEnv('BIDDER_KEYPAIR_PATH'));
+const proxyKeypair = await loadKeypair(requireEnv('BIDDER_KEYPAIR_PATH'));
 const bitcoinInitializerDelegateKeypair = await loadKeypair(requireEnv('VAULT_DELEGATE_KEYPAIR_PATH'));
 const db = new Db(datadir);
 db.migrate();
@@ -31,7 +31,8 @@ const bot = new Bot({
   ethereumBeaconApiUrl,
   ...requireAll({
     datadir,
-    bidderKeypair,
+    fundingAccountId: process.env.MINING_FUNDING_ACCOUNT_ID,
+    proxyKeypair,
     archiveRpcUrl,
     localRpcUrl: process.env.LOCAL_RPC_URL,
     vaultOperatorAddress: process.env.VAULT_OPERATOR_ADDRESS,

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -31,7 +31,7 @@ const bot = new Bot({
   ethereumBeaconApiUrl,
   ...requireAll({
     datadir,
-    fundingAccountId: process.env.MINING_FUNDING_ACCOUNT_ID,
+    fundingAccountId: requireEnv('MINING_FUNDING_ACCOUNT_ID'),
     proxyKeypair,
     archiveRpcUrl,
     localRpcUrl: process.env.LOCAL_RPC_URL,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -119,7 +119,7 @@ export async function accountsetFromCli(program: Command, proxyForAddress?: stri
     return new Accountset({
       client,
       isProxy: true,
-      seedAddress: proxyForAddress,
+      fundingAccountId: proxyForAddress,
       txSubmitter: keypair,
       sessionMiniSecretOrMnemonic: opts.sessionMiniSecretOrMnemonic,
       subaccountRange: opts.subaccounts,

--- a/cli/src/miningCli.ts
+++ b/cli/src/miningCli.ts
@@ -104,7 +104,7 @@ export default function miningCli() {
     .requiredOption('--outfile <path>', 'The file to use to store the proxy account json (eg: proxy.json)')
     .requiredOption(
       '--fee-argons <argons>',
-      'How many argons should be sent to the proxy account for fees (proxies must pay fees)',
+      'How many argons should be sent to the proxy account during setup',
       parseFloat,
     )
     .option('--proxy-passphrase <passphrase>', 'The passphrase for your proxy account')
@@ -119,7 +119,7 @@ export default function miningCli() {
       const address = keyringPair.address;
       console.log(`✅ Created proxy account at "${outfile}" with address ${address}`);
       const tx = client.tx.utility.batchAll([
-        client.tx.proxy.addProxy(address, 'MiningBid', 0),
+        client.tx.proxy.addProxy(address, 'MiningBidRealPaysFee', 0),
         client.tx.balances.transferAllowDeath(address, BigInt(feeArgons * MICROGONS_PER_ARGON)),
       ]);
       let keypair: KeyringPair;

--- a/core/__test__/Accountset.integration.test.ts
+++ b/core/__test__/Accountset.integration.test.ts
@@ -99,4 +99,60 @@ describe.skipIf(skipE2E)('Accountset tests', {}, () => {
     const seats = await accountset.miningSeatsAndBids(api);
     expect(seats.filter(x => !!x.seat || x.hasWinningBid)).toHaveLength(5);
   });
+
+  it('can submit bids through a real-pays proxy', async () => {
+    const fundingAccount = sudo();
+    const proxyAccount = createKeyringPair({});
+    const fundingSetup = new TxSubmitter(
+      client,
+      client.tx.sudo.sudo(client.tx.ownership.forceSetBalance(fundingAccount.address, 500_000)),
+      fundingAccount,
+    );
+    const setupResult = await fundingSetup.submit();
+    await setupResult.waitForInFirstBlock;
+
+    const accountset = new Accountset({
+      client,
+      fundingAccountId: fundingAccount.address,
+      isProxy: true,
+      txSubmitter: proxyAccount,
+      subaccountRange: getRange(0, 49),
+      sessionMiniSecretOrMnemonic: sessionMiniSecretOrMnemonic,
+    });
+    const proxySetupPlan = await accountset.planMiningBidProxySetup();
+
+    expect(proxySetupPlan.kind).toBe('tx');
+    if (proxySetupPlan.kind !== 'tx') {
+      throw new Error(`Expected proxy setup transaction, got ${proxySetupPlan.kind}`);
+    }
+    expect(proxySetupPlan.metadata).toEqual({
+      fundingAccountId: fundingAccount.address,
+      proxyAccountId: proxyAccount.address,
+    });
+
+    const proxySetup = await new TxSubmitter(client, proxySetupPlan.tx, fundingAccount).submit();
+    await proxySetup.waitForInFirstBlock;
+
+    const readyPlan = await accountset.planMiningBidProxySetup();
+    expect(readyPlan).toEqual({ kind: 'ready' });
+
+    const nextSeats = await accountset.getAvailableMinerAccounts(5);
+    expect(nextSeats).toHaveLength(5);
+
+    const submitter = await accountset.createMiningBidTx({
+      bidAmount: 10_000n,
+      subaccounts: nextSeats,
+    });
+    const result = await submitter.submit({
+      useLatestNonce: true,
+    });
+    const blockHash = await result.waitForInFirstBlock;
+
+    expect(result).toBeTruthy();
+    expect(result.extrinsicError).toBeFalsy();
+
+    const api = await client.at(blockHash);
+    const seats = await accountset.miningSeatsAndBids(api);
+    expect(seats.filter(x => !!x.seat || x.hasWinningBid).length).toBeGreaterThanOrEqual(5);
+  });
 });

--- a/core/__test__/CohortBidder.integration.test.ts
+++ b/core/__test__/CohortBidder.integration.test.ts
@@ -625,10 +625,10 @@ describe.skipIf(SKIP_E2E)('Cohort Integration Bidder tests', () => {
     const cohortSeats = await finalizedApi.query.miningSlot.minersByCohort(cohortStartingFrameId);
 
     const bobSeatsWonOnChain = cohortSeats.filter(x => {
-      return x.externalFundingAccount.isSome && x.externalFundingAccount.value.toHuman() === bob.seedAddress;
+      return x.externalFundingAccount.isSome && x.externalFundingAccount.value.toHuman() === bob.fundingAccountId;
     }).length;
     const aliceSeatsWonOnChain = cohortSeats.filter(x => {
-      return x.externalFundingAccount.isSome && x.externalFundingAccount.value.toHuman() === alice.seedAddress;
+      return x.externalFundingAccount.isSome && x.externalFundingAccount.value.toHuman() === alice.fundingAccountId;
     }).length;
     const bidLevels = new Set(
       [...bobBidEvents, ...aliceBidEvents].map(({ microgonsPerSeat }) => microgonsPerSeat.toString()),

--- a/core/src/Accountset.ts
+++ b/core/src/Accountset.ts
@@ -5,6 +5,8 @@ import {
   getOfflineRegistry,
   Keyring,
   type KeyringPair,
+  MICROGONS_PER_ARGON,
+  type SubmittableExtrinsic,
   TxSubmitter,
   u8aToHex,
 } from '@argonprotocol/mainchain';
@@ -29,10 +31,26 @@ export interface IMiningIndex {
   bidAmount: bigint;
 }
 
+export const MINING_BID_PROXY_FEE_FLOAT = 1n * BigInt(MICROGONS_PER_ARGON);
+
+export type MiningBidProxySetupMetadata = {
+  fundingAccountId: string;
+  proxyAccountId: string;
+};
+
+export type MiningBidProxySetupPlan =
+  | { kind: 'ready' }
+  | { kind: 'insufficientFunds'; error: string }
+  | {
+      kind: 'tx';
+      tx: SubmittableExtrinsic;
+      metadata: MiningBidProxySetupMetadata;
+    };
+
 export class Accountset {
   public txSubmitterPair: KeyringPair;
   public isProxy = false;
-  public seedAddress: string;
+  public fundingAccountId: string;
   public subAccountsByAddress: {
     [address: string]: { index: number };
   } = {};
@@ -49,7 +67,7 @@ export class Accountset {
     } & (
       | { seedAccount: KeyringPair }
       | {
-          seedAddress: string;
+          fundingAccountId: string;
           isProxy: true;
           txSubmitter: KeyringPair;
         }
@@ -57,18 +75,18 @@ export class Accountset {
   ) {
     if ('seedAccount' in options) {
       this.txSubmitterPair = options.seedAccount;
-      this.seedAddress = options.seedAccount.address;
+      this.fundingAccountId = options.seedAccount.address;
       this.isProxy = false;
     } else {
       this.isProxy = options.isProxy;
       this.txSubmitterPair = options.txSubmitter;
-      this.seedAddress = options.seedAddress;
+      this.fundingAccountId = options.fundingAccountId;
     }
     this.sessionMiniSecretOrMnemonic = options.sessionMiniSecretOrMnemonic;
     this.client = options.client;
     const defaultRange = options.subaccountRange ?? getRange();
     for (const i of defaultRange) {
-      const hashedAccount = Accountset.createMiningSubaccount(this.seedAddress, i);
+      const hashedAccount = Accountset.createMiningSubaccount(this.fundingAccountId, i);
       this.subAccountsByAddress[hashedAccount] = { index: i };
     }
   }
@@ -84,7 +102,7 @@ export class Accountset {
   public async submitterBalance(blockHash?: Uint8Array): Promise<bigint> {
     const client = this.client;
     const api = blockHash ? await client.at(blockHash) : client;
-    const accountData = await api.query.system.account(this.txSubmitterPair.address);
+    const accountData = await api.query.system.account(this.fundingAccountId);
 
     return accountData.data.free.toBigInt();
   }
@@ -92,7 +110,7 @@ export class Accountset {
   public async accountMicronots(blockHash?: Uint8Array): Promise<bigint> {
     const client = this.client;
     const api = blockHash ? await client.at(blockHash) : client;
-    const accountData = await api.query.ownership.account(this.seedAddress);
+    const accountData = await api.query.ownership.account(this.fundingAccountId);
 
     return accountData.free.toBigInt();
   }
@@ -100,7 +118,7 @@ export class Accountset {
   public async balance(blockHash?: Uint8Array): Promise<bigint> {
     const client = this.client;
     const api = blockHash ? await client.at(blockHash) : client;
-    const accountData = await api.query.system.account(this.seedAddress);
+    const accountData = await api.query.system.account(this.fundingAccountId);
 
     return accountData.data.free.toBigInt();
   }
@@ -129,7 +147,7 @@ export class Accountset {
   }
 
   public async loadRegisteredMiners(api: ApiDecoration<'promise'>): Promise<ISubaccountMiner[]> {
-    const addressToMiningIndex = await Mining.fetchMiningSeatsForAccount(this.seedAddress, api);
+    const addressToMiningIndex = await Mining.fetchMiningSeatsForAccount(this.fundingAccountId, api);
 
     return Object.entries(this.subAccountsByAddress).map(([address, { index }]) => {
       return {
@@ -155,7 +173,7 @@ export class Accountset {
 
     const nextCohort = await Mining.fetchWinningBids(api);
     for (const bid of nextCohort) {
-      if (bid.managedByAddress === this.seedAddress) {
+      if (bid.managedByAddress === this.fundingAccountId) {
         const address = bid.address;
         const existing = miners.find(x => x.address === address);
         const details = {
@@ -250,9 +268,48 @@ export class Accountset {
 
     let tx = batch;
     if (this.isProxy) {
-      tx = client.tx.proxy.proxy(this.seedAddress, 'MiningBid', batch);
+      tx = client.tx.proxy.proxy(this.fundingAccountId, 'MiningBidRealPaysFee', batch);
     }
     return new TxSubmitter(client, tx, this.txSubmitterPair);
+  }
+
+  public async planMiningBidProxySetup(): Promise<MiningBidProxySetupPlan> {
+    if (!this.isProxy) {
+      throw new Error('Mining bid proxy setup requires a proxy submitter.');
+    }
+
+    const client = this.client;
+    const proxyAccountId = this.txSubmitterPair.address;
+    const [proxyDefinitions, fundingAccountBalance] = await Promise.all([
+      client.query.proxy.proxies(this.fundingAccountId).then(([definitions]) => definitions),
+      this.balance(),
+    ]);
+
+    const isProxyRegistered = proxyDefinitions.some(def => {
+      return def.delegate.toString() === proxyAccountId && def.proxyType.isMiningBidRealPaysFee;
+    });
+    if (isProxyRegistered) {
+      return { kind: 'ready' };
+    }
+
+    if (fundingAccountBalance < MINING_BID_PROXY_FEE_FLOAT) {
+      return {
+        kind: 'insufficientFunds',
+        error: 'Mining bid account needs 1 ARGN to seed its bid proxy.',
+      };
+    }
+
+    return {
+      kind: 'tx',
+      tx: client.tx.utility.batchAll([
+        client.tx.proxy.addProxy(proxyAccountId, 'MiningBidRealPaysFee', 0),
+        client.tx.balances.transferAllowDeath(proxyAccountId, MINING_BID_PROXY_FEE_FLOAT),
+      ]),
+      metadata: {
+        fundingAccountId: this.fundingAccountId,
+        proxyAccountId,
+      },
+    };
   }
 
   public getAccountsInRange(range?: SubaccountRange): IAccountAndIndex[] {

--- a/core/src/CohortBidder.ts
+++ b/core/src/CohortBidder.ts
@@ -265,7 +265,7 @@ export class CohortBidder {
           .filter(
             x =>
               x.externalFundingAccount.isSome &&
-              this.accountset.seedAddress === x.externalFundingAccount.value.toHuman(),
+              this.accountset.fundingAccountId === x.externalFundingAccount.value.toHuman(),
           )
           .map(x => {
             return {

--- a/e2e/flows/operations/Mining.op.finalizeSetup.ts
+++ b/e2e/flows/operations/Mining.op.finalizeSetup.ts
@@ -143,11 +143,6 @@ export default new Operation<IMiningFlowContext, IFinalizeSetupState>(import.met
     }
 
     if (!state.launchBotClickable) {
-      if (!state.installingVisible) {
-        throw new Error(
-          `${flowName}: launch mining bot is not ready (visible=${state.launchBotVisible}, enabled=${state.launchBotEnabled}, clickable=${state.launchBotClickable}).`,
-        );
-      }
       console.info(`[E2E] ${flowName}: finalizeSetup waiting for launch button to become ready`);
       await waitForServerInstallToReachLaunchableState(flow, flowName);
     }

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -1,7 +1,6 @@
 import './helpers/mocks.ts';
 import { beforeEach, expect, it, vi } from 'vitest';
 import * as Vue from 'vue';
-import { TxSubmitter } from '@argonprotocol/mainchain';
 import { Config } from '../lib/Config';
 import Installer, { resetInstaller } from '../lib/Installer';
 import { createMockedDbPromise } from './helpers/db';
@@ -11,14 +10,15 @@ import { InstallerCheck } from '../lib/InstallerCheck.ts';
 import * as MiningAccount from '../lib/MiningAccount.ts';
 import { MiningMachine } from '../lib/MiningMachine.ts';
 import { WalletKeys } from '../lib/WalletKeys.ts';
-import { getMainchainClient } from '../stores/mainchain.ts';
+import { getTransactionTracker } from '../stores/transactions.ts';
 import { createMockWalletKeys, createTestWallet } from './helpers/wallet.ts';
 
-vi.mock('../stores/mainchain.ts', () => ({
-  getMainchainClient: vi.fn(),
+vi.mock('../stores/transactions.ts', () => ({
+  getTransactionTracker: vi.fn(),
 }));
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   resetInstaller();
   WalletKeys.prototype.didWalletHavePreviousLife = vi.fn().mockResolvedValue(false);
 });
@@ -161,11 +161,12 @@ it('should run through entire install process', async () => {
   expect(config.serverInstaller.ServerConnect.status).toBe('Completed');
 });
 
-it('sets up the mining bid proxy during non-fresh installs before uploading bot config files', async () => {
+it('waits for existing-user mining bid proxy setup before uploading bot config files', async () => {
   const dbPromise = createMockedDbPromise({});
   const walletKeys = createMockWalletKeys();
   const config = new Config(dbPromise, walletKeys);
   await config.load();
+  config.miningSetupStatus = MiningSetupStatus.Finished;
 
   const installer = new Installer(config, walletKeys);
   await installer.load();
@@ -181,21 +182,18 @@ it('sets up the mining bid proxy during non-fresh installs before uploading bot 
     startInstallerScript: vi.fn().mockResolvedValue(undefined),
   };
   const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
-  const proxyKeypair = await walletKeys.getMiningBidProxyKeypair();
-  const fundingAccount = await walletKeys.getMiningBotKeypair();
-  const proxySetupSpy = vi.spyOn(MiningAccount, 'planMiningBidProxySetup').mockResolvedValue({
-    fundingAccount,
-    proxySetup: {
-      kind: 'tx',
-      tx: 'proxy-setup-tx' as any,
-      metadata: {
-        fundingAccountId: walletKeys.miningBotAddress,
-        proxyAccountId: proxyKeypair.address,
-      },
-    },
+  const transactionTracker = {
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  let resolveProxySetup: () => void = () => undefined;
+  const proxySetupWait = new Promise<void>(resolve => {
+    resolveProxySetup = resolve;
   });
-  const submitSpy = vi.spyOn(TxSubmitter.prototype, 'submit').mockResolvedValue({
-    waitForInFirstBlock: Promise.resolve(undefined),
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({
+    kind: 'trackingExisting',
+    txInfo: {
+      waitForPostProcessing: proxySetupWait,
+    },
   } as any);
 
   // @ts-ignore - exercise the upgrade path directly
@@ -216,12 +214,119 @@ it('sets up the mining bid proxy during non-fresh installs before uploading bot 
   installer.installerCheck.activateServer = vi.fn();
   // @ts-ignore - avoid background polling in this unit test
   installer.installerCheck.noThrowWaitForInstallToComplete = vi.fn().mockResolvedValue(undefined);
-  vi.mocked(getMainchainClient).mockResolvedValue({} as any);
+  vi.mocked(getTransactionTracker).mockReturnValue(transactionTracker as any);
+
+  const runPromise = installer.run(false);
+
+  await vi.waitFor(() => expect(proxySetupSpy).toHaveBeenCalledOnce());
+  expect(transactionTracker.load).toHaveBeenCalledOnce();
+  expect(uploadBotConfigFiles).not.toHaveBeenCalled();
+
+  resolveProxySetup();
+  await runPromise;
+
+  expect(uploadBotConfigFiles).toHaveBeenCalledOnce();
+});
+
+it('skips installer proxy setup before mining setup is finished', async () => {
+  const dbPromise = createMockedDbPromise({});
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  const installer = new Installer(config, walletKeys);
+  await installer.load();
+
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+
+  const server = {
+    downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    createLogsDir: vi.fn().mockResolvedValue(undefined),
+    startInstallerScript: vi.fn().mockResolvedValue(undefined),
+  };
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup');
+
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsRunning = vi.fn().mockResolvedValue(false);
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsReadyToRun = vi.fn().mockResolvedValue(true);
+  // @ts-ignore - avoid real server setup in this unit test
+  installer.getServer = vi.fn().mockResolvedValue(server);
+  // @ts-ignore - avoid port polling in this unit test
+  installer.saveLocalGatewayPortWhenReady = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - drive the non-fresh path directly
+  installer.isFreshInstall = false;
+  // @ts-ignore - skip core file upload in this unit test
+  installer.remoteFilesNeedUpdating = false;
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.start = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.activateServer = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.noThrowWaitForInstallToComplete = vi.fn().mockResolvedValue(undefined);
+
+  await installer.run(false);
+
+  expect(proxySetupSpy).not.toHaveBeenCalled();
+  expect(uploadBotConfigFiles).toHaveBeenCalledOnce();
+});
+
+it('does not fail installer proxy migration when the mining funding account is short on funds', async () => {
+  const dbPromise = createMockedDbPromise({});
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+  config.miningSetupStatus = MiningSetupStatus.Finished;
+
+  const installer = new Installer(config, walletKeys);
+  await installer.load();
+
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+
+  const server = {
+    downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    createLogsDir: vi.fn().mockResolvedValue(undefined),
+    startInstallerScript: vi.fn().mockResolvedValue(undefined),
+  };
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
+  const transactionTracker = {
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({
+    kind: 'insufficientFunds',
+    error: 'Mining bid account needs 1 ARGN to seed its bid proxy.',
+  });
+
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsRunning = vi.fn().mockResolvedValue(false);
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsReadyToRun = vi.fn().mockResolvedValue(true);
+  // @ts-ignore - avoid real server setup in this unit test
+  installer.getServer = vi.fn().mockResolvedValue(server);
+  // @ts-ignore - avoid port polling in this unit test
+  installer.saveLocalGatewayPortWhenReady = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - drive the non-fresh path directly
+  installer.isFreshInstall = false;
+  // @ts-ignore - skip core file upload in this unit test
+  installer.remoteFilesNeedUpdating = false;
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.start = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.activateServer = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.noThrowWaitForInstallToComplete = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(getTransactionTracker).mockReturnValue(transactionTracker as any);
 
   await installer.run(false);
 
   expect(proxySetupSpy).toHaveBeenCalledOnce();
-  expect(submitSpy).toHaveBeenCalledWith({ useLatestNonce: true });
+  expect(transactionTracker.load).toHaveBeenCalledOnce();
   expect(uploadBotConfigFiles).toHaveBeenCalledOnce();
-  expect(submitSpy.mock.invocationCallOrder[0]).toBeLessThan(uploadBotConfigFiles.mock.invocationCallOrder[0]);
 });

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -1,15 +1,22 @@
 import './helpers/mocks.ts';
 import { beforeEach, expect, it, vi } from 'vitest';
 import * as Vue from 'vue';
+import { TxSubmitter } from '@argonprotocol/mainchain';
 import { Config } from '../lib/Config';
 import Installer, { resetInstaller } from '../lib/Installer';
 import { createMockedDbPromise } from './helpers/db';
 import { IInstallStepStatuses, InstallStepStatusType } from '../lib/ServerAdmin';
 import { InstallStepKey, MiningSetupStatus, ServerType } from '../interfaces/IConfig';
 import { InstallerCheck } from '../lib/InstallerCheck.ts';
+import * as MiningAccount from '../lib/MiningAccount.ts';
 import { MiningMachine } from '../lib/MiningMachine.ts';
 import { WalletKeys } from '../lib/WalletKeys.ts';
+import { getMainchainClient } from '../stores/mainchain.ts';
 import { createMockWalletKeys, createTestWallet } from './helpers/wallet.ts';
+
+vi.mock('../stores/mainchain.ts', () => ({
+  getMainchainClient: vi.fn(),
+}));
 
 beforeEach(() => {
   resetInstaller();
@@ -82,6 +89,22 @@ it('should install if all conditions are met', async () => {
   expect(didRun).toBe(true);
 });
 
+it('only uploads bot config files when updating server config', async () => {
+  const dbPromise = createMockedDbPromise({});
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  const installer = new Installer(config, walletKeys);
+  await installer.load();
+
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
+
+  await installer.updateServerConfig();
+
+  expect(uploadBotConfigFiles).toHaveBeenCalledOnce();
+});
+
 it('should run through entire install process', async () => {
   const dbPromise = createMockedDbPromise({ serverAdd: '{ "localComputer": {} }' });
   const walletKeys = createMockWalletKeys();
@@ -130,9 +153,75 @@ it('should run through entire install process', async () => {
   installer.getLocalShasum = vi.fn().mockResolvedValue('dummy-sha256');
   // @ts-ignore
   installer.uploadCoreFiles = vi.fn().mockResolvedValue();
+  vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
 
   // should call run
   await installer.load();
 
   expect(config.serverInstaller.ServerConnect.status).toBe('Completed');
+});
+
+it('sets up the mining bid proxy during non-fresh installs before uploading bot config files', async () => {
+  const dbPromise = createMockedDbPromise({});
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  const installer = new Installer(config, walletKeys);
+  await installer.load();
+
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+
+  const server = {
+    downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    createLogsDir: vi.fn().mockResolvedValue(undefined),
+    startInstallerScript: vi.fn().mockResolvedValue(undefined),
+  };
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockResolvedValue(undefined);
+  const proxyKeypair = await walletKeys.getMiningBidProxyKeypair();
+  const fundingAccount = await walletKeys.getMiningBotKeypair();
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'planMiningBidProxySetup').mockResolvedValue({
+    fundingAccount,
+    proxySetup: {
+      kind: 'tx',
+      tx: 'proxy-setup-tx' as any,
+      metadata: {
+        fundingAccountId: walletKeys.miningBotAddress,
+        proxyAccountId: proxyKeypair.address,
+      },
+    },
+  });
+  const submitSpy = vi.spyOn(TxSubmitter.prototype, 'submit').mockResolvedValue({
+    waitForInFirstBlock: Promise.resolve(undefined),
+  } as any);
+
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsRunning = vi.fn().mockResolvedValue(false);
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsReadyToRun = vi.fn().mockResolvedValue(true);
+  // @ts-ignore - avoid real server setup in this unit test
+  installer.getServer = vi.fn().mockResolvedValue(server);
+  // @ts-ignore - avoid port polling in this unit test
+  installer.saveLocalGatewayPortWhenReady = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - drive the non-fresh path directly
+  installer.isFreshInstall = false;
+  // @ts-ignore - skip core file upload in this unit test
+  installer.remoteFilesNeedUpdating = false;
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.start = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.activateServer = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.noThrowWaitForInstallToComplete = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(getMainchainClient).mockResolvedValue({} as any);
+
+  await installer.run(false);
+
+  expect(proxySetupSpy).toHaveBeenCalledOnce();
+  expect(submitSpy).toHaveBeenCalledWith({ useLatestNonce: true });
+  expect(uploadBotConfigFiles).toHaveBeenCalledOnce();
+  expect(submitSpy.mock.invocationCallOrder[0]).toBeLessThan(uploadBotConfigFiles.mock.invocationCallOrder[0]);
 });

--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -46,7 +46,7 @@ describe('MoveCapital', () => {
   it('submits vault security moves through the vault allocation path', async () => {
     const { moveCapital, myVault } = createMoveCapital();
     const txInfo = { tx: { id: 11 } } as any;
-    myVault.increaseVaultAllocations.mockResolvedValue(txInfo);
+    myVault.increaseVaultSecuritization.mockResolvedValue(txInfo);
     const wallet = createWallet({ address: 'vaulting-address', availableMicrogons: 250n });
 
     const result = await moveCapital.move(
@@ -57,9 +57,8 @@ describe('MoveCapital', () => {
       'vaulting-address',
     );
 
-    expect(myVault.increaseVaultAllocations).toHaveBeenCalledWith({
+    expect(myVault.increaseVaultSecuritization).toHaveBeenCalledWith({
       addedSecuritizationMicrogons: 100n,
-      addedTreasuryMicrogons: 0n,
       metadata: {
         moveFrom: MoveFrom.VaultingHold,
         moveTo: MoveTo.VaultingSecurity,
@@ -73,7 +72,7 @@ describe('MoveCapital', () => {
   it('calculates vault security move fees from the actual allocation transaction', async () => {
     const { moveCapital, myVault } = createMoveCapital();
     const allocationTx = createMockFeeTx(7n);
-    myVault.buildIncreaseVaultAllocationsTx.mockResolvedValue(allocationTx);
+    myVault.buildIncreaseBitcoinSecurityTx.mockResolvedValue(allocationTx);
     const buildTransactionSpy = vi.spyOn(moveCapital, 'buildTransaction');
     const wallet = createWallet({ address: 'vaulting-address', availableMicrogons: 250n });
     const client = { id: 'client' } as any;
@@ -88,12 +87,7 @@ describe('MoveCapital', () => {
       client,
     );
 
-    expect(myVault.buildIncreaseVaultAllocationsTx).toHaveBeenCalledWith(
-      {
-        addedSecuritizationMicrogons: 100n,
-      },
-      client,
-    );
+    expect(myVault.buildIncreaseBitcoinSecurityTx).toHaveBeenCalledWith(100n, client);
     expect(allocationTx.paymentInfo).toHaveBeenCalledWith('vaulting-address');
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(fee).toBe(7n);
@@ -112,7 +106,7 @@ describe('MoveCapital', () => {
         'vaulting-address',
       ),
     ).rejects.toThrow('Only ARGN can be moved into vault allocations.');
-    expect(myVault.increaseVaultAllocations).not.toHaveBeenCalled();
+    expect(myVault.increaseVaultSecuritization).not.toHaveBeenCalled();
   });
 
   it('does not treat Ethereum addresses as valid external move destinations', () => {
@@ -125,7 +119,8 @@ describe('MoveCapital', () => {
   });
 
   it('keeps the mining hold operational reserve when sweeping to the bot', async () => {
-    const { moveCapital, transactionTracker } = createMoveCapital();
+    const { moveCapital, transactionTracker, postProcessMiningBidProxySetupSpy } = createMoveCapital();
+    postProcessMiningBidProxySetupSpy.mockRestore();
     const calculateFeeSpy = vi.spyOn(moveCapital, 'calculateFee').mockResolvedValue(5n);
     const buildTransactionSpy = vi.spyOn(moveCapital, 'buildTransaction').mockResolvedValue({
       tx: 'transfer-tx' as any,
@@ -158,9 +153,6 @@ describe('MoveCapital', () => {
         waitForPostProcessing: proxySetupWait,
       },
     } as any);
-    (moveCapital as any).postProcessMiningBidProxySetup.mockImplementation((submittedTxInfo: any) => {
-      return (MoveCapital.prototype as any).postProcessMiningBidProxySetup.call(moveCapital, submittedTxInfo);
-    });
     const wallet = createWallet({
       availableMicrogons: miningHoldOperationalReserveMicrogons + 50n,
       availableMicronots: 7n,
@@ -386,7 +378,6 @@ describe('MoveCapital', () => {
     expect(feeSpy).not.toHaveBeenCalled();
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
-    expect((moveCapital as any).postProcessMiningBidProxySetup).not.toHaveBeenCalled();
     expect(result).toEqual({ kind: 'noSpendableFundsToSweep' });
     expect(moveCapital.transactionError).toBe('');
   });
@@ -518,8 +509,8 @@ function createMoveCapital(existingTxInfo?: MockTxInfo) {
     submitAndWatch: vi.fn(),
   };
   const myVault = {
-    increaseVaultAllocations: vi.fn(),
-    buildIncreaseVaultAllocationsTx: vi.fn(),
+    increaseVaultSecuritization: vi.fn(),
+    buildIncreaseBitcoinSecurityTx: vi.fn(),
   };
   const moveCapitalWalletKeys = {
     miningBotAddress: 'mining-bot-address',
@@ -530,12 +521,15 @@ function createMoveCapital(existingTxInfo?: MockTxInfo) {
   const moveCapital = new MoveCapital(moveCapitalWalletKeys, transactionTracker as any, myVault as any);
 
   vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({ kind: 'ready' });
-  vi.spyOn(moveCapital as any, 'postProcessMiningBidProxySetup').mockResolvedValue(undefined);
+  const postProcessMiningBidProxySetupSpy = vi
+    .spyOn(moveCapital as any, 'postProcessMiningBidProxySetup')
+    .mockResolvedValue(undefined);
 
   return {
     moveCapital,
     transactionTracker,
     myVault,
+    postProcessMiningBidProxySetupSpy,
   };
 }
 

--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -4,6 +4,7 @@ import { MoveCapital } from '../lib/MoveCapital.ts';
 import { existentialDepositMicrogons, miningHoldOperationalReserveMicrogons } from '../lib/WalletForArgon.ts';
 import { type IWallet } from '../lib/Wallet.ts';
 import { buildOperatorAccountRegistrationTx } from '../lib/OperationalAccount.ts';
+import * as MiningAccount from '../lib/MiningAccount.ts';
 import { Config } from '../lib/Config.ts';
 import { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestDb } from './helpers/db.ts';
@@ -31,9 +32,10 @@ type MockTxInfo = {
   };
 };
 
+let config: Config;
+let walletKeys: WalletKeys;
+
 describe('MoveCapital', () => {
-  let config: Config;
-  let walletKeys: WalletKeys;
   beforeAll(async () => {
     const db = await createTestDb();
     setDbPromise(Promise.resolve(db));
@@ -134,8 +136,31 @@ describe('MoveCapital', () => {
       },
     });
     vi.spyOn(moveCapital as any, 'getSigner').mockResolvedValue('signer');
-    const txInfo = { tx: { id: 1 } } as any;
+    let resolveProxySetup: () => void = () => undefined;
+    const proxySetupWait = new Promise<void>(resolve => {
+      resolveProxySetup = resolve;
+    });
+    const postProcessor = {
+      resolve: vi.fn(),
+      reject: vi.fn(),
+    };
+    const txInfo = {
+      tx: { id: 1 },
+      txResult: {
+        waitForFinalizedBlock: Promise.resolve(undefined),
+      },
+      createPostProcessor: vi.fn().mockReturnValue(postProcessor),
+    } as any;
     transactionTracker.submitAndWatch.mockResolvedValue(txInfo);
+    vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({
+      kind: 'submitted',
+      txInfo: {
+        waitForPostProcessing: proxySetupWait,
+      },
+    } as any);
+    (moveCapital as any).postProcessMiningBidProxySetup.mockImplementation((submittedTxInfo: any) => {
+      return (MoveCapital.prototype as any).postProcessMiningBidProxySetup.call(moveCapital, submittedTxInfo);
+    });
     const wallet = createWallet({
       availableMicrogons: miningHoldOperationalReserveMicrogons + 50n,
       availableMicronots: 7n,
@@ -173,6 +198,14 @@ describe('MoveCapital', () => {
     });
     expect(buildOperatorAccountRegistrationTx).toHaveBeenCalledOnce();
     expect(result).toEqual({ kind: 'submitted', txInfo });
+
+    await vi.waitFor(() => expect(MiningAccount.ensureMiningBidProxySetup).toHaveBeenCalledOnce());
+    expect(postProcessor.resolve).not.toHaveBeenCalled();
+
+    resolveProxySetup();
+
+    await vi.waitFor(() => expect(postProcessor.resolve).toHaveBeenCalledOnce());
+    expect(postProcessor.reject).not.toHaveBeenCalled();
   });
 
   it('retries the fee calculation without argons when only argonots should move', async () => {
@@ -353,6 +386,7 @@ describe('MoveCapital', () => {
     expect(feeSpy).not.toHaveBeenCalled();
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
+    expect((moveCapital as any).postProcessMiningBidProxySetup).not.toHaveBeenCalled();
     expect(result).toEqual({ kind: 'noSpendableFundsToSweep' });
     expect(moveCapital.transactionError).toBe('');
   });
@@ -487,13 +521,19 @@ function createMoveCapital(existingTxInfo?: MockTxInfo) {
     increaseVaultAllocations: vi.fn(),
     buildIncreaseVaultAllocationsTx: vi.fn(),
   };
+  const moveCapitalWalletKeys = {
+    miningBotAddress: 'mining-bot-address',
+    getMiningBotKeypair: walletKeys.getMiningBotKeypair.bind(walletKeys),
+    getMiningBidProxyKeypair: walletKeys.getMiningBidProxyKeypair.bind(walletKeys),
+    getWalletKeypair: walletKeys.getWalletKeypair.bind(walletKeys),
+  } as WalletKeys;
+  const moveCapital = new MoveCapital(moveCapitalWalletKeys, transactionTracker as any, myVault as any);
+
+  vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({ kind: 'ready' });
+  vi.spyOn(moveCapital as any, 'postProcessMiningBidProxySetup').mockResolvedValue(undefined);
 
   return {
-    moveCapital: new MoveCapital(
-      { miningBotAddress: 'mining-bot-address' } as any,
-      transactionTracker as any,
-      myVault as any,
-    ),
+    moveCapital,
     transactionTracker,
     myVault,
   };

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -420,7 +420,6 @@ describe('MyVault cosign recovery', () => {
       extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
       metadataJson: {
         addedSecuritizationMicrogons: 100n,
-        addedTreasuryMicrogons: 0n,
         vaultId: 7,
       },
     });
@@ -430,10 +429,10 @@ describe('MyVault cosign recovery', () => {
       securitizationRatio: 1,
     } as any;
     vi.spyOn(
-      myVault as unknown as { buildIncreaseVaultAllocationsTx: MyVault['buildIncreaseVaultAllocationsTx'] },
-      'buildIncreaseVaultAllocationsTx',
+      myVault as unknown as { buildIncreaseBitcoinSecurityTx: MyVault['buildIncreaseBitcoinSecurityTx'] },
+      'buildIncreaseBitcoinSecurityTx',
     ).mockResolvedValue(tx as any);
-    vi.spyOn(myVault as any, 'onIncreaseVaultAllocations').mockResolvedValue(undefined);
+    vi.spyOn(myVault as any, 'onIncreaseVaultSecuritization').mockResolvedValue(undefined);
     trackTxResult.mockResolvedValue(txResultInfo);
     const client = {
       genesisHash: { toHex: () => '0xgenesis' },
@@ -454,9 +453,8 @@ describe('MyVault cosign recovery', () => {
     };
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue(client as any);
 
-    const result = await myVault.increaseVaultAllocations({
+    const result = await myVault.increaseVaultSecuritization({
       addedSecuritizationMicrogons: 100n,
-      addedTreasuryMicrogons: 0n,
       metadata: { moveFrom: 'VaultingHold', moveTo: 'VaultingSecurity' },
     });
 
@@ -475,7 +473,6 @@ describe('MyVault cosign recovery', () => {
       extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
       metadata: {
         addedSecuritizationMicrogons: 100n,
-        addedTreasuryMicrogons: 0n,
         vaultId: 7,
         moveFrom: 'VaultingHold',
         moveTo: 'VaultingSecurity',

--- a/src-vue/__test__/TransactionInfo.test.ts
+++ b/src-vue/__test__/TransactionInfo.test.ts
@@ -76,3 +76,22 @@ it('should update progress throughout the entire finalization process', async ()
   expect(lastProgressUpdate.progressPct).toBe(100);
   expect(lastProgressUpdate.confirmations).toBe(5);
 }, 60_000);
+
+it('treats a watched finalized tx result as finalized before the record is persisted', () => {
+  const txInfo = new TransactionInfo({
+    tx: {
+      blockHeight: 100,
+      isFinalized: false,
+    } as ITransactionRecord,
+    txResult: {
+      isFinalized: true,
+    } as TxResult,
+  });
+
+  txInfo.finalizedHeadHeight = 100;
+
+  expect(txInfo.getStatus()).toMatchObject({
+    progressPct: 100,
+    isFinalized: true,
+  });
+});

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -301,9 +301,9 @@ describe('TransactionTracker', () => {
     });
     const recordWatchStatus = (
       tracker as unknown as {
-        recordWatchStatus: (tx: ITransactionRecord, result: any) => Promise<void>;
+        recordWatchStatus: (tx: ITransactionRecord, watchUpdate: any) => Promise<void>;
       }
-    ).recordWatchStatus.bind(tracker) as (tx: ITransactionRecord, result: any) => Promise<void>;
+    ).recordWatchStatus.bind(tracker) as (tx: ITransactionRecord, watchUpdate: any) => Promise<void>;
     const findSpy = vi.spyOn(TransactionEvents, 'findByExtrinsicHashInBlock').mockResolvedValueOnce({
       blockNumber: 130,
       blockHash: '0xwatched-block',
@@ -315,17 +315,15 @@ describe('TransactionTracker', () => {
     });
 
     await recordWatchStatus(tx, {
+      isBroadcast: false,
+      isInBlock: false,
+      isFinalized: true,
+      isRetracted: false,
+      isUsurped: false,
+      isDropped: false,
+      isInvalid: false,
       blockNumber: 130,
-      status: {
-        isBroadcast: false,
-        isInBlock: false,
-        isFinalized: true,
-        isRetracted: false,
-        isUsurped: false,
-        isDropped: false,
-        isInvalid: false,
-        asFinalized: { toHex: () => '0xwatched-block' },
-      },
+      blockHash: '0xwatched-block',
     });
 
     expect(findSpy).toHaveBeenCalledWith(
@@ -346,6 +344,45 @@ describe('TransactionTracker', () => {
       }),
     );
     expect(table.markFinalized).toHaveBeenCalledWith(tx, expect.objectContaining({ blockNumber: 130 }));
+  });
+
+  it('ignores non-block watch updates without touching finalized accessors', async () => {
+    const tx = createTransaction({
+      id: 11,
+      status: TransactionStatus.Submitted,
+      blockHeight: undefined,
+      blockHash: undefined,
+    });
+    const { tracker } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 130,
+    });
+    const handleWatchedResult = (
+      tracker as unknown as {
+        handleWatchedResult: (tx: ITransactionRecord, txResult: any, result: any) => Promise<void>;
+      }
+    ).handleWatchedResult.bind(tracker) as (tx: ITransactionRecord, txResult: any, result: any) => Promise<void>;
+
+    await expect(
+      handleWatchedResult(
+        tx,
+        { isFinalized: true },
+        {
+          status: {
+            isBroadcast: true,
+            isInBlock: false,
+            isFinalized: false,
+            isRetracted: false,
+            isUsurped: false,
+            isDropped: false,
+            isInvalid: false,
+            get asFinalized() {
+              throw new Error('should not touch asFinalized');
+            },
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it('reserves local nonces above restored pending submissions for concurrent same-account work', async () => {

--- a/src-vue/app-operations/screens/mining-screen/FirstAuctionWinning.vue
+++ b/src-vue/app-operations/screens/mining-screen/FirstAuctionWinning.vue
@@ -67,7 +67,7 @@
       <div class="flex flex-row justify-center items-center space-x-6 mt-10">
         <ActiveBidsOverlayButton />
         <BotHistoryOverlayButton />
-        <button @click="openBotConfig" class="border border-argon-300 text-center text-lg font-bold whitespace-nowrap text-argon-600 px-7 py-1 rounded cursor-pointer hover:bg-argon-50/40 hover:border-argon-600 transition-all duration-300">
+        <button @click="openBotConfig" class="border border-argon-300 text-center text-lg font-bold mt-10 whitespace-nowrap text-argon-600 px-7 py-2 rounded cursor-pointer hover:bg-argon-50/40 hover:border-argon-600 transition-all duration-300">
           Open Bot Config
         </button>
       </div>

--- a/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
@@ -172,7 +172,7 @@
         <button
           @click="launchMiningBot"
           :class="[
-          walletIsFullyFunded && hasMiningMachine && !basics.overlayIsOpen
+          canLaunchMiningBot
             ? 'text-white'
             : 'text-white/70 pointer-events-none opacity-30',
           isLaunchingMiningBot ? 'opacity-30 pointer-events-none' : '',
@@ -311,6 +311,10 @@ const walletIsFullyFunded = Vue.computed(() => {
   return fundingState.value.isFullyFunded;
 });
 
+const canLaunchMiningBot = Vue.computed(() => {
+  return walletIsFullyFunded.value && hasMiningMachine.value && config.isServerInstalled && !basics.overlayIsOpen;
+});
+
 const hasMiningMachine = Vue.computed(() => {
   const x = config.serverAdd;
   return !!x?.customServer || !!x?.localComputer || !!x?.digitalOcean;
@@ -357,7 +361,7 @@ function goBack() {
 }
 
 async function launchMiningBot() {
-  if (isLaunchingMiningBot.value) return;
+  if (isLaunchingMiningBot.value || !canLaunchMiningBot.value) return;
 
   isLaunchingMiningBot.value = true;
 

--- a/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
@@ -72,7 +72,9 @@ const installerProgressPct = Vue.computed(() => {
 });
 
 const installerProgressScaled = Vue.computed(() => installerProgressPct.value * 0.8);
-const hasEnteredTransactionPhase = Vue.computed(() => installerProgressPct.value >= 100);
+const hasEnteredTransactionPhase = Vue.computed(() => {
+  return installerProgressPct.value >= 100 || (config.isServerInstalled && !config.isServerInstalling);
+});
 const transactionProgressScaled = Vue.computed(() => 80 + txProgressPct.value * 0.2);
 const targetProgressPct = Vue.computed(() =>
   hasEnteredTransactionPhase.value ? transactionProgressScaled.value : installerProgressScaled.value,
@@ -191,6 +193,32 @@ function trackTxInfo(txInfo: TransactionInfo) {
 
     void ensureTrackedSetupTransfer();
   });
+
+  void txInfo.waitForPostProcessing
+    .then(async () => {
+      txProgressLabel.value = 'Mining capital is ready.';
+      txProgressPct.value = 100;
+      await finalizeMiningSetup();
+    })
+    .catch(error => {
+      transactionErrorMessage.value =
+        error instanceof Error ? error.message : 'Unknown error occurred while preparing mining capital.';
+    });
+}
+
+async function finalizeMiningSetup() {
+  if (errorMessage.value || isFinalizingSetup.value) return;
+  if (config.miningSetupStatus === MiningSetupStatus.Finished) return;
+
+  isFinalizingSetup.value = true;
+  progressPct.value = 100;
+
+  try {
+    config.miningSetupStatus = MiningSetupStatus.Finished;
+    await config.save();
+  } finally {
+    isFinalizingSetup.value = false;
+  }
 }
 
 async function ensureTrackedSetupTransfer(force = false) {
@@ -222,6 +250,7 @@ async function ensureTrackedSetupTransfer(force = false) {
         transactionErrorMessage.value = '';
         txProgressLabel.value = 'Mining capital is ready.';
         txProgressPct.value = 100;
+        await finalizeMiningSetup();
         return;
       }
 
@@ -246,19 +275,6 @@ Vue.watch(
   },
   { immediate: true },
 );
-
-Vue.watch(progressPct, async value => {
-  if (value < 100 || errorMessage.value || isFinalizingSetup.value) return;
-  if (config.miningSetupStatus === MiningSetupStatus.Finished) return;
-
-  isFinalizingSetup.value = true;
-  try {
-    config.miningSetupStatus = MiningSetupStatus.Finished;
-    await config.save();
-  } finally {
-    isFinalizingSetup.value = false;
-  }
-});
 
 Vue.watch(
   () => transactionTracker.data.txInfos.length,

--- a/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupInstalling.vue
@@ -146,18 +146,21 @@ function getStepLabel(stepLabel: IStepLabel, stepStatus: InstallStepStatus): str
   return stepLabel.options[optionIndexByStatus[stepStatus]];
 }
 
-function isMiningSetupTransfer(txInfo: TransactionInfo): boolean {
+function isMiningSetupTx(txInfo: TransactionInfo): boolean {
+  if (txInfo.tx.extrinsicType === ExtrinsicType.MiningBidProxySetup) {
+    return true;
+  }
   if (txInfo.tx.extrinsicType !== ExtrinsicType.Transfer) return false;
 
   const metadata = txInfo.tx.metadataJson as Partial<ITransactionMoveMetadata> | undefined;
   return metadata?.moveFrom === MoveFrom.MiningHold && metadata?.moveTo === MoveTo.MiningBot;
 }
 
-function findLatestSetupTransferTxInfo(): TransactionInfo | null {
+function findLatestSetupTxInfo(): TransactionInfo | null {
   let latestTxInfo: TransactionInfo | null = null;
 
   for (const txInfo of transactionTracker.data.txInfos) {
-    if (!isMiningSetupTransfer(txInfo)) continue;
+    if (!isMiningSetupTx(txInfo)) continue;
     if (!latestTxInfo || txInfo.tx.id > latestTxInfo.tx.id) {
       latestTxInfo = txInfo;
     }
@@ -191,7 +194,7 @@ function trackTxInfo(txInfo: TransactionInfo) {
 }
 
 async function ensureTrackedSetupTransfer(force = false) {
-  const txInfo = findLatestSetupTransferTxInfo();
+  const txInfo = findLatestSetupTxInfo();
   if (txInfo) {
     trackTxInfo(txInfo);
   }

--- a/src-vue/app-operations/screens/mining-screen/miningFunding.ts
+++ b/src-vue/app-operations/screens/mining-screen/miningFunding.ts
@@ -1,8 +1,6 @@
-import { MICROGONS_PER_ARGON } from '@argonprotocol/apps-core';
+import { MINING_BID_PROXY_FEE_FLOAT } from '@argonprotocol/apps-core';
 import { bigIntMax } from '@argonprotocol/apps-core/src/utils.ts';
 import { MiningSetupStatus } from '../../../interfaces/IConfig.ts';
-
-const FUTURE_TRANSACTION_FEE_BUDGET_MICROGONS = 2n * BigInt(MICROGONS_PER_ARGON);
 
 export interface IMiningFundingState {
   isFullyFunded: boolean;
@@ -32,7 +30,7 @@ export function getMiningFundingState(args: {
 
   const requiredMicrogons =
     (args.initialMicrogonRequirement ?? 0n) +
-    (args.miningSetupStatus === MiningSetupStatus.Finished ? 0n : FUTURE_TRANSACTION_FEE_BUDGET_MICROGONS);
+    (args.miningSetupStatus === MiningSetupStatus.Finished ? 0n : MINING_BID_PROXY_FEE_FLOAT);
   const requiredMicronots = args.initialMicronotRequirement ?? 0n;
   const additionalMicrogonsNeeded = bigIntMax(requiredMicrogons - args.miningMicrogonsOnHand, 0n);
   const additionalMicronotsNeeded = bigIntMax(requiredMicronots - args.miningMicronotsOnHand, 0n);

--- a/src-vue/interfaces/ITransactionRecord.ts
+++ b/src-vue/interfaces/ITransactionRecord.ts
@@ -7,6 +7,7 @@ export enum ExtrinsicType {
   VaultSetCommittedArgonots = 'VaultSetCommittedArgonots',
   VaultSetBitcoinLockDelegate = 'VaultSetBitcoinLockDelegate',
   VaultTopUpBitcoinLockDelegate = 'VaultTopUpBitcoinLockDelegate',
+  MiningBidProxySetup = 'MiningBidProxySetup',
   OperationalActivateAndClaim = 'OperationalActivateAndClaim',
   OperationalClaimRewards = 'OperationalClaimRewards',
 

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -12,7 +12,6 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { ensureOnlyOneInstance, resetOnlyOneInstance } from './Utils';
 import { createDeferred, type IDeferred } from '@argonprotocol/apps-core';
-import { TxSubmitter } from '@argonprotocol/mainchain';
 import { ask as tauriAsk, message as tauriMessage } from '@tauri-apps/plugin-dialog';
 import { exit as tauriExit } from '@tauri-apps/plugin-process';
 import { ServerAdmin } from './ServerAdmin';
@@ -23,8 +22,9 @@ import { IS_LOCAL_BUILD, NETWORK_NAME } from './Env.ts';
 import * as semver from 'semver';
 import { getEthereumBeaconApiUrl, getEthereumExecutionRpcUrl } from './EthereumClient.ts';
 import { MyVault } from './MyVault.ts';
-import { getMainchainClient } from '../stores/mainchain.ts';
-import { planMiningBidProxySetup } from './MiningAccount.ts';
+import { ensureMiningBidProxySetup } from './MiningAccount.ts';
+import { getTransactionTracker } from '../stores/transactions.ts';
+import { MiningSetupStatus } from '../interfaces/IConfig.ts';
 
 dayjs.extend(utc);
 
@@ -260,27 +260,24 @@ export default class Installer {
           this.fileUploadProgress = 2 + (uploadedCount / totalCount) * 88;
         });
       }
+      if (!this.isFreshInstall && this.config.miningSetupStatus === MiningSetupStatus.Finished) {
+        const transactionTracker = getTransactionTracker();
+        await transactionTracker.load();
 
-      if (!this.isFreshInstall) {
-        const client = await getMainchainClient(false);
-        const { fundingAccount, proxySetup } = await planMiningBidProxySetup({
+        const proxySetup = await ensureMiningBidProxySetup({
+          transactionTracker,
           walletKeys: this.walletKeys,
-          client,
         });
 
         if (proxySetup.kind === 'insufficientFunds') {
-          throw new Error(proxySetup.error);
-        }
-
-        if (proxySetup.kind === 'tx') {
-          const proxySetupResult = await new TxSubmitter(client, proxySetup.tx, fundingAccount).submit({
-            useLatestNonce: true,
-          });
-          await proxySetupResult.waitForInFirstBlock;
-          const proxySetupError = proxySetupResult.submissionError ?? proxySetupResult.extrinsicError;
-          if (proxySetupError) {
-            throw proxySetupError;
-          }
+          console.warn(
+            '[Installer] Skipping mining bid proxy migration until the mining funding account is topped up',
+            {
+              error: proxySetup.error,
+            },
+          );
+        } else if (proxySetup.kind === 'submitted' || proxySetup.kind === 'trackingExisting') {
+          await proxySetup.txInfo.waitForPostProcessing;
         }
       }
 

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { ensureOnlyOneInstance, resetOnlyOneInstance } from './Utils';
 import { createDeferred, type IDeferred } from '@argonprotocol/apps-core';
+import { TxSubmitter } from '@argonprotocol/mainchain';
 import { ask as tauriAsk, message as tauriMessage } from '@tauri-apps/plugin-dialog';
 import { exit as tauriExit } from '@tauri-apps/plugin-process';
 import { ServerAdmin } from './ServerAdmin';
@@ -20,10 +21,10 @@ import { MiningMachine } from './MiningMachine.ts';
 import { WalletKeys } from './WalletKeys.ts';
 import { IS_LOCAL_BUILD, NETWORK_NAME } from './Env.ts';
 import * as semver from 'semver';
-import { TxSubmitter } from '@argonprotocol/mainchain';
-import { getMainchainClient } from '../stores/mainchain.ts';
 import { getEthereumBeaconApiUrl, getEthereumExecutionRpcUrl } from './EthereumClient.ts';
 import { MyVault } from './MyVault.ts';
+import { getMainchainClient } from '../stores/mainchain.ts';
+import { planMiningBidProxySetup } from './MiningAccount.ts';
 
 dayjs.extend(utc);
 
@@ -258,6 +259,29 @@ export default class Installer {
         await this.uploadCoreFiles((totalCount, uploadedCount) => {
           this.fileUploadProgress = 2 + (uploadedCount / totalCount) * 88;
         });
+      }
+
+      if (!this.isFreshInstall) {
+        const client = await getMainchainClient(false);
+        const { fundingAccount, proxySetup } = await planMiningBidProxySetup({
+          walletKeys: this.walletKeys,
+          client,
+        });
+
+        if (proxySetup.kind === 'insufficientFunds') {
+          throw new Error(proxySetup.error);
+        }
+
+        if (proxySetup.kind === 'tx') {
+          const proxySetupResult = await new TxSubmitter(client, proxySetup.tx, fundingAccount).submit({
+            useLatestNonce: true,
+          });
+          await proxySetupResult.waitForInFirstBlock;
+          const proxySetupError = proxySetupResult.submissionError ?? proxySetupResult.extrinsicError;
+          if (proxySetupError) {
+            throw proxySetupError;
+          }
+        }
       }
 
       console.info('Uploading bot config files');
@@ -655,8 +679,8 @@ export default class Installer {
 
     const totalCount = 5;
 
-    const miningBotAccount = await this.walletKeys.exportMiningBotAccountJson('');
-    await server.uploadMiningBotWallet(miningBotAccount);
+    const miningBidProxyAccount = await this.walletKeys.exportMiningBidProxyAccountJson('');
+    await server.uploadMiningBotWallet(miningBidProxyAccount);
     progressFn?.(totalCount, 1);
 
     await server.uploadVaultDelegateWallet(delegateKeypair.toJson(''));
@@ -667,6 +691,7 @@ export default class Installer {
 
     await server.uploadEnvState({
       oldestFrameIdToSync: this.config.oldestFrameIdToSync,
+      miningFundingAccountId: this.walletKeys.miningBotAddress,
       vaultOperatorAddress: this.walletKeys.vaultingAddress,
       operatorAccountId: this.walletKeys.operationalAddress,
       ethereumBeaconApiUrl,

--- a/src-vue/lib/MemoryWalletKeys.ts
+++ b/src-vue/lib/MemoryWalletKeys.ts
@@ -18,6 +18,7 @@ export class MemoryWalletKeys extends WalletKeys {
   private readonly masterMnemonic: string;
   private readonly miningHoldAccount: KeyringPair;
   private readonly miningBotAccount: KeyringPair;
+  private readonly miningBidProxyAccount: KeyringPair;
   private readonly vaultingAccount: KeyringPair;
   private readonly investmentAccount: KeyringPair;
   private readonly operationalAccount: KeyringPair;
@@ -41,6 +42,7 @@ export class MemoryWalletKeys extends WalletKeys {
     const rootAccount = new Keyring({ type: 'sr25519' }).addFromUri(args.substrateSuri);
     const miningHoldAccount = rootAccount.derive('//holding');
     const miningBotAccount = rootAccount.derive('//mining');
+    const miningBidProxyAccount = miningBotAccount.derive('//proxy');
     const vaultingAccount = rootAccount.derive('//vaulting');
     const investmentAccount = rootAccount.derive('//investment');
     const operationalAccount = rootAccount.derive('//operational');
@@ -67,6 +69,7 @@ export class MemoryWalletKeys extends WalletKeys {
     this.masterMnemonic = args.masterMnemonic;
     this.miningHoldAccount = miningHoldAccount;
     this.miningBotAccount = miningBotAccount;
+    this.miningBidProxyAccount = miningBidProxyAccount;
     this.vaultingAccount = vaultingAccount;
     this.investmentAccount = investmentAccount;
     this.operationalAccount = operationalAccount;
@@ -86,8 +89,8 @@ export class MemoryWalletKeys extends WalletKeys {
     return bytesToHex(privateKey);
   }
 
-  public async exportMiningBotAccountJson(passphrase: string): Promise<KeyringPair$Json> {
-    return this.miningBotAccount.toJson(passphrase);
+  public async exportMiningBidProxyAccountJson(passphrase: string): Promise<KeyringPair$Json> {
+    return this.miningBidProxyAccount.toJson(passphrase);
   }
 
   public async getMiningSessionMiniSecret(): Promise<string> {
@@ -124,6 +127,10 @@ export class MemoryWalletKeys extends WalletKeys {
 
   public async getMiningBotKeypair(): Promise<KeyringPair> {
     return this.miningBotAccount;
+  }
+
+  public async getMiningBidProxyKeypair(): Promise<KeyringPair> {
+    return this.miningBidProxyAccount;
   }
 
   public async signEthereumPersonalMessage(

--- a/src-vue/lib/MiningAccount.ts
+++ b/src-vue/lib/MiningAccount.ts
@@ -1,8 +1,4 @@
-import {
-  Accountset,
-  type MiningBidProxySetupMetadata,
-  type MiningBidProxySetupPlan,
-} from '@argonprotocol/apps-core';
+import { Accountset, type MiningBidProxySetupMetadata, type MiningBidProxySetupPlan } from '@argonprotocol/apps-core';
 import { type ArgonClient, type KeyringPair } from '@argonprotocol/mainchain';
 import { getMainchainClient } from '../stores/mainchain.ts';
 import { ExtrinsicType } from './db/TransactionsTable.ts';
@@ -38,7 +34,7 @@ export async function planMiningBidProxySetup(args: {
 
 export async function findTrackedMiningBidProxySetup(args: {
   transactionTracker: TransactionTracker;
-  followWindowFinalizedBlocks: number;
+  followWindowFinalizedBlocks?: number;
 }): Promise<TransactionInfo<MiningBidProxySetupMetadata> | undefined> {
   const latestMiningBidProxySetupTxInfo = args.transactionTracker.findLatestTxInfo<MiningBidProxySetupMetadata>(
     txInfo => txInfo.tx.extrinsicType === ExtrinsicType.MiningBidProxySetup,
@@ -49,7 +45,7 @@ export async function findTrackedMiningBidProxySetup(args: {
 
   const txAttemptState = await args.transactionTracker.getTxAttemptState(
     latestMiningBidProxySetupTxInfo,
-    args.followWindowFinalizedBlocks,
+    args.followWindowFinalizedBlocks ?? 2,
   );
   if (txAttemptState === TxAttemptState.Follow) {
     return latestMiningBidProxySetupTxInfo;
@@ -59,7 +55,7 @@ export async function findTrackedMiningBidProxySetup(args: {
 export async function ensureMiningBidProxySetup(args: {
   transactionTracker: TransactionTracker;
   walletKeys: WalletKeys;
-  followWindowFinalizedBlocks: number;
+  followWindowFinalizedBlocks?: number;
   client?: ArgonClient;
 }): Promise<MiningBidProxySetupResult> {
   const trackedTxInfo = await findTrackedMiningBidProxySetup(args);

--- a/src-vue/lib/MiningAccount.ts
+++ b/src-vue/lib/MiningAccount.ts
@@ -1,0 +1,101 @@
+import {
+  Accountset,
+  type MiningBidProxySetupMetadata,
+  type MiningBidProxySetupPlan,
+} from '@argonprotocol/apps-core';
+import { type ArgonClient, type KeyringPair } from '@argonprotocol/mainchain';
+import { getMainchainClient } from '../stores/mainchain.ts';
+import { ExtrinsicType } from './db/TransactionsTable.ts';
+import { type TransactionInfo } from './TransactionInfo.ts';
+import { TransactionTracker, TxAttemptState } from './TransactionTracker.ts';
+import { WalletKeys } from './WalletKeys.ts';
+
+export type MiningBidProxySetupResult =
+  | { kind: 'trackingExisting'; txInfo: TransactionInfo<MiningBidProxySetupMetadata> }
+  | { kind: 'submitted'; txInfo: TransactionInfo<MiningBidProxySetupMetadata> }
+  | { kind: 'ready' }
+  | { kind: 'insufficientFunds'; error: string };
+
+export async function planMiningBidProxySetup(args: {
+  walletKeys: WalletKeys;
+  client: ArgonClient;
+}): Promise<{ fundingAccount: KeyringPair; proxySetup: MiningBidProxySetupPlan }> {
+  const [fundingAccount, proxyKeypair] = await Promise.all([
+    args.walletKeys.getMiningBotKeypair(),
+    args.walletKeys.getMiningBidProxyKeypair(),
+  ]);
+  const proxyAccountset = new Accountset({
+    client: args.client,
+    fundingAccountId: fundingAccount.address,
+    isProxy: true,
+    subaccountRange: [],
+    txSubmitter: proxyKeypair,
+  });
+  const proxySetup = await proxyAccountset.planMiningBidProxySetup();
+
+  return { fundingAccount, proxySetup };
+}
+
+export async function findTrackedMiningBidProxySetup(args: {
+  transactionTracker: TransactionTracker;
+  followWindowFinalizedBlocks: number;
+}): Promise<TransactionInfo<MiningBidProxySetupMetadata> | undefined> {
+  const latestMiningBidProxySetupTxInfo = args.transactionTracker.findLatestTxInfo<MiningBidProxySetupMetadata>(
+    txInfo => txInfo.tx.extrinsicType === ExtrinsicType.MiningBidProxySetup,
+  );
+  if (!latestMiningBidProxySetupTxInfo) {
+    return;
+  }
+
+  const txAttemptState = await args.transactionTracker.getTxAttemptState(
+    latestMiningBidProxySetupTxInfo,
+    args.followWindowFinalizedBlocks,
+  );
+  if (txAttemptState === TxAttemptState.Follow) {
+    return latestMiningBidProxySetupTxInfo;
+  }
+}
+
+export async function ensureMiningBidProxySetup(args: {
+  transactionTracker: TransactionTracker;
+  walletKeys: WalletKeys;
+  followWindowFinalizedBlocks: number;
+  client?: ArgonClient;
+}): Promise<MiningBidProxySetupResult> {
+  const trackedTxInfo = await findTrackedMiningBidProxySetup(args);
+  if (trackedTxInfo) {
+    return {
+      kind: 'trackingExisting',
+      txInfo: trackedTxInfo,
+    };
+  }
+
+  const client = args.client ?? (await getMainchainClient(false));
+  const { fundingAccount, proxySetup } = await planMiningBidProxySetup({
+    walletKeys: args.walletKeys,
+    client,
+  });
+
+  if (proxySetup.kind === 'ready') {
+    return { kind: 'ready' };
+  }
+
+  if (proxySetup.kind === 'insufficientFunds') {
+    return {
+      kind: 'insufficientFunds',
+      error: proxySetup.error,
+    };
+  }
+
+  const txInfo = await args.transactionTracker.submitAndWatch<MiningBidProxySetupMetadata>({
+    tx: proxySetup.tx,
+    txSigner: fundingAccount,
+    useLatestNonce: true,
+    extrinsicType: ExtrinsicType.MiningBidProxySetup,
+    metadata: proxySetup.metadata,
+  });
+  return {
+    kind: 'submitted',
+    txInfo,
+  };
+}

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -1,10 +1,5 @@
 import { getMainchainClient } from '../stores/mainchain.ts';
-import {
-  ArgonClient,
-  FIXED_U128_DECIMALS,
-  SubmittableExtrinsic,
-  toFixedNumber,
-} from '@argonprotocol/mainchain';
+import { ArgonClient, FIXED_U128_DECIMALS, SubmittableExtrinsic, toFixedNumber } from '@argonprotocol/mainchain';
 import { bigIntMax, isValidArgonAccountAddress, MoveFrom, MoveTo, MoveToken } from '@argonprotocol/apps-core';
 import { MyVault } from './MyVault.ts';
 import { existentialDepositMicrogons, getSpendableMiningHoldMicrogons } from './WalletForArgon.ts';
@@ -76,15 +71,8 @@ export class MoveCapital {
       };
     }
     if ([MoveTo.VaultingSecurity].includes(moveTo)) {
-      const allocations = {
-        addedSecuritizationMicrogons: 0n,
-        addedTreasuryMicrogons: 0n,
-      };
-      if (moveTo === MoveTo.VaultingSecurity) {
-        allocations.addedSecuritizationMicrogons = assetsToMove.ARGN ?? 0n;
-      }
-      return await this.myVault.increaseVaultAllocations({
-        ...allocations,
+      return await this.myVault.increaseVaultSecuritization({
+        addedSecuritizationMicrogons: moveTo === MoveTo.VaultingSecurity ? (assetsToMove.ARGN ?? 0n) : 0n,
         metadata: this.buildMoveMetadata(moveFrom, moveTo, assetsToMove, toAddress),
       });
     } else {
@@ -418,11 +406,8 @@ export class MoveCapital {
       let tx: SubmittableExtrinsic;
       if ([MoveTo.VaultingSecurity].includes(moveTo)) {
         this.validateVaultAllocationMove(moveFrom, moveTo, assetsToMove);
-        tx = await this.myVault.buildIncreaseVaultAllocationsTx(
-          {
-            addedSecuritizationMicrogons:
-              moveTo === MoveTo.VaultingSecurity ? (assetsToMove[MoveToken.ARGN] ?? 0n) : 0n,
-          },
+        tx = await this.myVault.buildIncreaseBitcoinSecurityTx(
+          moveTo === MoveTo.VaultingSecurity ? (assetsToMove[MoveToken.ARGN] ?? 0n) : 0n,
           client,
         );
       } else {

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -1,5 +1,10 @@
 import { getMainchainClient } from '../stores/mainchain.ts';
-import { ArgonClient, FIXED_U128_DECIMALS, SubmittableExtrinsic, toFixedNumber } from '@argonprotocol/mainchain';
+import {
+  ArgonClient,
+  FIXED_U128_DECIMALS,
+  SubmittableExtrinsic,
+  toFixedNumber,
+} from '@argonprotocol/mainchain';
 import { bigIntMax, isValidArgonAccountAddress, MoveFrom, MoveTo, MoveToken } from '@argonprotocol/apps-core';
 import { MyVault } from './MyVault.ts';
 import { existentialDepositMicrogons, getSpendableMiningHoldMicrogons } from './WalletForArgon.ts';
@@ -9,6 +14,7 @@ import { TransactionInfo } from './TransactionInfo.ts';
 import { WalletKeys } from './WalletKeys.ts';
 import { TransactionTracker, TxAttemptState } from './TransactionTracker.ts';
 import { buildOperatorAccountRegistrationTx } from './OperationalAccount.ts';
+import { ensureMiningBidProxySetup } from './MiningAccount.ts';
 import { Config } from './Config.ts';
 
 export interface IAssetsToMove {
@@ -258,6 +264,9 @@ export class MoveCapital {
         metadata,
       });
       followOnTx?.resolve(txInfo);
+      void this.postProcessMiningBidProxySetup(txInfo).catch(error => {
+        console.error('[MoveCapital] Failed to post-process mining bid proxy setup', error);
+      });
       return {
         kind: 'submitted',
         txInfo,
@@ -270,6 +279,36 @@ export class MoveCapital {
 
   private async getSigner(moveFrom: MoveFrom) {
     return await this.walletKeys.getWalletKeypair(this.getWalletTypeFromMove(moveFrom));
+  }
+
+  private async postProcessMiningBidProxySetup(txInfo: TransactionInfo): Promise<void> {
+    const postProcessor = txInfo.createPostProcessor();
+
+    try {
+      await txInfo.txResult.waitForFinalizedBlock;
+
+      const proxySetup = await ensureMiningBidProxySetup({
+        transactionTracker: this.transactionTracker,
+        walletKeys: this.walletKeys,
+        followWindowFinalizedBlocks: MINING_HOLD_SWEEP_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+      });
+      if (proxySetup.kind === 'trackingExisting' || proxySetup.kind === 'submitted') {
+        await proxySetup.txInfo.waitForPostProcessing;
+      }
+      if (proxySetup.kind === 'insufficientFunds') {
+        txInfo.txResult.extrinsicError = new Error(proxySetup.error);
+      }
+
+      if (proxySetup.kind === 'insufficientFunds') {
+        postProcessor.reject(txInfo.txResult.extrinsicError);
+        return;
+      }
+
+      postProcessor.resolve();
+    } catch (error) {
+      txInfo.txResult.extrinsicError = error as Error;
+      postProcessor.reject(error as Error);
+    }
   }
 
   public checkAddressType(address: string): {

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -21,22 +21,21 @@ import { BitcoinNetwork, CosignScript, getBitcoinNetworkFromApi, HDKey } from '@
 import { Db } from './Db.ts';
 import { getFinalizedClient, getMainchainClient, getMainchainClients } from '../stores/mainchain.ts';
 import {
+  ArgonQueryClient,
   bigIntMax,
-  bigIntMin,
   BondLot,
   createDeferred,
   IBlockHeaderInfo,
-  ArgonQueryClient,
   IDeferred,
   IVaultStats,
+  minimumVaultDelegateBalance,
   MiningFrames,
   MoveFrom,
   MoveTo,
   NetworkConfig,
   SingleFileQueue,
-  TreasuryBonds,
-  minimumVaultDelegateBalance,
   targetVaultDelegateBalance,
+  TreasuryBonds,
   vaultDelegateFeeBuffer,
 } from '@argonprotocol/apps-core';
 import { IVaultRecord, VaultsTable } from './db/VaultsTable.ts';
@@ -104,7 +103,6 @@ export class MyVault {
     externalLocks: { [utxoId: number]: IExternalBitcoinLock };
     pendingAllocateTxInfo: TransactionInfo<{
       addedSecuritizationMicrogons: bigint;
-      addedTreasuryMicrogons: bigint;
       vaultId: number;
     }> | null;
   };
@@ -233,7 +231,7 @@ export class MyVault {
         } else if (tx.extrinsicType === ExtrinsicType.VaultModifySettings) {
           void this.onModifySettings(txInfo);
         } else if (tx.extrinsicType === ExtrinsicType.VaultIncreaseAllocation) {
-          void this.onIncreaseVaultAllocations(txInfo);
+          void this.onIncreaseVaultSecuritization(txInfo);
         } else if (tx.extrinsicType === ExtrinsicType.VaultCosignBitcoinRelease) {
           void this.onCosignResult(txInfo);
         } else if (tx.extrinsicType === ExtrinsicType.VaultCosignOrphanedUtxoRelease) {
@@ -1711,9 +1709,8 @@ export class MyVault {
     }
   }
 
-  public async increaseVaultAllocations(args: {
+  public async increaseVaultSecuritization(args: {
     addedSecuritizationMicrogons: bigint;
-    addedTreasuryMicrogons: bigint;
     tip?: bigint;
     metadata?: object;
   }): Promise<TransactionInfo> {
@@ -1723,90 +1720,48 @@ export class MyVault {
       throw new Error('No vault created to get changes needed');
     }
 
-    const tx = await this.buildIncreaseVaultAllocationsTx(args, client);
+    const tx = await this.buildIncreaseBitcoinSecurityTx(args.addedSecuritizationMicrogons, client);
     const txSigner = await this.walletKeys.getVaultingKeypair();
     const submitOptions = {
       useLatestNonce: true,
       tip: args.tip,
     };
-    console.info('[VaultIncreaseAllocation] Preparing submit', {
-      vaultId: vault.vaultId,
-      walletVaultingAddress: this.walletKeys.vaultingAddress,
-      txSignerAddress: txSigner.address,
-      vaultOperatorAccountId: vault.operatorAccountId,
-      addedSecuritizationMicrogons: args.addedSecuritizationMicrogons,
-      addedTreasuryMicrogons: args.addedTreasuryMicrogons,
-      clientType: (client as ArgonClient & { clientType?: string }).clientType,
-      genesisHash: client.genesisHash?.toHex(),
-      runtime: {
-        specVersion: client.runtimeVersion.specVersion.toNumber(),
-        transactionVersion: client.runtimeVersion.transactionVersion.toNumber(),
-      },
-      signedExtensions: client.registry.signedExtensions,
-    });
     const submitter = new TxSubmitter(client, tx, txSigner);
-    const signedTx = await submitter.sign(submitOptions);
-    console.info('[VaultIncreaseAllocation] Signed transaction', {
-      signedHash: signedTx.hash.toHex(),
-      nonce: signedTx.nonce.toNumber(),
-      method: signedTx.method.toHuman(),
-      mode: signedTx.mode?.toHuman?.(),
-      metadataHash: signedTx.metadataHash?.toHuman?.(),
-    });
-    try {
-      const dryRunResult = await client.rpc.system.dryRun(signedTx.toHex());
-      console.info('[VaultIncreaseAllocation] Dry run result', dryRunResult.toHuman());
-    } catch (error) {
-      console.error('[VaultIncreaseAllocation] Dry run failed', error);
-    }
-    const txResult = await submitter.submitSigned(signedTx, submitOptions);
+    const txResult = await submitter.submit(submitOptions);
     const info = await this.#transactionTracker.trackTxResult({
       txResult,
       extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
       metadata: {
         addedSecuritizationMicrogons: args.addedSecuritizationMicrogons,
-        addedTreasuryMicrogons: args.addedTreasuryMicrogons,
         vaultId: vault.vaultId,
         ...args.metadata,
       },
     });
     this.data.pendingAllocateTxInfo = info;
-    void this.onIncreaseVaultAllocations(info);
+    void this.onIncreaseVaultSecuritization(info);
     return info;
   }
 
-  public async buildIncreaseVaultAllocationsTx(
-    args: {
-      addedSecuritizationMicrogons: bigint;
-    },
+  public async buildIncreaseBitcoinSecurityTx(
+    addedSecuritizationMicrogons: bigint,
     client?: ArgonClient,
   ): Promise<SubmittableExtrinsic> {
     const vault = this.createdVault;
     if (!vault) {
       throw new Error('No vault created to get changes needed');
     }
-
+    if (addedSecuritizationMicrogons === 0n)
+      throw new Error('Invalid securitization increase amount, must be greater than 0');
     client ??= await getMainchainClient(false);
-    const txs: SubmittableExtrinsic[] = [];
 
-    if (args.addedSecuritizationMicrogons > 0n) {
-      txs.push(
-        client.tx.vaults.modifyFunding(
-          vault.vaultId,
-          vault.securitization + args.addedSecuritizationMicrogons,
-          toFixedNumber(vault.securitizationRatio, FIXED_U128_DECIMALS),
-        ),
-      );
-    }
-
-    if (!txs.length) {
-      throw new Error('No vault allocation changes to submit.');
-    }
-
-    return txs.length > 1 ? client.tx.utility.batchAll(txs) : txs[0];
+    return client.tx.vaults.modifyFunding(
+      vault.vaultId,
+      vault.securitization + addedSecuritizationMicrogons,
+      toFixedNumber(vault.securitizationRatio, FIXED_U128_DECIMALS),
+    );
   }
 
-  private async onIncreaseVaultAllocations(txInfo: TransactionInfo): Promise<void> {
+  private async onIncreaseVaultSecuritization(txInfo: TransactionInfo): Promise<void> {
     const { txResult } = txInfo;
     const postProcessor = txInfo.createPostProcessor();
     try {

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -145,6 +145,7 @@ export class ServerAdmin {
 
   public async uploadEnvState(envState: {
     oldestFrameIdToSync: number;
+    miningFundingAccountId: string;
     vaultOperatorAddress: string;
     operatorAccountId: string;
     ethereumBeaconApiUrl?: string;
@@ -152,6 +153,7 @@ export class ServerAdmin {
   }): Promise<void> {
     const lines = [
       `OLDEST_FRAME_ID_TO_SYNC=${envState.oldestFrameIdToSync || ''}`,
+      `MINING_FUNDING_ACCOUNT_ID=${envState.miningFundingAccountId}`,
       `VAULT_OPERATOR_ADDRESS=${envState.vaultOperatorAddress}`,
       `OPERATOR_ACCOUNT_ID=${envState.operatorAccountId}`,
     ];

--- a/src-vue/lib/TransactionInfo.ts
+++ b/src-vue/lib/TransactionInfo.ts
@@ -187,7 +187,9 @@ export class TransactionInfo<MetadataType = unknown> {
   }
 
   public getStatus() {
-    this.blockProgress.setIsFinalized(this.tx.isFinalized);
+    const isFinalized = this.tx.isFinalized || this.txResult.isFinalized;
+
+    this.blockProgress.setIsFinalized(isFinalized);
     this.blockProgress.setBlockHeightGoal(this.tx.blockHeight);
     const progressPct = this.blockProgress.getProgress();
     const confirmations = this.blockProgress.getConfirmations();
@@ -200,7 +202,7 @@ export class TransactionInfo<MetadataType = unknown> {
       confirmations,
       expectedConfirmations,
       error,
-      isFinalized: this.tx.isFinalized,
+      isFinalized,
       isMaxed: this.blockProgress.isMaxed,
     };
   }

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -23,7 +23,18 @@ import {
   type TransactionStatusHistoryTable,
 } from './db/TransactionStatusHistoryTable.ts';
 
-type IWatchedTxResult = ISubmittableResult & { blockNumber?: number };
+type IWatchedTxStatus = {
+  isBroadcast: boolean;
+  isInBlock: boolean;
+  isFinalized: boolean;
+  isRetracted: boolean;
+  isUsurped: boolean;
+  isDropped: boolean;
+  isInvalid: boolean;
+  blockHash?: string;
+  blockNumber?: number;
+  replacementTxHash?: string;
+};
 
 export enum TxAttemptState {
   Follow = 'Follow',
@@ -592,22 +603,55 @@ export class TransactionTracker {
     return nextNonce;
   }
 
-  private async handleWatchedResult(record: ITransactionRecord, txResult: TxResult, result: IWatchedTxResult) {
+  private async handleWatchedResult(record: ITransactionRecord, txResult: TxResult, result: ISubmittableResult) {
     try {
-      await this.recordWatchStatus(record, result);
-      if (txResult.submissionError) {
-        await this.recordSubmissionError(record, txResult.submissionError);
+      const { status } = result;
+      const isInBlock = status.isInBlock;
+      const isFinalized = status.isFinalized || txResult.isFinalized;
+      let blockHash: string | undefined;
+      if (isInBlock) {
+        blockHash = status.asInBlock.toHex();
+      } else if (status.isFinalized) {
+        blockHash = status.asFinalized.toHex();
+      }
+      const submissionError = txResult.submissionError;
+
+      await this.recordWatchStatus(record, {
+        isBroadcast: status.isBroadcast,
+        isInBlock,
+        isFinalized,
+        isRetracted: status.isRetracted,
+        isUsurped: status.isUsurped,
+        isDropped: status.isDropped,
+        isInvalid: status.isInvalid,
+        blockHash,
+        blockNumber: txResult.blockNumber,
+        replacementTxHash: status.isUsurped ? status.asUsurped.toHex() : undefined,
+      });
+      if (submissionError) {
+        await this.recordSubmissionError(record, submissionError);
       }
     } catch (error) {
       console.error(`[TransactionTracker] Error handling watched tx #${record.id} update`, error);
     }
   }
 
-  private async recordWatchStatus(record: ITransactionRecord, result: IWatchedTxResult) {
-    const { blockNumber, status } = result;
-    const watchBlockHash = status.isInBlock ? status.asInBlock?.toHex() : status.asFinalized?.toHex();
-
-    if (status.isBroadcast) {
+  private async recordWatchStatus(
+    record: ITransactionRecord,
+    {
+      isBroadcast,
+      isInBlock,
+      isFinalized,
+      isRetracted,
+      isUsurped,
+      isDropped,
+      isInvalid,
+      blockHash,
+      blockNumber,
+      replacementTxHash,
+    }: IWatchedTxStatus,
+  ) {
+    if (isBroadcast) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Broadcast,
@@ -615,33 +659,33 @@ export class TransactionTracker {
       });
     }
 
-    if (status.isInBlock) {
+    if (isInBlock) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.InBlock,
         source: TransactionHistorySource.Watch,
         blockHeight: blockNumber,
-        blockHash: status.asInBlock?.toHex(),
+        blockHash,
       });
     }
 
-    if (status.isFinalized) {
+    if (isFinalized) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Finalized,
         source: TransactionHistorySource.Watch,
         blockHeight: blockNumber,
-        blockHash: status.asFinalized?.toHex(),
+        blockHash,
       });
     }
 
-    if ((status.isInBlock || status.isFinalized) && blockNumber != null && watchBlockHash) {
+    if ((isInBlock || isFinalized) && blockNumber != null && blockHash) {
       const findTransactionResult = await TransactionEvents.findByExtrinsicHashInBlock({
         blockWatch: this.blockWatch,
         extrinsicHash: record.extrinsicHash,
         block: {
           blockNumber,
-          blockHash: watchBlockHash,
+          blockHash,
         },
         blockCache: this.#blockCache,
       });
@@ -661,7 +705,7 @@ export class TransactionTracker {
           extrinsicIndex,
         });
 
-        if (status.isFinalized) {
+        if (isFinalized) {
           const finalizedBlockNumber = Math.max(this.blockWatch.finalizedBlockHeader.blockNumber, blockNumber);
           const finalizedBlockTime =
             finalizedBlockNumber === blockNumber
@@ -676,7 +720,7 @@ export class TransactionTracker {
       }
     }
 
-    if (status.isRetracted) {
+    if (isRetracted) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Retracted,
@@ -684,16 +728,16 @@ export class TransactionTracker {
       });
     }
 
-    if (status.isUsurped) {
+    if (isUsurped && replacementTxHash) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Usurped,
         source: TransactionHistorySource.Watch,
-        replacementTxHash: status.asUsurped.toHex(),
+        replacementTxHash,
       });
     }
 
-    if (status.isDropped) {
+    if (isDropped) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Dropped,
@@ -701,7 +745,7 @@ export class TransactionTracker {
       });
     }
 
-    if (status.isInvalid) {
+    if (isInvalid) {
       await this.recordHistoryStatus({
         transactionId: record.id,
         status: TransactionHistoryStatus.Invalid,

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -77,11 +77,8 @@ export class WalletKeys {
     return await invokeWithTimeout<Hex>('export_default_ethereum_private_key', {}, 60e3);
   }
 
-  // TODO: move to a refunding proxy account.
-  public async exportMiningBotAccountJson(passphrase: string): Promise<KeyringPair$Json> {
-    const miningBotAccount = await invokeWithTimeout<Uint8Array>('derive_sr25519_seed', { suri: `//mining` }, 60e3);
-    const keyring = new Keyring({ type: 'sr25519' }).addFromSeed(miningBotAccount);
-    return keyring.toJson(passphrase);
+  public async exportMiningBidProxyAccountJson(passphrase: string): Promise<KeyringPair$Json> {
+    return (await this.getMiningBidProxyKeypair()).toJson(passphrase);
   }
 
   public async getMiningBotSubaccounts(count = 144): Promise<{ [address: string]: { index: number } }> {
@@ -238,6 +235,11 @@ export class WalletKeys {
   // TODO: move signing to backend instead of passing around key
   public async getMiningBotKeypair(): Promise<KeyringPair> {
     const account = await invokeWithTimeout<Uint8Array>('derive_sr25519_seed', { suri: `//mining` }, 60e3);
+    return new Keyring({ type: 'sr25519' }).addFromSeed(account);
+  }
+
+  public async getMiningBidProxyKeypair(): Promise<KeyringPair> {
+    const account = await invokeWithTimeout<Uint8Array>('derive_sr25519_seed', { suri: `//mining//proxy` }, 60e3);
     return new Keyring({ type: 'sr25519' }).addFromSeed(account);
   }
 


### PR DESCRIPTION
## Summary
- give the mining bot its own bidding account instead of handing the server the main mining funding account
- register that bidding account as a restricted `MiningBidRealPaysFee` proxy, which lets it place mining bids while the parent mining funding account still pays the fees
- keep mining from starting until that proxy account is registered, funded, and uploaded to the server

## Why
- the server only needs enough access to place bids, not full control of the mining funding account
- using the restricted proxy narrows what the bot account can do if it is ever misused or leaked
- we still keep the existing fee flow, because the parent mining funding account pays the transaction fees and the proxy only carries a small working balance

## Existing users
- existing miners keep the same mining funding account and do not need to reinstall
- on the next mining setup or funding pass, the app creates the proxy account for that existing funding account, registers it on-chain, seeds its fee float, and uploads the proxy account to the server
- after that setup completes, the miner resumes and all bids go through the restricted proxy account instead of the parent funding account
