### PR TITLE
fix: stabilize v1.4.3 setup and recovery flows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.2] - 2026-07-03
+## [1.4.3] - 2026-07-03
 - Fix windows server installer crashes
 - Ease loading of bitcoins when Mining/Vaulting loads
 - Various small UI tweaks

--- a/core/__test__/BiddingCalculator.test.ts
+++ b/core/__test__/BiddingCalculator.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import BiddingCalculator from '../src/BiddingCalculator.ts';
+
+describe('BiddingCalculator loading', () => {
+  it('allows a later load to retry after a frame load failure', async () => {
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+    const load = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+    const unsubscribeFirst = vi.fn();
+    const unsubscribeSecond = vi.fn();
+    const onFrameId = vi.fn((callback: (frameId: number) => Promise<void> | void) => {
+      void callback(1);
+      return { unsubscribe: onFrameId.mock.calls.length === 1 ? unsubscribeFirst : unsubscribeSecond };
+    });
+    const calculator = new BiddingCalculator(
+      {
+        load,
+        miningFrames: {
+          load: vi.fn().mockResolvedValue(undefined),
+          onFrameId,
+        },
+      } as any,
+      {} as any,
+    );
+    vi.spyOn(calculator, 'calculateBidAmounts').mockImplementation(() => undefined);
+
+    await expect(calculator.load()).rejects.toBe(error);
+    await expect(calculator.load()).resolves.toBeUndefined();
+
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(onFrameId).toHaveBeenCalledTimes(2);
+    expect(unsubscribeFirst).toHaveBeenCalledOnce();
+  });
+});

--- a/core/__test__/BiddingCalculator.test.ts
+++ b/core/__test__/BiddingCalculator.test.ts
@@ -2,6 +2,41 @@ import { describe, expect, it, vi } from 'vitest';
 import BiddingCalculator from '../src/BiddingCalculator.ts';
 
 describe('BiddingCalculator loading', () => {
+  it('keeps the frame subscription after a later frame load failure', async () => {
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+    const load = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+    const unsubscribe = vi.fn();
+    let onFrame: (frameId: number) => Promise<void> | void = () => undefined;
+    const onFrameId = vi.fn((callback: typeof onFrame) => {
+      onFrame = callback;
+      void callback(1);
+      return { unsubscribe };
+    });
+    const calculator = new BiddingCalculator(
+      {
+        load,
+        miningFrames: {
+          load: vi.fn().mockResolvedValue(undefined),
+          onFrameId,
+        },
+      } as any,
+      {} as any,
+    );
+    const calculateBidAmounts = vi.spyOn(calculator, 'calculateBidAmounts').mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await calculator.load();
+    await onFrame(2);
+    await onFrame(3);
+
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(load).toHaveBeenCalledTimes(3);
+    expect(calculateBidAmounts).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith('Error loading bidding calculator frame', error);
+
+    consoleError.mockRestore();
+  });
+
   it('allows a later load to retry after a frame load failure', async () => {
     const error = new Error('Unable to retrieve header and parent from supplied hash');
     const load = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);

--- a/core/__test__/BiddingCalculatorData.test.ts
+++ b/core/__test__/BiddingCalculatorData.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 describe('BiddingCalculatorData best-block recovery', () => {
-  it('loads with the latest readable chain api for current-state bidding data', async () => {
+  it('retries the same frame after a current-state chain api failure', async () => {
     NetworkConfig.setNetwork('dev-docker');
 
     const finalizedApi = {
@@ -37,7 +37,8 @@ describe('BiddingCalculatorData best-block recovery', () => {
         },
       },
     };
-    const getCurrentApi = vi.fn().mockResolvedValue(finalizedApi);
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+    const getCurrentApi = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(finalizedApi);
     const calculatorData = new BiddingCalculatorData(
       {
         clients: {},
@@ -60,9 +61,10 @@ describe('BiddingCalculatorData best-block recovery', () => {
       } as any,
     );
 
+    await expect(calculatorData.load(15)).rejects.toBe(error);
     await expect(calculatorData.load(15)).resolves.toBeUndefined();
 
-    expect(getCurrentApi).toHaveBeenCalledOnce();
+    expect(getCurrentApi).toHaveBeenCalledTimes(2);
     expect(calculatorData.microgonsInCirculation).toBe(1_000n);
     expect(calculatorData.maximumMicronotsForBid).toBe(36n);
     expect(calculatorData.allowedBidIncrementMicrogons).toBe(10_000n);

--- a/core/src/BiddingCalculator.ts
+++ b/core/src/BiddingCalculator.ts
@@ -70,8 +70,9 @@ export default class BiddingCalculator {
 
   public async load(): Promise<void> {
     await this.data.miningFrames.load();
+    let unsubscribeOnFailure: (() => void) | undefined;
     this.onFrameSubscription ??= new Promise(async (resolve, reject) => {
-      const { unsubscribe } = this.data.miningFrames.onFrameId(async frameId => {
+      const subscription = this.data.miningFrames.onFrameId(async frameId => {
         try {
           await this.data.load(frameId);
           this.calculateBidAmounts();
@@ -79,12 +80,19 @@ export default class BiddingCalculator {
             callbackFn();
           }
         } catch (err) {
+          unsubscribeOnFailure?.();
           reject(err);
         }
-        resolve({ unsubscribe });
+        resolve(subscription);
       });
+      unsubscribeOnFailure = subscription.unsubscribe;
     });
-    await this.onFrameSubscription;
+    try {
+      await this.onFrameSubscription;
+    } catch (error) {
+      this.onFrameSubscription = null;
+      throw error;
+    }
   }
 
   public get startingBidAmountOverride(): bigint | null {

--- a/core/src/BiddingCalculator.ts
+++ b/core/src/BiddingCalculator.ts
@@ -71,6 +71,7 @@ export default class BiddingCalculator {
   public async load(): Promise<void> {
     await this.data.miningFrames.load();
     let unsubscribeOnFailure: (() => void) | undefined;
+    let isSubscriptionReady = false;
     this.onFrameSubscription ??= new Promise(async (resolve, reject) => {
       const subscription = this.data.miningFrames.onFrameId(async frameId => {
         try {
@@ -80,10 +81,18 @@ export default class BiddingCalculator {
             callbackFn();
           }
         } catch (err) {
-          unsubscribeOnFailure?.();
-          reject(err);
+          if (!isSubscriptionReady) {
+            unsubscribeOnFailure?.();
+            reject(err);
+          } else {
+            console.error('Error loading bidding calculator frame', err);
+          }
+          return;
         }
-        resolve(subscription);
+        if (!isSubscriptionReady) {
+          isSubscriptionReady = true;
+          resolve(subscription);
+        }
       });
       unsubscribeOnFailure = subscription.unsubscribe;
     });

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -70,10 +70,15 @@ export default class BiddingCalculatorData {
 
   public async load(biddingFrameId: number): Promise<void> {
     if (this.loadingFrameId !== biddingFrameId) {
+      const previousLoad = this.loadedFrameIdPromise;
       this.loadingFrameId = biddingFrameId;
       // wait for any previous load to finish
-      void (await this.loadedFrameIdPromise);
-      this.loadedFrameIdPromise = new Promise<number>(async (resolve, reject) => {
+      try {
+        await previousLoad;
+      } catch {
+        // A failed previous frame load must not prevent the current frame from retrying.
+      }
+      this.loadedFrameIdPromise = (async () => {
         try {
           const mining = this.mining;
           await this.miningFrames.waitForFrameId(biddingFrameId);
@@ -134,14 +139,23 @@ export default class BiddingCalculatorData {
           this.microgonExchangeRateTo = await currency.fetchMainchainRates(api);
           this.maxPossibleMiningSeatCount = maxPossibleMinersInNextEpoch;
           this.allowedBidIncrementMicrogons = api.consts.miningSlot.bidIncrements.toBigInt();
-          resolve(biddingFrameId);
+          return biddingFrameId;
         } catch (error) {
           console.error('Error initializing BiddingCalculatorData', error);
-          reject(error);
+          throw error;
         }
-      });
+      })();
     }
 
-    await this.loadedFrameIdPromise;
+    const loadPromise = this.loadedFrameIdPromise;
+    try {
+      await loadPromise;
+    } catch (error) {
+      if (this.loadedFrameIdPromise === loadPromise && this.loadingFrameId === biddingFrameId) {
+        this.loadingFrameId = undefined;
+        this.loadedFrameIdPromise = undefined;
+      }
+      throw error;
+    }
   }
 }

--- a/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
+++ b/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
@@ -86,9 +86,7 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
         throw new Error(`${flowName}: Bitcoin lock entry point is not clickable on the vault dashboard.`);
       }
     }
-    if (!state.uiState.lockStartVisible) {
-      await flow.waitFor('LockStart.submitLiquidLock()', { timeoutMs: 10_000 });
-    }
+    await flow.waitFor('LockStart.submitLiquidLock()', { state: 'enabled', timeoutMs: 10_000 });
 
     if (input.minimumLockMicrogons != null) {
       const argonAmount =

--- a/src-tauri/src/ssh_access.rs
+++ b/src-tauri/src/ssh_access.rs
@@ -1,10 +1,12 @@
 use crate::security::Security;
 use crate::ssh;
-use crate::ssh_pool;
 use secrecy::{ExposeSecret, SecretString};
 use sp_core::Pair;
+use std::time::Duration;
 use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
+
+const SSH_ACCESS_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct SshAccessState {
     pub access: Mutex<Option<SshAccessSession>>,
@@ -61,14 +63,12 @@ pub async fn ssh_access_activate(
     port: u16,
     username: String,
 ) -> Result<SshAccessStatus, String> {
+    log::debug!("Activating temporary SSH access for {address}");
     if state.access.lock().await.is_some() {
-        let _ = clear_ssh_access(&app, &state, address, host, port, &username).await;
+        clear_ssh_access(&app, &state, address, host, port, &username).await?;
     }
 
-    let private_key = Security::expose_private_key_openssh(&app).map_err(|e| e.to_string())?;
-    let ssh = ssh_pool::open_connection(address, host, port, username, private_key)
-        .await
-        .map_err(|e| e.to_string())?;
+    let ssh = open_access_connection(&app, host, port, &username).await?;
 
     let (pair, _phrase, _seed) = sp_core::ed25519::Pair::generate_with_phrase(None);
     let (private_key_openssh, public_key_openssh) =
@@ -81,12 +81,16 @@ pub async fn ssh_access_activate(
     let add_cmd = format!(
         "grep -q '{public_key_material}' ~/.ssh/authorized_keys || echo '{public_key_with_comment}' >> ~/.ssh/authorized_keys"
     );
-    ssh.run_command(add_cmd).await.map_err(|e| e.to_string())?;
-
-    *state.access.lock().await = Some(SshAccessSession {
+    let access = SshAccessSession {
         private_key: SecretString::new(private_key_openssh.clone().into()),
         public_key: public_key_openssh.clone(),
-    });
+    };
+    let result = ssh.run_command(add_cmd).await;
+    ssh.close().await;
+
+    // An SSH error can occur after the server added the key, so retain it for cleanup on retry.
+    *state.access.lock().await = Some(access);
+    result.map_err(|e| e.to_string())?;
 
     Ok(SshAccessStatus {
         active: true,
@@ -104,7 +108,8 @@ pub async fn ssh_access_deactivate(
     port: u16,
     username: String,
 ) -> Result<SshAccessStatus, String> {
-    let _ = clear_ssh_access(&app, &state, address, host, port, &username).await;
+    log::debug!("Deactivating temporary SSH access for {address}");
+    clear_ssh_access(&app, &state, address, host, port, &username).await?;
     Ok(SshAccessStatus {
         active: false,
         public_key: None,
@@ -120,20 +125,41 @@ async fn clear_ssh_access(
     port: u16,
     username: &str,
 ) -> Result<(), String> {
-    let access = state.access.lock().await.take();
+    log::debug!("Clearing temporary SSH access for {address}");
+    let access = state.access.lock().await.clone();
     if let Some(access) = access {
-        let private_key = Security::expose_private_key_openssh(app).map_err(|e| e.to_string())?;
-        let ssh = ssh_pool::open_connection(address, host, port, username.to_string(), private_key)
-            .await
-            .map_err(|e| e.to_string())?;
+        let ssh = open_access_connection(app, host, port, username).await?;
 
         let remove_cmd = format!(
             "if [ -f ~/.ssh/authorized_keys ]; then grep -v '{key}' ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.tmp && mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys; fi",
             key = access.public_key.trim()
         );
-        ssh.run_command(remove_cmd)
-            .await
-            .map_err(|e| e.to_string())?;
+        let result = ssh.run_command(remove_cmd).await;
+        ssh.close().await;
+        result.map_err(|e| e.to_string())?;
+
+        let mut current = state.access.lock().await;
+        // Do not clear a replacement session created while the remote cleanup was running.
+        if current
+            .as_ref()
+            .is_some_and(|current| current.public_key == access.public_key)
+        {
+            current.take();
+        }
     }
     Ok(())
+}
+
+async fn open_access_connection(
+    app: &AppHandle,
+    host: &str,
+    port: u16,
+    username: &str,
+) -> Result<ssh::SSH, String> {
+    let private_key = Security::expose_private_key_openssh(app).map_err(|e| e.to_string())?;
+    let config = ssh::SSHConfig::new(host, port, username.to_string(), private_key)
+        .map_err(|e| e.to_string())?;
+    ssh::SSH::connect(&config, SSH_ACCESS_CONNECT_TIMEOUT)
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-vue/AppRoot.vue
+++ b/src-vue/AppRoot.vue
@@ -1,5 +1,8 @@
 <template>
-  <RuntimeCompatibilityScreen v-if="shouldShowCompatibilityScreen" />
+  <template v-if="shouldShowCompatibilityScreen">
+    <RuntimeCompatibilityScreen />
+    <SecuritySettingsOverlay />
+  </template>
   <AppTreasury v-else-if="IS_TREASURY_APP" />
   <AppOperations v-else />
 </template>
@@ -9,6 +12,7 @@ import { storeToRefs } from 'pinia';
 import AppTreasury from './app-treasury/App.vue';
 import AppOperations from './app-operations/App.vue';
 import RuntimeCompatibilityScreen from './app-shared/screens/RuntimeCompatibilityScreen.vue';
+import SecuritySettingsOverlay from './app-operations/overlays/SecuritySettingsOverlay.vue';
 import { IS_TREASURY_APP } from './lib/Env.ts';
 import { useAppUpdater } from './stores/appUpdater.ts';
 import { useRuntimeCompatibility } from './stores/runtimeCompatibility.ts';

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -330,6 +330,44 @@ it('should run through entire install process', async () => {
   expect(config.serverInstaller.ServerConnect.status).toBe('Completed');
 });
 
+it('persists SSH details before later installation work can fail', async () => {
+  const dbPromise = createMockedDbPromise({ serverAdd: '{ "localComputer": {} }' });
+  const db = await dbPromise;
+  const insertOrReplace = vi.spyOn(db.configTable, 'insertOrReplace');
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  MiningMachine.setupLocalComputer = vi.fn().mockResolvedValue({
+    type: ServerType.LocalComputer,
+    ipAddress: '127.0.0.1',
+    sshPort: 2222,
+    sshUser: 'argon',
+    workDir: '/app',
+  });
+
+  const installer = new Installer(config, walletKeys);
+  let wereSshDetailsSavedBeforeFailure = false;
+  // @ts-ignore - keep the failure after machine setup and before bot installation
+  installer.getServer = vi.fn().mockImplementation(async () => {
+    wereSshDetailsSavedBeforeFailure = insertOrReplace.mock.calls.some(([data]) =>
+      data.serverDetails?.includes('"sshPort": 2222'),
+    );
+    throw new Error('SSH server unavailable');
+  });
+  // @ts-ignore - avoid background status polling in this focused persistence test
+  installer.installerCheck.start = vi.fn();
+
+  await installer.load();
+
+  expect(wereSshDetailsSavedBeforeFailure).toBe(true);
+  expect(config.serverDetails).toMatchObject({
+    ipAddress: '127.0.0.1',
+    sshPort: 2222,
+    sshUser: 'argon',
+  });
+});
+
 it('does not resume installer polling when the remote installer is no longer running', async () => {
   const dbPromise = createMockedDbPromise({});
   const walletKeys = createMockWalletKeys();

--- a/src-vue/app-operations/overlays/security-settings/SSHAccess.vue
+++ b/src-vue/app-operations/overlays/security-settings/SSHAccess.vue
@@ -111,14 +111,14 @@ async function refreshStatus() {
 
 async function activateAccess() {
   errorMessage.value = '';
-  await config.isLoadedPromise;
-  const { host, port, username, address } = getServerDetails();
-  if (!host || !username) {
-    errorMessage.value = 'Missing SSH server details.';
-    return;
-  }
   isLoading.value = true;
   try {
+    await config.isLoadedPromise;
+    const { host, port, username, address } = getServerDetails();
+    if (!host || !username) {
+      errorMessage.value = 'Missing SSH server details.';
+      return;
+    }
     status.value = await invokeWithTimeout<SshAccessStatus>(
       'ssh_access_activate',
       {
@@ -127,7 +127,7 @@ async function activateAccess() {
         port,
         username,
       },
-      30e3,
+      60e3,
     );
   } catch (err) {
     errorMessage.value = String(err);
@@ -154,7 +154,7 @@ async function deactivateAccess() {
         port,
         username,
       },
-      30e3,
+      60e3,
     );
   } catch (err) {
     errorMessage.value = String(err);
@@ -165,9 +165,16 @@ async function deactivateAccess() {
 
 Vue.onMounted(() => {
   void (async () => {
-    await refreshStatus();
-    if (!isActive.value) {
-      await activateAccess();
+    isLoading.value = true;
+    try {
+      await refreshStatus();
+      if (!isActive.value) {
+        await activateAccess();
+      }
+    } catch (err) {
+      errorMessage.value = String(err);
+    } finally {
+      isLoading.value = false;
     }
   })();
 });

--- a/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
@@ -399,6 +399,8 @@ async function launchMiningBot() {
 }
 
 async function updateAPYs() {
+  if (calculatorLoadError.value) return;
+
   calculator.updateBiddingRules(config.biddingRules);
   calculator.calculateBidAmounts();
   averageAPY.value = calculator.averageAPY;

--- a/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
+++ b/src-vue/app-operations/screens/mining-screen/SetupChecklist.vue
@@ -72,6 +72,9 @@
               <p v-if="!config.hasSavedBiddingRules">
                 Decide how much capital you want to commit, your starting bid, maximum bid, and other basic settings.
               </p>
+              <p v-else-if="calculatorLoadError">
+                Live bidding estimates are temporarily unavailable. You can still start mining.
+              </p>
               <p v-else>
                 Your bidding rules expect a
                 <BotCapital align="start" :alignOffset="alignOffsetForBotCapital">
@@ -242,6 +245,7 @@ const alignOffsetForBotCapital = Vue.ref(0);
 const capitalCommitment = Vue.ref(0n);
 const isLaunchingMiningBot = Vue.ref(false);
 const averageAPY = Vue.ref(0);
+const calculatorLoadError = Vue.ref(false);
 
 const serverConnectIsChecked = Vue.computed(() => {
   return wallets.isLoaded && hasMiningMachine.value;
@@ -405,9 +409,14 @@ async function updateAPYs() {
 
 Vue.watch(config.biddingRules, () => updateAPYs(), { deep: true });
 
-Vue.onMounted(async () => {
-  await calculator.load();
-  await updateAPYs();
+Vue.onMounted(() => {
+  void calculator
+    .load()
+    .then(updateAPYs)
+    .catch(error => {
+      calculatorLoadError.value = true;
+      console.error('[SetupChecklist] Failed to load bidding estimates', error);
+    });
 });
 </script>
 

--- a/src-vue/app-shared/navigation/StatusMenu.vue
+++ b/src-vue/app-shared/navigation/StatusMenu.vue
@@ -583,7 +583,9 @@ Vue.onMounted(async () => {
     requiredMicrogonsForGoal.value = projections.microgonRequirement;
     requiredMicronotsForGoal.value = projections.micronotRequirement;
   });
-  void calculator.load();
+  void calculator.load().catch(error => {
+    console.error('[StatusMenu] Failed to load bidding estimates', error);
+  });
 });
 
 Vue.onUnmounted(() => {

--- a/src-vue/app-shared/screens/RuntimeCompatibilityScreen.vue
+++ b/src-vue/app-shared/screens/RuntimeCompatibilityScreen.vue
@@ -16,6 +16,13 @@
 
       <div class="pointer-events-none relative top-px mr-3 flex w-1/2 grow flex-row items-center justify-end space-x-2">
         <button
+          class="text-argon-600/70 hover:text-argon-600 decoration-argon-600/30 hover:decoration-argon-600/70 pointer-events-auto cursor-pointer px-2 py-2 text-xs font-medium underline underline-offset-4 transition"
+          @click="openMnemonicExport"
+        >
+          Export recovery phrase
+        </button>
+        <button
+          v-if="phase !== 'upgrade-required'"
           class="text-argon-600 border-argon-600/20 hover:border-argon-600/40 hover:bg-argon-600/6 pointer-events-auto cursor-pointer rounded-full border bg-white/70 px-4 py-2 text-sm font-semibold transition disabled:opacity-70"
           :disabled="isLoading"
           @click="runtimeCompatibility.refreshCompatibility('manual')"
@@ -55,7 +62,10 @@
           </div>
 
           <h1 class="text-argon-text-primary mb-4 text-4xl leading-tight font-semibold">
-            <template v-if="phase === 'paused'">
+            <template v-if="isNewDownloadRequired">
+              {{ APP_NAME }} is becoming Argon Desktop. Download the new app to continue.
+            </template>
+            <template v-else-if="phase === 'paused'">
               The Argon Network has been upgraded and needs a new version of {{ APP_NAME }} to work properly.
             </template>
             <template v-else>A new {{ APP_NAME }} version is required before you can continue.</template>
@@ -80,7 +90,17 @@
 
         <div class="flex flex-wrap items-center gap-3">
           <button
-            v-if="update && !isReadyToInstall"
+            v-if="isNewDownloadRequired"
+            class="bg-argon-button hover:bg-argon-button-hover border-argon-button-hover cursor-pointer rounded-full border px-6 py-3 text-sm font-semibold text-white transition"
+            @click="void tauriOpenUrl('https://argon.network/desktop-app')"
+          >
+            <span class="inline-flex items-center gap-2">
+              Download Argon Desktop
+              <ExternalIcon class="h-4 w-4" aria-hidden="true" />
+            </span>
+          </button>
+          <button
+            v-else-if="update && !isReadyToInstall"
             :disabled="isDownloading"
             class="bg-argon-button hover:bg-argon-button-hover border-argon-button-hover cursor-pointer rounded-full border px-6 py-3 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-60"
             @click="updater.downloadAndInstallUpdate()"
@@ -95,7 +115,8 @@
             Restart App to Activate Update
           </button>
           <div class="text-argon-text-primary/80 max-w-2xl text-xl leading-7">
-            <template v-if="phase === 'upgrade-required'">Install the latest app update to continue.</template>
+            <template v-if="isNewDownloadRequired">Download Argon Desktop from the Argon website to continue.</template>
+            <template v-else-if="phase === 'upgrade-required'">Install the latest app update to continue.</template>
             <template v-else>Waiting for a compatible app update...</template>
           </div>
         </div>
@@ -109,9 +130,12 @@ import { storeToRefs } from 'pinia';
 import WindowControls from '../../tauri-controls/WindowControls.vue';
 import ProgressBar from '../../components/ProgressBar.vue';
 import Spinner from '../../components/Spinner.vue';
+import basicEmitter from '../../emitters/basicEmitter.ts';
+import ExternalIcon from '../../assets/external.svg';
 import { APP_NAME } from '../../lib/Env.ts';
 import { useAppUpdater } from '../../stores/appUpdater.ts';
 import { useRuntimeCompatibility } from '../../stores/runtimeCompatibility.ts';
+import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';
 
 const updater = useAppUpdater();
 const runtimeCompatibility = useRuntimeCompatibility();
@@ -122,5 +146,14 @@ const {
   isReadyToInstall,
   update,
 } = storeToRefs(updater);
-const { errorMessage: compatibilityErrorMessage, isLoading, phase } = storeToRefs(runtimeCompatibility);
+const {
+  errorMessage: compatibilityErrorMessage,
+  isLoading,
+  newDownloadRequired: isNewDownloadRequired,
+  phase,
+} = storeToRefs(runtimeCompatibility);
+
+function openMnemonicExport() {
+  basicEmitter.emit('openSecuritySettingsOverlay', { screen: 'mnemonics' });
+}
 </script>

--- a/src-vue/stores/runtimeCompatibility.ts
+++ b/src-vue/stores/runtimeCompatibility.ts
@@ -8,18 +8,20 @@ import { useAppUpdater } from './appUpdater.ts';
 
 export type RuntimeCompatibilityPhase = 'disabled' | 'loading' | 'compatible' | 'paused' | 'upgrade-required';
 
-type CompatibilityInfo = { maxSpecVersion?: number };
+type CompatibilityInfo = { maxSpecVersion?: number; newDownloadRequired?: boolean };
 type Unsubscribe = () => void | Promise<void>;
 type ClientType = 'archive' | 'pruned';
 
 const INITIAL_LOADING_POLL_MILLIS = 5e3;
 const INITIAL_LOADING_TIMEOUT_MILLIS = 15e3;
 const BLOCKED_COMPATIBILITY_POLL_MILLIS = 60e3;
+const COMPATIBLE_COMPATIBILITY_POLL_MILLIS = 60 * 60e3;
 const UPDATE_CHECK_STALE_MILLIS = 60e3;
 
 export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () => {
   const phase = Vue.ref<RuntimeCompatibilityPhase>('disabled');
   const errorMessage = Vue.ref('');
+  const newDownloadRequired = Vue.ref(false);
   const isLoading = Vue.computed(() => phase.value === 'loading');
   const shouldShowCompatibilityScreen = Vue.computed(
     () => isLoading.value || phase.value === 'paused' || phase.value === 'upgrade-required',
@@ -91,6 +93,8 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
           pollMillis = INITIAL_LOADING_POLL_MILLIS;
         } else if (nextPhase === 'paused' || nextPhase === 'upgrade-required') {
           pollMillis = BLOCKED_COMPATIBILITY_POLL_MILLIS;
+        } else if (nextPhase === 'compatible') {
+          pollMillis = COMPATIBLE_COMPATIBILITY_POLL_MILLIS;
         }
 
         if (!pollMillis) {
@@ -186,6 +190,17 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
     return refreshQueue.add(async () => {
       try {
         const version = await updater.ensureInstalledVersion();
+        const compatibilityByVersion = await loadCompatibilityByVersion();
+        const compatibility = compatibilityByVersion[version];
+        const newDownloadRequiredForVersion = compatibility?.newDownloadRequired === true;
+        newDownloadRequired.value = newDownloadRequiredForVersion;
+        errorMessage.value = '';
+
+        if (newDownloadRequiredForVersion) {
+          phase.value = 'upgrade-required';
+          return;
+        }
+
         if (!observedSpecVersionByClient.archive) {
           await loadObservedSpecVersion('archive');
         }
@@ -197,10 +212,7 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
           throw new Error('Unable to determine the current Argon network version');
         }
 
-        const compatibilityByVersion = await loadCompatibilityByVersion();
-        const compatibility = compatibilityByVersion[version];
         const maxSpecVersion = compatibility?.maxSpecVersion;
-        errorMessage.value = '';
 
         if (maxSpecVersion == null || specVersions.every(specVersion => specVersion <= maxSpecVersion)) {
           phase.value = 'compatible';
@@ -233,6 +245,7 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
   return {
     phase,
     errorMessage,
+    newDownloadRequired,
     isLoading,
     shouldShowCompatibilityScreen,
     start,


### PR DESCRIPTION
## Summary

This addresses two v1.4.3 E2E failures that exposed real timing and recovery gaps in the app.

Mining setup could remain stuck after a transient current-state API failure because the rejected bidding-calculator load was cached. It can now retry, and setup remains usable when live estimates are temporarily unavailable.

The Bitcoin lock flow could continue when the lock screen was visible but its submit action was still disabled. It now waits for the action to become enabled.

This PR also preserves direct SSH recovery access after a late installer failure and directs retired app versions to Argon Desktop while keeping recovery-phrase export available.
