### PR TITLE
fix(ethereum): improve funding readiness and gateway catch-up

### DIFF
--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -184,7 +184,9 @@ describe('EthereumGatewayProverService', () => {
       })),
     };
     const client = createClient({ tx, accountNextNonce: 9 });
-    const service = new EthereumGatewayProverService(createSubmitLane(client));
+    const service = new EthereumGatewayProverService(createSubmitLane(client), {
+      shouldApplySharedRelayStagger: true,
+    });
 
     gatewayProofMock.buildGatewayActivityProofPayload
       .mockResolvedValueOnce({
@@ -232,7 +234,9 @@ describe('EthereumGatewayProverService', () => {
 
   it('retries with a refreshed nonce when the node drops the delegate submission', async () => {
     const client = createClient();
-    const service = new EthereumGatewayProverService(createSubmitLane(client));
+    const service = new EthereumGatewayProverService(createSubmitLane(client), {
+      shouldApplySharedRelayStagger: true,
+    });
     const accountNextIndex = client.rpc.system.accountNextIndex as ReturnType<typeof vi.fn>;
     accountNextIndex.mockResolvedValueOnce({ toNumber: () => 4 }).mockResolvedValueOnce({ toNumber: () => 5 });
 
@@ -315,7 +319,9 @@ describe('EthereumGatewayProverService', () => {
     vi.useFakeTimers();
 
     const client = createClient();
-    const service = new EthereumGatewayProverService(createSubmitLane(client));
+    const service = new EthereumGatewayProverService(createSubmitLane(client), {
+      shouldApplySharedRelayStagger: true,
+    });
     gatewayProofMock.buildGatewayActivityProofPayload.mockResolvedValue({
       previousGatewayActivityNonce: 6n,
       proof: { batch: 'proof' },
@@ -400,7 +406,9 @@ describe('EthereumGatewayProverService', () => {
         })),
       },
     });
-    const service = new EthereumGatewayProverService(createSubmitLane(client));
+    const service = new EthereumGatewayProverService(createSubmitLane(client), {
+      shouldApplySharedRelayStagger: true,
+    });
 
     gatewayProofMock.buildGatewayActivityProofPayload.mockResolvedValue({
       previousGatewayActivityNonce: 6n,
@@ -601,6 +609,46 @@ describe('EthereumGatewayProverService', () => {
     await service.shutdown();
   });
 
+  it('bypasses staggered relay scheduling when disabled', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-13T16:00:00.000Z'));
+
+    const signedTx = {
+      method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+      nonce: { toNumber: () => 5 },
+    };
+    const client = createClient({ runtimeGatewayActivityNonce: 6n, accountNextNonce: 5, freeHeadersInterval: 2n });
+    const service = new EthereumGatewayProverService(createSubmitLane(client), {
+      shouldApplySharedRelayStagger: false,
+    });
+
+    gatewayProofMock.buildGatewayActivityProofPayload.mockResolvedValue({
+      previousGatewayActivityNonce: 6n,
+      proof: { batch: 'proof' },
+      gatewayActivityNonceRange: { start: 7n, end: 7n },
+      executionBlockNumberRange: { start: 160n, end: 160n },
+      activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
+    });
+    submissionMock.submitWithTerminalStatusWatch.mockResolvedValue({
+      signedTx,
+      result: {
+        extrinsic: {
+          signedHash: '0xrelaytx',
+          submittedAtBlockNumber: 321,
+          submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+        },
+        blockNumber: 321,
+        waitForInFirstBlock: Promise.resolve(new Uint8Array([1])),
+      },
+    });
+
+    await service.start();
+
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
+
+    await service.shutdown();
+  });
+
   it('rechecks shared relay work inside the stagger window after startup', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-13T16:00:00.000Z'));
@@ -653,6 +701,7 @@ describe('EthereumGatewayProverService', () => {
     const client = createClient({ runtimeGatewayActivityNonce: 6n, accountNextNonce: 5, freeHeadersInterval: 2n });
     const service = new EthereumGatewayProverService(createSubmitLane(client), {
       backgroundSweepMs: 1_000,
+      shouldApplySharedRelayStagger: true,
     });
     const runBackgroundSweep = (
       service as unknown as {

--- a/bot/src/Bot.ts
+++ b/bot/src/Bot.ts
@@ -23,6 +23,7 @@ import {
   JsonExt,
   MainchainClients,
   MiningFrames,
+  NetworkConfig,
 } from '@argonprotocol/apps-core';
 import { MiningFrameHistory } from './MiningFrameHistory.ts';
 import { History } from './History.ts';
@@ -97,6 +98,7 @@ export default class Bot {
       this.delegateSubmitLane,
     );
     this.ethereumGatewayProverService = new EthereumGatewayProverService(this.delegateSubmitLane, {
+      shouldApplySharedRelayStagger: NetworkConfig.networkName !== 'dev-docker',
       vaultOperatorAddress: this.options.vaultOperatorAddress,
     });
   }

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -45,6 +45,7 @@ export class EthereumGatewayProverService {
   constructor(
     private readonly submitLane: DelegateSubmitLane,
     private readonly options: {
+      shouldApplySharedRelayStagger?: boolean;
       backgroundSweepMs?: number;
       vaultOperatorAddress?: string;
     } = {},
@@ -267,11 +268,15 @@ export class EthereumGatewayProverService {
         return;
       }
 
-      if (sharedRelayIsPastFreeHeaderInterval) {
+      if (sharedRelayIsPastFreeHeaderInterval || this.options.shouldApplySharedRelayStagger === false) {
+        let bypassReason = 'has shared relay staggering disabled';
+        if (sharedRelayIsPastFreeHeaderInterval) {
+          bypassReason = `is ${sharedRelayExecutionBlockLag} blocks behind the latest anchor`;
+        }
+
         console.log(
           `[EthereumGatewayProverService] Shared gateway relay through activity ` +
-            `${proofPayload.gatewayActivityNonceRange.end} is ${sharedRelayExecutionBlockLag} blocks behind the latest ` +
-            'anchor; bypassing the stagger window',
+            `${proofPayload.gatewayActivityNonceRange.end} ${bypassReason}; bypassing the stagger window`,
         );
         const response = await this.queueCheckpoint(proofPayload.gatewayActivityNonceRange.end, proofPayload);
         if (response.outcome !== 'Rejected') {
@@ -625,7 +630,7 @@ export class EthereumGatewayProverService {
     for (const activity of activities) {
       let activitySigners: string[] = [];
       if (activity.kind === 'TransferOutOfArgonFinalized') {
-        for (const collateral of activity.mintingCollateral) {
+        for (const collateral of activity.mintingCollateral ?? []) {
           activitySigners.push(collateral.signingKey);
         }
       } else if (activity.kind === 'MintingAuthorityActivated' || activity.kind === 'MintingAuthorityDeactivated') {

--- a/core/src/fetch.ts
+++ b/core/src/fetch.ts
@@ -155,7 +155,9 @@ function summarizeUrl(url: string): string {
 }
 
 function sanitizeDiagnosticText(text: string): string {
-  return text.replace(/https?:\/\/[^\s)]+/g, url => summarizeUrl(url));
+  return text
+    .replace(/0x[a-fA-F0-9]{32,}/g, value => `${value.slice(0, 10)}...${value.slice(-8)}`)
+    .replace(/https?:\/\/[^\s)]+/g, url => summarizeUrl(url));
 }
 
 function hasQueryString(url?: string): boolean {

--- a/e2e/actors/VaultActor.ts
+++ b/e2e/actors/VaultActor.ts
@@ -85,7 +85,9 @@ export class VaultActor {
     const bitcoinLocks = new BitcoinLocks(dbPromise, walletKeys, miningFrames.blockWatch, currency, transactionTracker);
     const globalCouncil = new GlobalCouncil(dbPromise, walletKeys, miningFrames);
     const relaySubmitLane = new DelegateSubmitLane(new Keyring({ type: 'sr25519' }).createFromUri('//Charlie'));
-    const ethereumGatewayProverService = new EthereumGatewayProverService(relaySubmitLane);
+    const ethereumGatewayProverService = new EthereumGatewayProverService(relaySubmitLane, {
+      shouldApplySharedRelayStagger: false,
+    });
     const mintingAuthorities = new MintingAuthorities(
       dbPromise,
       walletKeys,

--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -52,7 +52,6 @@ const MINIMUM_BOOTSTRAP_FINALIZED_SLOT_BY_PRESET: Record<DevEthereumBeaconPreset
 };
 const DEV_ETHEREUM_LAUNCH_MAX_ATTEMPTS = 3;
 const DEV_ETHEREUM_LAUNCH_RETRY_DELAY_MS = 1_000;
-
 export type DevEthereumBeaconPreset = 'mainnet' | 'minimal';
 
 export interface IDevEthereumConfig {
@@ -156,10 +155,11 @@ export async function startDevEthereum(config: IDevEthereumConfig): Promise<ISta
       return result;
     } catch (error) {
       const errorText = error instanceof Error ? error.message : String(error);
+      const hitPortCollision = errorText.includes('port is already allocated');
 
       await ethereum.teardown().catch(() => undefined);
 
-      if (attempt === DEV_ETHEREUM_LAUNCH_MAX_ATTEMPTS || !errorText.includes('port is already allocated')) {
+      if (attempt === DEV_ETHEREUM_LAUNCH_MAX_ATTEMPTS || !hitPortCollision) {
         throw error;
       }
 
@@ -442,6 +442,7 @@ async function startDevEthereumRelayer(args: {
   });
   const ethereumGatewayProverService = new EthereumGatewayProverService(submitLane, {
     backgroundSweepMs: args.relayerPollMs,
+    shouldApplySharedRelayStagger: false,
   });
 
   try {

--- a/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
+++ b/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
@@ -10,6 +10,7 @@ const ETHEREUM_MOVE_TIMEOUT_MS = 6 * 60_000;
 const EMPTY_FUNDING_STATE = {
   ethereumAddress: '',
   archiveUrl: '',
+  ethereumChainConfigReady: false,
   ethereumFetchErrorMsg: '',
   ethereumMicrogons: 0n,
   ethereumMicronots: 0n,
@@ -48,6 +49,9 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
   async inspect(context: IAppFundWalletFromEthereumContext) {
     const targetWalletType = parseTargetWalletType(context.input.targetWalletType);
     const walletOverlay = await context.flow.isVisible('WalletOverlay');
+    const chainState = targetWalletType
+      ? await readEthereumFundingState(context.flow, targetWalletType)
+      : EMPTY_FUNDING_STATE;
 
     const blockers: string[] = [];
     if (!targetWalletType) {
@@ -56,13 +60,12 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
     if (!walletOverlay.visible) {
       blockers.push('Wallet overlay is not visible.');
     }
-
-    const chainState = targetWalletType
-      ? await readEthereumFundingState(context.flow, targetWalletType)
-      : EMPTY_FUNDING_STATE;
+    if (targetWalletType && walletOverlay.visible && !chainState.ethereumChainConfigReady) {
+      blockers.push('Ethereum chain config is still loading on the local Argon network.');
+    }
     const fundingRunStarted = context.flow.getData<boolean>('App.op.fundWalletFromEthereum.started') ?? false;
     const isComplete = fundingRunStarted && !walletOverlay.visible;
-    const canRun = !!targetWalletType && walletOverlay.visible;
+    const canRun = !!targetWalletType && walletOverlay.visible && chainState.ethereumChainConfigReady;
 
     return {
       chainState,
@@ -81,6 +84,9 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
     const targetWalletType = parseTargetWalletType(context.input.targetWalletType);
     if (!targetWalletType) {
       throw new Error('Ethereum funding target wallet type is required.');
+    }
+    if (!state.chainState.ethereumChainConfigReady) {
+      throw new Error('Ethereum chain config is still loading on the local Argon network.');
     }
 
     context.flow.setData('App.op.fundWalletFromEthereum.started', true);
@@ -215,12 +221,19 @@ async function readEthereumFundingState(flow: IE2EFlowRuntime, targetWalletType:
       const archiveUrl =
         (mainchainClient as { _options?: { provider?: { endpoint?: string } } } | undefined)?._options?.provider
           ?.endpoint ?? '';
+      const ethereumChainConfigReady = mainchainClient
+        ? await mainchainClient.query.crosschainTransfer
+            .chainConfigBySourceChain('Ethereum')
+            .then(config => config.isSome && config.unwrap().isEvm)
+            .catch(() => false)
+        : false;
       const argnTransfer = ethereumMoveTracker.getTransferStateForToken(args.argnMoveToken);
       const argnotTransfer = ethereumMoveTracker.getTransferStateForToken(args.argnotMoveToken);
 
       return {
         ethereumAddress: refs.wallets.ethereumWallet.address,
         archiveUrl,
+        ethereumChainConfigReady,
         ethereumFetchErrorMsg: refs.wallets.ethereumWallet.fetchErrorMsg,
         ethereumMicrogons: refs.wallets.ethereumWallet.availableMicrogons.toString(),
         ethereumMicronots: refs.wallets.ethereumWallet.availableMicronots.toString(),
@@ -255,6 +268,7 @@ async function readEthereumFundingState(flow: IE2EFlowRuntime, targetWalletType:
   return {
     ethereumAddress: state.ethereumAddress,
     archiveUrl: state.archiveUrl,
+    ethereumChainConfigReady: state.ethereumChainConfigReady,
     ethereumFetchErrorMsg: state.ethereumFetchErrorMsg,
     ethereumMicrogons: BigInt(state.ethereumMicrogons),
     ethereumMicronots: BigInt(state.ethereumMicronots),

--- a/e2e/flows/operations/Vaulting.flow.fundThroughEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.fundThroughEthereum.ts
@@ -82,6 +82,10 @@ export default new OperationalFlow<IVaultingFlowContext, IFundingState>(import.m
         },
       },
       appFundWalletFromEthereum,
+      {
+        timeoutMs: 180_000,
+        timeoutMessage: `${flowName}: Ethereum funding did not become ready on Argon in time.`,
+      },
     );
 
     await flow.poll(this, nextState => nextState.chainState.walletIsFullyFunded, {

--- a/src-vue/__test__/EthereumCrosschain.integration.test.ts
+++ b/src-vue/__test__/EthereumCrosschain.integration.test.ts
@@ -258,6 +258,7 @@ describe.skipIf(skipE2E || !TestEthereum.isInstalled())('EthereumCrosschain inte
     });
     gatewayProverService = new EthereumGatewayProverService(submitLane, {
       backgroundSweepMs: 1_000,
+      shouldApplySharedRelayStagger: false,
     });
     ethereumClient = new EthereumClient(walletKeys, ethereum.executionRpcUrl!);
     tracker = new EthereumInboundTransferTracker(

--- a/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
@@ -114,6 +114,7 @@ describe('EthereumInboundTransferTracker integration', () => {
         txSubmittedAtTime: new Date('2026-05-19T12:00:00.000Z'),
       };
     });
+    const upstreamCatchUp = vi.fn(async () => ({ outcome: 'Noop' as const, throughGatewayActivityNonce: 7n }));
     const mainchainClient = createMainchainClient({
       getProvenNonce: () => provenNonce,
     });
@@ -137,8 +138,8 @@ describe('EthereumInboundTransferTracker integration', () => {
         requestEthereumGatewayCatchUp,
       },
       {
-        operatorHost: undefined,
-        requestEthereumGatewayCatchUp: vi.fn(),
+        operatorHost: 'https://upstream.example',
+        requestEthereumGatewayCatchUp: upstreamCatchUp,
       },
     );
 
@@ -150,6 +151,10 @@ describe('EthereumInboundTransferTracker integration', () => {
 
     await vi.waitFor(() => {
       expect(requestEthereumGatewayCatchUp).toHaveBeenCalledWith({
+        sourceChain: 'Ethereum',
+        throughGatewayActivityNonce: 7n,
+      });
+      expect(upstreamCatchUp).toHaveBeenCalledWith({
         sourceChain: 'Ethereum',
         throughGatewayActivityNonce: 7n,
       });
@@ -467,6 +472,206 @@ describe('EthereumInboundTransferTracker integration', () => {
       await vi.advanceTimersByTimeAsync(1);
       await requestBackendCatchUp(activeTransfer);
       expect(requestEthereumGatewayCatchUp).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries local catch-up immediately once the relayer becomes ready', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const db = await createTestDb();
+      const walletKeys = createMockWalletKeys();
+      const getEthereumRelayStatus = vi
+        .fn()
+        .mockResolvedValueOnce({
+          isReady: false,
+          reason: 'Local Ethereum relayer is still starting.',
+        })
+        .mockResolvedValue({
+          isReady: true,
+        });
+      const requestEthereumGatewayCatchUp = vi.fn(async () => ({ outcome: 'Noop' as const }));
+      const mainchainClient = createMainchainClient({
+        getProvenNonce: () => 6n,
+      });
+
+      const tracker = new EthereumInboundTransferTracker(
+        Promise.resolve(db),
+        createTransactionTracker(),
+        createBlockWatch(mainchainClient),
+        walletKeys,
+        createEthereumClient({
+          sourceAddress: walletKeys.ethereumAddress,
+          destinationAddress: walletKeys.investmentAddress,
+          sourceTxHash: `0x${'38'.repeat(32)}`,
+          sourceBlockNumber: 42,
+          sourceBlockHash: `0x${'49'.repeat(32)}`,
+          sourceLogIndex: 8,
+          gatewayActivityNonce: 7n,
+          waitEstimateMs: 1_000,
+        }),
+        {
+          getEthereumRelayStatus,
+          requestEthereumGatewayCatchUp,
+        },
+        {
+          operatorHost: undefined,
+          requestEthereumGatewayCatchUp: vi.fn(),
+        },
+      );
+
+      const persistedRecord = await insertTransferRecord(db, walletKeys.ethereumAddress, {
+        id: nanoid(),
+        token: MoveToken.ARGN,
+        argonDestinationAddress: walletKeys.investmentAddress,
+        sourceTxHash: `0x${'38'.repeat(32)}`,
+        sourceBlockNumber: 42,
+        sourceBlockHash: `0x${'49'.repeat(32)}`,
+        sourceLogIndex: 8,
+        gatewayActivityNonce: 7n,
+        status: CrosschainInboundTransferStatus.SourceFinalized,
+      });
+      const progress = setInboundRelayStepProgress(createCrosschainTransferProgress(INBOUND_TRANSFER_STEP_TITLES), {
+        progressPct: 0,
+        detail: 'Waiting for Argon to receive finalized Ethereum state...',
+      });
+      const activeTransfer = {
+        id: persistedRecord.id,
+        moveToken: MoveToken.ARGN,
+        persistedRecord,
+        transferState: {
+          ...tracker.getTransferStateForToken(MoveToken.ARGN),
+          hasPersistedTransfer: true,
+          isSubmitting: true,
+          targetWalletType: WalletType.investment,
+          progress,
+        },
+      };
+      (
+        tracker as unknown as {
+          data: {
+            transfersById: Record<string, unknown>;
+            latestTransferIdByToken: Partial<Record<MoveToken.ARGN | MoveToken.ARGNOT, string>>;
+          };
+        }
+      ).data.transfersById[persistedRecord.id] = activeTransfer;
+
+      const requestBackendCatchUp = (
+        tracker as unknown as {
+          requestBackendCatchUp: (transfer: typeof activeTransfer) => Promise<void>;
+        }
+      ).requestBackendCatchUp.bind(tracker);
+
+      await requestBackendCatchUp(activeTransfer);
+      expect(getEthereumRelayStatus).toHaveBeenCalledTimes(1);
+      expect(requestEthereumGatewayCatchUp).not.toHaveBeenCalled();
+
+      await requestBackendCatchUp(activeTransfer);
+      expect(getEthereumRelayStatus).toHaveBeenCalledTimes(2);
+      expect(requestEthereumGatewayCatchUp).toHaveBeenCalledWith({
+        sourceChain: 'Ethereum',
+        throughGatewayActivityNonce: 7n,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('backs off local catch-up retries after a generic relay request failure', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const db = await createTestDb();
+      const walletKeys = createMockWalletKeys();
+      const getEthereumRelayStatus = vi.fn(async () => {
+        throw new Error('Server auth session was not accepted.');
+      });
+      const requestEthereumGatewayCatchUp = vi.fn(async () => ({ outcome: 'Noop' as const }));
+      const mainchainClient = createMainchainClient({
+        getProvenNonce: () => 6n,
+      });
+
+      const tracker = new EthereumInboundTransferTracker(
+        Promise.resolve(db),
+        createTransactionTracker(),
+        createBlockWatch(mainchainClient),
+        walletKeys,
+        createEthereumClient({
+          sourceAddress: walletKeys.ethereumAddress,
+          destinationAddress: walletKeys.investmentAddress,
+          sourceTxHash: `0x${'39'.repeat(32)}`,
+          sourceBlockNumber: 42,
+          sourceBlockHash: `0x${'4a'.repeat(32)}`,
+          sourceLogIndex: 8,
+          gatewayActivityNonce: 7n,
+          waitEstimateMs: 1_000,
+        }),
+        {
+          getEthereumRelayStatus,
+          requestEthereumGatewayCatchUp,
+        },
+        {
+          operatorHost: undefined,
+          requestEthereumGatewayCatchUp: vi.fn(),
+        },
+      );
+
+      const persistedRecord = await insertTransferRecord(db, walletKeys.ethereumAddress, {
+        id: nanoid(),
+        token: MoveToken.ARGN,
+        argonDestinationAddress: walletKeys.investmentAddress,
+        sourceTxHash: `0x${'39'.repeat(32)}`,
+        sourceBlockNumber: 42,
+        sourceBlockHash: `0x${'4a'.repeat(32)}`,
+        sourceLogIndex: 8,
+        gatewayActivityNonce: 7n,
+        status: CrosschainInboundTransferStatus.SourceFinalized,
+      });
+      const progress = setInboundRelayStepProgress(createCrosschainTransferProgress(INBOUND_TRANSFER_STEP_TITLES), {
+        progressPct: 0,
+        detail: 'Waiting for Argon to receive finalized Ethereum state...',
+      });
+      const activeTransfer = {
+        id: persistedRecord.id,
+        moveToken: MoveToken.ARGN,
+        persistedRecord,
+        transferState: {
+          ...tracker.getTransferStateForToken(MoveToken.ARGN),
+          hasPersistedTransfer: true,
+          isSubmitting: true,
+          targetWalletType: WalletType.investment,
+          progress,
+        },
+      };
+      (
+        tracker as unknown as {
+          data: {
+            transfersById: Record<string, unknown>;
+            latestTransferIdByToken: Partial<Record<MoveToken.ARGN | MoveToken.ARGNOT, string>>;
+          };
+        }
+      ).data.transfersById[persistedRecord.id] = activeTransfer;
+
+      const requestBackendCatchUp = (
+        tracker as unknown as {
+          requestBackendCatchUp: (transfer: typeof activeTransfer) => Promise<void>;
+        }
+      ).requestBackendCatchUp.bind(tracker);
+
+      await requestBackendCatchUp(activeTransfer);
+      await requestBackendCatchUp(activeTransfer);
+      expect(getEthereumRelayStatus).toHaveBeenCalledTimes(1);
+      expect(requestEthereumGatewayCatchUp).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(999);
+      await requestBackendCatchUp(activeTransfer);
+      expect(getEthereumRelayStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await requestBackendCatchUp(activeTransfer);
+      expect(getEthereumRelayStatus).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -842,6 +1047,53 @@ describe('EthereumInboundTransferTracker integration', () => {
     expect(ethereumClient.waitForTransactionFinality).toHaveBeenCalledTimes(2);
   });
 
+  it('surfaces a clear error when the Ethereum wallet cannot cover the network fee', async () => {
+    const db = await createTestDb();
+    const walletKeys = createMockWalletKeys();
+    const ethereumClient = createEthereumClient({
+      sourceAddress: walletKeys.ethereumAddress,
+      destinationAddress: walletKeys.investmentAddress,
+      sourceTxHash: `0x${'77'.repeat(32)}`,
+      sourceBlockNumber: 42,
+      sourceBlockHash: `0x${'88'.repeat(32)}`,
+      sourceLogIndex: 9,
+      gatewayActivityNonce: 7n,
+      nativeBalanceWei: 0n,
+      feeEstimateWei: 5n,
+    });
+    const tracker = new EthereumInboundTransferTracker(
+      Promise.resolve(db),
+      createTransactionTracker(),
+      createBlockWatch(
+        createMainchainClient({
+          getProvenNonce: () => 6n,
+        }),
+      ),
+      walletKeys,
+      ethereumClient,
+      undefined,
+      {
+        operatorHost: undefined,
+        requestEthereumGatewayCatchUp: vi.fn(),
+      },
+    );
+
+    const activeTransfer = await tracker.startMove({
+      moveToken: MoveToken.ARGN,
+      amountBaseUnits: 5_000_000_000_000n,
+      targetWalletType: WalletType.investment,
+    });
+
+    await vi.waitFor(() => {
+      expect(activeTransfer?.transferState.isSubmitting).toBe(false);
+      expect(activeTransfer?.transferState.needsAttention).toBe(true);
+      expect(activeTransfer?.transferState.error).toContain('Your Ethereum wallet has 0 ETH');
+      expect(activeTransfer?.transferState.error).toContain('Add about 0.000000000000000005 ETH and retry.');
+    });
+
+    expect(ethereumClient.startTransferToArgon).not.toHaveBeenCalled();
+  });
+
   it('keeps the inbound Argon catch-up loop alive after a transient finalized-head read error', async () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
@@ -910,12 +1162,16 @@ function createEthereumClient(args: {
   gatewayActivityNonce: bigint;
   pollMs?: number;
   waitEstimateMs?: number;
+  feeEstimateWei?: bigint;
+  nativeBalanceWei?: bigint;
 }): Pick<
   EthereumClient,
   | 'sourceAddress'
   | 'executionRpcUrl'
   | 'startTransferToArgon'
   | 'confirmTransferToArgon'
+  | 'estimateTransferToArgonFee'
+  | 'getNativeBalanceWei'
   | 'getTransactionProgress'
   | 'getTransactionFinalityPollMs'
   | 'getTransactionFinalityBlocks'
@@ -942,6 +1198,8 @@ function createEthereumClient(args: {
       executionRpcUrl: 'http://ethereum.test',
       sourceTxHash: args.sourceTxHash,
     })),
+    estimateTransferToArgonFee: vi.fn(async () => args.feeEstimateWei ?? 1n),
+    getNativeBalanceWei: vi.fn(async () => args.nativeBalanceWei ?? 10n),
     confirmTransferToArgon: vi.fn(async () => ({
       moveToken: MoveToken.ARGN,
       amountBaseUnits: 5_000_000_000_000n,

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -1,4 +1,10 @@
-import { fetch, getObjectStringProperty, MoveToken, NetworkConfig } from '@argonprotocol/apps-core';
+import {
+  fetch,
+  getErrorDiagnostics,
+  getObjectStringProperty,
+  MoveToken,
+  NetworkConfig,
+} from '@argonprotocol/apps-core';
 import {
   decodeAddress,
   decodeEthereumGatewayActivityLog,
@@ -203,7 +209,6 @@ export class EthereumClient {
   }): Promise<IEthereumTransferToArgon> {
     const { moveToken, amountBaseUnits, destinationAddress } = args;
     const { publicClient, transaction, unsignedTransaction } = await this.prepareTransferToArgon(args);
-    await this.ensureEthereumSignerPolicyConfigured();
     const signature = await this.walletKeys.signEthereumTransaction(unsignedTransaction);
     const sourceTxHash = await submitEthereumTransaction({
       publicClient,
@@ -691,6 +696,7 @@ export class EthereumClient {
         functionName: 'name',
       }),
     ]);
+    await this.ensureEthereumSignerPolicyConfigured(chainConfig);
     const permitSignature = await this.walletKeys.signEthereumPermit({
       tokenAddress,
       tokenName,
@@ -1418,6 +1424,11 @@ export async function submitEthereumTransaction(args: {
     if (await isSubmittedEthereumTransactionVisible(publicClient, derivedHash)) {
       return derivedHash;
     }
+
+    console.warn('[EthereumClient] sendRawTransaction rejected before transaction became visible', {
+      derivedHash,
+      error: getErrorDiagnostics(error),
+    });
 
     throw new Error(getEthereumUserErrorMessage(error, fallbackErrorMessage));
   }

--- a/src-vue/lib/EthereumGatewayCatchup.ts
+++ b/src-vue/lib/EthereumGatewayCatchup.ts
@@ -1,0 +1,96 @@
+import type { IEthereumGatewayRelayReasonCode } from '@argonprotocol/apps-core';
+import type { ServerApiClient } from './ServerApiClient.ts';
+import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
+
+export type IEthereumGatewayRelaySource = 'localServer' | 'upstreamOperator';
+
+export type IEthereumGatewayCatchupResult = {
+  relaySource?: IEthereumGatewayRelaySource;
+  relayError: string;
+  relayReasonCode?: IEthereumGatewayRelayReasonCode;
+  localRelayAttemptOutcome?: 'notReady' | 'requestFailed' | 'rejected';
+  localRelayError: string;
+  localRelayReasonCode?: IEthereumGatewayRelayReasonCode;
+};
+
+export async function requestEthereumGatewayCatchup(args: {
+  throughGatewayActivityNonce: bigint;
+  serverApiClient?: Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
+  upstreamOperatorClient?: Pick<UpstreamOperatorClient, 'operatorHost' | 'requestEthereumGatewayCatchUp'>;
+}): Promise<IEthereumGatewayCatchupResult> {
+  const { throughGatewayActivityNonce, serverApiClient, upstreamOperatorClient } = args;
+  let relaySource: IEthereumGatewayRelaySource | undefined;
+  let relayError = '';
+  let relayReasonCode: IEthereumGatewayRelayReasonCode | undefined;
+  let localRelayAttemptOutcome: 'notReady' | 'requestFailed' | 'rejected' | undefined;
+  let localRelayError = '';
+  let localRelayReasonCode: IEthereumGatewayRelayReasonCode | undefined;
+
+  if (serverApiClient) {
+    try {
+      const relayStatus = await serverApiClient.getEthereumRelayStatus();
+      if (relayStatus.isReady) {
+        const response = await serverApiClient.requestEthereumGatewayCatchUp({
+          sourceChain: 'Ethereum',
+          throughGatewayActivityNonce,
+        });
+        if (response.outcome !== 'Rejected') {
+          relaySource = 'localServer';
+
+          if (upstreamOperatorClient?.operatorHost) {
+            try {
+              await upstreamOperatorClient.requestEthereumGatewayCatchUp({
+                sourceChain: 'Ethereum',
+                throughGatewayActivityNonce,
+              });
+            } catch {
+              // The local relay request already succeeded; the upstream nudge is best-effort.
+            }
+          }
+        } else {
+          localRelayAttemptOutcome = 'rejected';
+          localRelayError = response.reason;
+          localRelayReasonCode = response.reasonCode;
+        }
+      } else {
+        localRelayAttemptOutcome = 'notReady';
+        localRelayError = relayStatus.reason ?? '';
+        localRelayReasonCode = relayStatus.reasonCode;
+      }
+    } catch (error) {
+      localRelayAttemptOutcome = 'requestFailed';
+      localRelayError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  if (!relaySource && upstreamOperatorClient?.operatorHost) {
+    try {
+      const response = await upstreamOperatorClient.requestEthereumGatewayCatchUp({
+        sourceChain: 'Ethereum',
+        throughGatewayActivityNonce,
+      });
+      if (response.outcome === 'Rejected') {
+        relayError = response.reason;
+        relayReasonCode = response.reasonCode;
+      } else {
+        relaySource = 'upstreamOperator';
+      }
+    } catch (error) {
+      relayError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  if (!relaySource && !relayError) {
+    relayError = localRelayError;
+    relayReasonCode = localRelayReasonCode;
+  }
+
+  return {
+    relaySource,
+    relayError,
+    relayReasonCode,
+    localRelayAttemptOutcome,
+    localRelayError,
+    localRelayReasonCode,
+  };
+}

--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -1,6 +1,7 @@
 import { MoveToken, type IEthereumGatewayRelayReasonCode } from '@argonprotocol/apps-core';
 import { BlockWatch } from '@argonprotocol/apps-core/src/BlockWatch.ts';
 import { nanoid } from 'nanoid';
+import { formatEther } from 'viem';
 import type { IArgonWalletType, IEthereumInboundTransferState } from '../interfaces/IEthereumInboundTransferTracker.ts';
 import {
   completeInboundTransferProgress,
@@ -20,11 +21,8 @@ import {
   type ICrosschainInboundTransferRecord,
 } from './db/CrosschainInboundTransfersTable.ts';
 import type { Db } from './Db.ts';
-import {
-  requestEthereumGatewayCatchUpDispatch,
-  type IEthereumGatewayRelaySource,
-  type ServerApiClient,
-} from './ServerApiClient.ts';
+import type { ServerApiClient } from './ServerApiClient.ts';
+import { requestEthereumGatewayCatchup, type IEthereumGatewayRelaySource } from './EthereumGatewayCatchup.ts';
 import { getEthereumGatewayPauseReason } from '../stores/mainchain.ts';
 import { TransactionTracker } from './TransactionTracker.ts';
 import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
@@ -51,6 +49,8 @@ type IEthereumInboundTransferClient = Pick<
   | 'sourceAddress'
   | 'executionRpcUrl'
   | 'startTransferToArgon'
+  | 'estimateTransferToArgonFee'
+  | 'getNativeBalanceWei'
   | 'confirmTransferToArgon'
   | 'getTransactionProgress'
   | 'getTransactionFinalityPollMs'
@@ -58,8 +58,7 @@ type IEthereumInboundTransferClient = Pick<
   | 'getTransferToArgonPollMs'
   | 'getTransferToArgonWaitEstimateMs'
   | 'waitForTransactionFinality'
-> &
-  Partial<Pick<EthereumClient, 'estimateTransferToArgonFee'>>;
+>;
 
 class InboundTransferInvariantError extends Error {}
 
@@ -202,15 +201,7 @@ export class EthereumInboundTransferTracker {
       return;
     }
 
-    let destinationAddress: string;
-    if (targetWalletType === WalletType.investment) {
-      destinationAddress = this.walletKeys.investmentAddress;
-    } else if (targetWalletType === WalletType.miningHold) {
-      destinationAddress = this.walletKeys.miningHoldAddress;
-    } else {
-      destinationAddress = this.walletKeys.vaultingAddress;
-    }
-
+    const destinationAddress = this.walletKeys.getWalletAddress(targetWalletType);
     return await this.ethereumClient.estimateTransferToArgonFee?.({
       moveToken,
       amountBaseUnits,
@@ -327,14 +318,12 @@ export class EthereumInboundTransferTracker {
     const transferState = transfer.transferState;
 
     try {
-      let destinationAddress: string;
-      if (targetWalletType === WalletType.investment) {
-        destinationAddress = this.walletKeys.investmentAddress;
-      } else if (targetWalletType === WalletType.miningHold) {
-        destinationAddress = this.walletKeys.miningHoldAddress;
-      } else {
-        destinationAddress = this.walletKeys.vaultingAddress;
-      }
+      const destinationAddress = this.walletKeys.getWalletAddress(targetWalletType);
+      await this.ensureSufficientEthereumFeeBalance({
+        moveToken,
+        amountBaseUnits,
+        destinationAddress,
+      });
 
       const submittedTransfer = await this.ethereumClient.startTransferToArgon({
         moveToken,
@@ -361,6 +350,29 @@ export class EthereumInboundTransferTracker {
     } catch (error) {
       await this.failTransfer(id, error instanceof Error ? error.message : 'Unable to move funds from Ethereum.');
     }
+  }
+
+  private async ensureSufficientEthereumFeeBalance(args: {
+    moveToken: IEthereumMoveToken;
+    amountBaseUnits: bigint;
+    destinationAddress: string;
+  }) {
+    const feeEstimateWei = await this.ethereumClient.estimateTransferToArgonFee({
+      moveToken: args.moveToken,
+      amountBaseUnits: args.amountBaseUnits,
+      destinationAddress: args.destinationAddress,
+    });
+    const ethereumBalanceWei = await this.ethereumClient.getNativeBalanceWei();
+    if (ethereumBalanceWei >= feeEstimateWei) {
+      return;
+    }
+
+    const missingWei = feeEstimateWei - ethereumBalanceWei;
+    throw new Error(
+      `Your Ethereum wallet has ${formatEther(ethereumBalanceWei)} ETH, but this transfer needs about ${formatEther(
+        feeEstimateWei,
+      )} ETH for network fees. Add about ${formatEther(missingWei)} ETH and retry.`,
+    );
   }
 
   private async continueTrackedMove(
@@ -673,23 +685,39 @@ export class EthereumInboundTransferTracker {
 
     const upstreamOperatorHost = this.upstreamOperatorClient.operatorHost;
     if (this.serverApiClient || upstreamOperatorHost) {
-      this.#lastCatchUpRequestAt.set(record.id, now);
-      const relayDispatch = await requestEthereumGatewayCatchUpDispatch({
+      const relayResult = await requestEthereumGatewayCatchup({
         throughGatewayActivityNonce,
         serverApiClient: this.serverApiClient,
         upstreamOperatorClient: upstreamOperatorHost ? this.upstreamOperatorClient : undefined,
       });
+
+      const shouldRetryImmediately =
+        relayResult.localRelayAttemptOutcome === 'notReady' &&
+        relayResult.relaySource === undefined &&
+        relayResult.relayReasonCode === undefined &&
+        relayResult.localRelayReasonCode === undefined;
+      const shouldBackOffCatchUpRetry =
+        !shouldRetryImmediately &&
+        (relayResult.relaySource !== undefined ||
+          relayResult.relayError !== '' ||
+          relayResult.relayReasonCode !== undefined ||
+          relayResult.localRelayReasonCode !== undefined);
+      if (shouldBackOffCatchUpRetry) {
+        this.#lastCatchUpRequestAt.set(record.id, now);
+      } else {
+        this.#lastCatchUpRequestAt.delete(record.id);
+      }
       let isLocalRelaySetupComplete: boolean | undefined;
-      if (isRelayFundingReason(relayDispatch.localRelayReasonCode)) {
+      if (isRelayFundingReason(relayResult.localRelayReasonCode)) {
         const delegateAddress = await this.walletKeys.getVaultDelegateKeypair().then(x => x.address);
         if (this.myVault?.createdVault) {
           isLocalRelaySetupComplete = this.myVault.createdVault.delegateAccountId === delegateAddress;
         }
       }
       const relayHint = getRelayProgressHint({
-        relaySource: relayDispatch.relaySource,
-        localRelayError: relayDispatch.localRelayError,
-        localRelayReasonCode: relayDispatch.localRelayReasonCode,
+        relaySource: relayResult.relaySource,
+        localRelayError: relayResult.localRelayError,
+        localRelayReasonCode: relayResult.localRelayReasonCode,
         isLocalRelaySetupComplete,
         isFinalizingOnArgon: transfer.transferState.progress.currentStep >= 3,
       });
@@ -709,16 +737,16 @@ export class EthereumInboundTransferTracker {
       }
 
       transfer.transferState.error = shouldSurfaceRelayError({
-        relayError: relayDispatch.relayError ?? '',
-        relayReasonCode: relayDispatch.relayReasonCode,
+        relayError: relayResult.relayError,
+        relayReasonCode: relayResult.relayReasonCode,
         hasExceededWaitEstimate,
       })
         ? getRelayErrorMessage({
-            relayError: relayDispatch.relayError ?? '',
-            relayReasonCode: relayDispatch.relayReasonCode,
-            relaySource: relayDispatch.relaySource,
-            localRelayError: relayDispatch.localRelayError,
-            localRelayReasonCode: relayDispatch.localRelayReasonCode,
+            relayError: relayResult.relayError,
+            relayReasonCode: relayResult.relayReasonCode,
+            relaySource: relayResult.relaySource,
+            localRelayError: relayResult.localRelayError,
+            localRelayReasonCode: relayResult.localRelayReasonCode,
             isLocalRelaySetupComplete,
           })
         : '';

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -494,7 +494,7 @@ export class EthereumOutboundTransferTracker {
         destinationChain: NETWORK,
         token: moveToken,
         amount,
-        argonSourceAddress: getSourceWalletAddress(this.walletKeys, sourceWalletType),
+        argonSourceAddress: this.walletKeys.getWalletAddress(sourceWalletType),
         destinationAddress: this.walletKeys.ethereumAddress,
         argonRequestTransactionId: txInfo.tx.id,
         progressJson: transfer.transferState.progress,
@@ -1399,17 +1399,6 @@ async function extractTransferId(txInfo: TransactionInfo<ICrosschainTransferOutM
   }
 
   throw new Error('TransferOutStarted event not found in transaction events.');
-}
-
-function getSourceWalletAddress(walletKeys: WalletKeys, sourceWalletType: IArgonWalletType) {
-  switch (sourceWalletType) {
-    case WalletType.investment:
-      return walletKeys.investmentAddress;
-    case WalletType.miningHold:
-      return walletKeys.miningHoldAddress;
-    case WalletType.vaulting:
-      return walletKeys.vaultingAddress;
-  }
 }
 
 async function getSourceWalletKeypair(walletKeys: WalletKeys, sourceWalletType: IArgonWalletType) {

--- a/src-vue/lib/MintingAuthorities.ts
+++ b/src-vue/lib/MintingAuthorities.ts
@@ -3,7 +3,8 @@ import { ApiDecoration, EvmContracts, MICROGONS_PER_ARGON, u8aToHex } from '@arg
 import { u8aConcat } from '@polkadot/util';
 import type { Db } from './Db.ts';
 import { getGatewayActivityWaitEstimateMs } from './EthereumClient.ts';
-import { requestEthereumGatewayCatchUpThroughOperator, type ServerApiClient } from './ServerApiClient.ts';
+import { requestEthereumGatewayCatchup } from './EthereumGatewayCatchup.ts';
+import type { ServerApiClient } from './ServerApiClient.ts';
 import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
 import type { WalletKeys } from './WalletKeys.ts';
 import type { WalletHdKeysTable } from './db/WalletHdKeysTable.ts';
@@ -478,7 +479,7 @@ export class MintingAuthorities {
     this.#lastPendingActivationRelayRequestAt = now;
 
     const relayPromise = (async () => {
-      const relayError = await requestEthereumGatewayCatchUpThroughOperator({
+      const { relayError } = await requestEthereumGatewayCatchup({
         throughGatewayActivityNonce: nextGatewayActivityNonce,
         serverApiClient,
         upstreamOperatorClient: upstreamOperatorClient?.operatorHost ? upstreamOperatorClient : undefined,

--- a/src-vue/lib/ServerApiClient.ts
+++ b/src-vue/lib/ServerApiClient.ts
@@ -4,7 +4,6 @@ import {
   fetch,
   type IEthereumGatewayCatchUpRequest,
   type IEthereumGatewayCatchUpResponse,
-  type IEthereumGatewayRelayReasonCode,
   type IEthereumGatewayRelayStatus,
 } from '@argonprotocol/apps-core';
 import type {
@@ -26,17 +25,8 @@ import {
   type ServerAuthClient,
   type ServerAuthOptions,
 } from './ServerAuthClient.ts';
-import type { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
 
 export type ServerGatewayDetails = Pick<IConfigServerDetails, 'ipAddress' | 'gatewayPort' | 'type'>;
-export type IEthereumGatewayRelaySource = 'localServer' | 'upstreamOperator';
-export type IEthereumGatewayCatchUpDispatchResult = {
-  relayError?: string;
-  relayReasonCode?: IEthereumGatewayRelayReasonCode;
-  relaySource?: IEthereumGatewayRelaySource;
-  localRelayError?: string;
-  localRelayReasonCode?: IEthereumGatewayRelayReasonCode;
-};
 
 export interface IBitcoinBlockChainInfo {
   chain: string;
@@ -371,88 +361,4 @@ function getGatewayHost(serverDetails: ServerGatewayDetails): string {
 
 function isLoopbackIp(ipAddress: string): boolean {
   return ipAddress === '127.0.0.1' || ipAddress === '::1';
-}
-
-export async function requestEthereumGatewayCatchUpThroughOperator(args: {
-  throughGatewayActivityNonce: bigint;
-  serverApiClient?: Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
-  upstreamOperatorClient?: Pick<UpstreamOperatorClient, 'operatorHost' | 'requestEthereumGatewayCatchUp'>;
-}): Promise<string | undefined> {
-  const result = await requestEthereumGatewayCatchUpDispatch(args);
-  return result.relayError;
-}
-
-export async function requestEthereumGatewayCatchUpDispatch(args: {
-  throughGatewayActivityNonce: bigint;
-  serverApiClient?: Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
-  upstreamOperatorClient?: Pick<UpstreamOperatorClient, 'operatorHost' | 'requestEthereumGatewayCatchUp'>;
-}): Promise<IEthereumGatewayCatchUpDispatchResult> {
-  const { throughGatewayActivityNonce, serverApiClient, upstreamOperatorClient } = args;
-  let localRelayError = '';
-  let localRelayReasonCode: IEthereumGatewayRelayReasonCode | undefined;
-
-  if (serverApiClient) {
-    try {
-      const relayStatus = await serverApiClient.getEthereumRelayStatus();
-      if (relayStatus.isReady) {
-        const response = await serverApiClient.requestEthereumGatewayCatchUp({
-          sourceChain: 'Ethereum',
-          throughGatewayActivityNonce,
-        });
-        if (response.outcome !== 'Rejected') {
-          return {
-            relaySource: 'localServer',
-          };
-        }
-
-        localRelayError = response.reason;
-        localRelayReasonCode = response.reasonCode;
-      } else {
-        localRelayError = relayStatus.reason ?? '';
-        localRelayReasonCode = relayStatus.reasonCode;
-      }
-    } catch (error) {
-      localRelayError = error instanceof Error ? error.message : String(error);
-    }
-
-    if (!upstreamOperatorClient?.operatorHost) {
-      return {
-        relayError: localRelayError,
-        relayReasonCode: localRelayReasonCode,
-        localRelayError,
-        localRelayReasonCode,
-      };
-    }
-  }
-
-  if (!upstreamOperatorClient?.operatorHost) {
-    return {};
-  }
-
-  try {
-    const response = await upstreamOperatorClient.requestEthereumGatewayCatchUp({
-      sourceChain: 'Ethereum',
-      throughGatewayActivityNonce,
-    });
-    if (response.outcome === 'Rejected') {
-      return {
-        relayError: response.reason,
-        relayReasonCode: response.reasonCode,
-        localRelayError: localRelayError || undefined,
-        localRelayReasonCode,
-      };
-    }
-
-    return {
-      relaySource: 'upstreamOperator',
-      localRelayError: localRelayError || undefined,
-      localRelayReasonCode,
-    };
-  } catch (error) {
-    return {
-      relayError: error instanceof Error ? error.message : String(error),
-      localRelayError: localRelayError || undefined,
-      localRelayReasonCode,
-    };
-  }
 }

--- a/src-vue/lib/VaultCalculator.ts
+++ b/src-vue/lib/VaultCalculator.ts
@@ -7,7 +7,7 @@ import {
   calculateAPY,
   createDeferred,
 } from '@argonprotocol/apps-core';
-import { Config } from './Config';
+import { Config } from './Config.ts';
 import { Vaults } from './Vaults.ts';
 
 export class VaultCalculator {

--- a/src-vue/lib/Vaults.ts
+++ b/src-vue/lib/Vaults.ts
@@ -15,11 +15,15 @@ export class Vaults extends VaultsBase {
     super(network, currency, miningFrames, clients);
   }
 
-  private statsFile() {
+  private statsDirectory() {
     if (this.network === 'dev-docker') {
-      return `${this.network}/${INSTANCE_NAME}/vaultStats.json`;
+      return `${this.network}/${INSTANCE_NAME}`;
     }
-    return `${this.network}/vaultStats.json`;
+    return this.network;
+  }
+
+  private statsFile() {
+    return `${this.statsDirectory()}/vaultStats.json`;
   }
 
   protected async saveStats(): Promise<void> {
@@ -30,7 +34,7 @@ export class Vaults extends VaultsBase {
     this.isSavingStats = true;
     try {
       const statsJson = JsonExt.stringify(this.stats, 2);
-      await mkdir(`${this.network}`, { baseDir: BaseDirectory.AppConfig, recursive: true }).catch(() => null);
+      await mkdir(this.statsDirectory(), { baseDir: BaseDirectory.AppConfig, recursive: true }).catch(() => null);
       await writeTextFile(this.statsFile() + '.tmp', statsJson, {
         baseDir: BaseDirectory.AppConfig,
       }).catch(error => {

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -243,6 +243,25 @@ export class WalletKeys {
     return new Keyring({ type: 'sr25519' }).addFromSeed(account);
   }
 
+  public getWalletAddress(walletType: WalletType): string {
+    switch (walletType) {
+      case WalletType.miningHold:
+        return this.miningHoldAddress;
+      case WalletType.miningBot:
+        return this.miningBotAddress;
+      case WalletType.vaulting:
+        return this.vaultingAddress;
+      case WalletType.operational:
+        return this.operationalAddress;
+      case WalletType.investment:
+        return this.investmentAddress;
+      case WalletType.ethereum:
+        return this.ethereumAddress;
+    }
+
+    throw new Error('Unsupported wallet type.');
+  }
+
   public async getWalletKeypair(walletType: WalletType): Promise<KeyringPair> {
     switch (walletType) {
       case WalletType.miningHold:


### PR DESCRIPTION
## Summary
- Ethereum-to-Argon transfers now stop with a clear ETH fee-balance error before submission instead of surfacing the generic invalid-parameters failure.
- Inbound transfer catch-up and minting-authority activation now share the same app-level relay path, so the app can try the local relay first, nudge the upstream operator after a local accept, and keep retry behavior consistent.
- Dev-docker funding now becomes ready more reliably by bypassing local relay staggering, waiting for Ethereum chain config readiness in the flow, and keeping vault stats isolated per instance.

## Validation
- `yarn vitest --run src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts src-vue/__test__/MintingAuthorities.test.ts`
- `ARGON_E2E_HEADLESS=1 E2E_FLOW_APP_LOGS=quiet E2E_FLOWS=Vaulting.flow.fundThroughEthereum yarn e2e:docker`
