### PR TITLE
fix: improve app load stability around startup

### DIFF
--- a/core/__test__/BiddingCalculatorData.test.ts
+++ b/core/__test__/BiddingCalculatorData.test.ts
@@ -14,18 +14,15 @@ vi.mock('../src/Currency.js', () => ({
 
 import BiddingCalculatorData from '../src/BiddingCalculatorData.ts';
 import { NetworkConfig } from '../src/NetworkConfig.ts';
-import type { IBlockHeaderInfo } from '../src/BlockWatch.ts';
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('BiddingCalculatorData best-block recovery', () => {
-  it('retries with the finalized block when the latest head cannot be decorated', async () => {
+  it('loads with the latest readable chain api for current-state bidding data', async () => {
     NetworkConfig.setNetwork('dev-docker');
 
-    const latestHeader = createHeaderInfo(155, '0xbest', '0x154', false);
-    const finalizedHeader = createHeaderInfo(154, '0xfinalized', '0x153', true);
     const finalizedApi = {
       consts: {
         miningSlot: {
@@ -40,11 +37,7 @@ describe('BiddingCalculatorData best-block recovery', () => {
         },
       },
     };
-    const clientAt = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('Unable to retrieve header and parent from supplied hash'))
-      .mockResolvedValueOnce(finalizedApi);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getCurrentApi = vi.fn().mockResolvedValue(finalizedApi);
     const calculatorData = new BiddingCalculatorData(
       {
         clients: {},
@@ -60,10 +53,8 @@ describe('BiddingCalculatorData best-block recovery', () => {
       } as any,
       {
         waitForFrameId: vi.fn().mockResolvedValue(undefined),
-        clientAt,
         blockWatch: {
-          bestBlockHeader: latestHeader,
-          finalizedBlockHeader: finalizedHeader,
+          getCurrentApi,
         },
         framesById: {},
       } as any,
@@ -71,26 +62,9 @@ describe('BiddingCalculatorData best-block recovery', () => {
 
     await expect(calculatorData.load(15)).resolves.toBeUndefined();
 
-    expect(clientAt.mock.calls).toEqual([[latestHeader], [finalizedHeader]]);
+    expect(getCurrentApi).toHaveBeenCalledOnce();
     expect(calculatorData.microgonsInCirculation).toBe(1_000n);
     expect(calculatorData.maximumMicronotsForBid).toBe(36n);
     expect(calculatorData.allowedBidIncrementMicrogons).toBe(10_000n);
   });
 });
-
-function createHeaderInfo(
-  blockNumber: number,
-  blockHash: string,
-  parentHash: string,
-  isFinalized: boolean,
-): IBlockHeaderInfo {
-  return {
-    isFinalized,
-    blockNumber,
-    blockHash,
-    blockTime: blockNumber * 1_000,
-    parentHash,
-    author: 'author',
-    tick: blockNumber,
-  };
-}

--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BlockWatch, type IBlockHeaderInfo } from '../src/BlockWatch.ts';
 
+type IBlockApi = Awaited<ReturnType<BlockWatch['getApi']>>;
+
 describe('BlockWatch archive recovery', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -122,6 +124,121 @@ describe('BlockWatch archive recovery', () => {
     expect(prunedClient.at).toHaveBeenCalledWith('0xblock');
     expect(archiveClient.at).toHaveBeenCalledWith('0xblock');
     expect(result).toBe(blockApi);
+  });
+
+  it('retries start after an initial startup failure without an explicit stop', async () => {
+    const blockWatch = new BlockWatch(createClients({}, {}) as any);
+    const startSubscription = vi
+      .spyOn(blockWatch as any, 'startSubscription')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(blockWatch.start('archive')).rejects.toThrow('offline');
+    await expect(blockWatch.start('archive')).resolves.toBeUndefined();
+
+    expect(startSubscription).toHaveBeenCalledTimes(2);
+    expect(blockWatch.isLoaded.isResolved).toBe(true);
+  });
+
+  it('retries with a newer best block when the previous best head becomes unreadable', async () => {
+    const finalizedHeader = createHeaderInfo(100, '0xfinalized', '0x099');
+    finalizedHeader.isFinalized = true;
+    const initialBestHeader = createHeaderInfo(110, '0xbest-1', '0x109');
+    const newerBestHeader = createHeaderInfo(111, '0xbest-2', '0x110');
+    const newerBestApi = { query: { system: { events: vi.fn() } } } as unknown as IBlockApi;
+    const blockWatch = new BlockWatch(createClients({}, {}) as any);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    blockWatch.latestHeaders = [finalizedHeader, initialBestHeader];
+    const getApiMock = vi.spyOn(blockWatch, 'getApi').mockImplementation(async block => {
+      if (block.blockHash === initialBestHeader.blockHash) {
+        blockWatch.latestHeaders = [finalizedHeader, newerBestHeader];
+        throw new Error('Unable to retrieve header and parent from supplied hash');
+      }
+      if (block.blockHash === newerBestHeader.blockHash) {
+        return newerBestApi;
+      }
+      throw new Error(`Unexpected block hash ${block.blockHash}`);
+    });
+
+    await expect(blockWatch.getCurrentApi()).resolves.toBe(newerBestApi);
+
+    expect(getApiMock.mock.calls).toEqual([[initialBestHeader], [newerBestHeader]]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[BlockWatch]: Failed to decorate best block, retrying with newer best block',
+      expect.objectContaining({
+        bestBlockNumber: 110,
+        latestBestBlockNumber: 111,
+      }),
+    );
+  });
+
+  it('retries with the archive best block when no newer readable watched best is available', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    const finalizedHeader = createHeaderInfo(100, '0xfinalized', '0x099');
+    finalizedHeader.isFinalized = true;
+    const bestHeader = createHeaderInfo(110, '0xbest', '0x109');
+    const archiveBestHeader = createHeaderInfo(112, '0xarchive-best', '0x111');
+    const archiveBestApi = { query: { system: { events: vi.fn() } } } as unknown as IBlockApi;
+    const archiveClient = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({ __info: archiveBestHeader }),
+        },
+      },
+    };
+    const blockWatch = new BlockWatch(createClients({}, archiveClient) as any);
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    blockWatch.latestHeaders = [finalizedHeader, bestHeader];
+    const getApiMock = vi.spyOn(blockWatch, 'getApi').mockImplementation(async block => {
+      if (block.blockHash === bestHeader.blockHash) {
+        throw error;
+      }
+      if (block.blockHash === archiveBestHeader.blockHash) {
+        return archiveBestApi;
+      }
+      throw new Error(`Unexpected block hash ${block.blockHash}`);
+    });
+
+    await expect(blockWatch.getCurrentApi()).resolves.toBe(archiveBestApi);
+
+    expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith();
+    expect(getApiMock.mock.calls).toEqual([[bestHeader], [archiveBestHeader]]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[BlockWatch]: Failed to decorate watched best block, retrying with archive best block',
+      expect.objectContaining({
+        bestBlockNumber: 110,
+        archiveBestBlockNumber: 112,
+      }),
+    );
+  });
+
+  it('throws when archive best matches the unreadable watched best', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    const finalizedHeader = createHeaderInfo(100, '0xfinalized', '0x099');
+    finalizedHeader.isFinalized = true;
+    const bestHeader = createHeaderInfo(110, '0xbest', '0x109');
+    const archiveClient = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn().mockResolvedValue({ __info: bestHeader }),
+        },
+      },
+    };
+    const blockWatch = new BlockWatch(createClients({}, archiveClient) as any);
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+
+    blockWatch.latestHeaders = [finalizedHeader, bestHeader];
+    const getApiMock = vi.spyOn(blockWatch, 'getApi').mockRejectedValue(error);
+
+    await expect(blockWatch.getCurrentApi()).rejects.toBe(error);
+
+    expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith();
+    expect(getApiMock.mock.calls).toEqual([[bestHeader]]);
   });
 
   it('retries signed block lookup on archive when the selected client disconnects', async () => {

--- a/core/__test__/MiningFrames.test.ts
+++ b/core/__test__/MiningFrames.test.ts
@@ -91,6 +91,60 @@ describe('MiningFrames frame refresh recovery', () => {
     );
     expect(miningFrames.framesById[18]).toBeUndefined();
   });
+
+  it('retries load after an initial bootstrap failure and cleans up the temporary subscription', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = createHeaderInfo(0, '0xgenesis', '0xparent', 0, 0);
+    const unsubscribeFirst = vi.fn();
+    const unsubscribeSecond = vi.fn();
+    const blockWatch = {
+      latestHeaders: [latestHeader],
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+      isLoaded: { isRejected: false },
+      events: {
+        on: vi.fn().mockReturnValueOnce(unsubscribeFirst).mockReturnValueOnce(unsubscribeSecond),
+      },
+    };
+    const clients = createClientsWithGenesis('0xgenesis');
+    const miningFrames = new MiningFrames(clients as any, blockWatch as any);
+    const onBestBlocks = vi
+      .spyOn(miningFrames as any, 'onBestBlocks')
+      .mockRejectedValueOnce(new Error('bootstrap failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(miningFrames.load()).rejects.toThrow('bootstrap failed');
+    await expect(miningFrames.load()).resolves.toBeUndefined();
+
+    expect(blockWatch.events.on).toHaveBeenCalledTimes(2);
+    expect(unsubscribeFirst).toHaveBeenCalledOnce();
+    expect(unsubscribeSecond).not.toHaveBeenCalled();
+    expect(onBestBlocks).toHaveBeenNthCalledWith(1, [latestHeader]);
+    expect(onBestBlocks).toHaveBeenNthCalledWith(2, [latestHeader]);
+  });
+
+  it('retries load after a failed startup', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = {
+      ...createHeaderInfo(0, '0xgenesis', '0xparent', 0, 0),
+      frameRewardTicksRemaining: 12,
+    };
+    const blockWatch = {
+      latestHeaders: [latestHeader],
+      start: vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined),
+      events: { on: vi.fn().mockReturnValue(vi.fn()) },
+    };
+    const clients = createClientsWithGenesis('0xgenesis');
+    const miningFrames = new MiningFrames(clients as any, blockWatch as any);
+
+    await expect(miningFrames.load()).rejects.toThrow('offline');
+    await expect(miningFrames.load()).resolves.toBeUndefined();
+
+    expect(blockWatch.start).toHaveBeenCalledTimes(2);
+    expect(miningFrames.currentFrameRewardTicksRemaining).toBe(12);
+  });
 });
 
 function createHeaderInfo(
@@ -115,6 +169,17 @@ function createHeaderInfo(
 function createNumberLike(value: number) {
   return {
     toNumber: () => value,
+  };
+}
+
+function createClientsWithGenesis(genesisHash: string) {
+  return {
+    prunedClientOrArchivePromise: Promise.resolve({
+      genesisHash: { toHex: () => genesisHash },
+      runtimeVersion: {
+        specVersion: createNumberLike(153),
+      },
+    }),
   };
 }
 

--- a/core/__test__/Vaults.test.ts
+++ b/core/__test__/Vaults.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Vaults } from '../src/Vaults.ts';
+
+describe('Vaults load retry', () => {
+  it('retries after an initial bootstrap failure', async () => {
+    const miningFrames = {
+      load: vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(undefined),
+    };
+    const client = {
+      query: {
+        vaults: {
+          vaultsById: {
+            entries: vi.fn().mockResolvedValue([]),
+          },
+        },
+      },
+    };
+    const mainchainClients = {
+      get: vi.fn().mockResolvedValue(client),
+    };
+    const vaults = new Vaults('dev-docker', {} as any, miningFrames as any, mainchainClients as any);
+
+    await expect(vaults.load()).rejects.toThrow('offline');
+    await expect(vaults.load()).resolves.toBeUndefined();
+
+    expect(mainchainClients.get).toHaveBeenCalledTimes(2);
+    expect(miningFrames.load).toHaveBeenCalledTimes(2);
+    expect(client.query.vaults.vaultsById.entries).toHaveBeenCalledOnce();
+  });
+});

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { Mining } from './Mining.js';
 import { Currency } from './Currency.js';
 import { bigIntMax, bigIntMin, bigNumberToBigInt, percentOf } from './utils.js';
-import { type ApiDecoration, type ArgonClient, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
+import { type ArgonClient, MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { type IBiddingRules, SeatGoalInterval, SeatGoalType } from './interfaces/index.js';
 import { NetworkConfig } from './NetworkConfig.js';
 import type { MiningFrames } from './MiningFrames.ts';
@@ -78,23 +78,7 @@ export default class BiddingCalculatorData {
           const mining = this.mining;
           await this.miningFrames.waitForFrameId(biddingFrameId);
 
-          const latestHeader = this.miningFrames.blockWatch.bestBlockHeader;
-          let api: ApiDecoration<'promise'>;
-          try {
-            api = await this.miningFrames.clientAt(latestHeader);
-          } catch (error) {
-            if (latestHeader.isFinalized) {
-              throw error;
-            }
-
-            const finalizedHeader = this.miningFrames.blockWatch.finalizedBlockHeader;
-            console.warn('[BiddingCalculatorData] Failed to decorate best block, retrying with finalized block', {
-              bestBlockNumber: latestHeader.blockNumber,
-              finalizedBlockNumber: finalizedHeader.blockNumber,
-              error: String(error),
-            });
-            api = await this.miningFrames.clientAt(finalizedHeader);
-          }
+          let api = await this.miningFrames.blockWatch.getCurrentApi();
 
           const nextFrameId = await this.mining.fetchNextFrameId(api);
           if (biddingFrameId !== nextFrameId - 1) {

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -103,8 +103,11 @@ export class BlockWatch {
   }
 
   public async start(source = this.getPreferredSubscriptionSource()): Promise<void> {
-    if (this.isLoaded.isRunning || this.isLoaded.isSettled) {
+    if (this.isLoaded.isResolved || this.isLoaded.isRunning) {
       return this.isLoaded.promise;
+    }
+    if (this.isLoaded.isRejected) {
+      this.isLoaded = createDeferred(false);
     }
     this.isLoaded.setIsRunning(true);
 
@@ -292,6 +295,47 @@ export class BlockWatch {
 
   public async getFinalizedApi(): Promise<ApiDecoration<'promise'>> {
     return this.getApi(this.finalizedBlockHeader);
+  }
+
+  public async getCurrentApi(): Promise<ApiDecoration<'promise'>> {
+    const initialBestHeader = this.bestBlockHeader;
+    try {
+      return await this.getApi(initialBestHeader);
+    } catch (error) {
+      if (initialBestHeader.isFinalized) {
+        throw error;
+      }
+
+      const latestBestHeader = this.bestBlockHeader;
+      if (latestBestHeader.blockHash !== initialBestHeader.blockHash) {
+        console.warn('[BlockWatch]: Failed to decorate best block, retrying with newer best block', {
+          bestBlockNumber: initialBestHeader.blockNumber,
+          latestBestBlockNumber: latestBestHeader.blockNumber,
+          error: String(error),
+        });
+        try {
+          return await this.getApi(latestBestHeader);
+        } catch (nextError) {
+          error = nextError;
+        }
+      }
+
+      const archiveClient = await this.clients.archiveClientPromise;
+      const archiveBestHeader = BlockWatch.readHeader(
+        await this.runQueryWithTimeout('getCurrentApi.archiveBestHeader', archiveClient.rpc.chain.getHeader()),
+      );
+      if (archiveBestHeader.blockHash === latestBestHeader.blockHash) {
+        throw error;
+      }
+
+      console.warn('[BlockWatch]: Failed to decorate watched best block, retrying with archive best block', {
+        bestBlockNumber: latestBestHeader.blockNumber,
+        archiveBestBlockNumber: archiveBestHeader.blockNumber,
+        error: String(error),
+      });
+
+      return await this.getApi(archiveBestHeader);
+    }
   }
 
   public async getApi(block: Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>): Promise<ApiDecoration<'promise'>> {

--- a/core/src/Currency.ts
+++ b/core/src/Currency.ts
@@ -114,16 +114,18 @@ export class Currency {
 
   public isLoaded: boolean;
   public isLoadedPromise: Promise<void>;
-  private isLoadedDeferred: IDeferred<void>;
+  protected isLoadedDeferred: IDeferred<void>;
   private offchainRatesTimeout?: number;
   private priceIndexSubscription?: () => void;
   private priceIndexSubscriptionPromise?: Promise<void>;
   private lastPriceIndexStorageValue?: string;
+  private initialLoadPromise?: Promise<void>;
 
   constructor(public clients: MainchainClients) {
     this.isLoaded = false;
-    this.isLoadedDeferred = createDeferred<void>();
+    this.isLoadedDeferred = createDeferred<void>(false);
     this.isLoadedPromise = this.isLoadedDeferred.promise;
+    void this.isLoadedPromise.catch(() => undefined);
     this.clients.events.on('on-pruned-client', client => {
       if (!this.priceIndexSubscription && !this.priceIndexSubscriptionPromise) return;
       void this.replacePriceIndexSubscription(client).catch(e =>
@@ -133,23 +135,50 @@ export class Currency {
   }
 
   public async load(skipCache = false): Promise<void> {
-    const loadStartedAt = Date.now();
-    let stage = 'fetchMainchainRates';
-    try {
-      await this.fetchMainchainRates(undefined, skipCache);
-
-      if (!this.isLoaded) {
-        this.isLoaded = true;
-        this.isLoadedDeferred.resolve();
+    const isInitialLoad = !this.isLoaded;
+    if (isInitialLoad) {
+      if (this.initialLoadPromise) return await this.initialLoadPromise;
+      if (this.isLoadedDeferred.isRejected) {
+        this.isLoadedDeferred = createDeferred<void>(false);
+        this.isLoadedPromise = this.isLoadedDeferred.promise;
+        void this.isLoadedPromise.catch(() => undefined);
       }
-      stage = 'subscribeToPriceIndex';
-      await this.subscribeToPriceIndex();
-    } catch (error) {
-      console.error(`[Currency] Load failed at ${stage} after ${Date.now() - loadStartedAt}ms`, error);
-      throw error;
-    } finally {
-      this.scheduleOffchainRatesRefresh();
     }
+
+    const loadPromise = (async () => {
+      const loadStartedAt = Date.now();
+      let stage = 'fetchMainchainRates';
+      try {
+        await this.fetchMainchainRates(undefined, skipCache);
+
+        if (!this.isLoaded) {
+          this.isLoaded = true;
+          this.isLoadedDeferred.resolve();
+        }
+        stage = 'subscribeToPriceIndex';
+        await this.subscribeToPriceIndex();
+      } catch (error) {
+        console.error(`[Currency] Load failed at ${stage} after ${Date.now() - loadStartedAt}ms`, error);
+        if (isInitialLoad && !this.isLoaded) {
+          this.isLoadedDeferred.reject(error as Error);
+        }
+        throw error;
+      } finally {
+        this.scheduleOffchainRatesRefresh();
+      }
+    })();
+
+    if (isInitialLoad) {
+      const trackedLoadPromise = loadPromise.finally(() => {
+        if (this.initialLoadPromise === trackedLoadPromise) {
+          this.initialLoadPromise = undefined;
+        }
+      });
+      this.initialLoadPromise = trackedLoadPromise;
+      return await trackedLoadPromise;
+    }
+
+    await loadPromise;
   }
 
   public adjustByTargetOffset(value: bigint): bigint;

--- a/core/src/MiningFrames.ts
+++ b/core/src/MiningFrames.ts
@@ -45,7 +45,7 @@ export class MiningFrames {
       .sort((a, b) => a - b);
   }
 
-  private readonly loadDeferred = createDeferred(false);
+  private loadDeferred = createDeferred<void>(false);
   private readonly ownsBlockWatch: boolean;
   private readonly unsubscribes: (() => void)[] = [];
   private readonly updateQueue = new SingleFileQueue();
@@ -80,10 +80,17 @@ export class MiningFrames {
   }
 
   public async load(): Promise<void> {
+    if (this.loadDeferred.isRejected) {
+      this.loadDeferred = createDeferred<void>(false);
+    }
     if (this.loadDeferred.isResolved || this.loadDeferred.isRunning) return this.loadDeferred.promise;
     this.loadDeferred.setIsRunning(true);
+
+    let startedLoadTimer = false;
+    let realtimeWatch: (() => void) | undefined;
     try {
       console.time('[Mining Frames] loaded');
+      startedLoadTimer = true;
 
       if (this.updatesWriter) {
         const savedFrameHistory = await this.updatesWriter
@@ -125,13 +132,19 @@ export class MiningFrames {
           firstBlockSpecVersion: spec.specVersion.toNumber(),
         });
       }
-      const realtimeWatch = this.blockWatch.events.on('best-blocks', headers => void this.onBestBlocks(headers));
       await this.blockWatch.start();
+      realtimeWatch = this.blockWatch.events.on('best-blocks', headers => void this.onBestBlocks(headers));
       await this.onBestBlocks(this.blockWatch.latestHeaders);
       this.unsubscribes.push(realtimeWatch);
+      realtimeWatch = undefined;
       this.loadDeferred.resolve();
       console.timeEnd('[Mining Frames] loaded');
+      startedLoadTimer = false;
     } catch (error) {
+      if (startedLoadTimer) {
+        console.timeEnd('[Mining Frames] loaded');
+      }
+      realtimeWatch?.();
       this.loadDeferred.reject(error);
     }
     return this.loadDeferred.promise;

--- a/core/src/Vaults.ts
+++ b/core/src/Vaults.ts
@@ -35,9 +35,11 @@ export class Vaults {
   protected isSavingStats: boolean = false;
 
   public async load(reload = false): Promise<void> {
-    if (this.waitForLoad && !reload) return this.waitForLoad.promise;
+    if (this.waitForLoad?.isRunning) return this.waitForLoad.promise;
+    if (!reload && this.waitForLoad?.isResolved) return this.waitForLoad.promise;
 
-    this.waitForLoad ??= createDeferred();
+    this.waitForLoad =
+      reload || this.waitForLoad?.isRejected ? createDeferred() : (this.waitForLoad ??= createDeferred());
     try {
       const client = await this.mainchainClients.get(false);
       await this.miningFrames.load();

--- a/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
+++ b/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
@@ -101,10 +101,6 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
         clear: true,
         timeoutMs: 3_000,
       });
-      await flow.click(
-        { selector: '[data-testid="LockStart.bitcoinAmount"] [data-testid="input-number"]' },
-        { timeoutMs: 3_000 },
-      );
       await sleep(500);
     } else if (input.minimumLockSatoshis != null) {
       await flow.type(
@@ -114,10 +110,6 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
           clear: true,
           timeoutMs: 3_000,
         },
-      );
-      await flow.click(
-        { selector: '[data-testid="LockStart.argonAmount"] [data-testid="input-number"]' },
-        { timeoutMs: 3_000 },
       );
       await sleep(500);
     }

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -9,6 +9,8 @@ import type { WalletKeys } from '../lib/WalletKeys.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import { ExtrinsicType, TransactionStatus } from '../lib/db/TransactionsTable.ts';
+import { BitcoinLock } from '@argonprotocol/mainchain';
+import * as mainchainStore from '../stores/mainchain.ts';
 
 function createStore(options: { txInfos?: TransactionInfo[] } = {}) {
   const blockWatch = Object.assign(Object.create(null), {
@@ -116,6 +118,77 @@ function createTxInfo(status: TransactionStatus, metadataJson: Record<string, un
 }
 
 describe('BitcoinLocks getActiveLocks', () => {
+  it('retries load without duplicating pending locks or block subscriptions', async () => {
+    const firstSubscription = vi.fn();
+    const secondSubscription = vi.fn();
+    const start = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined);
+    const onBestBlocks = vi.fn().mockReturnValueOnce(firstSubscription).mockReturnValueOnce(secondSubscription);
+    const blockWatch = {
+      start,
+      bestBlockHeader: { blockNumber: 1, blockHash: '0x1' },
+      events: {
+        on: onBestBlocks,
+      },
+    } as unknown as BlockWatch;
+    const store = new BitcoinLocks(
+      Promise.resolve(Object.create(null) as Db),
+      Object.create(null) as WalletKeys,
+      blockWatch,
+      {
+        load: async () => undefined,
+        priceIndex: {},
+      } as CurrencyBase,
+      {
+        load: vi.fn(async () => undefined),
+        pendingBlockTxInfosAtLoad: [],
+        data: { txInfos: [], txInfosByType: {} },
+      } as unknown as TransactionTracker,
+    );
+    const pendingLock = createLock({
+      uuid: 'pending-load',
+      status: BitcoinLockStatus.LockIsProcessingOnArgon,
+      createdAt: '2026-01-05T00:00:00Z',
+    });
+    const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue({
+      consts: {
+        bitcoinLocks: {
+          argonTicksPerDay: {
+            toNumber: () => 1440,
+          },
+        },
+      },
+    } as any);
+    vi.spyOn(BitcoinLock, 'getConfig').mockResolvedValue({
+      bitcoinNetwork: {
+        isBitcoin: false,
+        isTestnet: true,
+      },
+      tickDurationMillis: 60_000,
+      pendingConfirmationExpirationBlocks: 6,
+    } as any);
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      fetchAll: vi.fn(async () => [pendingLock]),
+    } as any);
+    vi.spyOn(store.utxoTracking, 'load').mockResolvedValue(undefined);
+    vi.spyOn(store as any, 'syncFailedBitcoinRequestLocksFromTransactions').mockResolvedValue(undefined);
+    vi.spyOn(store as any, 'migrateLegacyBitcoinLockHdKeys').mockResolvedValue(undefined);
+    vi.spyOn(store as any, 'checkIncomingArgonBlock').mockResolvedValue(undefined);
+    vi.spyOn(store as any, 'runPendingLoadReconciliation').mockResolvedValue(undefined);
+
+    await expect(store.load()).rejects.toThrow('offline');
+    await expect(store.load()).resolves.toBeUndefined();
+    await expect(store.load(true)).resolves.toBeUndefined();
+
+    expect(store.data.pendingLocks).toHaveLength(1);
+    expect(store.data.pendingLocks[0].uuid).toBe('pending-load');
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(onBestBlocks).toHaveBeenCalledTimes(2);
+    expect(firstSubscription).toHaveBeenCalledOnce();
+    expect(secondSubscription).not.toHaveBeenCalled();
+
+    getMainchainClient.mockRestore();
+  });
+
   it('keeps resumable and unacknowledged expired locks active while excluding released locks', () => {
     const store = createStore();
 

--- a/src-vue/__test__/Currency.test.ts
+++ b/src-vue/__test__/Currency.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Currency, UnitOfMeasurement } from '../lib/Currency.ts';
+
+describe('Currency', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retries the initial load after a config bootstrap failure', async () => {
+    let shouldFailConfig = true;
+    const current = createCurrentPriceIndexQuery();
+    const currency = new Currency(
+      {
+        prunedClientOrArchivePromise: Promise.resolve({
+          query: {
+            priceIndex: { current },
+          },
+        }),
+        events: { on: vi.fn() },
+      } as any,
+      {
+        get isLoadedPromise() {
+          return shouldFailConfig ? Promise.reject(new Error('config failed')) : Promise.resolve();
+        },
+        defaultCurrencyKey: UnitOfMeasurement.USD,
+      } as any,
+    );
+
+    const firstLoadedPromise = currency.isLoadedPromise;
+    await expect(currency.load()).rejects.toThrow('config failed');
+    await expect(firstLoadedPromise).rejects.toThrow('config failed');
+
+    shouldFailConfig = false;
+
+    await expect(currency.load()).resolves.toBeUndefined();
+    await expect(currency.isLoadedPromise).resolves.toBeUndefined();
+
+    expect(currency.key).toBe(UnitOfMeasurement.USD);
+    expect(current).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares the in-flight initial load', async () => {
+    let resolveConfig!: () => void;
+    const configReady = new Promise<void>(resolve => {
+      resolveConfig = resolve;
+    });
+    const current = createCurrentPriceIndexQuery();
+    const currency = new Currency(
+      {
+        prunedClientOrArchivePromise: Promise.resolve({
+          query: {
+            priceIndex: { current },
+          },
+        }),
+        events: { on: vi.fn() },
+      } as any,
+      {
+        isLoadedPromise: configReady,
+        defaultCurrencyKey: UnitOfMeasurement.USD,
+      } as any,
+    );
+
+    const firstLoad = currency.load();
+    const secondLoad = currency.load();
+    let didSecondLoadResolve = false;
+    void secondLoad.then(() => {
+      didSecondLoadResolve = true;
+    });
+
+    await Promise.resolve();
+    expect(didSecondLoadResolve).toBe(false);
+
+    resolveConfig();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(current).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createCurrentPriceIndexQuery() {
+  const option = {
+    isSome: false,
+    toHex: () => '0x00',
+    unwrap: () => {
+      throw new Error('should not unwrap an empty price index');
+    },
+  };
+
+  return vi.fn((callback?: (value: typeof option) => void) => {
+    if (callback) {
+      callback(option);
+      return Promise.resolve(() => undefined);
+    }
+    return Promise.resolve(option);
+  });
+}

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -796,6 +796,100 @@ describe('MyVault cosign recovery', () => {
 
     expect(latestTxAttempt).toMatchObject({ txInfo, txAttemptState: TxAttemptState.Replace });
   });
+
+  it('renders ready before load resolves, but still waits for council and authority state', async () => {
+    let resolveBitcoinLocksLoad!: () => void;
+    let resolveGlobalCouncilLoad!: () => void;
+    let resolveMintingAuthoritiesLoad!: () => void;
+
+    const bitcoinLocksLoad = new Promise<void>(resolve => {
+      resolveBitcoinLocksLoad = resolve;
+    });
+    const globalCouncilLoad = new Promise<void>(resolve => {
+      resolveGlobalCouncilLoad = resolve;
+    });
+    const mintingAuthoritiesLoad = new Promise<void>(resolve => {
+      resolveMintingAuthoritiesLoad = resolve;
+    });
+    const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue({
+      consts: {
+        vaults: {
+          revenueCollectionExpirationFrames: {
+            toNumber: () => 10,
+          },
+        },
+      },
+    } as any);
+    const myVault = new MyVault(
+      Promise.resolve({
+        vaultsTable: {
+          get: vi.fn(async () => ({ id: 7, createdAtBlockHeight: 10 })),
+        },
+        transactionsTable: {
+          fetchStatusHistory: vi.fn(async () => []),
+        },
+      } as any),
+      {
+        load: vi.fn(async () => undefined),
+        updateRevenue: vi.fn(async () => undefined),
+        vaultsById: { 7: { vaultId: 7 } },
+        stats: {
+          synchedToFrame: 1,
+          vaultsById: { 7: { vaultId: 7 } },
+        },
+      } as any,
+      createMockWalletKeys(),
+      {
+        load: vi.fn(async () => undefined),
+        pendingBlockTxInfosAtLoad: [],
+        data: { txInfosByType: {} },
+      } as any,
+      {
+        load: vi.fn(() => bitcoinLocksLoad),
+      } as any,
+      {
+        load: vi.fn(async () => undefined),
+        currentFrameId: 2,
+      } as any,
+      {
+        load: vi.fn(() => globalCouncilLoad),
+        data: { pendingApprovals: [] },
+      } as any,
+      {
+        load: vi.fn(() => mintingAuthoritiesLoad),
+        data: {
+          authorities: [],
+          pendingMintingAuthorizations: [],
+          pendingMintingAuthorizeTxInfosByTransferId: new Map(),
+        },
+      } as any,
+    );
+
+    vi.spyOn(myVault as any, 'refreshExternalLocks').mockResolvedValue(undefined);
+
+    const loadPromise = myVault.load();
+    let isResolved = false;
+    void loadPromise.then(() => {
+      isResolved = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(myVault.data.isReady).toBe(true);
+    });
+    expect(isResolved).toBe(false);
+
+    resolveBitcoinLocksLoad();
+    await Promise.resolve();
+    expect(isResolved).toBe(false);
+
+    resolveGlobalCouncilLoad();
+    resolveMintingAuthoritiesLoad();
+    await loadPromise;
+
+    expect(isResolved).toBe(true);
+
+    getMainchainClient.mockRestore();
+  });
 });
 
 function createVault(args?: {

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -985,7 +985,14 @@ function createVault(args?: {
     mintingAuthorities as any,
   );
 
-  return { myVault, blockWatch, submitAndWatch, transactionTracker, trackTxResult, globalCouncil, mintingAuthorities };
+  return {
+    myVault,
+    blockWatch,
+    globalCouncil,
+    mintingAuthorities,
+    submitAndWatch,
+    trackTxResult,
+  };
 }
 
 function createMockTxResultTx() {

--- a/src-vue/__test__/Stats.test.ts
+++ b/src-vue/__test__/Stats.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Stats } from '../lib/Stats.ts';
+import { botEmitter } from '../lib/Bot.ts';
+
+describe('Stats', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('waits on the active load instead of resolving early', async () => {
+    let resolveCurrencyLoad!: () => void;
+    const currencyLoad = new Promise<void>(resolve => {
+      resolveCurrencyLoad = resolve;
+    });
+    const { stats, currency } = createStats({
+      currency: {
+        load: vi.fn().mockReturnValue(currencyLoad),
+      },
+    });
+
+    const firstLoad = stats.load();
+    const secondLoad = stats.load();
+    let didSecondLoadResolve = false;
+    void secondLoad.then(() => {
+      didSecondLoadResolve = true;
+    });
+
+    await Promise.resolve();
+    expect(didSecondLoadResolve).toBe(false);
+
+    resolveCurrencyLoad();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(currency.load).toHaveBeenCalledOnce();
+  });
+
+  it('retries a failed bootstrap without duplicating bot subscriptions', async () => {
+    const onSpy = vi.spyOn(botEmitter, 'on');
+    const { stats } = createStats();
+    vi.spyOn(stats as any, 'updateMiningSeats')
+      .mockRejectedValueOnce(new Error('bootstrap failed'))
+      .mockResolvedValue(undefined);
+
+    const firstLoadedPromise = stats.isLoadedPromise;
+    await expect(stats.load()).rejects.toThrow('bootstrap failed');
+    await expect(firstLoadedPromise).rejects.toThrow('bootstrap failed');
+    expect(onSpy).not.toHaveBeenCalled();
+
+    await expect(stats.load()).resolves.toBeUndefined();
+    await expect(stats.isLoadedPromise).resolves.toBeUndefined();
+
+    expect(onSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+function createStats(
+  args: {
+    config?: Record<string, any>;
+    currency?: Record<string, any>;
+    miningFrames?: Record<string, any>;
+  } = {},
+) {
+  const stats = new Stats(
+    Promise.resolve({} as any),
+    {
+      isLoadedPromise: Promise.resolve(),
+      ...args.config,
+    } as any,
+    {
+      load: vi.fn().mockResolvedValue(undefined),
+      ...args.currency,
+    } as any,
+    {
+      currentFrameId: 12,
+      load: vi.fn().mockResolvedValue(undefined),
+      ...args.miningFrames,
+    } as any,
+  );
+
+  vi.spyOn(stats as any, 'updateDashboard').mockResolvedValue(undefined);
+  vi.spyOn(stats as any, 'updateMiningSeats').mockResolvedValue(undefined);
+  vi.spyOn(stats as any, 'updateMiningBids').mockResolvedValue(undefined);
+  vi.spyOn(stats as any, 'updateAccruedProfits').mockResolvedValue(undefined);
+  vi.spyOn(stats as any, 'updateServerState').mockResolvedValue(undefined);
+
+  return {
+    stats,
+    currency: (stats as any).currency,
+  };
+}

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -19,6 +19,55 @@ describe('TransactionTracker', () => {
     vi.clearAllMocks();
   });
 
+  it('retries a failed load and clears stale tx type entries on reload', async () => {
+    let resolveReload!: (value: ITransactionRecord[]) => void;
+    const reloadRows = new Promise<ITransactionRecord[]>(resolve => {
+      resolveReload = resolve;
+    });
+    const initialTx = createTransaction({
+      id: 20,
+      extrinsicType: ExtrinsicType.VaultCollect,
+      status: TransactionStatus.Finalized,
+      isFinalized: true,
+    });
+    const reloadedTx = createTransaction({
+      id: 21,
+      extrinsicType: ExtrinsicType.Transfer,
+      status: TransactionStatus.Finalized,
+      isFinalized: true,
+    });
+    const { tracker, table, blockWatch } = createLoadTracker({
+      txsByLoad: [[], [initialTx], reloadRows],
+      blockWatch: {
+        start: vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined),
+      },
+    });
+
+    await expect(tracker.load()).rejects.toThrow('offline');
+    await tracker.load();
+
+    expect(blockWatch.start).toHaveBeenCalledTimes(2);
+    expect(tracker.data.txInfosByType[ExtrinsicType.VaultCollect]?.tx.id).toBe(initialTx.id);
+
+    const reloadPromise = tracker.load(true);
+    let didReloadResolve = false;
+    void reloadPromise.then(() => {
+      didReloadResolve = true;
+    });
+    await Promise.resolve();
+
+    expect(table.fetchAll).toHaveBeenCalledTimes(3);
+    expect(didReloadResolve).toBe(false);
+
+    resolveReload([reloadedTx]);
+    await reloadPromise;
+
+    expect(tracker.data.txInfos).toHaveLength(1);
+    expect(tracker.data.txInfos[0].tx.id).toBe(reloadedTx.id);
+    expect(tracker.data.txInfosByType[ExtrinsicType.Transfer]?.tx.id).toBe(reloadedTx.id);
+    expect(tracker.data.txInfosByType[ExtrinsicType.VaultCollect]).toBeUndefined();
+  });
+
   it('does not resume dropped attempts at load, but keeps tracking them on-chain', async () => {
     const tx = createTransaction({
       id: 1,
@@ -535,6 +584,42 @@ async function createTracker(args: {
   );
   vi.spyOn(tracker as any, 'watchForUpdates').mockResolvedValue(undefined);
   await tracker.load();
+
+  return { tracker, table, blockWatch };
+}
+
+function createLoadTracker(args: {
+  txsByLoad: Array<ITransactionRecord[] | Promise<ITransactionRecord[]>>;
+  blockWatch?: Record<string, any>;
+}) {
+  const txLoads = [...args.txsByLoad];
+  const table = {
+    fetchAll: vi.fn().mockImplementation(async () => await txLoads.shift()),
+  };
+  const historyTable = {
+    fetchLatestByTransactionIds: vi.fn().mockResolvedValue(new Map()),
+  };
+  const blockWatch = {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+    isLoaded: { isRejected: false },
+    bestBlockHeader: { blockNumber: 100 },
+    finalizedBlockHeader: {
+      blockNumber: 100,
+      blockTime: new Date('2026-03-20T20:05:00Z').getTime(),
+      blockHash: '0x64',
+    },
+    getFinalizedHash: vi.fn(async () => '0xfinalized-block'),
+    events: { on: vi.fn() },
+    ...args.blockWatch,
+  };
+  const tracker = new TransactionTracker(
+    Promise.resolve({
+      transactionsTable: table,
+      transactionStatusHistoryTable: historyTable,
+    } as any),
+    blockWatch as any,
+  );
 
   return { tracker, table, blockWatch };
 }

--- a/src-vue/__test__/TxResultPatch.test.ts
+++ b/src-vue/__test__/TxResultPatch.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TxResult, u8aEq } from '@argonprotocol/mainchain';
+
+describe('TxResult patch', () => {
+  it('waits to publish in-block until it has a real block number', async () => {
+    const inBlockHash = Uint8Array.from([1, 2, 3]);
+    const finalizedHash = Uint8Array.from([4, 5, 6]);
+    const getHeader = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Unable to retrieve header and parent from supplied hash'))
+      .mockResolvedValue({
+        number: {
+          toNumber: () => 145,
+        },
+      });
+    const txResult = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    });
+
+    let inBlockHashResult: Uint8Array | undefined;
+    void txResult.waitForInFirstBlock.then(hash => {
+      inBlockHashResult = hash;
+    });
+
+    txResult.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: false,
+        isInBlock: true,
+        asInBlock: inBlockHash,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    expect(getHeader).toHaveBeenCalledTimes(1);
+    expect(inBlockHashResult).toBeUndefined();
+    expect(txResult.blockHash).toBeUndefined();
+    expect(txResult.blockNumber).toBeUndefined();
+
+    txResult.onSubscriptionResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: true,
+        asFinalized: finalizedHash,
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await expect(txResult.waitForInFirstBlock).resolves.toEqual(finalizedHash);
+    await expect(txResult.waitForFinalizedBlock).resolves.toEqual(finalizedHash);
+
+    expect(txResult.blockNumber).toBe(145);
+    expect(txResult.extrinsicIndex).toBe(4);
+    expect(txResult.blockHash).toEqual(finalizedHash);
+  });
+
+  it('publishes in-block immediately when given a real block number', async () => {
+    const txResult = createTxResult();
+    const blockHash = Uint8Array.from([7, 8, 9]);
+
+    await txResult.setSeenInBlock({
+      blockHash,
+      blockNumber: 201,
+      extrinsicIndex: 5,
+      events: [],
+    });
+
+    await expect(txResult.waitForInFirstBlock).resolves.toEqual(blockHash);
+    expect(txResult.blockNumber).toBe(201);
+    expect(txResult.extrinsicIndex).toBe(5);
+  });
+
+  it('ignores a stale in-block lookup after finalized wins', async () => {
+    const inBlockHash = Uint8Array.from([1, 2, 3]);
+    const finalizedHash = Uint8Array.from([4, 5, 6]);
+    let resolveInBlockHeader!: (value: unknown) => void;
+    let resolveFinalizedHeader!: (value: unknown) => void;
+    const getHeader = vi.fn().mockImplementation((hash: Uint8Array) => {
+      if (u8aEq(hash, inBlockHash)) {
+        return new Promise(resolve => {
+          resolveInBlockHeader = resolve;
+        });
+      }
+
+      if (u8aEq(hash, finalizedHash)) {
+        return new Promise(resolve => {
+          resolveFinalizedHeader = resolve;
+        });
+      }
+
+      throw new Error('Unexpected hash');
+    });
+    const txResult = createTxResult({
+      rpc: {
+        chain: {
+          getHeader,
+        },
+      },
+    });
+
+    txResult.onSubscriptionResult({
+      events: [],
+      isFinalized: false,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: false,
+        isInBlock: true,
+        asInBlock: inBlockHash,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    txResult.onSubscriptionResult({
+      events: [],
+      isFinalized: true,
+      status: {
+        isBroadcast: false,
+        isDropped: false,
+        isFinalized: true,
+        asFinalized: finalizedHash,
+        isInBlock: false,
+        isInvalid: false,
+        isUsurped: false,
+      },
+      txIndex: 4,
+    } as any);
+
+    await Promise.resolve();
+
+    resolveFinalizedHeader({
+      number: {
+        toNumber: () => 145,
+      },
+    });
+
+    await expect(txResult.waitForInFirstBlock).resolves.toEqual(finalizedHash);
+    await expect(txResult.waitForFinalizedBlock).resolves.toEqual(finalizedHash);
+    expect(txResult.blockHash).toEqual(finalizedHash);
+    expect(txResult.blockNumber).toBe(145);
+
+    resolveInBlockHeader({
+      number: {
+        toNumber: () => 144,
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(txResult.blockHash).toEqual(finalizedHash);
+    expect(txResult.blockNumber).toBe(145);
+  });
+});
+
+function createTxResult(client: Record<string, unknown> = {}): TxResult {
+  return new TxResult(
+    {
+      events: {
+        system: { ExtrinsicFailed: { is: vi.fn().mockReturnValue(false) } },
+        utility: { BatchInterrupted: { is: vi.fn().mockReturnValue(false) } },
+        transactionPayment: { TransactionFeePaid: { is: vi.fn().mockReturnValue(false) } },
+      },
+      ...client,
+    } as any,
+    {
+      signedHash: '0xtx',
+      method: {},
+      accountAddress: '5Submitter',
+      submittedTime: new Date('2026-07-05T00:00:00.000Z'),
+      submittedAtBlockNumber: 123,
+      nonce: 7,
+    },
+  );
+}

--- a/src-vue/__test__/helpers/bitcoinLocksHarness.ts
+++ b/src-vue/__test__/helpers/bitcoinLocksHarness.ts
@@ -181,6 +181,7 @@ export async function createBitcoinLocksHarness(args: {
 
 export async function cleanupBitcoinLocksClientHarness(harness: BitcoinLocksClientHarness): Promise<void> {
   await harness.bitcoinLocks.shutdown();
+  harness.transactionTracker.shutdown();
   harness.miningFrames.blockWatch.stop();
   await harness.db.close();
   await harness.clients.disconnect();

--- a/src-vue/app-operations/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/app-operations/overlays/bitcoin-locking/LockStart.vue
@@ -244,12 +244,13 @@ const showFeePanel = Vue.computed(() => {
   return !isVaultOperator.value && !isOperatorCouponLock.value && securityFee.value > 0n;
 });
 
-const handleBtcChange = useDebounceFn(internalHandleBtcChange, 100, { maxWait: 200 });
-const handleArgonChange = useDebounceFn(internalHandleArgonChange, 100, { maxWait: 200 });
+const debouncedHandleBtcChange = useDebounceFn(internalHandleBtcChange, 100, { maxWait: 200 });
+const debouncedHandleArgonChange = useDebounceFn(internalHandleArgonChange, 100, { maxWait: 200 });
 
 let lastSetLiquidityMicrogons = 0n;
 let lastSetBitcoinAmount = 0;
 let availableLiquiditySyncId = 0;
+let pendingAmountSync: Promise<unknown> | undefined;
 
 function updateFeeEstimate() {
   if (!props.vault || liquidityToReceive.value <= 0n || isVaultOperator.value || isOperatorCouponLock.value) {
@@ -274,7 +275,6 @@ async function internalHandleArgonChange(liquidityMicrogons: bigint) {
   if (liquidityMicrogons === lastSetLiquidityMicrogons) {
     return;
   }
-  hasEditedAmounts.value = true;
   const sats = await bitcoinLocks.satoshisForArgonLiquidity(liquidityMicrogons);
   lockSatoshis.value = sats;
   const btc = currency.convertSatToBtc(sats);
@@ -289,7 +289,6 @@ async function internalHandleBtcChange(value: number) {
   if (value === lastSetBitcoinAmount) {
     return;
   }
-  hasEditedAmounts.value = true;
   const satoshis = BigInt(Math.round(value * Number(SATS_PER_BTC)));
   lockSatoshis.value = satoshis;
   liquidityToReceive.value = BitcoinLock.calculateRedemptionAmountFromSatoshis(currency.priceIndex, satoshis);
@@ -298,12 +297,34 @@ async function internalHandleBtcChange(value: number) {
   updateFeeEstimate();
 }
 
+function handleArgonChange(liquidityMicrogons: bigint) {
+  hasEditedAmounts.value = true;
+  const sync = debouncedHandleArgonChange(liquidityMicrogons).finally(() => {
+    if (pendingAmountSync === sync) {
+      pendingAmountSync = undefined;
+    }
+  });
+  pendingAmountSync = sync;
+}
+
+function handleBtcChange(value: number) {
+  hasEditedAmounts.value = true;
+  const sync = debouncedHandleBtcChange(value).finally(() => {
+    if (pendingAmountSync === sync) {
+      pendingAmountSync = undefined;
+    }
+  });
+  pendingAmountSync = sync;
+}
+
 async function submitLiquidLock() {
   if (isSaving.value) return;
 
-  let satoshis = lockSatoshis.value;
   try {
     await config.isLoadedPromise;
+    await pendingAmountSync;
+
+    let satoshis = lockSatoshis.value;
     isSaving.value = true;
     errorMessage.value = null;
     if (satoshis <= 0n && liquidityToReceive.value > 0n) {

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -323,8 +323,14 @@ export default class BitcoinLocks {
   }
 
   public async load(force = false): Promise<void> {
-    if (this.#waitForLoad && !force) return this.#waitForLoad.promise;
-    this.#waitForLoad = createDeferred<void>();
+    if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
+    if (!force && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
+
+    if (force || this.#waitForLoad?.isRejected) {
+      this.#waitForLoad = createDeferred<void>();
+    } else {
+      this.#waitForLoad ??= createDeferred<void>();
+    }
     try {
       const archiveClient = await getMainchainClient(true);
       this.#config ??= await BitcoinLock.getConfig(archiveClient);
@@ -337,7 +343,12 @@ export default class BitcoinLocks {
         if (lock.utxoId) {
           this.locksByUtxoId[lock.utxoId] = lock;
         } else {
-          this.data.pendingLocks.push(lock);
+          const existingIndex = this.data.pendingLocks.findIndex(x => x.uuid === lock.uuid);
+          if (existingIndex >= 0) {
+            this.data.pendingLocks.splice(existingIndex, 1, lock);
+          } else {
+            this.data.pendingLocks.push(lock);
+          }
         }
       }
       await this.utxoTracking.load();
@@ -411,6 +422,7 @@ export default class BitcoinLocks {
             },
           );
         });
+      this.#subscription?.();
       this.#subscription = this.blockWatch.events.on('best-blocks', async headers => {
         void this.#blockQueue.add(async () => {
           await this.checkIncomingArgonBlock(headers.at(-1)!);

--- a/src-vue/lib/Currency.ts
+++ b/src-vue/lib/Currency.ts
@@ -6,6 +6,7 @@ import {
   UnitOfMeasurement,
   MainchainClients,
   bigNumberToBigInt,
+  createDeferred,
   type ICurrencyRecord,
   type ICurrencyKey,
 } from '@argonprotocol/apps-core';
@@ -27,6 +28,7 @@ export class Currency extends CurrencyBase {
   public symbol!: string;
   public record!: ICurrencyRecord;
   private config: Config;
+  private loadPromise?: Promise<void>;
 
   constructor(clients: MainchainClients, config: Config) {
     super(clients);
@@ -39,10 +41,41 @@ export class Currency extends CurrencyBase {
     return this._key;
   }
 
-  public async load() {
-    await this.config.isLoadedPromise;
-    this.setKey(this.config.defaultCurrencyKey, false);
-    await super.load();
+  public async load(skipCache = false) {
+    const isInitialLoad = !this.isLoaded;
+    if (isInitialLoad) {
+      if (this.loadPromise) return await this.loadPromise;
+      if (this.isLoadedDeferred.isRejected) {
+        this.isLoadedDeferred = createDeferred<void>(false);
+        this.isLoadedPromise = this.isLoadedDeferred.promise;
+        void this.isLoadedPromise.catch(() => undefined);
+      }
+    }
+
+    const loadPromise = (async () => {
+      try {
+        await this.config.isLoadedPromise;
+        this.setKey(this.config.defaultCurrencyKey, false);
+        await super.load(skipCache);
+      } catch (error) {
+        if (isInitialLoad && !this.isLoaded) {
+          this.isLoadedDeferred.reject(error as Error);
+        }
+        throw error;
+      }
+    })();
+
+    if (isInitialLoad) {
+      const trackedLoadPromise = loadPromise.finally(() => {
+        if (this.loadPromise === trackedLoadPromise) {
+          this.loadPromise = undefined;
+        }
+      });
+      this.loadPromise = trackedLoadPromise;
+      return await trackedLoadPromise;
+    }
+
+    await loadPromise;
   }
 
   public setKey(key: ICurrencyKey, saveToConfig: boolean = true) {

--- a/src-vue/lib/GlobalCouncil.ts
+++ b/src-vue/lib/GlobalCouncil.ts
@@ -49,15 +49,21 @@ export class GlobalCouncil {
   }
 
   public async load(reload = false): Promise<void> {
-    if (this.#waitForLoad && !reload) return this.#waitForLoad.promise;
+    if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
+    if (!reload && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
 
-    this.#waitForLoad = createDeferred();
+    if (reload || this.#waitForLoad?.isRejected) {
+      this.#waitForLoad = createDeferred();
+    } else {
+      this.#waitForLoad ??= createDeferred();
+    }
     try {
       await this.miningFrames.blockWatch.start();
       await this.refresh(await this.miningFrames.blockWatch.getFinalizedApi());
       this.data.isReady = true;
       this.#waitForLoad.resolve();
     } catch (error) {
+      console.error('[GlobalCouncil] Error loading council approvals', error);
       this.#waitForLoad.reject(error as Error);
     }
     return this.#waitForLoad.promise;

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -28,7 +28,7 @@ export default class Importer {
   }
 
   public async importFromMnemonic(mnemonic: string) {
-    if (NETWORK_NAME !== 'dev-docker') {
+    if (NETWORK_NAME === 'mainnet') {
       const importWalletKeys = new MemoryWalletKeys({
         substrateSuri: mnemonic,
         masterMnemonic: mnemonic,

--- a/src-vue/lib/MintingAuthorities.ts
+++ b/src-vue/lib/MintingAuthorities.ts
@@ -100,9 +100,14 @@ export class MintingAuthorities {
   }
 
   public async load(reload = false): Promise<void> {
-    if (this.#waitForLoad && !reload) return this.#waitForLoad.promise;
+    if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
+    if (!reload && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
 
-    this.#waitForLoad = createDeferred();
+    if (reload || this.#waitForLoad?.isRejected) {
+      this.#waitForLoad = createDeferred();
+    } else {
+      this.#waitForLoad ??= createDeferred();
+    }
     try {
       this.recoveredAuthorityCountOnLoad = 0;
       await this.miningFrames.blockWatch.start();
@@ -127,6 +132,7 @@ export class MintingAuthorities {
       this.data.isReady = true;
       this.#waitForLoad.resolve();
     } catch (error) {
+      console.error('[MintingAuthorities] Error loading minting authorities', error);
       this.#waitForLoad.reject(error as Error);
     }
     return this.#waitForLoad.promise;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -190,21 +190,29 @@ export class MyVault {
   }
 
   public async load(reload = false): Promise<void> {
-    if (this.#waitForLoad && !reload) return this.#waitForLoad.promise;
+    if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
+    if (!reload && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
 
-    this.#waitForLoad = createDeferred();
+    if (reload || this.#waitForLoad?.isRejected) {
+      this.#waitForLoad = createDeferred();
+    } else {
+      this.#waitForLoad ??= createDeferred();
+    }
     this.#collectFrames = [];
     try {
       console.log('Loading MyVault...');
       await this.miningFrames.load();
       await this.vaults.load(reload);
 
-      void this.vaults.updateRevenue().then(() => {
-        const vaultId = this.metadata?.id;
-        if (vaultId) {
-          this.data.stats = this.vaults.stats?.vaultsById[vaultId] ?? null;
-        }
-      });
+      const latestSyncedRevenueFrame = this.vaults.stats?.synchedToFrame ?? 0;
+      if (latestSyncedRevenueFrame < this.miningFrames.currentFrameId - 1) {
+        void this.vaults.updateRevenue().then(() => {
+          const vaultId = this.metadata?.id;
+          if (vaultId) {
+            this.data.stats = this.vaults.stats?.vaultsById[vaultId] ?? null;
+          }
+        });
+      }
       const table = await this.getTable();
       const client = await getMainchainClient(false);
       this.data.metadata = (await table.get()) ?? null;
@@ -215,8 +223,6 @@ export class MyVault {
       };
 
       await this.#transactionTracker.load();
-      await this.bitcoinLocks.load(reload);
-      await Promise.all([this.globalCouncil.load(reload), this.mintingAuthorities.load(reload)]);
 
       for (const txInfo of this.#transactionTracker.pendingBlockTxInfosAtLoad) {
         const { tx } = txInfo;
@@ -267,12 +273,25 @@ export class MyVault {
         this.data.createdVault = this.vaults.vaultsById[vaultId];
         this.data.stats = this.vaults.stats?.vaultsById[vaultId] ?? null;
 
-        await this.refreshExternalLocks();
+        void this.refreshExternalLocks().catch(error => {
+          console.warn('[MyVault] Error refreshing external locks during load', error);
+        });
       }
 
+      // Let the vault screen render once the core vault record is ready while bitcoin lock recovery finishes.
       this.data.isReady = true;
+
+      await this.bitcoinLocks.load(reload);
+      void this.globalCouncil.load(reload).catch(error => {
+        console.error('[MyVault] Error loading global council data', error);
+      });
+      void this.mintingAuthorities.load(reload).catch(error => {
+        console.error('[MyVault] Error loading minting authorities', error);
+      });
+
       this.#waitForLoad.resolve();
     } catch (error) {
+      console.error('[MyVault] Error loading vault data', error);
       this.#waitForLoad.reject(error as Error);
     }
     return this.#waitForLoad.promise;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -281,13 +281,16 @@ export class MyVault {
       // Let the vault screen render once the core vault record is ready while bitcoin lock recovery finishes.
       this.data.isReady = true;
 
-      await this.bitcoinLocks.load(reload);
-      void this.globalCouncil.load(reload).catch(error => {
+      const bitcoinLocksLoad = this.bitcoinLocks.load(reload);
+      const globalCouncilLoad = this.globalCouncil.load(reload).catch(error => {
         console.error('[MyVault] Error loading global council data', error);
       });
-      void this.mintingAuthorities.load(reload).catch(error => {
+      const mintingAuthoritiesLoad = this.mintingAuthorities.load(reload).catch(error => {
         console.error('[MyVault] Error loading minting authorities', error);
       });
+
+      await bitcoinLocksLoad;
+      await Promise.all([globalCouncilLoad, mintingAuthoritiesLoad]);
 
       this.#waitForLoad.resolve();
     } catch (error) {

--- a/src-vue/lib/Stats.ts
+++ b/src-vue/lib/Stats.ts
@@ -60,8 +60,8 @@ export class Stats {
   public isLoaded: boolean;
   public isLoadedPromise: Promise<void>;
 
-  private isLoading: boolean = false;
   private isLoadedDeferred!: IDeferred<void>;
+  private loadPromise?: Promise<void>;
 
   private db!: Db;
 
@@ -140,8 +140,9 @@ export class Stats {
     this.config = config;
     this.currency = currency;
 
-    this.isLoadedDeferred = createDeferred<void>();
+    this.isLoadedDeferred = createDeferred<void>(false);
     this.isLoadedPromise = this.isLoadedDeferred.promise;
+    void this.isLoadedPromise.catch(() => undefined);
   }
 
   public get prevFrameId(): number | null {
@@ -164,82 +165,93 @@ export class Stats {
   }
 
   public async load() {
-    if (this.isLoading || this.isLoaded) return;
-    this.isLoading = true;
-    const loadStartedAt = Date.now();
-    let stage: string | undefined;
+    if (this.isLoaded) return this.isLoadedPromise;
+    if (this.loadPromise) return await this.loadPromise;
+    if (this.isLoadedDeferred.isRejected) {
+      this.isLoadedDeferred = createDeferred<void>(false);
+      this.isLoadedPromise = this.isLoadedDeferred.promise;
+      void this.isLoadedPromise.catch(() => undefined);
+    }
 
-    try {
-      stage = 'config.isLoadedPromise';
-      await this.config.isLoadedPromise;
+    this.loadPromise = (async () => {
+      const loadStartedAt = Date.now();
+      let stage: string | undefined;
 
-      stage = 'dbPromise';
-      this.db = await this.dbPromise;
+      try {
+        stage = 'config.isLoadedPromise';
+        await this.config.isLoadedPromise;
 
-      stage = 'currency.load';
-      await this.currency.load();
+        stage = 'dbPromise';
+        this.db = await this.dbPromise;
 
-      const initialFrameId = this.latestFrameId;
-      stage = 'miningFrames.load';
-      await this.miningFrames.load();
-      this.latestFrameId = this.miningFrames.currentFrameId;
-      if (this.selectedFrameId === initialFrameId) {
-        this.selectedFrameId = this.latestFrameId;
-      }
+        stage = 'currency.load';
+        await this.currency.load();
 
-      stage = 'updateDashboard';
-      await this.updateDashboard();
+        const initialFrameId = this.latestFrameId;
+        stage = 'miningFrames.load';
+        await this.miningFrames.load();
+        this.latestFrameId = this.miningFrames.currentFrameId;
+        if (this.selectedFrameId === initialFrameId) {
+          this.selectedFrameId = this.latestFrameId;
+        }
 
-      botEmitter.on('updated-cohort-data', async frameId => {
+        stage = 'updateDashboard';
+        await this.updateDashboard();
+
+        stage = 'post-load-updates';
         await this.updateMiningSeats();
-
-        const isOnLatestFrame = this.selectedFrameId === this.latestFrameId;
-        this.latestFrameId = frameId;
-        if (isOnLatestFrame) this.selectFrameId(frameId, true);
         await this.updateMiningBids();
         await this.updateAccruedProfits();
 
-        if (this.isSubscribedToDashboard) {
-          await this.updateDashboard();
-          this.dashboardHasUpdates = false;
-        } else {
-          this.dashboardHasUpdates = true;
-        }
+        botEmitter.on('updated-cohort-data', async frameId => {
+          await this.updateMiningSeats();
 
-        // if (this.isSubscribedToActivity) {
-        await this.updateServerState();
-        this.activityHasUpdates = false;
-        // } else {
-        //   this.activityHasUpdates = true;
-        // }
-      });
+          const isOnLatestFrame = this.selectedFrameId === this.latestFrameId;
+          this.latestFrameId = frameId;
+          if (isOnLatestFrame) this.selectFrameId(frameId, true);
+          await this.updateMiningBids();
+          await this.updateAccruedProfits();
 
-      botEmitter.on('updated-bids-data', async () => {
-        void this.updateMiningBids();
-      });
+          if (this.isSubscribedToDashboard) {
+            await this.updateDashboard();
+            this.dashboardHasUpdates = false;
+          } else {
+            this.dashboardHasUpdates = true;
+          }
 
-      botEmitter.on('updated-server-state', async () => {
-        // if (this.isSubscribedToActivity) {
-        await this.updateServerState();
-        this.activityHasUpdates = false;
-        // } else {
-        //   this.activityHasUpdates = true;
-        // }
-      });
+          // if (this.isSubscribedToActivity) {
+          await this.updateServerState();
+          this.activityHasUpdates = false;
+          // } else {
+          //   this.activityHasUpdates = true;
+          // }
+        });
 
-      stage = 'post-load-updates';
-      await this.updateMiningSeats();
-      await this.updateMiningBids();
-      await this.updateAccruedProfits();
+        botEmitter.on('updated-bids-data', async () => {
+          void this.updateMiningBids();
+        });
 
-      this.isLoaded = true;
-      this.isLoading = false;
-      this.isLoadedDeferred.resolve();
-    } catch (error) {
-      this.isLoading = false;
-      console.error(`[Stats] Load failed at ${stage ?? 'start'} after ${Date.now() - loadStartedAt}ms`, error);
-      throw error;
-    }
+        botEmitter.on('updated-server-state', async () => {
+          // if (this.isSubscribedToActivity) {
+          await this.updateServerState();
+          this.activityHasUpdates = false;
+          // } else {
+          //   this.activityHasUpdates = true;
+          // }
+        });
+
+        this.isLoaded = true;
+        this.isLoadedDeferred.resolve();
+      } catch (error) {
+        this.isLoadedDeferred.reject(error as Error);
+        console.error(`[Stats] Load failed at ${stage ?? 'start'} after ${Date.now() - loadStartedAt}ms`, error);
+        throw error;
+      } finally {
+        this.loadPromise = undefined;
+      }
+    })();
+
+    return await this.loadPromise;
   }
 
   public async subscribeToDashboard(): Promise<void> {

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -56,6 +56,7 @@ export class TransactionTracker {
   #bestBlockNumber?: number;
   #watchUnsubscribe?: () => void;
   #nonceLaneByAddress = new Map<string, Promise<void>>();
+  #isClosed = false;
 
   constructor(
     private readonly dbPromise: Promise<Db>,
@@ -72,6 +73,7 @@ export class TransactionTracker {
   }
 
   public async load(reload = false): Promise<void> {
+    this.#isClosed = false;
     if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
     if (!reload && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
 
@@ -248,15 +250,26 @@ export class TransactionTracker {
 
     await signedTx
       .send(result => {
+        if (this.#isClosed) {
+          return;
+        }
         txResult.onSubscriptionResult(result);
         void this.handleWatchedResult(txInfo.tx, txResult, result);
       })
       .catch(async error => {
+        if (this.#isClosed) {
+          return;
+        }
         txResult.submissionError = error as Error;
         await this.recordSubmissionError(txInfo.tx, txResult.submissionError);
       });
 
     return txInfo;
+  }
+
+  public shutdown(): void {
+    this.#isClosed = true;
+    this.stopWatching();
   }
 
   public createIntentForFollowOnTx<T>(txInfo: TransactionInfo): IDeferred<TransactionInfo<T>> {
@@ -614,6 +627,9 @@ export class TransactionTracker {
   }
 
   private async handleWatchedResult(record: ITransactionRecord, txResult: TxResult, result: ISubmittableResult) {
+    if (this.#isClosed) {
+      return;
+    }
     try {
       const { status } = result;
       const isInBlock = status.isInBlock;

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -72,9 +72,14 @@ export class TransactionTracker {
   }
 
   public async load(reload = false): Promise<void> {
-    if (this.#waitForLoad && !reload) return this.#waitForLoad.promise;
+    if (this.#waitForLoad?.isRunning) return this.#waitForLoad.promise;
+    if (!reload && this.#waitForLoad?.isResolved) return this.#waitForLoad.promise;
 
-    this.#waitForLoad ??= createDeferred();
+    if (reload || this.#waitForLoad?.isRejected) {
+      this.#waitForLoad = createDeferred();
+    } else {
+      this.#waitForLoad ??= createDeferred();
+    }
     try {
       const table = await this.getTable();
       const txs = await table.fetchAll();
@@ -85,6 +90,9 @@ export class TransactionTracker {
       await this.blockWatch.start();
 
       this.data.txInfos.length = 0;
+      for (const extrinsicType of Object.keys(this.data.txInfosByType)) {
+        delete this.data.txInfosByType[extrinsicType as ExtrinsicType];
+      }
       for (const tx of txs) {
         const txResult = new TxResult(client, {
           accountAddress: tx.accountAddress,
@@ -141,6 +149,8 @@ export class TransactionTracker {
       }
       if (this.data.txInfos.some(x => this.isTrackedAsPending(x))) {
         await this.watchForUpdates();
+      } else {
+        this.stopWatching();
       }
       this.#waitForLoad.resolve();
     } catch (error) {

--- a/src-vue/lib/WalletsForArgon.ts
+++ b/src-vue/lib/WalletsForArgon.ts
@@ -125,8 +125,11 @@ export class WalletsForArgon {
   }
 
   public async load() {
-    if (this.deferredLoading.isRunning || this.deferredLoading.isSettled) {
+    if (this.deferredLoading.isResolved || this.deferredLoading.isRunning) {
       return this.deferredLoading.promise;
+    }
+    if (this.deferredLoading.isRejected) {
+      this.deferredLoading = createDeferred<void>(false);
     }
     this.deferredLoading.setIsRunning(true);
     const loadStartedAt = Date.now();

--- a/src-vue/lib/WalletsForArgon.ts
+++ b/src-vue/lib/WalletsForArgon.ts
@@ -197,8 +197,16 @@ export class WalletsForArgon {
       const oldestBlock = Math.min(...this.blockHistory.map(x => x.blockNumber), finalizedBlockNumber);
 
       /// PROCESS UP TO CURRENT BLOCK
-      let historyHeader = header;
-      for (let blockNumber = header.blockNumber; blockNumber >= oldestBlock; blockNumber--) {
+      let currentHeader = header;
+      const isCurrentBestTreeHash = this.blockWatch.latestHeaders.some(x => x.blockHash === currentHeader.blockHash);
+      if (!currentHeader.isFinalized && !isCurrentBestTreeHash) {
+        // Wallet history only needs a stable best-chain header at this height.
+        // If a non-finalized hash has already fallen off the watched best tree,
+        // normalize it up front instead of retrying later while mutating history.
+        currentHeader = await this.blockWatch.getHeaderByBlockNumber(currentHeader.blockNumber);
+      }
+      let historyHeader = currentHeader;
+      for (let blockNumber = currentHeader.blockNumber; blockNumber >= oldestBlock; blockNumber--) {
         if (historyHeader.blockNumber !== blockNumber) {
           throw new Error(
             `Inconsistent block numbers when loading wallet balances history. (Expected=${blockNumber}, actual=${historyHeader.blockNumber})`,
@@ -269,9 +277,9 @@ export class WalletsForArgon {
       for (const wallet of this.wallets) {
         wallet.trimToFinalizedBlock(finalizedBlock);
       }
-      this.bestBlock = header;
+      this.bestBlock = currentHeader;
       this.finalizedBlock = finalizedBlock;
-      this.events.emit('sync:best-block', header);
+      this.events.emit('sync:best-block', currentHeader);
       this.events.emit('sync:finalized', finalizedBlock);
     }).promise;
   }

--- a/src-vue/lib/patchTxResult.ts
+++ b/src-vue/lib/patchTxResult.ts
@@ -1,0 +1,168 @@
+import { type ArgonClient, TxResult, TxSubmissionError, TxSubmissionErrorCode, u8aEq } from '@argonprotocol/mainchain';
+
+const isPatched = Symbol('argon.tx-result-patched');
+const pendingInBlock = Symbol('argon.tx-result-pending-in-block');
+
+type IPendingInBlock = Omit<Parameters<TxResult['setSeenInBlock']>[0], 'blockNumber'>;
+type TxResultWithPending = TxResult & { [pendingInBlock]?: IPendingInBlock };
+
+const txResultPrototype = TxResult.prototype as TxResultWithPending & {
+  [isPatched]?: boolean;
+};
+
+const originalSetSeenInBlock = Object.getOwnPropertyDescriptor(txResultPrototype, 'setSeenInBlock')
+  ?.value as TxResult['setSeenInBlock'];
+const originalSetFinalized = Object.getOwnPropertyDescriptor(txResultPrototype, 'setFinalized')
+  ?.value as TxResult['setFinalized'];
+
+export function patchTxResult() {
+  if (txResultPrototype[isPatched]) {
+    return;
+  }
+  txResultPrototype[isPatched] = true;
+
+  TxResult.prototype.setSeenInBlock = async function (this: TxResultWithPending, block) {
+    if (block.blockNumber === undefined) {
+      this[pendingInBlock] = {
+        blockHash: block.blockHash,
+        extrinsicIndex: block.extrinsicIndex,
+        events: block.events,
+      };
+      return;
+    }
+
+    if (
+      this.blockHash &&
+      this.blockNumber === block.blockNumber &&
+      this.extrinsicIndex === block.extrinsicIndex &&
+      u8aEq(this.blockHash, block.blockHash)
+    ) {
+      delete this[pendingInBlock];
+      return;
+    }
+
+    delete this[pendingInBlock];
+    await originalSetSeenInBlock.call(this, block);
+  };
+
+  TxResult.prototype.setFinalized = function (this: TxResultWithPending) {
+    void finalizeTxResult(this).catch(error => {
+      this.submissionError = error as Error;
+    });
+  };
+
+  TxResult.prototype.onSubscriptionResult = function (this: TxResultWithPending, result) {
+    const { events, status, isFinalized, txIndex } = result;
+    const extrinsicEvents = events.map(x => x.event);
+
+    if (status.isBroadcast) {
+      this.isBroadcast = true;
+      if (result.internalError) this.submissionError = result.internalError;
+    }
+
+    if (status.isInBlock) {
+      const pending = createPendingInBlock(Uint8Array.from(status.asInBlock), txIndex, extrinsicEvents);
+      this[pendingInBlock] = pending;
+
+      void publishSeenInBlock(this, pending).catch(error => {
+        if (!isMissingBlockHeaderError(error)) {
+          this.submissionError = error as Error;
+        }
+      });
+    }
+
+    if (status.isUsurped) {
+      delete this[pendingInBlock];
+      this.submissionError = new TxSubmissionError(
+        TxSubmissionErrorCode.Usurped,
+        `Transaction was usurped by ${status.asUsurped.toHex()}.`,
+      );
+    }
+
+    if (status.isDropped) {
+      delete this[pendingInBlock];
+      this.submissionError = new TxSubmissionError(
+        TxSubmissionErrorCode.Dropped,
+        'Transaction was dropped before it was included in a block.',
+      );
+    }
+
+    if (status.isInvalid) {
+      delete this[pendingInBlock];
+      this.submissionError = new TxSubmissionError(
+        TxSubmissionErrorCode.Invalid,
+        'Transaction was rejected as invalid by the node.',
+      );
+    }
+
+    if (isFinalized) {
+      this[pendingInBlock] = createPendingInBlock(Uint8Array.from(status.asFinalized), txIndex, extrinsicEvents);
+      this.setFinalized();
+    }
+  };
+}
+
+function createPendingInBlock(
+  blockHash: Uint8Array,
+  txIndex: number | undefined,
+  events: IPendingInBlock['events'],
+): IPendingInBlock {
+  if (txIndex === undefined) {
+    throw new Error('Cannot publish transaction block state before extrinsic index is known');
+  }
+
+  return {
+    blockHash,
+    extrinsicIndex: txIndex,
+    events,
+  };
+}
+
+async function publishSeenInBlock(txResult: TxResultWithPending, block: IPendingInBlock) {
+  const pending = txResult[pendingInBlock];
+  if (!pending || pending.extrinsicIndex !== block.extrinsicIndex || !u8aEq(pending.blockHash, block.blockHash)) {
+    return;
+  }
+
+  const client = (txResult as TxResult & { client: ArgonClient }).client;
+  const blockNumber = await client.rpc.chain.getHeader(block.blockHash).then(x => x.number.toNumber());
+
+  const currentPending = txResult[pendingInBlock];
+  if (
+    !currentPending ||
+    currentPending.extrinsicIndex !== block.extrinsicIndex ||
+    !u8aEq(currentPending.blockHash, block.blockHash)
+  ) {
+    return;
+  }
+
+  await txResult.setSeenInBlock({
+    ...block,
+    blockNumber,
+  });
+}
+
+async function finalizeTxResult(txResult: TxResultWithPending) {
+  const pending = txResult[pendingInBlock];
+  if (pending) {
+    await publishSeenInBlock(txResult, pending);
+  } else if (txResult.blockHash && txResult.blockNumber === undefined) {
+    if (txResult.extrinsicIndex === undefined) {
+      throw new Error('Cannot finalize transaction before extrinsic index is known');
+    }
+
+    await publishSeenInBlock(txResult, {
+      blockHash: txResult.blockHash,
+      extrinsicIndex: txResult.extrinsicIndex,
+      events: txResult.events,
+    });
+  }
+
+  originalSetFinalized.call(txResult);
+}
+
+function isMissingBlockHeaderError(error: unknown) {
+  return String(error).includes('Unable to retrieve header and parent from supplied hash');
+}
+
+patchTxResult();

--- a/src-vue/main.ts
+++ b/src-vue/main.ts
@@ -1,5 +1,6 @@
 import './polyfills.ts';
 import './configureFetch.ts';
+import './lib/patchTxResult.ts';
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { MotionGlobalConfig } from 'motion-v';

--- a/src-vue/stores/bitcoin.ts
+++ b/src-vue/stores/bitcoin.ts
@@ -4,7 +4,7 @@ import { getDbPromise } from './helpers/dbPromise';
 import { reactive } from 'vue';
 import handleFatalError from './helpers/handleFatalError.ts';
 import { getBlockWatch } from './mainchain.ts';
-import { getCurrency, Currency } from './currency.ts';
+import { getCurrency } from './currency.ts';
 import { getTransactionTracker } from './transactions.ts';
 import { getUpstreamOperatorClient } from './upstreamOperator.ts';
 import { getWalletKeys } from './wallets.ts';
@@ -39,8 +39,8 @@ export function getBitcoinLocks(): BitcoinLocks {
     );
     locks.data = reactive(locks.data) as any;
     locks.utxoTracking.data = reactive(locks.utxoTracking.data) as any;
-    locks.load().catch(handleFatalError.bind('useBitcoinLocks'));
   }
+  void locks.load().catch(handleFatalError.bind('useBitcoinLocks'));
 
   return locks;
 }

--- a/src-vue/stores/currency.ts
+++ b/src-vue/stores/currency.ts
@@ -14,7 +14,9 @@ export function getCurrency(): Currency {
     const config = getConfig();
     const mainchainClients = getMainchainClients();
     currency = Vue.reactive(new Currency(mainchainClients, config as Config)) as Currency;
-    currency.load().catch(handleFatalError.bind('getCurrency'));
+  }
+  if (!currency.isLoaded) {
+    void currency.load().catch(handleFatalError.bind('getCurrency'));
   }
 
   return currency;

--- a/src-vue/stores/miningStats.ts
+++ b/src-vue/stores/miningStats.ts
@@ -5,7 +5,8 @@ import { Currency, getCurrency } from './currency.ts';
 import { calculateAPY, GlobalMiningStats, UnitOfMeasurement } from '@argonprotocol/apps-core';
 
 export const useMiningStats = defineStore('miningStats', () => {
-  let isLoading = false;
+  let hasLoaded = false;
+  let updatePromise: Promise<void> | undefined = undefined;
   let isLoadedPromise: Promise<void> | undefined = undefined;
 
   const mining = getMining();
@@ -22,18 +23,30 @@ export const useMiningStats = defineStore('miningStats', () => {
   const averageAPY = Vue.ref(0);
 
   async function update() {
-    if (!isLoading && !isLoadedPromise) await stats.load();
-    else if (!isLoading) await stats.update();
-    isLoading = true;
+    if (updatePromise) return await updatePromise;
 
-    activeMiningSeatCount.value = stats.activeSeatCount;
-    aggregatedBidCosts.value = stats.aggregatedBidCosts;
-    aggregatedBlockRewards.value = stats.aggregatedBlockRewards;
+    updatePromise = (async () => {
+      if (!hasLoaded) {
+        await stats.load();
+        hasLoaded = true;
+      } else {
+        await stats.update();
+      }
 
-    activeBidCosts.value = stats.activeBidCosts;
-    activeBlockRewards.value = stats.activeBlockRewards;
-    averageAPY.value = calculateAPY(stats.activeBidCosts, stats.activeBlockRewards);
-    isLoading = false;
+      activeMiningSeatCount.value = stats.activeSeatCount;
+      aggregatedBidCosts.value = stats.aggregatedBidCosts;
+      aggregatedBlockRewards.value = stats.aggregatedBlockRewards;
+
+      activeBidCosts.value = stats.activeBidCosts;
+      activeBlockRewards.value = stats.activeBlockRewards;
+      averageAPY.value = calculateAPY(stats.activeBidCosts, stats.activeBlockRewards);
+    })();
+
+    try {
+      await updatePromise;
+    } finally {
+      updatePromise = undefined;
+    }
   }
 
   isLoadedPromise = update();

--- a/src-vue/stores/miningStats.ts
+++ b/src-vue/stores/miningStats.ts
@@ -1,8 +1,8 @@
 import * as Vue from 'vue';
 import { defineStore } from 'pinia';
 import { getMining } from './mainchain.ts';
-import { Currency, getCurrency } from './currency.ts';
-import { calculateAPY, GlobalMiningStats, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { getCurrency } from './currency.ts';
+import { calculateAPY, GlobalMiningStats } from '@argonprotocol/apps-core';
 
 export const useMiningStats = defineStore('miningStats', () => {
   let hasLoaded = false;

--- a/src-vue/stores/stats.ts
+++ b/src-vue/stores/stats.ts
@@ -18,7 +18,9 @@ export function getStats(): Vue.Reactive<Stats> {
     const currency = getCurrency();
     const miningFrames = getMiningFrames();
     stats = Vue.reactive(new Stats(dbPromise, config as Config, currency, miningFrames));
-    stats.load().catch(handleFatalError.bind('getStats'));
+  }
+  if (!stats.isLoaded) {
+    void stats.load().catch(handleFatalError.bind('getStats'));
   }
 
   return stats;

--- a/src-vue/stores/vaultingStats.ts
+++ b/src-vue/stores/vaultingStats.ts
@@ -2,7 +2,7 @@ import * as Vue from 'vue';
 import { getVaults } from './vaults.ts';
 import { defineStore } from 'pinia';
 import { GlobalVaultingStats } from '@argonprotocol/apps-core';
-import { getCurrency, Currency } from './currency.ts';
+import { getCurrency } from './currency.ts';
 
 export const useVaultingStats = defineStore('vaultingStats', () => {
   let hasLoaded = false;

--- a/src-vue/stores/vaultingStats.ts
+++ b/src-vue/stores/vaultingStats.ts
@@ -5,7 +5,8 @@ import { GlobalVaultingStats } from '@argonprotocol/apps-core';
 import { getCurrency, Currency } from './currency.ts';
 
 export const useVaultingStats = defineStore('vaultingStats', () => {
-  let isLoading = false;
+  let hasLoaded = false;
+  let updatePromise: Promise<void> | undefined = undefined;
   let isLoadedPromise: Promise<void> | undefined = undefined;
 
   const vaults = getVaults();
@@ -22,18 +23,30 @@ export const useVaultingStats = defineStore('vaultingStats', () => {
   const finalPriceAfterTerraCollapse = Vue.ref(0n);
 
   async function update() {
-    if (!isLoading && !isLoadedPromise) await stats.load();
-    else if (!isLoading) await stats.update();
-    isLoading = true;
+    if (updatePromise) return await updatePromise;
 
-    vaultCount.value = stats.vaultCount;
-    bitcoinLocked.value = stats.bitcoinLocked;
-    microgonValueInVaults.value = stats.microgonValueOfVaultedBitcoins;
-    epochEarnings.value = stats.epochEarnings;
-    averageAPY.value = stats.activeAPY;
-    argonBurnCapacity.value = stats.argonBurnCapacity;
-    finalPriceAfterTerraCollapse.value = stats.finalPriceAfterTerraCollapse;
-    isLoading = false;
+    updatePromise = (async () => {
+      if (!hasLoaded) {
+        await stats.load();
+        hasLoaded = true;
+      } else {
+        await stats.update();
+      }
+
+      vaultCount.value = stats.vaultCount;
+      bitcoinLocked.value = stats.bitcoinLocked;
+      microgonValueInVaults.value = stats.microgonValueOfVaultedBitcoins;
+      epochEarnings.value = stats.epochEarnings;
+      averageAPY.value = stats.activeAPY;
+      argonBurnCapacity.value = stats.argonBurnCapacity;
+      finalPriceAfterTerraCollapse.value = stats.finalPriceAfterTerraCollapse;
+    })();
+
+    try {
+      await updatePromise;
+    } finally {
+      updatePromise = undefined;
+    }
   }
 
   isLoadedPromise = update();
@@ -47,5 +60,6 @@ export const useVaultingStats = defineStore('vaultingStats', () => {
     argonBurnCapacity,
     finalPriceAfterTerraCollapse,
     isLoadedPromise,
+    update,
   };
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     "src-vue/**/*.tsx",
     "src-vue/**/*.vue",
     "src-tauri/dev.ts",
+    "vitest.setup.ts",
     "scripts",
     "eslint.config.ts",
     "bot/**/*.ts",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,6 @@
 import { mnemonicGenerate } from '@argonprotocol/mainchain';
 import ISecurity from './src-vue/interfaces/ISecurity';
+import './src-vue/lib/patchTxResult.ts';
 
 (globalThis as any).__ARGON_APP_ID__ = 'com.argon.operations';
 (globalThis as any).__ARGON_APP_NAME__ = 'ARGON';


### PR DESCRIPTION
## Summary
- harden shared startup loads around block watch recovery, transaction restore, bitcoin lock restore, and stats bootstrapping
- let the vault page render once the core vault state is ready instead of hanging behind longer recovery work
- avoid replaying vault revenue history on startup when cached vault stats are already current enough

## Why
Startup and reload paths were stalling when best-block lookups churned during reconnects or when vault initialization repeated work that did not need to run again. These changes make the app more tolerant of short-lived chain instability and reduce the common "Loading..." stalls people were seeing.