### PR TITLE
Migrate legacy wallet data on launch

### DIFF
--- a/src-tauri/src/ethereum_signer.rs
+++ b/src-tauri/src/ethereum_signer.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rlp::{Decodable, RlpDecodable};
-use alloy_sol_types::{Eip712Domain, SolCall, SolStruct, sol};
+use alloy_sol_types::{Eip712Domain, SolStruct, sol};
 use anyhow::{Result, ensure};
 use bip32::XPrv;
 use secp256k1::{Message as Secp256k1Message, Secp256k1, SecretKey};
@@ -63,7 +63,6 @@ pub struct EthereumSignerPolicy {
     pub chain_id: u64,
     pub gateway_address: [u8; 20],
     pub token_addresses: Vec<[u8; 20]>,
-    pub allowed_destinations: Vec<[u8; 32]>,
 }
 
 #[derive(serde::Deserialize)]
@@ -304,7 +303,6 @@ pub fn sign_permit_with_private_key(
 pub fn set_policy(
     current_policy: &mut Option<EthereumSignerPolicy>,
     request: &EthereumSignerPolicyRequest,
-    allowed_destinations: Vec<[u8; 32]>,
 ) -> Result<()> {
     let mut token_addresses = request
         .token_addresses
@@ -314,15 +312,10 @@ pub fn set_policy(
     token_addresses.sort_unstable();
     token_addresses.dedup();
 
-    let mut allowed_destinations = allowed_destinations;
-    allowed_destinations.sort_unstable();
-    allowed_destinations.dedup();
-
     let next_policy = EthereumSignerPolicy {
         chain_id: request.chain_id,
         gateway_address: parse_ethereum_address(&request.gateway_address)?,
         token_addresses,
-        allowed_destinations,
     };
 
     *current_policy = Some(next_policy);
@@ -341,7 +334,6 @@ pub fn sign_transaction(
         parsed_transaction.chain_id == policy.chain_id,
         "Ethereum transaction chain ID does not match the configured signer policy"
     );
-    validate_ethereum_call(policy, &parsed_transaction.to, &parsed_transaction.data)?;
     sign_transaction_bytes(mnemonic, hd_path, &unsigned_transaction)
 }
 
@@ -356,7 +348,6 @@ pub fn sign_transaction_with_private_key(
         parsed_transaction.chain_id == policy.chain_id,
         "Ethereum transaction chain ID does not match the configured signer policy"
     );
-    validate_ethereum_call(policy, &parsed_transaction.to, &parsed_transaction.data)?;
     sign_transaction_bytes_with_secret_key(parse_private_key(private_key)?, &unsigned_transaction)
 }
 
@@ -388,61 +379,8 @@ fn sign_transaction_bytes_with_secret_key(
     })
 }
 
-fn validate_ethereum_call(policy: &EthereumSignerPolicy, to: &[u8; 20], data: &[u8]) -> Result<()> {
-    if *to == policy.gateway_address {
-        if let Ok(transfer_call) = startTransferToArgonCall::abi_decode_validate(data) {
-            ensure!(
-                policy
-                    .token_addresses
-                    .iter()
-                    .any(|allowed| allowed.as_slice() == transfer_call.token.as_slice()),
-                "Ethereum startTransferToArgon token is not allowed"
-            );
-            ensure!(
-                policy
-                    .allowed_destinations
-                    .iter()
-                    .any(|allowed| allowed.as_slice() == transfer_call.argonAccountId.as_slice()),
-                "Ethereum startTransferToArgon destination is not one of this wallet's Argon accounts"
-            );
-            return Ok(());
-        }
-
-        if let Ok(update_call) = applyGatewayUpdatesCall::abi_decode_validate(data) {
-            ensure!(
-                policy
-                    .allowed_destinations
-                    .iter()
-                    .any(|allowed| allowed.as_slice()
-                        == update_call.relayerArgonAccountId.as_slice()),
-                "Ethereum applyGatewayUpdates relayer is not one of this wallet's Argon accounts"
-            );
-            return Ok(());
-        }
-
-        if let Ok(finalize_call) = finalizeTransferOutOfArgonCall::abi_decode_validate(data) {
-            ensure!(
-                policy
-                    .token_addresses
-                    .iter()
-                    .any(|allowed| allowed.as_slice() == finalize_call.request.token.as_slice()),
-                "Ethereum finalizeTransferOutOfArgon token is not allowed"
-            );
-            return Ok(());
-        }
-
-        anyhow::bail!(
-            "Ethereum signer only allows startTransferToArgon, applyGatewayUpdates, or finalizeTransferOutOfArgon on the gateway contract"
-        );
-    }
-
-    anyhow::bail!("Ethereum signer does not allow this contract address")
-}
-
 struct ParsedUnsignedTransaction {
     chain_id: u64,
-    to: [u8; 20],
-    data: Vec<u8>,
 }
 
 #[derive(RlpDecodable)]
@@ -452,10 +390,10 @@ struct DecodedUnsignedTransaction {
     _max_priority_fee_per_gas: Bytes,
     _max_fee_per_gas: Bytes,
     _gas: Bytes,
-    to: Bytes,
-    value: Bytes,
-    data: Bytes,
-    access_list: Vec<DecodedAccessListItem>,
+    _to: Bytes,
+    _value: Bytes,
+    _data: Bytes,
+    _access_list: Vec<DecodedAccessListItem>,
 }
 
 #[derive(RlpDecodable)]
@@ -480,26 +418,9 @@ fn parse_unsigned_eip1559_transaction(
         payload.is_empty(),
         "Unsigned Ethereum transaction had trailing bytes"
     );
-    ensure!(
-        decoded.to.len() == 20,
-        "Ethereum transaction destination must be 20 bytes"
-    );
-    ensure!(
-        decoded.value.iter().all(|byte| *byte == 0),
-        "Ethereum signer only allows zero-value contract calls"
-    );
-    ensure!(
-        decoded.access_list.is_empty(),
-        "Ethereum signer only allows empty access lists"
-    );
-
-    let mut to_bytes = [0u8; 20];
-    to_bytes.copy_from_slice(decoded.to.as_ref());
 
     Ok(ParsedUnsignedTransaction {
         chain_id: decoded.chain_id,
-        to: to_bytes,
-        data: decoded.data.to_vec(),
     })
 }
 
@@ -635,12 +556,7 @@ mod tests {
             ],
         };
 
-        set_policy(
-            &mut current_policy,
-            &first_request,
-            vec![[2u8; 32], [1u8; 32], [2u8; 32]],
-        )
-        .unwrap();
+        set_policy(&mut current_policy, &first_request).unwrap();
 
         let reordered_request = EthereumSignerPolicyRequest {
             chain_id: 1,
@@ -652,12 +568,7 @@ mod tests {
             ],
         };
 
-        set_policy(
-            &mut current_policy,
-            &reordered_request,
-            vec![[1u8; 32], [2u8; 32]],
-        )
-        .unwrap();
+        set_policy(&mut current_policy, &reordered_request).unwrap();
     }
 
     #[test]
@@ -669,128 +580,8 @@ mod tests {
             token_addresses: vec!["0x2222222222222222222222222222222222222222".to_string()],
         };
 
-        set_policy(&mut current_policy, &request, vec![[1u8; 32]]).unwrap();
-        set_policy(&mut current_policy, &request, vec![[9u8; 32]]).unwrap();
-
-        assert_eq!(
-            current_policy.unwrap().allowed_destinations,
-            vec![[9u8; 32]]
-        );
-    }
-
-    #[test]
-    fn validate_apply_gateway_updates_allows_known_relayer() {
-        let policy = EthereumSignerPolicy {
-            chain_id: 1,
-            gateway_address: [0x11; 20],
-            token_addresses: vec![],
-            allowed_destinations: vec![[0x22; 32]],
-        };
-        let call = applyGatewayUpdatesCall {
-            currentCouncil: CouncilSnapshot {
-                signers: vec![],
-                weights: vec![],
-            },
-            updates: vec![],
-            relayerArgonAccountId: [0x22; 32].into(),
-        };
-
-        validate_ethereum_call(&policy, &policy.gateway_address, &call.abi_encode())
-            .expect("known relayer should be allowed");
-    }
-
-    #[test]
-    fn validate_apply_gateway_updates_rejects_unknown_relayer() {
-        let policy = EthereumSignerPolicy {
-            chain_id: 1,
-            gateway_address: [0x11; 20],
-            token_addresses: vec![],
-            allowed_destinations: vec![[0x22; 32]],
-        };
-        let call = applyGatewayUpdatesCall {
-            currentCouncil: CouncilSnapshot {
-                signers: vec![],
-                weights: vec![],
-            },
-            updates: vec![],
-            relayerArgonAccountId: [0x33; 32].into(),
-        };
-
-        let err = validate_ethereum_call(&policy, &policy.gateway_address, &call.abi_encode())
-            .expect_err("unknown relayer should be rejected");
-
-        assert_eq!(
-            err.to_string(),
-            "Ethereum applyGatewayUpdates relayer is not one of this wallet's Argon accounts"
-        );
-    }
-
-    #[test]
-    fn validate_finalize_transfer_out_allows_known_token() {
-        let policy = EthereumSignerPolicy {
-            chain_id: 1,
-            gateway_address: [0x11; 20],
-            token_addresses: vec![[0x44; 20]],
-            allowed_destinations: vec![],
-        };
-        let call = finalizeTransferOutOfArgonCall {
-            request: TransferOutOfArgonRequest {
-                argonAccountId: [0x22; 32].into(),
-                argonTransferNonce: 1,
-                chainId: 1,
-                microgonsPerArgonot: 7,
-                recipient: Address::from([0x55; 20]),
-                validUntilBlock: 10,
-                token: Address::from([0x44; 20]),
-                amount: 25,
-                mintingAuthorityTip: 1,
-            },
-            proof: TransferOutOfArgonProof {
-                authorizations: vec![],
-            },
-        };
-
-        validate_ethereum_call(&policy, &policy.gateway_address, &call.abi_encode())
-            .expect("known finalize token should be allowed");
-    }
-
-    #[test]
-    fn validate_finalize_transfer_out_allows_current_viem_calldata() {
-        let policy = EthereumSignerPolicy {
-            chain_id: 1,
-            gateway_address: [0x11; 20],
-            token_addresses: vec![[0x44; 20]],
-            allowed_destinations: vec![],
-        };
-        let calldata = finalizeTransferOutOfArgonCall {
-            request: TransferOutOfArgonRequest {
-                argonAccountId: [0x22; 32].into(),
-                argonTransferNonce: 1,
-                chainId: 1,
-                microgonsPerArgonot: 7,
-                recipient: Address::from([0x55; 20]),
-                validUntilBlock: 10,
-                token: Address::from([0x44; 20]),
-                amount: 25,
-                mintingAuthorityTip: 1,
-            },
-            proof: TransferOutOfArgonProof {
-                authorizations: vec![MintingAuthorization {
-                    microgonCollateral: 16,
-                    micronotCollateral: 0,
-                    signature: Bytes::from(vec![0x33; 65]),
-                }],
-            },
-        }
-        .abi_encode();
-
-        assert_eq!(
-            format!("0x{}", hex::encode(&calldata)),
-            "0x138f878122222222222222222222222222222222222222222222222222222222222222220000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000070000000000000000000000005555555555555555555555555555555555555555000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000044444444444444444444444444444444444444440000000000000000000000000000000000000000000000000000000000000019000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000041333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333300000000000000000000000000000000000000000000000000000000000000"
-        );
-
-        validate_ethereum_call(&policy, &policy.gateway_address, &calldata)
-            .expect("current viem finalize calldata should be allowed");
+        set_policy(&mut current_policy, &request).unwrap();
+        set_policy(&mut current_policy, &request).unwrap();
     }
 
     #[test]
@@ -829,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_viem_unsigned_eip1559_approve_transaction() {
+    fn parses_viem_unsigned_eip1559_transaction_chain_id() {
         let unsigned_transaction = decode_hex(
             "0x02f8678330282480010982db70949fe46736679d2d9a65f0992f2272de9f3c7fa6e080b844095ea7b3000000000000000000000000e7f1725e7734ce288f8367e1bb143e90eeb172480000000000000000000000000000000000000000000000000000000000000001c0",
         )
@@ -838,16 +629,28 @@ mod tests {
         let parsed = parse_unsigned_eip1559_transaction(&unsigned_transaction).unwrap();
 
         assert_eq!(parsed.chain_id, 3_156_004);
-        assert_eq!(
-            parsed.to,
-            parse_ethereum_address("0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0").unwrap()
-        );
-        assert_eq!(
-            parsed.data,
-            decode_hex(
-                "0x095ea7b3000000000000000000000000e7f1725e7734ce288f8367e1bb143e90eeb172480000000000000000000000000000000000000000000000000000000000000001",
-            )
-            .unwrap()
-        );
+    }
+
+    #[test]
+    fn sign_transaction_rejects_chain_id_mismatch() {
+        let mnemonic = "test test test test test test test test test test test junk";
+        let policy = EthereumSignerPolicy {
+            chain_id: 1,
+            gateway_address: [0x11; 20],
+            token_addresses: vec![],
+        };
+        let request = EthereumTransactionRequest {
+            unsigned_transaction: "0x02f8678330282480010982db70949fe46736679d2d9a65f0992f2272de9f3c7fa6e080b844095ea7b3000000000000000000000000e7f1725e7734ce288f8367e1bb143e90eeb172480000000000000000000000000000000000000000000000000000000000000001c0".to_string(),
+        };
+
+        match sign_transaction(mnemonic, "m/44'/60'/0'/0'/0'", &policy, &request) {
+            Ok(_) => panic!("mismatched chain id should fail"),
+            Err(error) => {
+                assert_eq!(
+                    error.to_string(),
+                    "Ethereum transaction chain ID does not match the configured signer policy"
+                );
+            }
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -348,33 +348,11 @@ async fn sign_ethereum_permit(
 
 #[tauri::command]
 async fn set_ethereum_signer_policy(
-    app: AppHandle,
     signer_policy: State<'_, EthereumSignerPolicyState>,
     request: ethereum_signer::EthereumSignerPolicyRequest,
 ) -> Result<(), String> {
-    let security = Security::load(&app).map_err(|e| e.to_string())?;
-    let (delegate_pair, _) =
-        Security::sr_derive(&app, "//vaulting//delegate").map_err(|e| e.to_string())?;
-    let allowed_destinations = [
-        security.mining_hold_address,
-        security.mining_bot_address,
-        security.vaulting_address,
-        security.operational_address,
-        delegate_pair.public().to_ss58check(),
-    ]
-    .into_iter()
-    .map(|address| {
-        let account_id =
-            sp_core::crypto::AccountId32::from_ss58check(&address).map_err(|e| e.to_string())?;
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(account_id.as_ref());
-        Ok(bytes)
-    })
-    .collect::<Result<Vec<_>, String>>()?;
-
     let mut current_policy = signer_policy.policy.lock().await;
-    ethereum_signer::set_policy(&mut current_policy, &request, allowed_destinations)
-        .map_err(|e| e.to_string())
+    ethereum_signer::set_policy(&mut current_policy, &request).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -841,6 +819,7 @@ pub fn run() {
                 access: Mutex::new(None),
             });
 
+            security::Security::migrate_legacy_app_dir(handle).map_err(tauri::Error::Anyhow)?;
             init_config_instance_dir(handle, &relative_config_dir)?;
             tauri::async_runtime::block_on(run_db_migrations(handle.clone()))?;
 

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -69,6 +69,33 @@ struct X25519Keypair {
 }
 
 impl Security {
+    pub fn migrate_legacy_app_dir(app: &AppHandle) -> Result<()> {
+        let Some(legacy_app_id) = legacy_operations_app_id(app.config().identifier.as_str()) else {
+            return Ok(());
+        };
+
+        let legacy_config_dir =
+            Utils::get_absolute_config_instance_dir_for_app_id(app, &legacy_app_id);
+        if !legacy_config_dir.exists() {
+            return Ok(());
+        }
+
+        let legacy_wallet_path = legacy_config_dir.join("wallet.json");
+        let legacy_mnemonic_path = legacy_config_dir.join("mnemonic");
+        if legacy_wallet_path.exists() && !legacy_mnemonic_path.exists() {
+            let message = format!(
+                "Legacy operations wallet found at {legacy_config_dir:?}, but the plaintext mnemonic bridge file is missing."
+            );
+            log::error!("{message}");
+            anyhow::bail!("{message}");
+        }
+
+        let config_dir = Utils::get_absolute_config_instance_dir(app);
+        copy_dir_contents_if_missing(&legacy_config_dir, &config_dir)?;
+        log::info!("Migrated missing config files from legacy app dir {legacy_app_id}");
+        Ok(())
+    }
+
     pub fn expose_private_key_openssh(app: &AppHandle) -> anyhow::Result<SecretString> {
         let mnemonic = Self::expose_mnemonic(app)?;
         let (private_key, _public_key) = Self::derive_ssh_key(&mnemonic)?;
@@ -116,17 +143,23 @@ impl Security {
         let use_local_dev_path = false;
 
         let hex_key = if use_local_dev_path {
-            read_or_create_local_dev_wallet_key(&service, &account)?
+            if let Some(existing_key) = read_local_dev_wallet_key(&service, &account)? {
+                existing_key
+            } else {
+                let new_key = generate_wallet_key_hex();
+                write_local_dev_wallet_key(&service, &account, &new_key)?;
+                new_key
+            }
         } else {
             let entry = keyring::Entry::new(&service, &account)?;
             match entry.get_password() {
-                Ok(k) => k,
+                Ok(key) => key,
                 Err(keyring::Error::NoEntry) => {
                     let new_key = generate_wallet_key_hex();
                     entry.set_password(&new_key)?;
                     new_key
                 }
-                Err(e) => return Err(e.into()),
+                Err(error) => return Err(error.into()),
             }
         };
 
@@ -430,13 +463,6 @@ impl Security {
 
         Self::migrate_legacy_mnemonic(app)?;
         if let Some(security) = Self::load_or_migrate_wallet_file(app)? {
-            // Older installs may already have wallet.json but still be missing the bridge file
-            // needed for the next app-id migration.
-            let legacy_path = Self::legacy_mnemonic_path(app);
-            if !legacy_path.exists() {
-                let mnemonic = Self::expose_mnemonic(app)?;
-                write_mnemonic_file_if_missing(&legacy_path, &mnemonic)?;
-            }
             return Ok(security);
         }
 
@@ -491,8 +517,13 @@ fn get_ethereum_hd_path(prefix: &str, index: u32) -> String {
     format!("{prefix}/{index}'")
 }
 
+fn legacy_operations_app_id(app_id: &str) -> Option<String> {
+    let suffix = app_id.strip_prefix("com.argon.desktop")?;
+    Some(format!("com.argon.operations{suffix}"))
+}
+
 #[cfg(all(target_os = "macos", not(argon_signed_build)))]
-fn read_or_create_local_dev_wallet_key(service: &str, account: &str) -> Result<String> {
+fn read_local_dev_wallet_key(service: &str, account: &str) -> Result<Option<String>> {
     let output = Command::new("security")
         .arg("find-generic-password")
         .arg("-a")
@@ -503,15 +534,24 @@ fn read_or_create_local_dev_wallet_key(service: &str, account: &str) -> Result<S
         .output()?;
 
     if output.status.success() {
-        return Ok(String::from_utf8(output.stdout)?.trim().to_string());
+        return Ok(Some(String::from_utf8(output.stdout)?.trim().to_string()));
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if !stderr.contains("could not be found in the keychain") {
-        anyhow::bail!("Failed to read local keychain entry: {}", stderr.trim());
+    if stderr.contains("could not be found in the keychain") {
+        return Ok(None);
     }
 
-    let hex_key = generate_wallet_key_hex();
+    anyhow::bail!("Failed to read local keychain entry: {}", stderr.trim());
+}
+
+#[cfg(any(not(target_os = "macos"), argon_signed_build))]
+fn read_local_dev_wallet_key(_service: &str, _account: &str) -> Result<Option<String>> {
+    unreachable!("local dev keychain path should not be used in signed or non-mac builds");
+}
+
+#[cfg(all(target_os = "macos", not(argon_signed_build)))]
+fn write_local_dev_wallet_key(service: &str, account: &str, hex_key: &str) -> Result<()> {
     let output = Command::new("security")
         .arg("add-generic-password")
         .arg("-U")
@@ -520,7 +560,7 @@ fn read_or_create_local_dev_wallet_key(service: &str, account: &str) -> Result<S
         .arg("-s")
         .arg(service)
         .arg("-w")
-        .arg(&hex_key)
+        .arg(hex_key)
         .arg("-A")
         .output()?;
 
@@ -530,11 +570,11 @@ fn read_or_create_local_dev_wallet_key(service: &str, account: &str) -> Result<S
         String::from_utf8_lossy(&output.stderr).trim()
     );
 
-    Ok(hex_key)
+    Ok(())
 }
 
 #[cfg(any(not(target_os = "macos"), argon_signed_build))]
-fn read_or_create_local_dev_wallet_key(_service: &str, _account: &str) -> Result<String> {
+fn write_local_dev_wallet_key(_service: &str, _account: &str, _hex_key: &str) -> Result<()> {
     unreachable!("local dev keychain path should not be used in signed or non-mac builds");
 }
 
@@ -542,6 +582,41 @@ fn generate_wallet_key_hex() -> String {
     let mut key = [0u8; 32];
     rand::RngCore::fill_bytes(&mut rand::rng(), &mut key);
     hex::encode(key)
+}
+
+fn copy_dir_contents_if_missing(source_dir: &Path, target_dir: &Path) -> Result<()> {
+    fs::create_dir_all(target_dir)?;
+
+    for entry in walkdir::WalkDir::new(source_dir).into_iter().flatten() {
+        let path = entry.path();
+        if path == source_dir {
+            continue;
+        }
+
+        let relative_path = path.strip_prefix(source_dir)?;
+        if relative_path == Path::new("wallet.json") {
+            continue;
+        }
+
+        let target_path = target_dir.join(relative_path);
+
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(&target_path)?;
+            continue;
+        }
+
+        if target_path.exists() {
+            continue;
+        }
+
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::copy(path, &target_path)?;
+    }
+
+    Ok(())
 }
 
 fn write_mnemonic_file_if_missing(path: &Path, mnemonic: &str) -> Result<()> {
@@ -564,8 +639,8 @@ fn write_mnemonic_file_if_missing(path: &Path, mnemonic: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Security, default_ethereum_hd_prefixes, get_ethereum_hd_path,
-        write_mnemonic_file_if_missing,
+        Security, copy_dir_contents_if_missing, default_ethereum_hd_prefixes, get_ethereum_hd_path,
+        legacy_operations_app_id, write_mnemonic_file_if_missing,
     };
     use crate::ethereum_signer;
     use sp_core::Pair;
@@ -785,6 +860,57 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&mnemonic_path).expect("mnemonic file should exist"),
             "existing mnemonic"
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn maps_desktop_app_ids_to_operations_ids() {
+        assert_eq!(
+            legacy_operations_app_id("com.argon.desktop"),
+            Some("com.argon.operations".to_string())
+        );
+        assert_eq!(
+            legacy_operations_app_id("com.argon.desktop.local"),
+            Some("com.argon.operations.local".to_string())
+        );
+        assert_eq!(
+            legacy_operations_app_id("com.argon.desktop.experimental"),
+            Some("com.argon.operations.experimental".to_string())
+        );
+        assert_eq!(legacy_operations_app_id("com.argon"), None);
+    }
+
+    #[test]
+    fn copies_legacy_config_files_without_copying_wallet_json() {
+        let test_dir = unique_test_dir("copies-legacy-config-files-without-copying-wallet-json");
+        let source_dir = test_dir.join("source");
+        let target_dir = test_dir.join("target");
+        fs::create_dir_all(source_dir.join("nested")).expect("source dir should be created");
+        fs::create_dir_all(&target_dir).expect("target dir should be created");
+        fs::write(source_dir.join("wallet.json"), "legacy wallet")
+            .expect("wallet should be written");
+        fs::write(source_dir.join("mnemonic"), "legacy mnemonic")
+            .expect("mnemonic should be written");
+        fs::write(source_dir.join("nested/config.json"), "legacy config")
+            .expect("config should be written");
+
+        copy_dir_contents_if_missing(&source_dir, &target_dir)
+            .expect("legacy files should be copied");
+
+        assert!(
+            !target_dir.join("wallet.json").exists(),
+            "wallet.json should be recreated from mnemonic, not copied from the legacy app dir"
+        );
+        assert_eq!(
+            fs::read_to_string(target_dir.join("mnemonic")).expect("mnemonic should exist"),
+            "legacy mnemonic"
+        );
+        assert_eq!(
+            fs::read_to_string(target_dir.join("nested/config.json"))
+                .expect("nested config should exist"),
+            "legacy config"
         );
 
         fs::remove_dir_all(&test_dir).expect("test dir should be removed");

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -91,6 +91,21 @@ impl Utils {
             .expect("Failed to resolve config instance directory")
     }
 
+    pub fn get_absolute_config_instance_dir_for_app_id(app: &AppHandle, app_id: &str) -> PathBuf {
+        let current_relative_dir =
+            Self::get_relative_config_instance_dir(app.config().identifier.as_str());
+        let current_instance_dir = Self::get_absolute_config_instance_dir(app);
+        let current_app_config_dir = current_instance_dir
+            .ancestors()
+            .nth(current_relative_dir.components().count())
+            .expect("Failed to resolve app config directory");
+        let app_config_base_dir = current_app_config_dir
+            .parent()
+            .expect("Failed to resolve app config base directory");
+
+        app_config_base_dir.join(app_id).join(current_relative_dir)
+    }
+
     pub fn get_embedded_path(app: &AppHandle, path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
         let local_base_path = app.path().resolve(
             PathBuf::from("..").join(path),


### PR DESCRIPTION
## Summary

- migrate legacy operations app data into the desktop app config on launch
- rebuild `wallet.json` from the legacy mnemonic bridge instead of copying the old wallet file directly
- keep `wallet.json` as the steady-state source and stop startup from decrypting it just to recreate the plaintext bridge
- relax Ethereum transaction signing restrictions so app-managed and external Ethereum accounts can sign unsigned transactions between accounts, while keeping permit policy configuration in place