### PR TITLE
fix(ci): set release commitish from release branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,6 +160,7 @@ jobs:
           releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: true
           prerelease: true
+          releaseCommitish: ${{ github.ref_name }}
           args: ${{ matrix.args }} --config ${{ github.workspace }}/src-tauri/tauri.operations.conf.json
 
       - name: Upload Operations Symbols
@@ -195,6 +196,7 @@ jobs:
           releaseBody: ${{ env.RELEASE_NOTES }}
           releaseDraft: true
           prerelease: true
+          releaseCommitish: ${{ github.ref_name }}
           args: ${{ matrix.args }} --config ${{ github.workspace }}/src-tauri/tauri.treasury.conf.json
 
       - name: Upload Treasury Symbols


### PR DESCRIPTION
## Summary
Draft desktop releases now use the release branch name as `releaseCommitish` when `tauri-action` creates or updates the release. That keeps the draft release aligned with the release branch tip instead of pinning it to the SHA from the first workflow run.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'publish.yml parses'"`
- pre-commit hooks completed during `git commit`
