### PR TITLE
Fix overlay stacking across top bars, dialogs, and nested popovers

### DIFF
--- a/src-vue/app-treasury/navigation/TopBar.vue
+++ b/src-vue/app-treasury/navigation/TopBar.vue
@@ -64,7 +64,8 @@
           </div>
         </NavigationMenuList>
         <NavigationMenuIndicator
-          class="pointer-events-none absolute top-full left-0 z-[2001] flex h-[10px] w-[var(--reka-navigation-menu-indicator-size)] translate-x-[var(--reka-navigation-menu-indicator-position)] items-end justify-center transition-[width,transform,opacity] duration-300 data-[state=hidden]:opacity-0 data-[state=visible]:opacity-100"
+          :style="navigationMenuIndicatorZIndex"
+          class="pointer-events-none absolute top-full left-0 flex h-[10px] w-[var(--reka-navigation-menu-indicator-size)] translate-x-[var(--reka-navigation-menu-indicator-position)] items-end justify-center transition-[width,transform,opacity] duration-300 data-[state=hidden]:opacity-0 data-[state=visible]:opacity-100"
         >
           <div
             class="relative top-[-1px] h-0 w-0 border-x-[13px] border-b-[13px] border-x-transparent border-b-gray-900/20"
@@ -76,7 +77,8 @@
         </NavigationMenuIndicator>
         <NavigationMenuViewport
           align="end"
-          class="bg-argon-menu-bg data-[state=closed]:animate-scaleOut data-[state=open]:animate-scaleIn pointer-events-auto absolute top-full left-[var(--reka-navigation-menu-viewport-left)] z-[2000] mt-[8px] h-[var(--reka-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-visible rounded border border-gray-900/20 shadow-lg transition-[left,_width,_height] duration-300 sm:w-[var(--reka-navigation-menu-viewport-width)]"
+          :style="navigationMenuViewportZIndex"
+          class="bg-argon-menu-bg data-[state=closed]:animate-scaleOut data-[state=open]:animate-scaleIn pointer-events-auto absolute top-full left-[var(--reka-navigation-menu-viewport-left)] mt-[8px] h-[var(--reka-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-visible rounded border border-gray-900/20 shadow-lg transition-[left,_width,_height] duration-300 sm:w-[var(--reka-navigation-menu-viewport-width)]"
           @mouseenter="clearNavigationMenuClose"
         />
       </NavigationMenuRoot>
@@ -99,10 +101,13 @@ import basicEmitter from '../../emitters/basicEmitter.ts';
 import PortfolioMenu from './PortfolioMenu.vue';
 import ProfitsMenu from '../../navigation/ProfitsMenu.vue';
 import AccountMenu from './AccountMenu.vue';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const config = getConfig();
 const wallets = useWallets();
 const controller = useTreasuryController();
+const navigationMenuViewportZIndex = useFloatingZIndex();
+const navigationMenuIndicatorZIndex = useFloatingZIndex(2);
 
 const navigationMenuValue = Vue.ref('');
 let navigationMenuCloseTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;

--- a/src-vue/app-treasury/panels/Portfolio.vue
+++ b/src-vue/app-treasury/panels/Portfolio.vue
@@ -3,12 +3,12 @@
   <DialogRoot class="absolute inset-0 z-10" :open="isOpen">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="closePanel" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closePanel" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="closePanel" :aria-describedby="undefined">
+      <DialogContent asChild @escapeKeyDown="closePanel" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
         <div
-          class="Portfolio Panel inner-input-shadow bg-argon-menu-bg absolute top-[50px] right-2 bottom-2 left-2 z-50 flex flex-col rounded-md border border-black/30 text-left transition-all focus:outline-none overflow-x-scroll"
+          class="Portfolio Panel inner-input-shadow bg-argon-menu-bg absolute top-[50px] right-2 bottom-2 left-2 flex flex-col rounded-md border border-black/30 text-left transition-all focus:outline-none overflow-x-scroll"
           style="
             box-shadow:
               0 -1px 2px 0 rgba(0, 0, 0, 0.1),
@@ -82,10 +82,13 @@ import Overview from './portfolio/Overview.vue';
 import AssetBreakdown from './portfolio/AssetBreakdown.vue';
 import ProfitAnalysis from './portfolio/ProfitAnalysis.vue';
 import TransactionHistory from './portfolio/TransactionHistory.vue';
+import { provideOverlayContentZIndex, useOverlayZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const isLoaded = Vue.ref(false);
 const selectedTab = Vue.ref<PortfolioTab>(PortfolioTab.Overview);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 function closePanel() {
   isOpen.value = false;

--- a/src-vue/components/AlertCalloutButton.vue
+++ b/src-vue/components/AlertCalloutButton.vue
@@ -20,7 +20,7 @@
       </div>
     </HoverCardTrigger>
     <HoverCardPortal>
-      <HoverCardContent side="bottom" :sideOffset="-6" class="z-[5000]">
+      <HoverCardContent side="bottom" :sideOffset="-6" :style="floatingZIndex">
         <div
           v-if="props.guidance"
           :style="{ backgroundColor: props.fillColor }"
@@ -65,6 +65,7 @@ import SparkleOutlineIcon from '../assets/sparkle-outline.svg';
 import SparkleFilledIcon from '../assets/sparkle-filled.svg';
 import { twMerge } from 'tailwind-merge';
 import { HoverCardArrow, HoverCardContent, HoverCardPortal, HoverCardRoot, HoverCardTrigger } from 'reka-ui';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import { useOperationsController, operationalSteps } from '../stores/operationsController.ts';
 
 defineOptions({
@@ -73,6 +74,7 @@ defineOptions({
 
 const controller = useOperationsController();
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 const props = withDefaults(
   defineProps<{

--- a/src-vue/components/ArrowCalloutButton.vue
+++ b/src-vue/components/ArrowCalloutButton.vue
@@ -38,7 +38,7 @@
         />
       </HoverCardTrigger>
       <HoverCardPortal>
-        <HoverCardContent :side="position" :sideOffset="-4" class="z-[5000]">
+        <HoverCardContent :side="position" :sideOffset="-4" :style="floatingZIndex">
           <div
             v-if="props.guidance"
             :style="{ backgroundColor: props.fillColor }"
@@ -84,6 +84,7 @@ import SparkleOutlineIcon from '../assets/sparkle-outline.svg';
 import SparkleFilledIcon from '../assets/sparkle-filled.svg';
 import { twMerge } from 'tailwind-merge';
 import { HoverCardArrow, HoverCardContent, HoverCardPortal, HoverCardRoot, HoverCardTrigger } from 'reka-ui';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import { useOperationsController, operationalSteps } from '../stores/operationsController.ts';
 
 defineOptions({
@@ -92,6 +93,7 @@ defineOptions({
 
 const controller = useOperationsController();
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 const props = withDefaults(
   defineProps<{

--- a/src-vue/components/BgOverlay.vue
+++ b/src-vue/components/BgOverlay.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <div :class="[roundedClass]" class="absolute top-0 left-0 w-full h-full pointer-events-none z-150">
+  <div :class="[roundedClass]" class="absolute top-0 left-0 w-full h-full pointer-events-none">
     <div v-if="enableTopBar" :class="[roundedTopClass]" class="absolute top-0 left-0 w-full h-14 pointer-events-none bg-black/20 transition-opacity"></div>
     <div
       @click="emitClose"

--- a/src-vue/components/CopyAddressMenu.vue
+++ b/src-vue/components/CopyAddressMenu.vue
@@ -37,7 +37,8 @@
             :align="'end'"
             :alignOffset="0"
             :sideOffset="-3"
-            class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[2000] data-[state=open]:transition-all">
+            :style="floatingZIndex"
+            class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all">
             <div class="bg-argon-menu-bg flex shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
               <DropdownMenuItem @click.capture="closeMenu" class="pt-1 pb-2">
                 <CopyToClipboard
@@ -110,6 +111,7 @@ import { IWallet, WalletType } from '../lib/Wallet.ts';
 import { useWallets } from '../stores/wallets.ts';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import QRCode from 'qrcode';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   walletType: WalletType.defaultArgon | WalletType.ethereum;
@@ -121,6 +123,7 @@ const wallets = useWallets();
 
 const isOpen = Vue.ref(false);
 const qrCode = Vue.ref('');
+const floatingZIndex = useFloatingZIndex();
 
 const walletAddressTestId = Vue.computed(() => {
   if (props.walletType === WalletType.defaultArgon) return 'defaultArgonWalletAddress';

--- a/src-vue/components/ImageZoom.vue
+++ b/src-vue/components/ImageZoom.vue
@@ -9,14 +9,14 @@
 
   <DialogRoot :open="zoomOpen" @update:open="zoomOpen = $event">
     <DialogPortal>
-      <DialogOverlay asChild class="fixed inset-0 z-100 bg-black/70 backdrop-blur-sm">
+      <DialogOverlay asChild class="fixed inset-0 bg-black/70 backdrop-blur-sm">
         <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-          <BgOverlay @close="zoomOpen = false" />
+          <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="zoomOpen = false" />
         </Motion>
       </DialogOverlay>
       <DialogContent
-        class="fixed inset-0 z-[110] flex items-center justify-center p-4 focus:outline-none"
-        style="pointer-events: none"
+        class="fixed inset-0 flex items-center justify-center p-4 focus:outline-none"
+        :style="{ pointerEvents: 'none', zIndex: overlayZIndex.contentZIndex }"
       >
         <img
           :src="src"
@@ -34,6 +34,7 @@ import { ref } from 'vue';
 import { DialogRoot, DialogOverlay, DialogPortal, DialogContent } from 'reka-ui';
 import { Motion } from 'motion-v';
 import BgOverlay from './BgOverlay.vue';
+import { useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   src: string;
@@ -42,4 +43,5 @@ const props = defineProps<{
 }>();
 
 const zoomOpen = ref(false);
+const overlayZIndex = useOverlayZIndex(() => zoomOpen.value);
 </script>

--- a/src-vue/components/InputMenu.vue
+++ b/src-vue/components/InputMenu.vue
@@ -18,9 +18,9 @@
 
     <SelectPortal>
       <SelectContent
-        class="bg-white cursor-default data-[side=bottom]:rounded-b-md data-[side=top]:rounded-t-md data-[side=bottom]:border-t-gray-400 data-[side=top]:border-b-gray-400 border border-slate-700/50 shadow-sm will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade z-[2000]"
+        class="bg-white cursor-default data-[side=bottom]:rounded-b-md data-[side=top]:rounded-t-md data-[side=bottom]:border-t-gray-400 data-[side=top]:border-b-gray-400 border border-slate-700/50 shadow-sm will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
         position="popper"
-        :style="{ minWidth: menuWidth, maxHeight: 'var(--reka-select-content-available-height)' }"
+        :style="[floatingZIndex, { minWidth: menuWidth, maxHeight: 'var(--reka-select-content-available-height)' }]"
         :avoidCollisions="true"
         :bodyLock="true"
         :collisionPadding="10"
@@ -83,6 +83,7 @@ import {
   SelectValue,
   SelectViewport,
 } from 'reka-ui';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const currency = getCurrency();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
@@ -120,6 +121,7 @@ const showMenu = Vue.ref(false);
 const triggerInstance = Vue.ref<any>(null);
 
 const menuWidth = Vue.ref('auto');
+const floatingZIndex = useFloatingZIndex();
 
 const selectedOption: Vue.Ref<IOption | undefined> = Vue.ref(undefined);
 const triggerTestId = Vue.computed(() => props.dataTestid ?? 'input-menu-trigger');

--- a/src-vue/components/Tooltip.vue
+++ b/src-vue/components/Tooltip.vue
@@ -10,8 +10,8 @@
           :sideOffset="-5"
           :avoidCollisions="true"
           :collisionPadding="30"
-          :style="{ width: width, maxWidth: maxWidth }"
-          class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-md pointer-events-none z-[10000] rounded-md border border-gray-800/20 bg-white px-4 py-3 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity] select-none"
+          :style="[floatingZIndex, { width: width, maxWidth: maxWidth }]"
+          class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-md pointer-events-none rounded-md border border-gray-800/20 bg-white px-4 py-3 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity] select-none"
         >
           {{ content }}
           <TooltipArrow :width="24" :height="12" class="fill-white stroke-gray-400/30 shadow-xl/50" />
@@ -33,6 +33,7 @@ import {
   TooltipTrigger,
   useForwardPropsEmits,
 } from 'reka-ui';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<
   TooltipRootProps & {
@@ -46,6 +47,7 @@ const emits = defineEmits<TooltipRootEmits>();
 
 const width = Vue.ref('fit-content');
 const maxWidth = Vue.ref();
+const floatingZIndex = useFloatingZIndex();
 
 function handleOpen(isOpen: boolean) {
   if (!isOpen) return;

--- a/src-vue/navigation/OperationsMenu.vue
+++ b/src-vue/navigation/OperationsMenu.vue
@@ -18,8 +18,8 @@
           :align="'end'"
           :alignOffset="-5"
           :sideOffset="-3"
-          :style="{ width: `${parentItemWidth}px` }"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[1000] data-[state=open]:transition-all"
+          :style="[floatingZIndex, { width: `${parentItemWidth}px` }]"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div
             class="bg-argon-menu-bg flex w-full shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20"
@@ -71,10 +71,12 @@ import {
 import { useOperationsController } from '../stores/operationsController.ts';
 import { getConfig } from '../stores/config.ts';
 import { MiningSetupStatus, TopTab, VaultingSetupStatus } from '../interfaces/IConfig.ts';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const rootRef = Vue.ref<HTMLElement | null>(null);
 const parentItemWidth = Vue.ref(0);
+const floatingZIndex = useFloatingZIndex();
 
 const controller = useOperationsController();
 const config = getConfig();

--- a/src-vue/navigation/StatusMenu.vue
+++ b/src-vue/navigation/StatusMenu.vue
@@ -94,7 +94,8 @@
           :align="'end'"
           :alignOffset="0"
           :sideOffset="-3"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-50 data-[state=open]:transition-all"
+          :style="floatingZIndex"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div
             class="text-md flex max-w-140 shrink flex-col rounded bg-white p-1 text-gray-900 shadow-lg ring-1 ring-gray-900/20"
@@ -414,6 +415,7 @@ import { getBiddingCalculator } from '../stores/mainchain.ts';
 import { bigIntMax } from '@argonprotocol/apps-core';
 import { WalletType } from '../lib/Wallet.ts';
 import { MiningSetupStatus, VaultingSetupStatus } from '../interfaces/IConfig.ts';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 enum Status {
   WaitingForSetup = 'WaitingForSetup',
@@ -440,6 +442,7 @@ const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency
 
 const isOpen = Vue.ref(false);
 const rootRef = Vue.ref<HTMLElement>();
+const floatingZIndex = useFloatingZIndex();
 
 const eyeballsElem = Vue.ref<HTMLElement | null>(null);
 

--- a/src-vue/navigation/TabSwitcher.vue
+++ b/src-vue/navigation/TabSwitcher.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <div class="relative z-[2501] mr-3 flex grow flex-row items-center pointer-events-none">
+  <div :style="tabSwitcherZIndex" class="relative mr-3 flex grow flex-row items-center pointer-events-none">
     <section
       ref="toggleRef"
       class="relative flex flex-row items-center pointer-events-auto w-fit gap-x-2 ml-1.5 text-center text-slate-600"
@@ -84,10 +84,12 @@ import { MiningSetupStatus, VaultingSetupStatus } from '../interfaces/IConfig.ts
 import ArrowCalloutButton from '../components/ArrowCalloutButton.vue';
 import OperationsMenu from './OperationsMenu.vue';
 import TreasuryMenu from './TreasuryMenu.vue';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const tour = useTour();
 const controller = useOperationsController();
 const config = getConfig();
+const tabSwitcherZIndex = useFloatingZIndex();
 
 const toggleRef = Vue.ref<HTMLElement | null>(null);
 

--- a/src-vue/navigation/TopBar.vue
+++ b/src-vue/navigation/TopBar.vue
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <div
-    class="bg-white/95 relative z-100 flex min-h-14 w-full flex-row items-center select-none"
+    class="bg-white/95 relative flex min-h-14 w-full flex-row items-center select-none"
     style="border-radius: 10px 10px 0 0; box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2)"
     data-tauri-drag-region
   >
@@ -18,7 +18,7 @@
 
     <NavigationMenuRoot
       v-if="controller.isLoaded && !controller.isImporting"
-      class="relative z-[2501] mr-3 flex w-1/3 grow flex-row items-center justify-end pointer-events-none"
+      class="relative mr-3 flex w-1/3 grow flex-row items-center justify-end pointer-events-none"
       :model-value="navigationMenuValue"
       :delay-duration="0"
       :skip-delay-duration="0"
@@ -46,7 +46,8 @@
         </div>
       </NavigationMenuList>
       <NavigationMenuIndicator
-        class="pointer-events-none absolute top-full left-0 z-[2001] flex h-[10px] w-[var(--reka-navigation-menu-indicator-size)] translate-x-[var(--reka-navigation-menu-indicator-position)] items-end justify-center transition-[width,transform,opacity] duration-300 data-[state=hidden]:opacity-0 data-[state=visible]:opacity-100"
+        :style="navigationMenuIndicatorZIndex"
+        class="pointer-events-none absolute top-full left-0 flex h-[10px] w-[var(--reka-navigation-menu-indicator-size)] translate-x-[var(--reka-navigation-menu-indicator-position)] items-end justify-center transition-[width,transform,opacity] duration-300 data-[state=hidden]:opacity-0 data-[state=visible]:opacity-100"
       >
         <div class="relative top-[-1px] h-0 w-0 border-x-[13px] border-b-[13px] border-x-transparent border-b-gray-900/20">
           <div class="absolute top-[2px] left-[-11px] h-0 w-0 border-x-[11px] border-b-[11px] border-x-transparent border-b-argon-menu-bg" />
@@ -54,7 +55,8 @@
       </NavigationMenuIndicator>
       <NavigationMenuViewport
         align="end"
-        class="pointer-events-auto absolute top-full left-[var(--reka-navigation-menu-viewport-left)] z-[2000] mt-[8px] h-[var(--reka-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-visible rounded border border-gray-900/20 bg-argon-menu-bg shadow-lg transition-[left,_width,_height] duration-300 data-[state=closed]:animate-scaleOut data-[state=open]:animate-scaleIn sm:w-[var(--reka-navigation-menu-viewport-width)]"
+        :style="navigationMenuViewportZIndex"
+        class="pointer-events-auto absolute top-full left-[var(--reka-navigation-menu-viewport-left)] mt-[8px] h-[var(--reka-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-visible rounded border border-gray-900/20 bg-argon-menu-bg shadow-lg transition-[left,_width,_height] duration-300 data-[state=closed]:animate-scaleOut data-[state=open]:animate-scaleIn sm:w-[var(--reka-navigation-menu-viewport-width)]"
         @mouseenter="clearNavigationMenuClose"
       />
     </NavigationMenuRoot>
@@ -80,6 +82,7 @@ import TabSwitcher from './TabSwitcher.vue';
 import ServerMenu from './ServerMenu.vue';
 import OperationalMenu from './OperationalMenu.vue';
 import { NavigationMenuIndicator, NavigationMenuList, NavigationMenuRoot, NavigationMenuViewport } from 'reka-ui';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import ProfitsMenu from './ProfitsMenu.vue';
 import PortfolioDetailsMenu from './PortfolioDetailsMenu.vue';
 import PortfolioCurrencyMenu from './PortfolioCurrencyMenu.vue';
@@ -90,6 +93,8 @@ const wallets = useWallets();
 const tour = useTour();
 const config = getConfig();
 const bot = getBot();
+const navigationMenuViewportZIndex = useFloatingZIndex();
+const navigationMenuIndicatorZIndex = useFloatingZIndex(2);
 
 const accountMenuRef = Vue.ref<InstanceType<typeof AccountMenu> | null>(null);
 const currencyMenuRef = Vue.ref<InstanceType<typeof PortfolioMenu> | null>(null);

--- a/src-vue/navigation/TreasuryMenu.vue
+++ b/src-vue/navigation/TreasuryMenu.vue
@@ -17,8 +17,8 @@
           :align="'end'"
           :alignOffset="-5"
           :sideOffset="-3"
-          :style="{ width: `${parentItemWidth}px` }"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[1000] data-[state=open]:transition-all"
+          :style="[floatingZIndex, { width: `${parentItemWidth}px` }]"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div
             class="bg-argon-menu-bg flex w-full shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20"
@@ -57,10 +57,12 @@ import {
 } from 'reka-ui';
 import { TopTab } from '../interfaces/IConfig.ts';
 import { useOperationsController } from '../stores/operationsController.ts';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const rootRef = Vue.ref<HTMLElement | null>(null);
 const parentItemWidth = Vue.ref(0);
+const floatingZIndex = useFloatingZIndex();
 
 const controller = useOperationsController();
 

--- a/src-vue/overlays/AboutOverlay.vue
+++ b/src-vue/overlays/AboutOverlay.vue
@@ -5,11 +5,11 @@
       <AnimatePresence>
         <DialogOverlay asChild>
           <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay @close="closeOverlay" />
+            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
           </Motion>
         </DialogOverlay>
 
-        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined">
+        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
           <Motion
             :ref="draggable.setModalRef"
             @mousedown="draggable.onMouseDown($event)"
@@ -22,7 +22,7 @@
               transform: 'translate(-50%, -50%)',
               cursor: draggable.isDragging ? 'grabbing' : 'default',
             }"
-            class="absolute z-50 bg-white text-md border border-black/40 px-4 pt-6 pb-4 rounded-lg text-center shadow-xl w-80 overflow-scroll focus:outline-none"
+            class="absolute bg-white text-md border border-black/40 px-4 pt-6 pb-4 rounded-lg text-center shadow-xl w-80 overflow-scroll focus:outline-none"
           >
             <img src="/app-icon.png" class="w-14 h-14 rounded-lg mx-auto" />
             <DialogTitle class="text-lg font-bold mt-4">{{ APP_NAME }}</DialogTitle>
@@ -61,12 +61,14 @@ import { getConfig } from '../stores/config.ts';
 import Draggable from './helpers/Draggable.ts';
 import { platformName, platformVersion } from '../tauri-controls/utils/os.ts';
 import { APP_NAME, INSTANCE_NAME, INSTANCE_PORT, NETWORK_NAME } from '../lib/Env.ts';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const config = getConfig();
 
 const isOpen = Vue.ref(false);
 const wasCopied = Vue.ref(false);
 const draggable = Vue.reactive(new Draggable());
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
 
 basicEmitter.on('openAboutOverlay', async (data: any) => {
   isOpen.value = true;

--- a/src-vue/overlays/ActiveBidsOverlayButton.vue
+++ b/src-vue/overlays/ActiveBidsOverlayButton.vue
@@ -16,7 +16,8 @@
         :sideOffset="10"
         :collisionPadding="24"
         :avoidCollisions="true"
-        class="group relative z-[2002] h-120 w-160 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
+        :style="floatingZIndex"
+        class="group relative h-120 w-160 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
       >
         <PopoverPanelArrow />
         <div class="h-full px-6 pt-5 pb-3 text-base text-center">
@@ -70,6 +71,7 @@ import { createNumeralHelpers } from '../lib/numeral.ts';
 import { TICK_MILLIS } from '../lib/Env.ts';
 import { getWalletKeys } from '../stores/wallets.ts';
 import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -88,6 +90,7 @@ const props = withDefaults(
 const stats = getStats();
 const currency = getCurrency();
 const walletKeys = getWalletKeys();
+const floatingZIndex = useFloatingZIndex();
 
 const popoverSide = Vue.computed(() => {
   if (props.position === 'left') {

--- a/src-vue/overlays/AppUpdatesOverlay.vue
+++ b/src-vue/overlays/AppUpdatesOverlay.vue
@@ -5,17 +5,17 @@
       <AnimatePresence>
         <DialogOverlay asChild>
           <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay @close="closeOverlay" />
+            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
           </Motion>
         </DialogOverlay>
 
-        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined">
+        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
           <Motion
             :ref="draggable.setModalRef"
             :initial="{ opacity: 0 }"
             :animate="{ opacity: 1 }"
             :exit="{ opacity: 0 }"
-            class="absolute z-50 min-h-60 w-160 overflow-scroll rounded-lg border border-black/40 bg-white px-3 pt-6 pb-4 shadow-xl focus:outline-none"
+            class="absolute min-h-60 w-160 overflow-scroll rounded-lg border border-black/40 bg-white px-3 pt-6 pb-4 shadow-xl focus:outline-none"
             :style="{
               top: `calc(50% + ${draggable.modalPosition.y}px)`,
               left: `calc(50% + ${draggable.modalPosition.x}px)`,
@@ -105,9 +105,11 @@ import { AnimatePresence, Motion } from 'motion-v';
 import { XMarkIcon } from '@heroicons/vue/24/outline';
 import dayjs from 'dayjs';
 import { useAppUpdater } from '../stores/appUpdater.ts';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const draggable = Vue.reactive(new Draggable());
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
 const updater = useAppUpdater();
 const { downloadProgress, errorMessage, installedVersion, isChecking, isDownloading, isReadyToInstall, update } =
   storeToRefs(updater);

--- a/src-vue/overlays/ArgonBlocksOverlay.vue
+++ b/src-vue/overlays/ArgonBlocksOverlay.vue
@@ -17,7 +17,8 @@
         :sideOffset="10"
         :collisionPadding="24"
         :avoidCollisions="true"
-        class="group relative z-[2002] h-140 w-150 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
+        :style="floatingZIndex"
+        class="group relative h-140 w-150 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
       >
         <PopoverPanelArrow />
         <div class="flex h-full max-w-full flex-col px-6 pt-4 pb-2 text-base">
@@ -87,9 +88,11 @@ import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka
 import { getWalletKeys } from '../stores/wallets.ts';
 import { UnitOfMeasurement } from '../lib/Currency.ts';
 import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 const walletKeys = getWalletKeys();
 const currency = getCurrency();
+const floatingZIndex = useFloatingZIndex();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 

--- a/src-vue/overlays/BitcoinBlocksOverlay.vue
+++ b/src-vue/overlays/BitcoinBlocksOverlay.vue
@@ -17,7 +17,8 @@
         :sideOffset="10"
         :collisionPadding="24"
         :avoidCollisions="true"
-        class="group relative z-[2002] h-140 w-150 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
+        :style="floatingZIndex"
+        class="group relative h-140 w-150 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
       >
         <PopoverPanelArrow />
         <div class="flex h-full max-w-full flex-col px-6 pt-4 pb-2 text-base">
@@ -72,10 +73,12 @@ import { getStats } from '../stores/stats.ts';
 import { getBot } from '../stores/bot.ts';
 import { getConfig } from '../stores/config.ts';
 import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 const stats = getStats();
 const bot = getBot();
 const config = getConfig();
+const floatingZIndex = useFloatingZIndex();
 
 const blocks = Vue.ref<IBitcoinBlockMeta[]>([]);
 

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -10,10 +10,13 @@
       leave-from="opacity-100"
       leave-to="opacity-0"
     >
-      <BgOverlay :enableTopBar="true" />
+      <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
     </TransitionChild>
 
-    <div class="absolute inset-0 z-100 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none">
+    <div
+      class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
+      :style="{ zIndex: overlayZIndex.contentZIndex }"
+    >
       <TransitionChild
         as="template"
         enter="ease-out duration-300"
@@ -70,10 +73,12 @@ import Draggable from './helpers/Draggable.ts';
 import { ConfigServerAddSchema, ConfigServerDetailsSchema, IConfig } from '../interfaces/IConfig.ts';
 import { SSH } from '../lib/SSH.ts';
 import { JsonExt } from '@argonprotocol/apps-core';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(true);
 const isRetrying = Vue.ref(false);
 const config = getConfig();
+const overlayZIndex = useOverlayZIndex(() => true);
 
 const draggable = Vue.reactive(new Draggable());
 

--- a/src-vue/overlays/BotEditOverlay.vue
+++ b/src-vue/overlays/BotEditOverlay.vue
@@ -3,10 +3,10 @@
   <DialogRoot class="absolute inset-0 z-10" :open="isOpen">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="cancelOverlay" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="cancelOverlay" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="cancelOverlay" :aria-describedby="undefined">
+      <DialogContent asChild @escapeKeyDown="cancelOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
         <div
           :ref="draggable.setModalRef"
           :style="{
@@ -14,10 +14,10 @@
             left: `calc(50% + ${draggable.modalPosition.x}px)`,
             transform: 'translate(-50%, -50%)',
           }"
-          class="BotEditOverlay absolute w-[1000px] min-h-[550px] flex flex-col rounded-md border border-black/30 bg-argon-menu-bg text-left z-200 focus:outline-none"
+          class="BotEditOverlay absolute w-[1000px] min-h-[550px] flex flex-col rounded-md border border-black/30 bg-argon-menu-bg text-left focus:outline-none"
           style="box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2), inset 2px 2px 0 rgba(255, 255, 255, 1)"
         >
-          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" class="z-100" />
+          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" :style="editBoxBackdropZIndex" />
           <div class="flex flex-col h-full w-full grow">
             <h2
               @mousedown="draggable.onMouseDown($event)"
@@ -78,6 +78,7 @@ import BotSettings from '../components/BotSettings.vue';
 import Draggable from './helpers/Draggable.ts';
 import { getBot } from '../stores/bot.ts';
 import basicEmitter from '../emitters/basicEmitter.ts';
+import { provideOverlayContentZIndex, useFloatingZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const config = getConfig();
 const bot = getBot();
@@ -97,6 +98,9 @@ const isLoaded = Vue.ref(false);
 const isSaving = Vue.ref(false);
 const savingError = Vue.ref<string | null>(null);
 const hasEditBoxOverlay = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
+const editBoxBackdropZIndex = useFloatingZIndex();
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 const botSettings = Vue.ref<typeof BotSettings | null>(null);
 const saveButtonElement = Vue.ref<HTMLElement | null>(null);

--- a/src-vue/overlays/BotHistoryOverlayButton.vue
+++ b/src-vue/overlays/BotHistoryOverlayButton.vue
@@ -16,7 +16,8 @@
         :sideOffset="10"
         :collisionPadding="24"
         :avoidCollisions="true"
-        class="group relative z-[2002] w-220 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
+        :style="floatingZIndex"
+        class="group relative w-220 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
       >
         <PopoverPanelArrow />
         <div class="flex h-full max-w-full flex-col px-6 pt-4 pb-2 text-base">
@@ -90,6 +91,7 @@ import { botEmitter } from '../lib/Bot.ts';
 import { getBot } from '../stores/bot.ts';
 import { getConfig } from '../stores/config.ts';
 import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -106,6 +108,7 @@ const props = withDefaults(
 const bot = getBot();
 const config = getConfig();
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 const popoverSide = Vue.computed(() => {
   if (props.position === 'left') {

--- a/src-vue/overlays/EditBoxOverlay.vue
+++ b/src-vue/overlays/EditBoxOverlay.vue
@@ -2,8 +2,8 @@
 <template>
   <div
     ref="modalElem"
-    class="absolute bg-white border border-slate-500/60 rounded-md shadow-lg z-200 text-base"
-    :style="[positionStyle, { cursor: isDragging ? 'grabbing' : 'default' }]"
+    class="absolute bg-white border border-slate-500/60 rounded-md shadow-lg text-base"
+    :style="[positionStyle, editBoxZIndex, { cursor: isDragging ? 'grabbing' : 'default' }]"
   >
     <div class="flex flex-col">
       <div class="flex flex-row items-center justify-center text-xl font-bold font-sans text-argon-600/70 mx-2 text-center border-b border-slate-400/30 select-none">
@@ -80,6 +80,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline';
 import { getConfig } from '../stores/config.ts';
 import { JsonExt } from '@argonprotocol/apps-core';
 import { IBiddingRules } from '@argonprotocol/apps-core';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   id: IEditBoxOverlayType;
@@ -95,6 +96,7 @@ const emit = defineEmits<{
 }>();
 
 const config = getConfig();
+const editBoxZIndex = useFloatingZIndex(2);
 
 const editorInstance = Vue.ref<IEditBoxChildExposed | null>(null);
 const saveButtonLabel = Vue.ref('Save');

--- a/src-vue/overlays/EthereumSyncPopover.vue
+++ b/src-vue/overlays/EthereumSyncPopover.vue
@@ -13,7 +13,8 @@
         :sideOffset="10"
         :collisionPadding="24"
         :avoidCollisions="true"
-        class="group relative z-[2002] w-[560px] rounded-lg border border-gray-300 bg-white text-left text-base shadow-lg"
+        :style="floatingZIndex"
+        class="group relative w-[560px] rounded-lg border border-gray-300 bg-white text-left text-base shadow-lg"
       >
         <PopoverPanelArrow />
         <div class="px-5 pt-4 pb-3 text-slate-700">
@@ -101,6 +102,7 @@ import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka
 import CountupClock from '../components/CountupClock.vue';
 import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
 import { getBot } from '../stores/bot.ts';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -110,6 +112,7 @@ const props = withDefaults(
     position: 'top',
   },
 );
+const floatingZIndex = useFloatingZIndex();
 
 const bot = getBot();
 

--- a/src-vue/overlays/ExistingNetworkVaultsOverlayButton.vue
+++ b/src-vue/overlays/ExistingNetworkVaultsOverlayButton.vue
@@ -8,7 +8,12 @@
         </span>
       </slot>
     </PopoverButton>
-    <PopoverPanel as="div" :class="panelPositioningClasses" class="absolute w-160 h-120 z-100 text-center text-lg font-bold mt-10 bg-white rounded-lg shadow-lg border border-gray-300 ">
+    <PopoverPanel
+      as="div"
+      :class="panelPositioningClasses"
+      :style="floatingZIndex"
+      class="absolute mt-10 h-120 w-160 rounded-lg border border-gray-300 bg-white text-center text-lg font-bold shadow-lg"
+    >
       <div :class="arrowPositioningClasses" class="absolute w-[30px] h-[15px] overflow-hidden">
         <div class="relative top-[5px] left-[5px] w-[20px] h-[20px] rotate-45 bg-white ring-1 ring-gray-900/20"></div>
       </div>
@@ -47,6 +52,7 @@ import { getCurrency } from '../stores/currency.ts';
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue';
 import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
 import { getVaults } from '../stores/vaults.ts';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -62,6 +68,7 @@ const props = withDefaults(
 
 const vaultStore = getVaults();
 const currency = getCurrency();
+const floatingZIndex = useFloatingZIndex();
 
 const panelPositioningClasses = Vue.computed(() => {
   if (props.position === 'left') {

--- a/src-vue/overlays/JurisdictionOverlay.vue
+++ b/src-vue/overlays/JurisdictionOverlay.vue
@@ -5,17 +5,17 @@
       <AnimatePresence>
         <DialogOverlay asChild>
           <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay @close="closeOverlay" />
+            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
           </Motion>
         </DialogOverlay>
 
-        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined">
+        <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
           <Motion
             :ref="draggable.setModalRef"
             :initial="{ opacity: 0 }"
             :animate="{ opacity: 1 }"
             :exit="{ opacity: 0 }"
-            class="absolute z-50 bg-white border border-black/40 px-3 pt-6 pb-4 rounded-lg shadow-xl w-160 min-h-60 overflow-scroll focus:outline-none"
+            class="absolute bg-white border border-black/40 px-3 pt-6 pb-4 rounded-lg shadow-xl w-160 min-h-60 overflow-scroll focus:outline-none"
             :style="{
               top: `calc(50% + ${draggable.modalPosition.y}px)`,
               left: `calc(50% + ${draggable.modalPosition.x}px)`,
@@ -61,11 +61,13 @@ import { XMarkIcon } from '@heroicons/vue/24/outline';
 import { ChevronLeftIcon } from '@heroicons/vue/24/outline';
 import Draggable from './helpers/Draggable.ts';
 import { ICurrencyKey } from '@argonprotocol/apps-core';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const currentScreen = Vue.ref<'overview' | 'fixJurisdiction'>('overview');
 const draggable = Vue.reactive(new Draggable());
 const setCurrencyKey = Vue.ref<ICurrencyKey | undefined>(undefined);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
 
 const title = Vue.computed(() => {
   if (currentScreen.value === 'overview') {

--- a/src-vue/overlays/MoveCapitalButton.vue
+++ b/src-vue/overlays/MoveCapitalButton.vue
@@ -12,7 +12,8 @@
       <PopoverContent
         :sideOffset="-5"
         :side="props.side"
-        class="border-argon-600/30 z-50 min-w-md max-w-lg rounded-md border bg-white px-6 py-4 text-sm font-medium text-gray-700 shadow-2xl"
+        :style="floatingZIndex"
+        class="border-argon-600/30 min-w-md max-w-lg rounded-md border bg-white px-6 py-4 text-sm font-medium text-gray-700 shadow-2xl"
       >
         <MoveCapitalCore
           :isOpen="isOpen"
@@ -34,6 +35,7 @@ import { twMerge } from 'tailwind-merge';
 import { PopoverArrow, PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui';
 import MoveCapitalCore from './move-capital/MoveCapitalCore.vue';
 import { MoveFrom, MoveTo, MoveToken } from '@argonprotocol/apps-core';
+import { useFloatingZIndex } from './helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -53,6 +55,7 @@ const emit = defineEmits<{
 }>();
 
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 function close() {
   isOpen.value = false;

--- a/src-vue/overlays/OverlayBase.vue
+++ b/src-vue/overlays/OverlayBase.vue
@@ -9,11 +9,16 @@
             :initial="disableOverlayMotion ? false : { opacity: 0 }"
             :animate="{ opacity: 1 }"
             :exit="{ opacity: 0 }">
-            <BgOverlay @close="clickBackdrop" />
+            <BgOverlay :enableTopBar="props.enableTopBar" :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="clickBackdrop" />
           </Motion>
         </DialogOverlay>
 
-        <DialogContent asChild @escapeKeyDown="handleEscapeKeyDown" :aria-describedby="undefined" class="pointer-events-none" :style="{ zIndex: zIndex + 1000 }">
+        <DialogContent
+          asChild
+          @escapeKeyDown="handleEscapeKeyDown"
+          :aria-describedby="undefined"
+          class="pointer-events-none"
+          :style="{ zIndex: overlayZIndex.contentZIndex }">
           <Motion
             asChild
             :initial="disableOverlayMotion ? false : { opacity: 0 }"
@@ -29,7 +34,7 @@
                 cursor: draggable.isDragging ? 'grabbing' : 'default',
               }"
               :class="twMerge(
-                'absolute z-50 pointer-events-auto min-h-40 w-6/12 focus:outline-none',
+                'absolute pointer-events-auto min-h-40 w-6/12 focus:outline-none',
                 props.leaveBlank ? '' : 'bg-white border border-black/40 rounded-lg shadow-2xl',
                 props.overflowScroll ? 'flex max-h-[85vh] flex-col overflow-hidden' : '',
                 props.class,
@@ -69,10 +74,6 @@
   </DialogRoot>
 </template>
 
-<script lang="ts">
-const openZIndexes = Vue.ref(new Set<number>());
-</script>
-
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { twMerge } from 'tailwind-merge';
@@ -81,9 +82,7 @@ import { AnimatePresence, Motion, MotionGlobalConfig } from 'motion-v';
 import { ChevronLeftIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import BgOverlay from '../components/BgOverlay.vue';
 import Draggable from './helpers/Draggable.ts';
-import { getConfig } from '../stores/config.ts';
-
-const config = getConfig();
+import { provideOverlayContentZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 defineOptions({
   inheritAttrs: false,
@@ -101,6 +100,7 @@ const props = withDefaults(
     overflowScroll?: boolean;
     leaveBlank?: boolean;
     hasHeaderBorder?: boolean;
+    enableTopBar?: boolean;
   }>(),
   {
     showCloseIcon: true,
@@ -108,6 +108,7 @@ const props = withDefaults(
     showBg: true,
     overflowScroll: true,
     hasHeaderBorder: true,
+    enableTopBar: false,
   },
 );
 
@@ -119,11 +120,12 @@ const emit = defineEmits<{
   (e: 'goBack'): void;
 }>();
 
-const zIndex = Vue.ref(0);
 const attrs = Vue.useAttrs();
 const disableOverlayMotion = MotionGlobalConfig.skipAnimations || MotionGlobalConfig.instantAnimations;
 
 const draggable = Vue.reactive(new Draggable());
+const overlayZIndex = useOverlayZIndex(() => props.isOpen);
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 function closeOverlay() {
   if (props.disallowClose) {
@@ -150,24 +152,6 @@ function handleEscapeKeyDown() {
   emit('pressEsc');
   closeOverlay();
 }
-
-Vue.watch(
-  () => props.isOpen,
-  isOpen => {
-    if (!isOpen) {
-      openZIndexes.value.delete(zIndex.value);
-      return;
-    }
-
-    zIndex.value = Math.max(...openZIndexes.value, 0) + 1;
-    openZIndexes.value.add(zIndex.value);
-  },
-  { immediate: true },
-);
-
-Vue.onUnmounted(() => {
-  openZIndexes.value.delete(zIndex.value);
-});
 
 defineExpose({
   draggable,

--- a/src-vue/overlays/ProvisioningCompleteOverlay.vue
+++ b/src-vue/overlays/ProvisioningCompleteOverlay.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <TransitionRoot class="absolute inset-0 z-10" :show="isOpen">
+  <TransitionRoot class="absolute inset-0" :show="isOpen">
     <TransitionChild
       as="template"
       enter="ease-out duration-300"
@@ -10,10 +10,13 @@
       leave-from="opacity-100"
       leave-to="opacity-0"
     >
-      <BgOverlay />
+      <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
     </TransitionChild>
 
-    <div class="absolute inset-0 z-100 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none">
+    <div
+      class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
+      :style="{ zIndex: overlayZIndex.contentZIndex }"
+    >
       <TransitionChild
         as="template"
         enter="ease-out duration-300"
@@ -55,9 +58,11 @@ import { TransitionChild, TransitionRoot } from '@headlessui/vue';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import BgOverlay from '../components/BgOverlay.vue';
 import { getConfig } from '../stores/config.ts';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const config = getConfig();
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
 
 basicEmitter.on('openProvisioningCompleteOverlay', () => {
   isOpen.value = true;

--- a/src-vue/overlays/ServerRemoveOverlay.vue
+++ b/src-vue/overlays/ServerRemoveOverlay.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <TransitionRoot class="absolute inset-0 z-10" :show="isOpen">
+  <TransitionRoot class="absolute inset-0" :show="isOpen">
     <TransitionChild
       as="template"
       enter="ease-out duration-300"
@@ -10,10 +10,13 @@
       leave-from="opacity-100"
       leave-to="opacity-0"
     >
-      <BgOverlay />
+      <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
     </TransitionChild>
 
-    <div class="absolute inset-0 z-100 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none">
+    <div
+      class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
+      :style="{ zIndex: overlayZIndex.contentZIndex }"
+    >
       <TransitionChild
         as="template"
         enter="ease-out duration-300"
@@ -75,12 +78,14 @@ import { type IConfigServerDetails, type IConfigServerInstallDetails, ServerType
 import { SSH } from '../lib/SSH.ts';
 import { invokeWithTimeout } from '../lib/tauriApi.ts';
 import { LocalMachine } from '../lib/LocalMachine.ts';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const config = getConfig();
 
 const isOpen = Vue.ref(false);
 const isLoaded = Vue.ref(false);
 const isRemoving = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
 
 basicEmitter.on('openServerRemoveOverlay', async (data: any) => {
   isOpen.value = true;

--- a/src-vue/overlays/SyncingOverlay.vue
+++ b/src-vue/overlays/SyncingOverlay.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <TransitionRoot class="absolute inset-0 z-10 pointer-events-none" :show="isOpen">
+  <TransitionRoot class="absolute inset-0 pointer-events-none" :show="isOpen">
     <TransitionChild
       as="template"
       enter="ease-out duration-300"
@@ -10,10 +10,13 @@
       leave-from="opacity-100"
       leave-to="opacity-0"
     >
-      <BgOverlay :enableTopBar="true" />
+      <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
     </TransitionChild>
 
-    <div class="absolute inset-0 z-200 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none">
+    <div
+      class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
+      :style="{ zIndex: overlayZIndex.contentZIndex }"
+    >
       <TransitionChild
         as="template"
         enter="ease-out duration-300"
@@ -64,10 +67,12 @@ import ProgressBar from '../components/ProgressBar.vue';
 import AlertIcon from '../assets/alert.svg?component';
 import { getBot } from '../stores/bot.ts';
 import Draggable from './helpers/Draggable.ts';
+import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(true);
 const isRetrying = Vue.ref(false);
 const bot = getBot();
+const overlayZIndex = useOverlayZIndex(() => true);
 
 const draggable = Vue.reactive(new Draggable());
 

--- a/src-vue/overlays/VaultEditOverlay.vue
+++ b/src-vue/overlays/VaultEditOverlay.vue
@@ -3,10 +3,10 @@
   <DialogRoot class="absolute inset-0 z-10" :open="true">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="cancelOverlay" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="cancelOverlay" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="cancelOverlay" :aria-describedby="undefined">
+      <DialogContent asChild @escapeKeyDown="cancelOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
         <div
           :ref="draggable.setModalRef"
           :style="{
@@ -14,10 +14,10 @@
             left: `calc(50% + ${draggable.modalPosition.x}px)`,
             transform: 'translate(-50%, -50%)',
           }"
-          class="VaultEditOverlay absolute w-[1000px] min-h-[400px] flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left z-50 focus:outline-none"
+          class="VaultEditOverlay absolute w-[1000px] min-h-[400px] flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left focus:outline-none"
           style="box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.2), inset 2px 2px 0 rgba(255, 255, 255, 1)"
         >
-          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" class="z-100" />
+          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" :style="editBoxBackdropZIndex" />
           <div class="flex flex-col h-full w-full grow">
             <h2
               @mousedown="draggable.onMouseDown($event)"
@@ -78,6 +78,7 @@ import Tooltip from '../components/Tooltip.vue';
 import VaultSettings from '../components/VaultSettings.vue';
 import Draggable from './helpers/Draggable.ts';
 import { getMyVault } from '../stores/vaults.ts';
+import { provideOverlayContentZIndex, useFloatingZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const emit = defineEmits<{
   (e: 'close'): void;
@@ -100,6 +101,9 @@ const isLoaded = Vue.ref(false);
 const isSaving = Vue.ref(false);
 const savingError = Vue.ref<string | null>(null);
 const hasEditBoxOverlay = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => true);
+const editBoxBackdropZIndex = useFloatingZIndex();
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 const vaultSettings = Vue.ref<typeof VaultSettings | null>(null);
 const saveButtonElement = Vue.ref<HTMLElement | null>(null);

--- a/src-vue/overlays/WelcomeOverlay.vue
+++ b/src-vue/overlays/WelcomeOverlay.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <OverlayBase :isOpen="isOpen" :showCloseIcon="false" :showGoBack="!!currentStep" @goBack="backToMain" class="w-7/12">
+  <OverlayBase :isOpen="isOpen" :showCloseIcon="false" :showGoBack="!!currentStep" :enableTopBar="true" @goBack="backToMain" class="w-7/12">
     <template #title>
       <DialogTitle class="grow pl-3">
         <template v-if="!currentStep">Welcome to Argon Desktop!</template>

--- a/src-vue/overlays/bot/BotCapital.vue
+++ b/src-vue/overlays/bot/BotCapital.vue
@@ -12,7 +12,8 @@
           :alignOffset="alignOffset ?? 0"
           :avoidCollisions="true"
           :collisionPadding="30"
-          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none z-100 w-[800px] rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
+          :style="floatingZIndex"
+          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none w-[800px] rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
         >
           <p>
             This box contains the number of tokens (both argons and argonots) that are committed to your mining
@@ -99,6 +100,7 @@ import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRo
 import { getBiddingCalculator, getBiddingCalculatorData } from '../../stores/mainchain.ts';
 import { getConfig } from '../../stores/config.ts';
 import { IBiddingRules, SeatGoalInterval, SeatGoalType, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   align?: 'start' | 'end' | 'center';
@@ -111,6 +113,7 @@ const calculatorData = getBiddingCalculatorData();
 const config = getConfig();
 const currency = getCurrency();
 const { microgonToMoneyNm, microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
+const floatingZIndex = useFloatingZIndex();
 
 const rules = Vue.computed(() => config.biddingRules as IBiddingRules);
 

--- a/src-vue/overlays/bot/BotReturns.vue
+++ b/src-vue/overlays/bot/BotReturns.vue
@@ -12,7 +12,8 @@
           :alignOffset="alignOffset ?? 0"
           :avoidCollisions="true"
           :collisionPadding="30"
-          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none z-100 w-[800px] rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
+          :style="floatingZIndex"
+          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none w-[800px] rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
         >
           <p>
             Calculating your future return is complex since it's difficult to predict what will happen at auction. For
@@ -101,6 +102,7 @@ import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
 import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui';
 import { IBiddingRules } from '@argonprotocol/apps-core';
 import { getBiddingCalculator, getBiddingCalculatorData } from '../../stores/mainchain.ts';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   align?: 'start' | 'end' | 'center';
@@ -113,6 +115,7 @@ const calculatorData = getBiddingCalculatorData();
 const config = getConfig();
 const currency = getCurrency();
 const { microgonToMoneyNm, microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
+const floatingZIndex = useFloatingZIndex();
 
 const rules = Vue.computed(() => config.biddingRules as IBiddingRules);
 

--- a/src-vue/overlays/bot/NeedMoreCapitalHover.vue
+++ b/src-vue/overlays/bot/NeedMoreCapitalHover.vue
@@ -11,7 +11,8 @@
         :sideOffset="5"
         :collisionPadding="24"
         align="end"
-        class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade text-md z-100 w-[500px] rounded-md border border-gray-800/20 bg-white px-4 pt-4 pb-5 text-left leading-5.5 text-gray-600 shadow-xl select-none data-[state=open]:transition-all"
+        :style="floatingZIndex"
+        class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade text-md w-[500px] rounded-md border border-gray-800/20 bg-white px-4 pt-4 pb-5 text-left leading-5.5 text-gray-600 shadow-xl select-none data-[state=open]:transition-all"
       >
         <p>
           You need a minimum of {{ currency.symbol }}{{ microgonToMoneyNm(idealCapitalCommitment).format('0,0.00') }} in
@@ -50,6 +51,7 @@ import { getConfig } from '../../stores/config.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
 import IncreaseIcon from '../../assets/increase.svg?component';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   calculator: BiddingCalculator;
@@ -67,6 +69,7 @@ const currency = getCurrency();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 const isClickedOpen = Vue.ref(false);
 let wasRecentlyClickedOutside = false;
 

--- a/src-vue/overlays/helpers/OverlayZIndex.ts
+++ b/src-vue/overlays/helpers/OverlayZIndex.ts
@@ -1,0 +1,82 @@
+import * as Vue from 'vue';
+
+const OVERLAY_BACKDROP_Z_INDEX = 1000;
+const OVERLAY_Z_INDEX_STEP = 2;
+const ROOT_FLOATING_Z_INDEX = OVERLAY_BACKDROP_Z_INDEX - OVERLAY_Z_INDEX_STEP;
+const openOverlayZIndexes = new Set<number>();
+const overlayContentZIndexKey = Symbol('overlay-content-z-index') as Vue.InjectionKey<
+  Vue.Ref<number> | Vue.ComputedRef<number>
+>;
+
+export function getOverlayBackdropZIndex(contentZIndex: number) {
+  if (!contentZIndex) {
+    return OVERLAY_BACKDROP_Z_INDEX;
+  }
+
+  return contentZIndex - 1;
+}
+
+export function releaseOverlayZIndex(contentZIndex: number) {
+  if (!contentZIndex) {
+    return;
+  }
+
+  openOverlayZIndexes.delete(contentZIndex);
+}
+
+export function reserveOverlayZIndex(contentZIndex = 0) {
+  releaseOverlayZIndex(contentZIndex);
+
+  const nextZIndex = Math.max(OVERLAY_BACKDROP_Z_INDEX - 1, ...openOverlayZIndexes) + OVERLAY_Z_INDEX_STEP;
+  openOverlayZIndexes.add(nextZIndex);
+  return nextZIndex;
+}
+
+export function useOverlayZIndex(getIsOpen: () => boolean) {
+  const contentZIndex = Vue.ref(0);
+
+  function bringToFront() {
+    if (!getIsOpen()) {
+      return;
+    }
+
+    contentZIndex.value = reserveOverlayZIndex(contentZIndex.value);
+  }
+
+  Vue.watch(
+    getIsOpen,
+    isOpen => {
+      if (!isOpen) {
+        releaseOverlayZIndex(contentZIndex.value);
+        contentZIndex.value = 0;
+        return;
+      }
+
+      bringToFront();
+    },
+    { immediate: true },
+  );
+
+  Vue.onUnmounted(() => {
+    releaseOverlayZIndex(contentZIndex.value);
+  });
+
+  return Vue.reactive({
+    backdropZIndex: Vue.computed(() => getOverlayBackdropZIndex(contentZIndex.value)),
+    contentZIndex,
+    bringToFront,
+  });
+}
+
+export function provideOverlayContentZIndex(contentZIndex: Vue.Ref<number> | Vue.ComputedRef<number>) {
+  Vue.provide(overlayContentZIndexKey, contentZIndex);
+}
+
+export function useFloatingZIndex(offset = 1) {
+  const parentOverlayContentZIndex = Vue.inject(overlayContentZIndexKey, undefined);
+  const rootFloatingZIndex = ROOT_FLOATING_Z_INDEX + Math.max(offset - 1, 0);
+
+  return Vue.computed(() => ({
+    zIndex: parentOverlayContentZIndex ? parentOverlayContentZIndex.value + offset : rootFloatingZIndex,
+  }));
+}

--- a/src-vue/overlays/helpers/OverlayZIndex.ts
+++ b/src-vue/overlays/helpers/OverlayZIndex.ts
@@ -1,7 +1,7 @@
 import * as Vue from 'vue';
 
 const OVERLAY_BACKDROP_Z_INDEX = 1000;
-const OVERLAY_Z_INDEX_STEP = 2;
+const OVERLAY_Z_INDEX_STEP = 6;
 const ROOT_FLOATING_Z_INDEX = OVERLAY_BACKDROP_Z_INDEX - OVERLAY_Z_INDEX_STEP;
 const openOverlayZIndexes = new Set<number>();
 const overlayContentZIndexKey = Symbol('overlay-content-z-index') as Vue.InjectionKey<

--- a/src-vue/overlays/vault/VaultCapital.vue
+++ b/src-vue/overlays/vault/VaultCapital.vue
@@ -12,8 +12,8 @@
           :alignOffset="alignOffset ?? 0"
           :avoidCollisions="true"
           :collisionPadding="30"
-          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none z-100 rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
-          :style="{ width: props.width }"
+          :style="[floatingZIndex, { width: props.width }]"
+          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
         >
           <p class="leading-5">
             As the box above shows, you're committing {{ currency.symbol
@@ -126,6 +126,7 @@ import { getVaultCalculator } from '../../stores/mainchain.ts';
 import { getConfig } from '../../stores/config.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -143,6 +144,7 @@ const calculator = getVaultCalculator();
 const config = getConfig();
 const currency = getCurrency();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
+const floatingZIndex = useFloatingZIndex();
 
 const rules = Vue.computed(() => config.vaultingRules);
 

--- a/src-vue/overlays/vault/VaultReturns.vue
+++ b/src-vue/overlays/vault/VaultReturns.vue
@@ -12,8 +12,8 @@
           :alignOffset="alignOffset ?? 0"
           :avoidCollisions="true"
           :collisionPadding="30"
-          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none z-100 rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
-          :style="{ width: props.width }"
+          :style="[floatingZIndex, { width: props.width }]"
+          class="text-md data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade pointer-events-none rounded-lg border border-gray-800/20 bg-white px-5 pt-4 pb-2 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity]"
         >
           <p>
             Your future returns are dependent on several factors, including the percent utilization of your Bitcoin and
@@ -168,6 +168,7 @@ import { getCurrency } from '../../stores/currency.ts';
 import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
 import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui';
 import { getVaultCalculator } from '../../stores/mainchain.ts';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -185,6 +186,7 @@ const calculator = getVaultCalculator();
 const config = getConfig();
 const currency = getCurrency();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
+const floatingZIndex = useFloatingZIndex();
 
 const rules = Vue.computed(() => config.vaultingRules);
 

--- a/src-vue/overlays/welcome-tour/StepFive.vue
+++ b/src-vue/overlays/welcome-tour/StepFive.vue
@@ -1,7 +1,11 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute left-0" :style="[floatingZIndex, { top, width: `${props.pos.width}px` }]">
+      <PopoverContent
+        ref="boxRef"
+        class="absolute left-0"
+        :style="[floatingZIndex, { top, width: `${props.pos.width}px` }]"
+      >
         <div Arrow class="absolute top-[calc(50%-4px)] left-[15%] z-1 -translate-y-1/2">
           <svg
             class="relative z-10"

--- a/src-vue/overlays/welcome-tour/StepFive.vue
+++ b/src-vue/overlays/welcome-tour/StepFive.vue
@@ -1,7 +1,7 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute left-0 z-[2001]" :style="{ top, width: `${props.pos.width}px` }">
+      <PopoverContent ref="boxRef" class="absolute left-0" :style="[floatingZIndex, { top, width: `${props.pos.width}px` }]">
         <div Arrow class="absolute top-[calc(50%-4px)] left-[15%] z-1 -translate-y-1/2">
           <svg
             class="relative z-10"
@@ -68,11 +68,13 @@ import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 dayjs.extend(dayjsUtc);
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/overlays/welcome-tour/StepFour.vue
+++ b/src-vue/overlays/welcome-tour/StepFour.vue
@@ -3,8 +3,8 @@
     <PopoverPortal>
       <PopoverContent
         ref="boxRef"
-        class="absolute z-[2001]"
-        :style="{ left, top, height: `${props.pos.height}px`, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, height: `${props.pos.height}px`, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-px left-1/2 z-1 -translate-x-1/2 -translate-y-full">
           <svg
@@ -71,11 +71,13 @@ import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 dayjs.extend(dayjsUtc);
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/overlays/welcome-tour/StepOne.vue
+++ b/src-vue/overlays/welcome-tour/StepOne.vue
@@ -1,7 +1,11 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute" :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]">
+      <PopoverContent
+        ref="boxRef"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
+      >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-[20%] z-1 -translate-y-full">
           <svg
             class="relative z-10"

--- a/src-vue/overlays/welcome-tour/StepOne.vue
+++ b/src-vue/overlays/welcome-tour/StepOne.vue
@@ -1,7 +1,7 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute z-[2001]" :style="{ left, top, width: `${props.pos.width}px` }">
+      <PopoverContent ref="boxRef" class="absolute" :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]">
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-[20%] z-1 -translate-y-full">
           <svg
             class="relative z-10"
@@ -68,11 +68,13 @@ import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 dayjs.extend(dayjsUtc);
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/overlays/welcome-tour/StepThree.vue
+++ b/src-vue/overlays/welcome-tour/StepThree.vue
@@ -3,8 +3,8 @@
     <PopoverPortal>
       <PopoverContent
         ref="boxRef"
-        class="absolute z-[2001]"
-        :style="{ left, top, height: `${props.pos.height}px`, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, height: `${props.pos.height}px`, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-px left-1/2 z-1 -translate-x-1/2 -translate-y-full">
           <svg
@@ -71,11 +71,13 @@ import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 dayjs.extend(dayjsUtc);
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/overlays/welcome-tour/StepTwo.vue
+++ b/src-vue/overlays/welcome-tour/StepTwo.vue
@@ -1,7 +1,11 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute" :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]">
+      <PopoverContent
+        ref="boxRef"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
+      >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-[72%] z-1 -translate-y-full">
           <svg
             class="relative z-10"

--- a/src-vue/overlays/welcome-tour/StepTwo.vue
+++ b/src-vue/overlays/welcome-tour/StepTwo.vue
@@ -1,7 +1,7 @@
 <template>
   <PopoverRoot :open="isOpen">
     <PopoverPortal>
-      <PopoverContent ref="boxRef" class="absolute z-[2001]" :style="{ left, top, width: `${props.pos.width}px` }">
+      <PopoverContent ref="boxRef" class="absolute" :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]">
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-[72%] z-1 -translate-y-full">
           <svg
             class="relative z-10"
@@ -68,11 +68,13 @@ import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import dayjsUtc from 'dayjs/plugin/utc';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 dayjs.extend(dayjsUtc);
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/BotCreatePanel.vue
+++ b/src-vue/panels/BotCreatePanel.vue
@@ -3,24 +3,25 @@
   <DialogRoot class="absolute inset-0 z-10" :open="true">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="cancelPanel" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="cancelPanel" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="cancelPanel" :aria-describedby="undefined">
-        <BotTour v-if="currentTourStep" @close="closeTour" @changeStep="currentTourStep = $event" :getPositionCheck="getTourPositionCheck" />
-        <div
-          :ref="draggable.setModalRef"
-          :style="{
-            // TODO: Need to fix draggable so it works for this overlay
-            // top: `calc(50% + ${draggable.modalPosition.y}px)`,
-            // left: `calc(50% + ${draggable.modalPosition.x}px)`,
-            // transform: 'translate(-50%, -50%)',
-            // cursor: draggable.isDragging ? 'grabbing' : 'default',
-          }"
-          class="BotCreatePanel absolute top-[40px] left-3 right-3 bottom-3 flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left z-200 transition-all focus:outline-none"
-          style="box-shadow: 0px -1px 2px 0 rgba(0, 0, 0, 0.1), inset 0 2px 0 rgba(255, 255, 255, 1)"
-        >
-          <BgOverlay v-if="hasEditBoxOverlay" @close="cancelEditOverlay" :showWindowControls="false" rounded="md" class="z-100" />
+      <DialogContent asChild @escapeKeyDown="cancelPanel" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
+        <div class="pointer-events-none absolute inset-0">
+          <BotTour v-if="currentTourStep" @close="closeTour" @changeStep="currentTourStep = $event" :getPositionCheck="getTourPositionCheck" />
+          <div
+            :ref="draggable.setModalRef"
+            :style="{
+              // TODO: Need to fix draggable so it works for this overlay
+              // top: `calc(50% + ${draggable.modalPosition.y}px)`,
+              // left: `calc(50% + ${draggable.modalPosition.x}px)`,
+              // transform: 'translate(-50%, -50%)',
+              // cursor: draggable.isDragging ? 'grabbing' : 'default',
+            }"
+            class="BotCreatePanel pointer-events-auto absolute top-[40px] left-3 right-3 bottom-3 flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left transition-all focus:outline-none"
+            style="box-shadow: 0px -1px 2px 0 rgba(0, 0, 0, 0.1), inset 0 2px 0 rgba(255, 255, 255, 1)"
+          >
+          <BgOverlay v-if="hasEditBoxOverlay" @close="cancelEditOverlay" :showWindowControls="false" rounded="md" :style="editBoxBackdropZIndex" />
           <div v-if="isSuggestingTour" class="absolute inset-0 bg-black/20 z-20 rounded-md"></div>
           <div class="flex flex-col h-full w-full">
             <h2
@@ -47,7 +48,7 @@
                     </div>
                   </PopoverTrigger>
                   <PopoverPortal>
-                    <PopoverContent @escapeKeyDown="stopSuggestingTour" side="bottom" class="rounded-lg p-5 -translate-y-1 w-[400px] bg-white shadow-sm border border-slate-800/30 z-1000">
+                    <PopoverContent @escapeKeyDown="stopSuggestingTour" side="bottom" :style="{ zIndex: overlayZIndex.contentZIndex + 1 }" class="rounded-lg p-5 -translate-y-1 w-[400px] bg-white shadow-sm border border-slate-800/30">
                       <p class="text-gray-800 font-light">We recommend first-time miners start with a brief tour of how to use this overlay.</p>
                       <div class="flex flex-row space-x-2 mt-6">
                         <button @click="stopSuggestingTour" tabindex="-1" class="cursor-pointer grow rounded-md border border-slate-500/30 px-4 py-1 focus:outline-none">Not Now</button>
@@ -154,6 +155,7 @@
             </div>
           </div>
         </div>
+      </div>
       </DialogContent>
     </DialogPortal>
   </DialogRoot>
@@ -202,6 +204,7 @@ import { ITourPos } from '../stores/tour.ts';
 import BotTour from './bot-create-tour/Base.vue';
 import { useOperationsController } from '../stores/operationsController.ts';
 import Draggable from '../overlays/helpers/Draggable.ts';
+import { provideOverlayContentZIndex, useFloatingZIndex, useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import BotSettings from '../components/BotSettings.vue';
 import { MiningSetupStatus } from '../interfaces/IConfig.ts';
 
@@ -233,6 +236,9 @@ const isLoaded = Vue.ref(false);
 const isCalculatorReady = Vue.ref(false);
 const isSaving = Vue.ref(false);
 const hasEditBoxOverlay = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => true);
+const editBoxBackdropZIndex = useFloatingZIndex();
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 const capitalToCommitElement = Vue.ref<HTMLElement | null>(null);
 const returnOnCapitalElement = Vue.ref<HTMLElement | null>(null);

--- a/src-vue/panels/Portfolio.vue
+++ b/src-vue/panels/Portfolio.vue
@@ -3,12 +3,12 @@
   <DialogRoot class="absolute inset-0 z-10" :open="isOpen">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="closePanel" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closePanel" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="closePanel" :aria-describedby="undefined">
+      <DialogContent asChild @escapeKeyDown="closePanel" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
         <div
-          class="Portfolio Panel inner-input-shadow bg-argon-menu-bg absolute top-[50px] right-2 bottom-2 left-2 z-200 flex flex-col rounded-md border border-black/30 text-left transition-all focus:outline-none overflow-x-scroll"
+          class="Portfolio Panel inner-input-shadow bg-argon-menu-bg absolute top-[50px] right-2 bottom-2 left-2 flex flex-col rounded-md border border-black/30 text-left transition-all focus:outline-none overflow-x-scroll"
           style="
             box-shadow:
               0 -1px 2px 0 rgba(0, 0, 0, 0.1),
@@ -89,10 +89,13 @@ import AssetBreakdown from './portfolio/AssetBreakdown.vue';
 import ProfitAnalysis from './portfolio/ProfitAnalysis.vue';
 import GrowthProjections from './portfolio/GrowthProjections.vue';
 import TransactionHistory from './portfolio/TransactionHistory.vue';
+import { provideOverlayContentZIndex, useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(false);
 const isLoaded = Vue.ref(false);
 const selectedTab = Vue.ref<PortfolioTab>(PortfolioTab.Overview);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 function closePanel() {
   isOpen.value = false;

--- a/src-vue/panels/ServerConnectPanel.vue
+++ b/src-vue/panels/ServerConnectPanel.vue
@@ -3,12 +3,12 @@
   <DialogRoot class="absolute inset-0 z-10" :open="isOpen">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="closeOverlay" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="closeOverlay" :aria-describedby="undefined">
+      <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
         <div
-          class="ConnectOverlay inner-input-shadow bg-argon-menu-bg absolute top-[40px] right-3 bottom-3 left-3 z-200 flex flex-col overflow-auto rounded-md border border-black/30 text-left transition-all focus:outline-none"
+          class="ConnectOverlay inner-input-shadow bg-argon-menu-bg absolute top-[40px] right-3 bottom-3 left-3 flex flex-col overflow-auto rounded-md border border-black/30 text-left transition-all focus:outline-none"
           style="box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.1), inset 0 2px 0 rgba(255, 255, 255, 1);"
         >
           <TabsRoot
@@ -144,6 +144,7 @@ import { MiningMachine } from '../lib/MiningMachine.ts';
 import { getWalletKeys } from '../stores/wallets.ts';
 import { MiningSetupStatus } from '../interfaces/IConfig.ts';
 import { getInstaller } from '../stores/installer.ts';
+import { provideOverlayContentZIndex, useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const config = getConfig();
 const walletKeys = getWalletKeys();
@@ -152,6 +153,8 @@ const installer = getInstaller();
 const isOpen = Vue.ref(false);
 const isLoaded = Vue.ref(false);
 const isSaving = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => isOpen.value);
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 const selectedTab = Vue.ref('digitalOcean');
 const serverAddError = Vue.ref('');

--- a/src-vue/panels/VaultCreatePanel.vue
+++ b/src-vue/panels/VaultCreatePanel.vue
@@ -3,15 +3,16 @@
   <DialogRoot class="absolute inset-0 z-10" :open="true">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay @close="cancelPanel" />
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="cancelPanel" />
       </DialogOverlay>
 
-      <DialogContent @escapeKeyDown="cancelPanel" :aria-describedby="undefined">
-        <VaultTour v-if="currentTourStep" @close="closeTour" @changeStep="currentTourStep = $event" :getPositionCheck="getTourPositionCheck" />
-        <div
-          class="VaultCreatePanel absolute top-[40px] left-3 right-3 bottom-3 flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left z-200 transition-all focus:outline-none"
-          style="box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.1), inset 0 2px 0 rgba(255, 255, 255, 1)">
-          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" class="z-100" />
+      <DialogContent asChild @escapeKeyDown="cancelPanel" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">
+        <div class="pointer-events-none absolute inset-0">
+          <VaultTour v-if="currentTourStep" @close="closeTour" @changeStep="currentTourStep = $event" :getPositionCheck="getTourPositionCheck" />
+          <div
+            class="VaultCreatePanel pointer-events-auto absolute top-[40px] left-3 right-3 bottom-3 flex flex-col rounded-md border border-black/30 inner-input-shadow bg-argon-menu-bg text-left transition-all focus:outline-none"
+            style="box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.1), inset 0 2px 0 rgba(255, 255, 255, 1)">
+          <BgOverlay v-if="hasEditBoxOverlay" @close="closeEditBoxOverlay" :showWindowControls="false" rounded="md" :style="editBoxBackdropZIndex" />
           <div v-if="isSuggestingTour" class="absolute inset-0 bg-black/20 z-20 rounded-md"></div>
           <div class="flex flex-col h-full w-full">
             <h2
@@ -36,7 +37,7 @@
                     </div>
                   </PopoverTrigger>
                   <PopoverPortal>
-                    <PopoverContent @escapeKeyDown="stopSuggestingTour" side="bottom" class="rounded-lg p-5 -translate-y-1 w-[400px] bg-white shadow-sm border border-slate-800/30 z-1000">
+                    <PopoverContent @escapeKeyDown="stopSuggestingTour" side="bottom" :style="{ zIndex: overlayZIndex.contentZIndex + 1 }" class="rounded-lg p-5 -translate-y-1 w-[400px] bg-white shadow-sm border border-slate-800/30">
                       <p class="text-gray-800 font-light">We recommend first-time vaulters start with a brief tour of how to use this panel.</p>
                       <div class="flex flex-row space-x-2 mt-6">
                         <button @click="stopSuggestingTour" tabindex="-1" class="cursor-pointer grow rounded-md border border-slate-500/30 px-4 py-1 focus:outline-none">Not Now</button>
@@ -143,6 +144,7 @@
 
           </div>
         </div>
+      </div>
       </DialogContent>
     </DialogPortal>
   </DialogRoot>
@@ -180,6 +182,7 @@ import PiechartIcon from '../assets/piechart.svg?component';
 import Tooltip from '../components/Tooltip.vue';
 import { ITourPos } from '../stores/tour.ts';
 import { useOperationsController } from '../stores/operationsController.ts';
+import { provideOverlayContentZIndex, useFloatingZIndex, useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import VaultSettings from '../components/VaultSettings.vue';
 import { VaultingSetupStatus } from '../interfaces/IConfig.ts';
 
@@ -204,6 +207,9 @@ const currentTourStep = Vue.ref<number>(0);
 const isLoaded = Vue.ref(false);
 const isSaving = Vue.ref(false);
 const hasEditBoxOverlay = Vue.ref(false);
+const overlayZIndex = useOverlayZIndex(() => true);
+const editBoxBackdropZIndex = useFloatingZIndex();
+provideOverlayContentZIndex(Vue.toRef(overlayZIndex, 'contentZIndex'));
 
 const capitalToCommitElement = Vue.ref<HTMLElement | null>(null);
 const returnOnCapitalElement = Vue.ref<HTMLElement | null>(null);

--- a/src-vue/panels/bot-create-tour/StepFour.vue
+++ b/src-vue/panels/bot-create-tour/StepFour.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001] -translate-x-full -translate-y-full"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute -translate-x-full -translate-y-full"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute bottom-4.5 -left-1.75 z-1 -translate-y-full rotate-90">
           <svg
@@ -71,9 +71,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/bot-create-tour/StepOne.vue
+++ b/src-vue/panels/bot-create-tour/StepOne.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="cancelTour"
         ref="boxRef"
-        class="absolute z-2001"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-6/12 z-1 -translate-y-full">
           <svg
@@ -72,9 +72,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/bot-create-tour/StepThree.vue
+++ b/src-vue/panels/bot-create-tour/StepThree.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001] -translate-y-full"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute -translate-y-full"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute bottom-0.5 left-1/2 z-1 translate-y-full rotate-180">
           <svg
@@ -70,9 +70,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/bot-create-tour/StepTwo.vue
+++ b/src-vue/panels/bot-create-tour/StepTwo.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001]"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-6/12 z-1 -translate-y-full">
           <svg
@@ -72,9 +72,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/vault-create-tour/StepFour.vue
+++ b/src-vue/panels/vault-create-tour/StepFour.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001] -translate-x-full -translate-y-full"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute -translate-x-full -translate-y-full"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute bottom-4.5 -left-1.75 z-1 -translate-y-full rotate-90">
           <svg
@@ -71,9 +71,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/vault-create-tour/StepOne.vue
+++ b/src-vue/panels/vault-create-tour/StepOne.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="cancelTour"
         ref="boxRef"
-        class="absolute z-[2001]"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-6/12 z-1 -translate-y-full">
           <svg
@@ -72,9 +72,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/vault-create-tour/StepThree.vue
+++ b/src-vue/panels/vault-create-tour/StepThree.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001] -translate-y-full"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute -translate-y-full"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute bottom-0.5 left-1/2 z-1 translate-y-full rotate-180">
           <svg
@@ -70,9 +70,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/panels/vault-create-tour/StepTwo.vue
+++ b/src-vue/panels/vault-create-tour/StepTwo.vue
@@ -4,8 +4,8 @@
       <PopoverContent
         @escapeKeyDown="previousStep"
         ref="boxRef"
-        class="absolute z-[2001]"
-        :style="{ left, top, width: `${props.pos.width}px` }"
+        class="absolute"
+        :style="[floatingZIndex, { left, top, width: `${props.pos.width}px` }]"
       >
         <div Arrow ref="arrowRef" class="absolute top-0.5 left-6/12 z-1 -translate-y-full">
           <svg
@@ -72,9 +72,11 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { PopoverContent, PopoverPortal, PopoverRoot } from 'reka-ui';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import { ITourPos } from '../../stores/tour.ts';
 
 const isOpen = Vue.ref(true);
+const floatingZIndex = useFloatingZIndex();
 
 const props = defineProps<{
   pos: ITourPos;

--- a/src-vue/screens/components/AssetMenu.vue
+++ b/src-vue/screens/components/AssetMenu.vue
@@ -18,7 +18,8 @@
           :align="'end'"
           :alignOffset="-5"
           :sideOffset="-3"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-50 data-[state=open]:transition-all"
+          :style="floatingZIndex"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div class="bg-argon-menu-bg flex shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
             <DropdownMenuItem @click="() => openMoveCapitalOverlay()" class="py-2">
@@ -58,12 +59,14 @@ import {
 import basicEmitter from '../../emitters/basicEmitter.ts';
 import { PortfolioTab } from '../../panels/interfaces/IPortfolioTab.ts';
 import { WalletType } from '../../lib/Wallet.ts';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   walletType: WalletType.defaultArgon;
 }>();
 
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 function openWalletOverlay() {
   basicEmitter.emit('openWalletOverlay', { walletType: props.walletType });

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -3,7 +3,7 @@
   <DialogRoot :open="true" :modal="props.showBackdrop">
     <DialogPortal>
       <DialogOverlay v-if="props.showBackdrop" asChild>
-        <BgOverlay @close="closeOverlay" />
+        <BgOverlay :style="{ zIndex: getOverlayBackdropZIndex(props.zIndex) }" @close="closeOverlay" />
       </DialogOverlay>
       <DialogContent
         asChild
@@ -21,7 +21,7 @@
           }"
           :class="[
             isSyncMode ? 'w-220' : 'w-110',
-            'absolute z-50 flex min-h-140 flex-col overflow-visible rounded-lg bg-linear-to-b from-[#cccccc] to-[#9f9f9f] shadow-2xl focus:outline-none pointer-events-auto',
+            'absolute flex min-h-140 flex-col overflow-visible rounded-lg bg-linear-to-b from-[#cccccc] to-[#9f9f9f] shadow-2xl focus:outline-none pointer-events-auto',
           ]"
           @mousedown="emit('focus')"
         >
@@ -132,6 +132,7 @@ import * as Vue from 'vue';
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui';
 import BgOverlay from '../components/BgOverlay.vue';
 import Draggable from '../overlays/helpers/Draggable.ts';
+import { getOverlayBackdropZIndex, provideOverlayContentZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import ArgonBottom from './components/ArgonBottom.vue';
 import EthereumBottom from './components/EthereumBottom.vue';
 import NavHeader, { type IWalletOption } from './components/NavHeader.vue';
@@ -177,6 +178,7 @@ const emit = defineEmits<{
 const walletStore = useWallets();
 const draggable = Vue.reactive(new Draggable({ constrainToViewport: false }));
 const walletRef = Vue.shallowRef<HTMLElement | null>(null);
+provideOverlayContentZIndex(Vue.computed(() => props.zIndex));
 
 const isSyncMode = Vue.computed(() => !!props.pairedWalletType);
 const activeTransferOverlay = Vue.ref<{

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -38,6 +38,7 @@ import { useBasics } from '../stores/basics.ts';
 import { TopTab } from '../interfaces/IConfig.ts';
 import { useOperationsController } from '../stores/operationsController.ts';
 import { useWallets } from '../stores/wallets.ts';
+import { releaseOverlayZIndex, reserveOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import WalletDialog from './WalletDialog.vue';
 
 type IOpenWallet = {
@@ -61,7 +62,6 @@ const snapPreview = Vue.ref<{
   bounds: { top: number; left: number; width: number; height: number };
 }>();
 let nextWalletId = 1;
-let nextZIndex = 1100;
 
 const operationsController = useOperationsController();
 const isWalletScreenOpen = Vue.computed(() => operationsController?.selectedTab === TopTab.Wallets);
@@ -73,10 +73,15 @@ function syncOverlayState() {
 function focusWallet(id: number) {
   const wallet = openWallets.value.find(x => x.id === id);
   if (!wallet) return;
-  wallet.zIndex = ++nextZIndex;
+  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
 }
 
 function closeWallet(id: number) {
+  const wallet = openWallets.value.find(x => x.id === id);
+  if (wallet) {
+    releaseOverlayZIndex(wallet.zIndex);
+  }
+
   openWallets.value = openWallets.value.filter(wallet => wallet.id !== id);
   if (snapPreview.value?.draggedWalletId === id || snapPreview.value?.targetWalletId === id) {
     snapPreview.value = undefined;
@@ -88,7 +93,7 @@ function pairWallet(id: number, pairedWalletType: WalletType.defaultArgon | Wall
   const wallet = openWallets.value.find(x => x.id === id);
   if (!wallet || wallet.pairedWalletType) return;
   wallet.pairedWalletType = pairedWalletType;
-  wallet.zIndex = ++nextZIndex;
+  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
 }
 
 function unpairWallet(id: number) {
@@ -100,7 +105,7 @@ function unpairWallet(id: number) {
   const singleWalletWidth = (wallet.rect?.width ?? window.innerWidth * (8 / 12)) * (5 / 8);
   const centerOffset = (singleWalletWidth + 15) / 2;
   wallet.pairedWalletType = undefined;
-  wallet.zIndex = ++nextZIndex;
+  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
   wallet.position = {
     x: originalPosition.x + centerOffset,
     y: originalPosition.y,
@@ -111,7 +116,7 @@ function unpairWallet(id: number) {
     walletType: pairedWalletType,
     showGuidance: false,
     showBackdrop: wallet.showBackdrop,
-    zIndex: ++nextZIndex,
+    zIndex: reserveOverlayZIndex(),
     position: {
       x: originalPosition.x - centerOffset,
       y: originalPosition.y,
@@ -171,6 +176,8 @@ function handleDragEnd(id: number, payload: { position: { x: number; y: number }
   const pairedWalletType = draggedIsLeft ? draggedWallet.walletType : targetWallet.walletType;
   const primaryShowGuidance = draggedIsLeft ? targetWallet.showGuidance : draggedWallet.showGuidance;
 
+  releaseOverlayZIndex(draggedWallet.zIndex);
+  releaseOverlayZIndex(targetWallet.zIndex);
   openWallets.value = openWallets.value.filter(
     wallet => wallet.id !== draggedWallet.id && wallet.id !== targetWallet.id,
   );
@@ -180,7 +187,7 @@ function handleDragEnd(id: number, payload: { position: { x: number; y: number }
     pairedWalletType,
     showGuidance: primaryShowGuidance,
     showBackdrop: draggedWallet.showBackdrop || targetWallet.showBackdrop,
-    zIndex: ++nextZIndex,
+    zIndex: reserveOverlayZIndex(),
     position: {
       x: (draggedWallet.position.x + targetWallet.position.x) / 2,
       y: (draggedWallet.position.y + targetWallet.position.y) / 2,
@@ -199,7 +206,7 @@ const snapPreviewStyle = Vue.computed(() => {
     left: `${bounds.left - padding}px`,
     width: `${bounds.width + padding * 2}px`,
     height: `${bounds.height + padding * 2}px`,
-    zIndex: nextZIndex + 1,
+    zIndex: Math.max(...openWallets.value.map(wallet => wallet.zIndex), 0) + 1,
   };
 });
 
@@ -287,7 +294,7 @@ const openWalletOverlay = async (payload: {
     showGuidance: payload.showGuidance || false,
     guidanceContext: payload.guidanceContext,
     showBackdrop: !isWalletScreenOpen.value,
-    zIndex: ++nextZIndex,
+    zIndex: reserveOverlayZIndex(),
     position: getNextPosition(),
   });
   syncOverlayState();
@@ -309,6 +316,7 @@ Vue.watch(
 
 Vue.onUnmounted(() => {
   basicEmitter.off('openWalletOverlay', openWalletOverlay);
+  openWallets.value.forEach(wallet => releaseOverlayZIndex(wallet.zIndex));
   openWalletOverlayCount.value = 0;
 });
 </script>

--- a/src-vue/wallets/components/ArgonBottom.vue
+++ b/src-vue/wallets/components/ArgonBottom.vue
@@ -69,7 +69,8 @@
                   align="start"
                   :sideOffset="-2"
                   :alignOffset="0"
-                  class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-md pointer-events-none z-[2000] w-88 rounded-md border border-gray-800/20 bg-white px-4 pt-3 pb-1 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity] select-none"
+                  :style="floatingZIndex"
+                  class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-md pointer-events-none w-88 rounded-md border border-gray-800/20 bg-white px-4 pt-3 pb-1 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity] select-none"
                 >
                   <p>
                     Your {{ guidanceContext === 'vaulting' ? 'vault' : 'mining' }} operations have the following funding
@@ -182,6 +183,7 @@ import AlertCalloutButton from '../../components/AlertCalloutButton.vue';
 import { getBiddingCalculator } from '../../stores/mainchain.ts';
 import { getMiningFundingState } from '../../screens/mining-screen/miningFunding.ts';
 import type { IWalletGuidanceContext } from '../../emitters/basicEmitter.ts';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
   direction: 'from' | 'to';
@@ -196,6 +198,7 @@ const currency = getCurrency();
 const wallets = useWallets();
 const controller = useOperationsController();
 const calculator = getBiddingCalculator();
+const floatingZIndex = useFloatingZIndex();
 
 const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 const guidanceContext = Vue.computed<IWalletGuidanceContext>(() => props.guidanceContext ?? 'mining');

--- a/src-vue/wallets/components/CrosschainMoveButton.vue
+++ b/src-vue/wallets/components/CrosschainMoveButton.vue
@@ -23,7 +23,8 @@
         side="top"
         align="end"
         :sideOffset="12"
-        class="pointer-events-none z-[2000] w-[360px] rounded-md border border-slate-300 bg-white px-5 py-4 text-sm text-slate-700 shadow-2xl"
+        :style="floatingZIndex"
+        class="pointer-events-none w-[360px] rounded-md border border-slate-300 bg-white px-5 py-4 text-sm text-slate-700 shadow-2xl"
       >
         <div class="flex flex-col gap-4">
           <div class="text-xl font-bold">
@@ -120,6 +121,7 @@ import { HoverCardArrow, HoverCardContent, HoverCardPortal, HoverCardRoot, Hover
 import ProgressBar from '../../components/ProgressBar.vue';
 import type { IArgonWalletType, IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
 import type { IEthereumInboundActiveTransfer } from '../../lib/EthereumInboundTransferTracker.ts';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 import MoveArrow from '../../assets/move-arrow.svg';
 import { formatEvmNativeFeeWei } from '../../lib/Utils.ts';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
@@ -153,6 +155,7 @@ const currency = getCurrency();
 const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 
 const isHovered = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 const hasActiveEthereumTransferConfig = Vue.ref(false);
 const progressNow = Vue.ref(Date.now());
 

--- a/src-vue/wallets/components/ExtraMenu.vue
+++ b/src-vue/wallets/components/ExtraMenu.vue
@@ -20,7 +20,8 @@
           :align="'end'"
           :alignOffset="-5"
           :sideOffset="-3"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[10000] data-[state=open]:transition-all"
+          :style="floatingZIndex"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div class="bg-argon-menu-bg flex min-w-66 shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
             <template v-if="!props.walletIsOpen">
@@ -95,6 +96,7 @@ import { WindowIcon, QrCodeIcon, ShieldCheckIcon } from '@heroicons/vue/24/outli
 import CopyIcon from '../../assets/copy.svg';
 import QRCode from 'qrcode';
 import CopyToClipboard from '../../components/CopyToClipboard.vue';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -111,6 +113,7 @@ const props = withDefaults(
 
 const rootRef = Vue.ref<HTMLElement>();
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
 
 const showQrCode = Vue.ref(false);
 const qrCode = Vue.ref('');

--- a/src-vue/wallets/components/PortalMenu.vue
+++ b/src-vue/wallets/components/PortalMenu.vue
@@ -20,7 +20,8 @@
           :align="'end'"
           :alignOffset="-5"
           :sideOffset="-3"
-          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[10000] data-[state=open]:transition-all"
+          :style="floatingZIndex"
+          class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
         >
           <div class="bg-argon-menu-bg flex min-w-66 shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
             <template v-if="!props.walletIsOpen">
@@ -40,7 +41,8 @@
                   @mouseleave="onMouseLeave"
                   :side="'left'"
                   :sideOffset="4"
-                  class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade z-[10001] data-[state=open]:transition-all"
+                  :style="subFloatingZIndex"
+                  class="data-[side=bottom]:animate-slideUpAndFade data-[side=right]:animate-slideLeftAndFade data-[side=left]:animate-slideRightAndFade data-[side=top]:animate-slideDownAndFade data-[state=open]:transition-all"
                 >
                   <div class="min-w-50 bg-argon-menu-bg flex shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
                     <DropdownMenuItem MenuItem @click="openWallet(WalletType.defaultArgon)">
@@ -97,6 +99,7 @@ import basicEmitter from '../../emitters/basicEmitter.ts';
 import { ChevronLeftIcon } from '@heroicons/vue/24/outline';
 import { WalletType } from '../../lib/Wallet.ts';
 import { UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const props = withDefaults(
   defineProps<{
@@ -111,6 +114,8 @@ const props = withDefaults(
 
 const rootRef = Vue.ref<HTMLElement>();
 const isOpen = Vue.ref(false);
+const floatingZIndex = useFloatingZIndex();
+const subFloatingZIndex = useFloatingZIndex(2);
 
 // Expose the root element to parent components
 defineExpose({


### PR DESCRIPTION
This PR removes the remaining hard-coded stacking assumptions that were causing overlays to overlap inconsistently.

The main change is to route root floating surfaces through the shared overlay z-index helper so top-bar menus and other root popovers no longer sit above modal backdrops. It also updates the affected dialogs and panels so the actual positioned panel element owns the stacking context, which fixes cases like portfolio and server-connect surfaces rendering under other UI.

Nested overlay surfaces that still depended on fixed z-index classes, including edit-box overlays and the existing network vaults popover, are moved onto the same shared layering model so they stay above their parent panel without introducing new global z-index constants.
