### PR TITLE
feat: explain open-source software model in-app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 various contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "argon-apps",
   "private": true,
   "version": "1.4.2",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "preinstall": "husky install",

--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -50,6 +50,7 @@
       <BotEditOverlay />
       <!-- <ProvisioningCompleteOverlay /> -->
       <AboutOverlay />
+      <SoftwareInfoOverlay />
       <ProfileOverlay />
       <JurisdictionOverlay />
       <ServerOverlay />
@@ -82,6 +83,7 @@ import { useTour } from './stores/tour.ts';
 import { getBot } from './stores/bot.ts';
 import { waitForLoad } from '@argonprotocol/mainchain';
 import AboutOverlay from './overlays/AboutOverlay.vue';
+import SoftwareInfoOverlay from './overlays/SoftwareInfoOverlay.vue';
 import JurisdictionOverlay from './overlays/JurisdictionOverlay.vue';
 import TroubleshootingOverlay from './overlays/Troubleshooting.vue';
 import BootingOverlay from './overlays/BootingOverlay.vue';

--- a/src-vue/NativeMenu.ts
+++ b/src-vue/NativeMenu.ts
@@ -253,6 +253,11 @@ export async function createMenu() {
         action: () => void tauriOpenUrl('https://argon.network/faq'),
       },
       {
+        id: 'open-source-software',
+        text: 'Open Source Software',
+        action: () => basicEmitter.emit('openSoftwareInfoOverlay'),
+      },
+      {
         id: 'tour',
         text: 'Take the Tour',
         action: () => tour.start(),

--- a/src-vue/emitters/basicEmitter.ts
+++ b/src-vue/emitters/basicEmitter.ts
@@ -25,6 +25,7 @@ type IBasicEmitter = {
   openServerConnectPanel: void;
   closeAllOverlays: void;
   openAboutOverlay: void;
+  openSoftwareInfoOverlay: void;
   openJurisdictionOverlay: { setCurrencyKey: ICurrencyKey } | undefined;
   openTroubleshootingOverlay: {
     screen: 'server-diagnostics' | 'data-and-log-files' | 'options-for-restart' | 'overview' | 'find-missing-data';

--- a/src-vue/lib/SoftwareInfo.ts
+++ b/src-vue/lib/SoftwareInfo.ts
@@ -1,0 +1,2 @@
+export const SOFTWARE_INFO_TITLE = 'Open Source Software';
+export const LICENSE_TITLE = 'MIT License';

--- a/src-vue/navigation/TopBar.vue
+++ b/src-vue/navigation/TopBar.vue
@@ -74,15 +74,9 @@ import { useCertificationController } from '../stores/certificationController.ts
 import WindowControls from '../tauri-controls/WindowControls.vue';
 import PortfolioMenu from './PortfolioMenu.vue';
 import AccountMenu from './AccountMenu.vue';
-import ArgonLogo from '../assets/resources/argon.svg?component';
-import InstanceMenu, { IInstance } from './InstanceMenu.vue';
 import { useWallets } from '../stores/wallets.ts';
 import { getBot } from '../stores/bot.ts';
 import { useTour } from '../stores/tour.ts';
-import { appConfigDir } from '@tauri-apps/api/path';
-import { readDir } from '@tauri-apps/plugin-fs';
-import { APP_NAME, INSTANCE_NAME, NETWORK_NAME } from '../lib/Env.ts';
-import TabSwitcher from './TabSwitcher.vue';
 import ServerMenu from './ServerMenu.vue';
 import OperationalMenu from './OperationalMenu.vue';
 import { NavigationMenuIndicator, NavigationMenuList, NavigationMenuRoot, NavigationMenuViewport } from 'reka-ui';
@@ -100,8 +94,10 @@ const bot = getBot();
 const navigationMenuViewportZIndex = useFloatingZIndex();
 const navigationMenuIndicatorZIndex = useFloatingZIndex(2);
 
+const serverMenuRef = Vue.ref<InstanceType<typeof ServerMenu> | null>(null);
 const accountMenuRef = Vue.ref<InstanceType<typeof AccountMenu> | null>(null);
 const currencyMenuRef = Vue.ref<InstanceType<typeof PortfolioMenu> | null>(null);
+const returnsMenuRef = Vue.ref<InstanceType<typeof ProfitsMenu> | null>(null);
 
 const navigationMenuValue = Vue.ref('');
 let navigationMenuCloseTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;

--- a/src-vue/overlays/AboutOverlay.vue
+++ b/src-vue/overlays/AboutOverlay.vue
@@ -41,8 +41,16 @@
                 Close
               </button>
             </div>
-            <div class="mt-4 italic text-black/50">
-              Open source. Zero rights reserved.
+            <div class="mt-4 border-t border-black/10 pt-4 text-sm text-black/60">
+              <div>Licensed under the MIT License.</div>
+              <div class="mt-3 flex flex-wrap justify-center gap-2">
+                <button
+                  @click="basicEmitter.emit('openSoftwareInfoOverlay')"
+                  class="cursor-pointer rounded-full border border-slate-900/15 bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200"
+                >
+                  {{ SOFTWARE_INFO_TITLE }}
+                </button>
+              </div>
             </div>
           </Motion>
         </DialogContent>
@@ -61,6 +69,7 @@ import { getConfig } from '../stores/config.ts';
 import Draggable from './helpers/Draggable.ts';
 import { platformName, platformVersion } from '../tauri-controls/utils/os.ts';
 import { APP_NAME, INSTANCE_NAME, INSTANCE_PORT, NETWORK_NAME } from '../lib/Env.ts';
+import { SOFTWARE_INFO_TITLE } from '../lib/SoftwareInfo.ts';
 import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const config = getConfig();

--- a/src-vue/overlays/SoftwareInfoOverlay.vue
+++ b/src-vue/overlays/SoftwareInfoOverlay.vue
@@ -1,0 +1,100 @@
+<!-- prettier-ignore -->
+<template>
+  <OverlayBase
+    :isOpen="isOpen"
+    :enableTopBar="true"
+    class="w-7/12"
+    @close="closeOverlay"
+  >
+    <template #title>
+      <DialogTitle class="grow pl-3">{{ SOFTWARE_INFO_TITLE }}</DialogTitle>
+    </template>
+
+    <article class="px-6 py-5 text-slate-700">
+      <p class="text-sm leading-6">
+        Argon Desktop is open-source software made available under the MIT License. It is provided as-is, without
+        warranties. You control your own keys and choose which transactions and protocol actions to make.
+      </p>
+
+      <section class="mt-5 border-t border-slate-300 pt-4">
+        <h3 class="text-sm font-semibold text-slate-800">Self-Custody</h3>
+        <div class="mt-2 space-y-3 text-sm leading-6">
+          <p>
+            Keep your device, passwords, recovery phrase, private keys, and backups safe. No one can recover them for
+            you if they are lost.
+          </p>
+          <p>Transactions may be irreversible, so verify the details before confirming an action.</p>
+        </div>
+      </section>
+
+      <section class="mt-5 border-t border-dashed border-slate-300 pt-4">
+        <h3 class="text-sm font-semibold text-slate-800">Software and External Systems</h3>
+        <div class="mt-2 space-y-3 text-sm leading-6">
+          <p>
+            Open-source software can contain bugs. The blockchains, public RPC providers, indexers, cross-chain transfer
+            systems, and linked third-party services used by some features can also change or become unavailable.
+          </p>
+          <p>Check important information before acting, especially when moving or locking funds.</p>
+        </div>
+      </section>
+
+      <section class="mt-5 border-t border-dashed border-slate-300 pt-4">
+        <h3 class="text-sm font-semibold text-slate-800">Troubleshooting</h3>
+        <div class="mt-2 space-y-3 text-sm leading-6">
+          <p>
+            As an open-source project, Argon Desktop does not have a dedicated support team. Community contributors may
+            offer help through the Discord and GitHub links in the app, but support is voluntary and not guaranteed.
+          </p>
+          <p>
+            Troubleshooting packages are created only when you choose to download one. They contain local app data and
+            logs; wallet mnemonic files are excluded unless you explicitly include them.
+          </p>
+        </div>
+      </section>
+
+      <section class="mt-5 border-t border-dashed border-slate-300 pt-4">
+        <h3 class="text-sm font-semibold text-slate-800">{{ LICENSE_TITLE }}</h3>
+        <p class="mt-2 text-sm font-semibold text-slate-800">{{ copyrightNotice }}</p>
+
+        <div class="mt-4 space-y-5">
+          <div>
+            <h4 class="text-sm font-semibold text-slate-800">Permission</h4>
+            <p class="mt-2 text-sm leading-6">{{ permissionGrant }}</p>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-800">Condition</h4>
+            <p class="mt-2 text-sm leading-6">{{ licenseCondition }}</p>
+          </div>
+          <div>
+            <h4 class="text-sm font-semibold text-slate-800">Warranty and Liability</h4>
+            <p class="mt-2 text-sm leading-6">{{ warrantyAndLiability }}</p>
+          </div>
+        </div>
+      </section>
+    </article>
+  </OverlayBase>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { DialogTitle } from 'reka-ui';
+import licenseText from '../../LICENSE?raw';
+import basicEmitter from '../emitters/basicEmitter.ts';
+import { LICENSE_TITLE, SOFTWARE_INFO_TITLE } from '../lib/SoftwareInfo.ts';
+import OverlayBase from './OverlayBase.vue';
+
+const [, copyrightNotice, permissionGrant, licenseCondition, warrantyAndLiability] = licenseText
+  .trim()
+  .split(/\n\s*\n/)
+  .map(paragraph => paragraph.replace(/\n/g, ' '));
+
+const isOpen = Vue.ref(false);
+
+basicEmitter.on('openSoftwareInfoOverlay', () => {
+  isOpen.value = true;
+});
+
+function closeOverlay() {
+  isOpen.value = false;
+}
+</script>

--- a/src-vue/overlays/SoftwareInfoOverlay.vue
+++ b/src-vue/overlays/SoftwareInfoOverlay.vue
@@ -62,7 +62,7 @@
             <p class="mt-2 text-sm leading-6">{{ permissionGrant }}</p>
           </div>
           <div>
-            <h4 class="text-sm font-semibold text-slate-800">Condition</h4>
+            <h4 class="text-sm font-semibold text-slate-800">Conditions</h4>
             <p class="mt-2 text-sm leading-6">{{ licenseCondition }}</p>
           </div>
           <div>

--- a/src-vue/overlays/WelcomeOverlay.vue
+++ b/src-vue/overlays/WelcomeOverlay.vue
@@ -28,14 +28,12 @@
       <div class="mt-6 flex flex-row items-center justify-between space-x-4 border-t border-slate-300 px-5 py-1">
         <button
           @click="startImportAccount"
-          tabindex="-1"
           class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-white border border-argon-600/50 hover:bg-argon-600/10 text-argon-600 font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none"
         >
           Import Existing Account
         </button>
         <button
           @click="closeOverlay"
-          tabindex="-1"
           class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-argon-button border border-argon-button-hover hover:bg-argon-button-hover text-white font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none"
         >
           Continue

--- a/src-vue/overlays/WelcomeOverlay.vue
+++ b/src-vue/overlays/WelcomeOverlay.vue
@@ -14,14 +14,31 @@
           yield-generating instruments underlying it. Savings, bonds, bitcoin locks, and stable swaps are all available,
           each with different risk and return profiles.
         </p>
+        <p>
+          This is open-source, self-custody software. You are responsible for your keys, backups, and transactions.
+          <button
+            @click="basicEmitter.emit('openSoftwareInfoOverlay')"
+            class="cursor-pointer text-argon-600 hover:underline focus-visible:underline"
+          >
+            What this means
+          </button>.
+        </p>
       </div>
 
-      <div class="flex flex-row items-center justify-between border-t border-slate-300 py-1 px-5 mt-6 space-x-4">
-        <button @click="startImportAccount" tabindex="-1" class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-white border border-argon-600/50 hover:bg-argon-600/10 text-argon-600 font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none">
+      <div class="mt-6 flex flex-row items-center justify-between space-x-4 border-t border-slate-300 px-5 py-1">
+        <button
+          @click="startImportAccount"
+          tabindex="-1"
+          class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-white border border-argon-600/50 hover:bg-argon-600/10 text-argon-600 font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none"
+        >
           Import Existing Account
         </button>
-        <button @click="closeOverlay" tabindex="-1" class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-white border border-argon-600/50 hover:bg-argon-600/10 text-argon-600 font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none">
-          Close Overlay
+        <button
+          @click="closeOverlay"
+          tabindex="-1"
+          class="mt-5 w-full flex flex-row items-center justify-center space-x-2 bg-argon-button border border-argon-button-hover hover:bg-argon-button-hover text-white font-bold inner-button-shadow px-6 py-2 rounded-md cursor-pointer focus:outline-none"
+        >
+          Continue
         </button>
       </div>
     </div>
@@ -35,22 +52,25 @@
           @goTo="showImportFrom"
         />
       </div>
-      <div  class="flex flex-row items-center justify-between border-t border-slate-300 py-5 px-5 mt-6 space-x-4">
-        <button @click="importFromMnemonic" tabindex="0" class="w-full flex flex-row justify-center items-center space-x-2 bg-argon-button border border-argon-button-hover hover:bg-argon-button-hover text-white font-bold inner-button-shadow px-12 py-2 rounded-md cursor-pointer focus:outline-none">
+      <div class="mt-6 flex flex-row items-center justify-between space-x-4 border-t border-slate-300 px-5 py-5">
+        <button
+          @click="importFromMnemonic"
+          tabindex="0"
+          class="w-full flex flex-row items-center justify-center space-x-2 rounded-md border border-argon-button-hover bg-argon-button px-12 py-2 font-bold text-white inner-button-shadow cursor-pointer hover:bg-argon-button-hover focus:outline-none"
+        >
           Import Account
         </button>
       </div>
     </div>
-
   </OverlayBase>
 </template>
 
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { DialogTitle } from 'reka-ui';
+import basicEmitter from '../emitters/basicEmitter.ts';
 import OverlayBase from './OverlayBase.vue';
 import { getConfig } from '../stores/config.ts';
-import { APP_NAME } from '../lib/Env.ts';
 import ImportAccountFromMnemonic from './import-account/FromMnemonic.vue';
 
 const config = getConfig();
@@ -59,10 +79,8 @@ const isOpen = Vue.ref(config.showWelcomeOverlay);
 const importAccountFromMnemonicRef = Vue.ref<InstanceType<typeof ImportAccountFromMnemonic> | null>(null);
 
 const currentStep = Vue.ref<'Create' | 'Import' | 'Import:FromMnemonic' | null>(null);
-const formError = Vue.ref('');
 
 function backToMain() {
-  formError.value = '';
   currentStep.value = null;
 }
 
@@ -82,11 +100,14 @@ async function importFromMnemonic() {
   const didImport = await importAccountFromMnemonicRef.value?.importAccount();
   if (!didImport) return;
 
+  config.showWelcomeOverlay = false;
+  await config.save();
   isOpen.value = false;
 }
 
 async function closeOverlay() {
   config.showWelcomeOverlay = false;
-  void config.save();
+  await config.save();
+  isOpen.value = false;
 }
 </script>


### PR DESCRIPTION
## Summary

Argon Desktop now explains its open-source, self-custody model inside the app without adding an acceptance gate or implying that a company, foundation, or dedicated support organization publishes it. Users can review concise guidance on key responsibility, software and network behavior, community troubleshooting, and the exact MIT license from the welcome flow, About dialog, or Help menu.

The branch also removes stale top-bar wiring that attempted to load the deleted TabSwitcher and restores the refs used by the current navigation menus.

## Validation

- Prettier passes for all changed source and configuration files.
- The five affected Vue templates compile successfully.
- The repository typecheck remains blocked by existing operational-account metadata mismatches in files outside this PR.
