### PR TITLE
fix(vaulting): stop blocking vault tab load on bitcoin lock sync

### DIFF
--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -67,6 +67,44 @@ describe('BlockWatch archive recovery', () => {
     expect(result).toBe(historicalHeader);
   });
 
+  it('retries historical header lookup on archive when the selected client query times out', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    try {
+      const historicalHeader = createHeaderInfo(108, '0x108', '0x107');
+      const prunedClient = {
+        rpc: {
+          chain: {
+            getBlockHash: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+            getHeader: vi.fn(),
+          },
+        },
+      };
+      const archiveClient = {
+        rpc: {
+          chain: {
+            getBlockHash: vi.fn().mockResolvedValue('0x108'),
+            getHeader: vi.fn().mockResolvedValue({ __info: historicalHeader }),
+          },
+        },
+      };
+      const blockWatch = new BlockWatch(createClients(prunedClient, archiveClient) as any);
+      blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+      getInternalBlockWatch(blockWatch).activeSource = 'pruned';
+
+      const resultPromise = blockWatch.getHeaderByBlockNumber(108);
+      await vi.advanceTimersByTimeAsync(120e3);
+
+      await expect(resultPromise).resolves.toBe(historicalHeader);
+      expect(prunedClient.rpc.chain.getBlockHash).toHaveBeenCalledWith(108);
+      expect(archiveClient.rpc.chain.getBlockHash).toHaveBeenCalledWith(108);
+      expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith('0x108');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('retries block api lookup on archive when pruned cannot decorate the supplied hash', async () => {
     const blockApi = { query: { system: { events: vi.fn() } } };
     const prunedClient = {

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -31,6 +31,8 @@ export interface IBlockHeaderInfo {
 type ISubscriptionSource = 'archive' | 'pruned';
 
 export class BlockWatch {
+  private static readonly queryTimeoutMs = 120e3;
+
   public get finalizedBlockHeader(): IBlockHeaderInfo {
     return this.latestHeaders.at(0)!;
   }
@@ -255,10 +257,21 @@ export class BlockWatch {
     if (best) {
       return best;
     }
-    const header = await this.readWithArchiveRetry(blockNumber, `getHeader(${blockNumber})`, async client => {
-      const blockHash = await client.rpc.chain.getBlockHash(blockNumber);
-      return await client.rpc.chain.getHeader(blockHash);
-    });
+    return await this.getHeaderByBlockNumber(blockNumber);
+  }
+
+  public async getHeaderByBlockNumber(blockNumber: number): Promise<IBlockHeaderInfo> {
+    if (blockNumber < 0) {
+      throw new Error(`[BlockWatch] getHeaderByBlockNumber called with negative blockNumber (${blockNumber})`);
+    }
+    const header = await this.readWithArchiveRetry(
+      blockNumber,
+      `getHeaderByBlockNumber(${blockNumber})`,
+      async client => {
+        const blockHash = await client.rpc.chain.getBlockHash(blockNumber);
+        return await client.rpc.chain.getHeader(blockHash);
+      },
+    );
     return BlockWatch.readHeader(header, blockNumber <= this.finalizedBlockHeader.blockNumber);
   }
 
@@ -450,7 +463,7 @@ export class BlockWatch {
     details: Record<string, unknown>,
   ): Promise<T> {
     try {
-      return await query(client);
+      return await this.runQueryWithTimeout(label, query(client));
     } catch (error) {
       if (!this.shouldRetryOnArchive(error)) {
         throw error;
@@ -465,13 +478,14 @@ export class BlockWatch {
         ...details,
         error: String(error),
       });
-      return await query(archiveClient);
+      return await this.runQueryWithTimeout(label, query(archiveClient));
     }
   }
 
   private shouldRetryOnArchive(error: unknown): boolean {
     const message = String(error).toLowerCase();
     return (
+      (message.includes('blockwatch') && message.includes('query timed out')) ||
       (message.includes('4003') &&
         (message.includes('state already discarded') || message.includes('unknown block'))) ||
       message.includes('unable to retrieve header and parent from supplied hash') ||
@@ -481,6 +495,23 @@ export class BlockWatch {
       message.includes('disconnected from ws://') ||
       message.includes('disconnected from wss://')
     );
+  }
+
+  private async runQueryWithTimeout<T>(label: string, promise: Promise<T>): Promise<T> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new Error(`[BlockWatch] Query timed out after ${BlockWatch.queryTimeoutMs}ms (${label})`));
+      }, BlockWatch.queryTimeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
   }
 
   private getPreferredSubscriptionSource(): ISubscriptionSource {

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -190,6 +190,7 @@ export default class BitcoinLocks {
   #relayPollingUuids = new Set<string>();
   #mempool: BitcoinMempool;
   #reportedMissingFundingForReleaseLocks = new Set<string>();
+  #needsLoadReconciliation = false;
 
   constructor(
     private readonly dbPromise: Promise<Db>,
@@ -393,18 +394,28 @@ export default class BitcoinLocks {
       }
 
       await this.blockWatch.start();
-      await this.#blockQueue.add(() => this.checkIncomingArgonBlock(this.blockWatch.bestBlockHeader), {
-        timeoutMs: 120e3,
-      }).promise;
-      for (const lock of Object.values(this.locksByUtxoId)) {
-        await this.reconcileMismatchState(lock);
-        await this.reconcileMismatchReturnOnBlock(lock);
-        await this.reconcileAcceptedFundingReleaseOnBlock(lock, false);
-      }
-      await this.syncLockReleaseBitcoinProcessing(this.locksByUtxoId);
-      await this.syncOrphanReturnBitcoinProcessing(this.oracleBitcoinBlockHeight);
+      this.#needsLoadReconciliation = true;
+      const initialBestBlock = this.blockWatch.bestBlockHeader;
+      void this.#blockQueue
+        .add(async () => {
+          await this.checkIncomingArgonBlock(initialBestBlock);
+          await this.runPendingLoadReconciliation();
+        })
+        .promise.catch(error => {
+          console.warn(
+            '[BitcoinLocks] Initial Argon block sync did not finish during load; continuing in the background',
+            {
+              blockNumber: initialBestBlock.blockNumber,
+              blockHash: initialBestBlock.blockHash,
+              error,
+            },
+          );
+        });
       this.#subscription = this.blockWatch.events.on('best-blocks', async headers => {
-        void this.#blockQueue.add(() => this.checkIncomingArgonBlock(headers.at(-1)!), { timeoutMs: 120e3 });
+        void this.#blockQueue.add(async () => {
+          await this.checkIncomingArgonBlock(headers.at(-1)!);
+          await this.runPendingLoadReconciliation();
+        });
       });
       this.#waitForLoad.resolve();
     } catch (error) {
@@ -412,6 +423,25 @@ export default class BitcoinLocks {
       this.#waitForLoad.reject(error);
     }
     return this.#waitForLoad.promise;
+  }
+
+  private async runPendingLoadReconciliation(): Promise<void> {
+    if (!this.#needsLoadReconciliation) {
+      return;
+    }
+
+    try {
+      for (const lock of Object.values(this.locksByUtxoId)) {
+        await this.reconcileMismatchState(lock);
+        await this.reconcileMismatchReturnOnBlock(lock);
+        await this.reconcileAcceptedFundingReleaseOnBlock(lock, false);
+      }
+      await this.syncLockReleaseBitcoinProcessing(this.locksByUtxoId);
+      await this.syncOrphanReturnBitcoinProcessing(this.oracleBitcoinBlockHeight);
+      this.#needsLoadReconciliation = false;
+    } catch (error) {
+      console.warn('[BitcoinLocks] Startup reconciliation did not finish; will retry on the next block', error);
+    }
   }
 
   private async checkForMissingBitcoinLockState(lock: IBitcoinLockRecord): Promise<void> {
@@ -2609,10 +2639,9 @@ export default class BitcoinLocks {
     }
 
     try {
-      // We look at the previous block to give more time for blocks to settle so we don't bounce data around, but don't
-      // wait for finality because of how long it can take. We might need to revisit this for anything where finality is
-      // important.
-      const header = await this.blockWatch.getHeader(newestHeader.blockNumber);
+      // Keep the original one-block settling lag, but resolve the header by block number so we do not
+      // get stuck retrying a transient best-head hash that the pruned node has already discarded.
+      const header = await this.blockWatch.getHeaderByBlockNumber(newestHeader.blockNumber - 1);
 
       if (header.blockNumber <= this.data.latestArgonBlockHeight) {
         return;


### PR DESCRIPTION
## Summary

Vaults could hang on `Loading...` when `BitcoinLocks.load()` waited for its first historical Argon block sync and full lock reconciliation before resolving. The app now renders once bitcoin lock state is loaded and subscribed, while the initial sync and reconciliation keep retrying in the background until they succeed.

Bitcoin lock processing still stays one settled block behind, but those historical reads now resolve the header by block number instead of reusing a transient best-head hash that pruned nodes may already have discarded.
