### PR TITLE
[codex] Fix Windows installer transfer path and dev Windows build issues

### DIFF
--- a/scripts/buildServer.ts
+++ b/scripts/buildServer.ts
@@ -2,11 +2,36 @@ import * as tar from 'tar';
 import * as fs from 'node:fs';
 import * as Path from 'path';
 import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'crypto';
 import { version as packageVersion } from '../package.json';
+import type { WriteEntry } from 'tar';
+
+function getGitExecutablePaths(repoRoot: string): Set<string> {
+  const result = spawnSync('git', ['ls-files', '--stage', 'server'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Unable to read git file modes for server bundle: ${result.stderr || result.stdout}`);
+  }
+
+  const executablePaths = new Set<string>();
+  for (const line of result.stdout.split(/\r?\n/)) {
+    if (!line) continue;
+    const match = /^100755\s+\S+\s+\d+\t(.+)$/.exec(line);
+    if (!match) continue;
+
+    const repoPath = match[1].replace(/\\/g, '/');
+    if (!repoPath.startsWith('server/')) continue;
+    executablePaths.add(repoPath.slice('server/'.length));
+  }
+  return executablePaths;
+}
 
 (async () => {
   const dirname = import.meta.dirname;
+  const repoRoot = Path.join(dirname, '..');
   const resourcesDir = Path.join(dirname, '../resources');
   const files = fs.readdirSync(resourcesDir);
   const serverFiles = files.filter(file => file.startsWith('server-') || file === 'SHASUM256');
@@ -18,6 +43,7 @@ import { version as packageVersion } from '../package.json';
   const filePath = Path.join('resources', fileName);
   const stagingDir = fs.mkdtempSync(Path.join(os.tmpdir(), 'argon-server-bundle-'));
   const serverSourceDir = Path.join(dirname, '../server');
+  const executablePaths = getGitExecutablePaths(repoRoot);
   try {
     fs.cpSync(serverSourceDir, stagingDir, { recursive: true });
     await tar.create(
@@ -27,6 +53,11 @@ import { version as packageVersion } from '../package.json';
         noMtime: true, // need for deterministic hashes
         file: filePath,
         cwd: stagingDir,
+        onWriteEntry: (entry: WriteEntry) => {
+          const normalizedPath = entry.path.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/$/, '');
+          if (!executablePaths.has(normalizedPath) || !entry.stat) return;
+          entry.stat.mode |= 0o111;
+        },
       },
       [''],
     );

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -119,7 +119,9 @@ async function main(): Promise<void> {
   }
 
   console.log(baseConfig);
-  const tauriArgs = ['tauri', 'dev', '--config', configJson];
+  const configArg =
+    process.platform === 'win32' ? `"${configJson.replace(/"/g, '\\"')}"` : configJson;
+  const tauriArgs = ['tauri', 'dev', '--config', configArg];
   const isE2EAppRun = Boolean(readNonEmpty(tauriEnv.ARGON_DRIVER_WS));
   if (isE2EAppRun) {
     tauriArgs.push('--features', 'e2e-screenshots,e2e-insecure-gateway-certs');
@@ -145,7 +147,12 @@ async function main(): Promise<void> {
   const child = spawn('yarn', tauriArgs, {
     env: tauriEnv,
     stdio: 'inherit',
-    shell: false,
+    shell: process.platform === 'win32',
+  });
+
+  child.on('error', err => {
+    console.error('[tauri-dev] Failed to start child process.', err);
+    process.exit(1);
   });
 
   if (shouldStartDevEthereumMintingAuthority) {

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -18,10 +18,13 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+type SSHClient = client::Handle<ClientHandler>;
+
 #[derive(Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct SSH {
-    client: Arc<Mutex<client::Handle<ClientHandler>>>,
+    client: Arc<Mutex<SSHClient>>,
+    transfer_client: Arc<Mutex<Option<SSHClient>>>,
     pub config: SSHConfig,
 }
 
@@ -79,16 +82,19 @@ impl PartialEq for SSHConfig {
 
 impl SSH {
     pub async fn connect(config: &SSHConfig, timeout_duration: Duration) -> Result<Self> {
-        let client = timeout(timeout_duration, Self::authenticate(config))
-            .await
-            .map_err(|_| {
-                anyhow::anyhow!("SSH connection timed out after {timeout_duration:?}")
-            })??;
+        let client = Self::connect_client(config, timeout_duration).await?;
         let ssh = SSH {
             client: Arc::new(Mutex::new(client)),
+            transfer_client: Arc::new(Mutex::new(None)),
             config: config.clone(),
         };
         Ok(ssh)
+    }
+
+    async fn connect_client(config: &SSHConfig, timeout_duration: Duration) -> Result<SSHClient> {
+        timeout(timeout_duration, Self::authenticate(config))
+            .await
+            .map_err(|_| anyhow::anyhow!("SSH connection timed out after {timeout_duration:?}"))?
     }
 
     async fn authenticate(ssh_config: &SSHConfig) -> Result<client::Handle<ClientHandler>> {
@@ -132,26 +138,51 @@ impl SSH {
         Ok(client)
     }
 
-    pub async fn reconnect(&self) -> Result<()> {
-        let client = Self::authenticate(&self.config).await?;
-        *self.client.lock().await = client;
+    async fn reconnect_client(client: &mut SSHClient, config: &SSHConfig) -> Result<()> {
+        *client = Self::authenticate(config).await?;
         Ok(())
     }
 
-    async fn open_channel(&self) -> Result<Channel<Msg>> {
-        if let Ok(channel) = self.client.lock().await.channel_open_session().await {
+    async fn get_or_connect_client<'a>(
+        client: &'a mut Option<SSHClient>,
+        config: &SSHConfig,
+        timeout_duration: Duration,
+    ) -> Result<&'a mut SSHClient> {
+        let needs_connect = match client {
+            Some(client) => client.is_closed(),
+            None => true,
+        };
+
+        if needs_connect {
+            *client = Some(Self::connect_client(config, timeout_duration).await?);
+        }
+
+        Ok(client
+            .as_mut()
+            .expect("SSH transfer client should exist after connect"))
+    }
+
+    async fn open_channel_on_client(
+        client: &mut SSHClient,
+        config: &SSHConfig,
+    ) -> Result<Channel<Msg>> {
+        if let Ok(channel) = client.channel_open_session().await {
             return Ok(channel);
         }
 
-        self.reconnect().await?;
-        Ok(self.client.lock().await.channel_open_session().await?)
+        Self::reconnect_client(client, config).await?;
+        Ok(client.channel_open_session().await?)
     }
 
-    pub async fn run_command(&self, command: impl Display) -> Result<(String, u32)> {
+    async fn run_command_on_client(
+        client: &mut SSHClient,
+        config: &SSHConfig,
+        command: String,
+    ) -> Result<(String, u32)> {
         let final_command = command.to_string().replace('\'', "'\\''");
         trace!("Executing ssh command: {final_command}");
         let shell_command = format!("bash -c '{final_command}'");
-        let mut channel = self.open_channel().await?;
+        let mut channel = Self::open_channel_on_client(client, config).await?;
         channel.exec(true, shell_command).await?;
         channel.eof().await?;
 
@@ -187,9 +218,24 @@ impl SSH {
         Ok((output, code))
     }
 
+    pub async fn run_command(&self, command: impl Display) -> Result<(String, u32)> {
+        let mut client = self.client.lock().await;
+        Self::run_command_on_client(&mut client, &self.config, command.to_string()).await
+    }
+
     pub async fn upload_file(&self, contents: &[u8], remote_path: &str) -> Result<()> {
+        let mut client = self.client.lock().await;
+        Self::upload_file_on_client(&mut client, &self.config, contents, remote_path).await
+    }
+
+    async fn upload_file_on_client(
+        client: &mut SSHClient,
+        config: &SSHConfig,
+        contents: &[u8],
+        remote_path: &str,
+    ) -> Result<()> {
         let escaped_remote = shell_escape_remote_path(remote_path);
-        let mut channel = self.open_channel().await?;
+        let mut channel = Self::open_channel_on_client(client, config).await?;
         let scp_command = format!("cat > {escaped_remote}");
         channel.exec(true, scp_command).await?;
 
@@ -210,14 +256,50 @@ impl SSH {
         remote_path: &str,
         event_progress_key: String,
     ) -> Result<()> {
+        let app = app.clone();
+        let file_name = file_name.to_string();
+        let remote_path = remote_path.to_string();
+        let transfer_client = self.transfer_client.clone();
+        let config = self.config.clone();
+        let runtime = tokio::runtime::Handle::current();
+        let timeout_duration = Duration::from_secs(10);
+        tauri::async_runtime::spawn_blocking(move || -> Result<()> {
+            runtime.block_on(async move {
+                let mut client = transfer_client.lock().await;
+                let client =
+                    Self::get_or_connect_client(&mut client, &config, timeout_duration).await?;
+                Self::upload_embedded_file_on_client(
+                    client,
+                    &config,
+                    &app,
+                    &file_name,
+                    &remote_path,
+                    &event_progress_key,
+                )
+                .await
+            })
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("SSH worker thread failed: {e}"))?
+    }
+
+    async fn upload_embedded_file_on_client(
+        client: &mut SSHClient,
+        config: &SSHConfig,
+        app: &AppHandle,
+        file_name: &str,
+        remote_path: &str,
+        event_progress_key: &str,
+    ) -> Result<()> {
         let path = Utils::get_embedded_path(app, file_name)?;
         let file = File::open(&path).await?;
 
         let escaped_remote = shell_escape_remote_path(remote_path);
         // ensure old file is removed
-        let _ = self.run_command(format!("rm -f {escaped_remote}")).await;
+        let _ =
+            Self::run_command_on_client(client, config, format!("rm -f {escaped_remote}")).await;
 
-        let mut channel = self.open_channel().await?;
+        let mut channel = Self::open_channel_on_client(client, config).await?;
         channel
             .exec(true, format!("cat > {escaped_remote}"))
             .await?;
@@ -225,30 +307,36 @@ impl SSH {
 
         let file_size = file.metadata().await?.len();
         let mut reader = BufReader::new(file);
-        let mut buffer = [0u8; 64 * 1024]; // 60KB buffer
-        let mut total = 0;
-
+        let mut buffer = [0u8; 64 * 1024];
+        let mut total = 0u64;
         let mut last_percent = -1;
+
         loop {
             let n = reader.read(&mut buffer).await?;
             if n == 0 {
                 break;
             }
+
             writer.write_all(&buffer[..n]).await?;
             total += n as u64;
-            let percent = (total * 100 / file_size) as i32;
-            if percent != last_percent {
-                last_percent = percent;
-                trace!("Uploading {file_name}: {percent}%");
-                app.emit(&event_progress_key, percent)?;
+
+            if file_size > 0 {
+                let percent = ((total.saturating_mul(100)) / file_size) as i32;
+                if percent != last_percent {
+                    last_percent = percent;
+                    trace!("Uploading {file_name}: {percent}%");
+                    app.emit(event_progress_key, percent)?;
+                }
             }
         }
 
-        app.emit(&event_progress_key, 100)?;
         writer.shutdown().await?;
         channel.eof().await?;
         while channel.wait().await.is_some() {}
 
+        if last_percent < 100 {
+            app.emit(event_progress_key, 100)?;
+        }
         Ok(())
     }
 
@@ -259,13 +347,48 @@ impl SSH {
         local_download_path: &str,
         event_progress_key: String,
     ) -> Result<()> {
+        let app = app.clone();
+        let remote_path = remote_path.to_string();
+        let local_download_path = local_download_path.to_string();
+        let transfer_client = self.transfer_client.clone();
+        let config = self.config.clone();
+        let runtime = tokio::runtime::Handle::current();
+        let timeout_duration = Duration::from_secs(10);
+        tauri::async_runtime::spawn_blocking(move || -> Result<()> {
+            runtime.block_on(async move {
+                let mut client = transfer_client.lock().await;
+                let client =
+                    Self::get_or_connect_client(&mut client, &config, timeout_duration).await?;
+                Self::download_remote_file_on_client(
+                    client,
+                    &config,
+                    &app,
+                    &remote_path,
+                    &local_download_path,
+                    &event_progress_key,
+                )
+                .await
+            })
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("SSH worker thread failed: {e}"))?
+    }
+
+    async fn download_remote_file_on_client(
+        client: &mut SSHClient,
+        config: &SSHConfig,
+        app: &AppHandle,
+        remote_path: &str,
+        local_download_path: &str,
+        event_progress_key: &str,
+    ) -> Result<()> {
         let escaped_remote = shell_escape_remote_path(remote_path);
 
         // Best-effort: get remote file size for progress (may fail; then size=0)
         let mut remote_size: u64 = 0;
-        if let Ok((out, _code)) = self
-            .run_command(format!("stat -c %s {escaped_remote}"))
-            .await
+        if let Ok((out, _code)) =
+            Self::run_command_on_client(client, config, format!("stat -c %s {escaped_remote}"))
+                .await
         {
             if let Ok(sz) = out.trim().parse::<u64>() {
                 remote_size = sz;
@@ -280,7 +403,7 @@ impl SSH {
         let mut writer = BufWriter::new(file);
 
         // Open a channel and stream the remote file via `cat`
-        let mut channel = self.open_channel().await?;
+        let mut channel = Self::open_channel_on_client(client, config).await?;
         channel.exec(true, format!("cat {escaped_remote}")).await?;
         {
             let mut reader = channel.make_reader();
@@ -301,7 +424,7 @@ impl SSH {
                     let percent = ((total.saturating_mul(100)) / remote_size) as i32;
                     if percent != last_percent {
                         last_percent = percent;
-                        app.emit(&event_progress_key, percent)?;
+                        app.emit(event_progress_key, percent)?;
                     }
                 }
             }
@@ -311,32 +434,44 @@ impl SSH {
         while channel.wait().await.is_some() {}
 
         // If size was unknown, emit 100% at the end so the UI completes
-        app.emit(&event_progress_key, 100)?;
+        app.emit(event_progress_key, 100)?;
         Ok(())
     }
 
+    async fn disconnect_client(client: &mut SSHClient, host: &str) {
+        if client.is_closed() {
+            return;
+        }
+
+        log::info!("Closing existing SSH connection to {host}");
+        let _ = client
+            .disconnect(Disconnect::ByApplication, "", "English")
+            .await
+            .map_err(|e| {
+                let msg = e.to_string();
+                let is_benign = matches!(e, russh::Error::SendError)
+                    || msg.contains("Channel send error")
+                    || msg.contains("send error")
+                    || msg.contains("connection closed");
+
+                if !is_benign {
+                    log::error!("Error closing existing SSH connection: {e:#}");
+                }
+            });
+    }
+
     pub async fn close(&self) {
-        if let Ok(handle) = self.client.try_lock() {
-            if handle.is_closed() {
-                return;
+        let host = self.config.host();
+
+        if let Ok(mut handle) = self.client.try_lock() {
+            Self::disconnect_client(&mut handle, &host).await;
+        }
+
+        if let Ok(mut handle) = self.transfer_client.try_lock() {
+            if let Some(client) = handle.as_mut() {
+                Self::disconnect_client(client, &host).await;
             }
-
-            log::info!("Closing existing SSH connection to {}", self.config.host());
-            let _ = handle
-                .disconnect(Disconnect::ByApplication, "", "English")
-                .await
-                .map_err(|e| {
-                    let msg = e.to_string();
-                    let is_benign = matches!(e,
-                        russh::Error::SendError
-                    ) || msg.contains("Channel send error")   // covers variant/name differences
-                        || msg.contains("send error")
-                        || msg.contains("connection closed");
-
-                    if !is_benign {
-                        log::error!("Error closing existing SSH connection: {e:#}");
-                    }
-                });
+            *handle = None;
         }
     }
 

--- a/src-tauri/src/troubleshooting.rs
+++ b/src-tauri/src/troubleshooting.rs
@@ -291,6 +291,7 @@ fn summarize_winhttp_proxy(value: Value) -> Value {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn run_command_text(command: &str, args: &[&str]) -> Result<String, String> {
     let output = Command::new(command)
         .args(args)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -89,7 +89,11 @@
       "deb"
     ],
     "icon": [
-      "icons/icon.png"
+      "icons-operations/stable/mainnet/32x32.png",
+      "icons-operations/stable/mainnet/128x128.png",
+      "icons-operations/stable/mainnet/128x128@2x.png",
+      "icons-operations/stable/mainnet/icon.icns",
+      "icons-operations/stable/mainnet/icon.ico"
     ]
   },
   "plugins": {


### PR DESCRIPTION
## What changed

This PR bundles the Windows installer and dev-build fixes we validated while reproducing the SSH upload crash and follow-on install issues.

- isolate large SSH file transfers from the shared installer polling connection
- preserve executable bits for tracked server scripts when building `resources/server-*.tar.gz` on Windows
- point the default Tauri bundle config at the tracked Operations icon set instead of relying on an untracked local `icon.ico`
- gate a non-Windows troubleshooting helper with `cfg` so Windows clippy/build flows stay clean

## Why

We were chasing a Windows-only installer failure during the large embedded tarball upload, plus a separate Windows packaging/install problem where extracted server scripts lost execute permissions.

The main theories and fixes here are:

- the installer poller and large tarball upload could overlap on the same SSH connection, which is a plausible trigger for the Windows stack-overflow crash around `ssh_upload_embedded_file`
- building the server tarball on Windows was dropping execute bits for scripts like `server/scripts/installer.sh`, which left remote installs hanging or failing with `Permission denied`
- local Windows builds were implicitly depending on a stray icon file instead of the tracked Operations icon assets

## Impact

- reduces contention between background installer polling and large SSH transfers during setup
- keeps remote server scripts executable when the tarball is built on Windows
- makes Windows/dev packaging more reproducible across machines

## Validation

- `yarn typecheck`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `yarn lint:check`
