### PR TITLE
feat(wallets): redesign wallet overlay

### DIFF
--- a/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
+++ b/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
@@ -120,7 +120,7 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
         micronots: requiredMicronots > 0n ? requiredMicronots : undefined,
       });
 
-      await context.flow.click('NavHeader.triggerSyncMode()', { timeoutMs: 15_000 });
+      await context.flow.click('WalletOverlay.chooseEthereumWallet()', { timeoutMs: 15_000 });
 
       await context.flow.poll<IAppFundWalletFromEthereumState>(
         nextState =>
@@ -151,8 +151,6 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
       requestedMicrogons: requiredMicrogons.toString(),
       requestedMicronots: requiredMicronots.toString(),
     });
-
-    await context.flow.click('NavHeader.close()', { timeoutMs: 8_000 });
 
     const overlayCloseButton = await context.flow.isVisible('OverlayBase.clickClose()');
     if (overlayCloseButton.clickable) {

--- a/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
@@ -112,7 +112,7 @@ export default new Operation<IVaultingFlowContext, ITransferOutToEthereumState>(
             return true;
           }
 
-          await clickIfVisible(flow, 'NavHeader.triggerSyncMode()', { timeoutMs: 1_500 });
+          await clickIfVisible(flow, 'WalletOverlay.chooseEthereumWallet()', { timeoutMs: 1_500 });
           return false;
         },
         {

--- a/src-vue/__test__/WalletKeys.test.ts
+++ b/src-vue/__test__/WalletKeys.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
+import { createTestWallet } from './helpers/wallet.ts';
+
+it('keeps the core Ethereum address separate from the active external wallet', () => {
+  const { walletKeys } = createTestWallet();
+  const defaultEthereumAddress = walletKeys.defaultEthereumAddress;
+  const externalWallet = {
+    id: 1,
+    walletType: 'ethereum',
+    role: 'externalEthereum',
+    name: 'External Ethereum',
+    address: '0x0000000000000000000000000000000000000001',
+    sortOrder: 1,
+    secretKind: 'privateKey',
+    encryptedSecret: 'encrypted',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } satisfies IWalletRecord;
+
+  walletKeys.configureEthereumWallet(externalWallet);
+
+  expect(walletKeys.ethereumAddress).toBe(externalWallet.address);
+  expect(walletKeys.defaultEthereumAddress).toBe(defaultEthereumAddress);
+
+  walletKeys.configureEthereumWallet();
+
+  expect(walletKeys.ethereumAddress).toBe(defaultEthereumAddress);
+});

--- a/src-vue/__test__/WalletOverlayState.test.ts
+++ b/src-vue/__test__/WalletOverlayState.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
+import { WalletType } from '../lib/Wallet.ts';
+import {
+  closeWalletOverlaySide,
+  flipWalletOverlay,
+  getAvailableWalletSelections,
+  getInitialWalletOverlayState,
+  getWalletSelectionKey,
+  getWalletSelectionName,
+  type IWalletOverlayState,
+  WALLET_JUMP_LABEL,
+} from '../wallets/walletOverlayState.ts';
+
+const defaultArgonRecord = {
+  id: 1,
+  walletType: 'argon',
+  role: 'defaultArgon',
+  name: 'Argon Wallet',
+  address: 'argon-address',
+  sortOrder: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} satisfies IWalletRecord;
+
+const ethereumA = {
+  ...defaultArgonRecord,
+  id: 2,
+  walletType: 'ethereum',
+  role: 'defaultEthereum',
+  name: 'Default Ethereum',
+  address: '0x0000000000000000000000000000000000000001',
+} satisfies IWalletRecord;
+
+const ethereumB = {
+  ...ethereumA,
+  id: 3,
+  role: 'externalEthereum',
+  name: 'External Ethereum',
+  address: '0x0000000000000000000000000000000000000002',
+} satisfies IWalletRecord;
+
+const openPair = {
+  leftWallet: { walletType: WalletType.ethereum, walletRecord: ethereumA },
+  rightWallet: { walletType: WalletType.defaultArgon },
+} satisfies IWalletOverlayState;
+
+describe('wallet overlay state', () => {
+  it('lists built-in wallets and each unopened Ethereum record', () => {
+    const available = getAvailableWalletSelections(
+      [defaultArgonRecord, ethereumA, ethereumB],
+      [openPair.leftWallet],
+      true,
+    );
+
+    expect(available.map(getWalletSelectionKey)).toEqual([
+      WalletType.defaultArgon,
+      WalletType.miningBot,
+      `ethereum:${ethereumB.id}`,
+    ]);
+  });
+
+  it('hides the mining wallet without the Operations extension', () => {
+    const available = getAvailableWalletSelections([ethereumA], [], false);
+
+    expect(available.map(getWalletSelectionKey)).toEqual([WalletType.defaultArgon, `ethereum:${ethereumA.id}`]);
+  });
+
+  it('empties only the left slot when the left wallet closes', () => {
+    expect(closeWalletOverlaySide(openPair, 'left')).toEqual({
+      rightWallet: openPair.rightWallet,
+    });
+  });
+
+  it('empties only the right slot when the right wallet closes', () => {
+    expect(closeWalletOverlaySide(openPair, 'right')).toEqual({
+      leftWallet: openPair.leftWallet,
+    });
+  });
+
+  it('leaves two empty slots after the final wallet closes', () => {
+    expect(closeWalletOverlaySide({ rightWallet: openPair.rightWallet }, 'right')).toEqual({});
+  });
+
+  it('swaps source and recipient', () => {
+    expect(flipWalletOverlay(openPair)).toEqual({
+      leftWallet: openPair.rightWallet,
+      rightWallet: openPair.leftWallet,
+    });
+  });
+
+  it('keeps the established default Argon wallet name', () => {
+    expect(getWalletSelectionName({ walletType: WalletType.defaultArgon })).toBe('Native Argon Wallet');
+  });
+
+  it('loads Native Argon on the right when another wallet is requested', () => {
+    expect(getInitialWalletOverlayState(openPair.leftWallet)).toEqual({
+      leftWallet: openPair.leftWallet,
+      rightWallet: { walletType: WalletType.defaultArgon },
+    });
+  });
+
+  it('labels transfers between loaded wallets as jumps', () => {
+    expect(WALLET_JUMP_LABEL).toBe('JUMP');
+  });
+});

--- a/src-vue/components/BgOverlay.vue
+++ b/src-vue/components/BgOverlay.vue
@@ -1,12 +1,12 @@
 <!-- prettier-ignore -->
 <template>
   <div :class="[roundedClass]" class="absolute top-0 left-0 w-full h-full pointer-events-none">
-    <div v-if="enableTopBar" :class="[roundedTopClass]" class="absolute top-0 left-0 w-full h-14 pointer-events-none bg-black/20 transition-opacity"></div>
+    <div v-if="enableTopBar" :class="[roundedTopClass]" class="absolute top-0 left-0 w-full h-14 pointer-events-none bg-black/20 backdrop-blur-xs"></div>
     <div
       @click="emitClose"
       @pointerdown="handlePointerDown"
       @pointermove="handlePointerMove"
-      class="absolute bg-black/20 transition-opacity pointer-events-auto"
+      class="absolute bg-black/20 backdrop-blur-xs pointer-events-auto"
       :class="[enableTopBar ? 'top-14 bottom-0 inset-x-0' : 'inset-0', enableTopBar ? roundedBottomClass : roundedClass]"
       data-tauri-drag-region
     >

--- a/src-vue/components/CopyAddressMenu.vue
+++ b/src-vue/components/CopyAddressMenu.vue
@@ -75,7 +75,7 @@
                 </CopyToClipboard>
               </DropdownMenuItem>
               <DropdownMenuItem
-                v-if="walletType === WalletType.ethereum && props.showSingleAddress"
+                v-if="canExportEthereumPrivateKey"
                 @select.prevent="openEthereumPrivateKeyExport"
                 class="flex justify-center border-t border-slate-400/30 py-2"
               >
@@ -137,6 +137,12 @@ const wallet = Vue.computed<IWallet>(() => {
     return wallets.ethereumWallet;
   }
   throw new Error(`Unknown wallet type: ${props.walletType}`);
+});
+const canExportEthereumPrivateKey = Vue.computed(() => {
+  if (props.walletType !== WalletType.ethereum || !props.showSingleAddress) return false;
+
+  const defaultEthereumWallet = wallets.walletRecords.find(record => record.role === 'defaultEthereum');
+  return defaultEthereumWallet?.address.toLowerCase() === wallet.value.address.toLowerCase();
 });
 
 let mouseLeaveTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;

--- a/src-vue/components/ImageZoom.vue
+++ b/src-vue/components/ImageZoom.vue
@@ -9,10 +9,8 @@
 
   <DialogRoot :open="zoomOpen" @update:open="zoomOpen = $event">
     <DialogPortal>
-      <DialogOverlay asChild class="fixed inset-0 bg-black/70 backdrop-blur-sm">
-        <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-          <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="zoomOpen = false" />
-        </Motion>
+      <DialogOverlay asChild class="fixed inset-0 bg-black/70 backdrop-blur-xs">
+        <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="zoomOpen = false" />
       </DialogOverlay>
       <DialogContent
         class="fixed inset-0 flex items-center justify-center p-4 focus:outline-none"
@@ -32,7 +30,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { DialogRoot, DialogOverlay, DialogPortal, DialogContent } from 'reka-ui';
-import { Motion } from 'motion-v';
 import BgOverlay from './BgOverlay.vue';
 import { useOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 

--- a/src-vue/emitters/basicEmitter.ts
+++ b/src-vue/emitters/basicEmitter.ts
@@ -15,7 +15,7 @@ export type IWalletOverlayRequest = {
 
 type IBasicEmitter = {
   openWalletOverlay: IWalletOverlayRequest;
-  openEthereumWalletImportOverlay: void;
+  openEthereumWalletImportOverlay: 'choice' | 'external';
   openMoveCapitalOverlay: {
     walletType: WalletType.defaultArgon;
     moveTo?: MoveTo;

--- a/src-vue/interfaces/IEthereumInboundTransferTracker.ts
+++ b/src-vue/interfaces/IEthereumInboundTransferTracker.ts
@@ -2,7 +2,7 @@ import { MoveToken } from '@argonprotocol/apps-core';
 import type { ICrosschainTransferProgress } from '../lib/CrosschainTransferProgress.ts';
 import { WalletType } from '../lib/Wallet.ts';
 
-export type IArgonWalletType = WalletType.defaultArgon;
+export type IArgonWalletType = WalletType.defaultArgon | WalletType.miningBot;
 
 export type IEthereumMoveToken = MoveToken.ARGN | MoveToken.ARGNOT;
 

--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -278,10 +278,8 @@ export class EthereumInboundTransferTracker {
     let targetWalletType: IArgonWalletType | undefined;
     if (record.argonDestinationAddress === this.walletKeys.defaultArgonAddress) {
       targetWalletType = WalletType.defaultArgon;
-    } else if (record.argonDestinationAddress === this.walletKeys.defaultArgonAddress) {
-      targetWalletType = WalletType.defaultArgon;
-    } else if (record.argonDestinationAddress === this.walletKeys.defaultArgonAddress) {
-      targetWalletType = WalletType.defaultArgon;
+    } else if (record.argonDestinationAddress === this.walletKeys.miningBotAddress) {
+      targetWalletType = WalletType.miningBot;
     } else if (record.argonDestinationAddress === this.walletKeys.vaultingAddress) {
       targetWalletType = WalletType.defaultArgon;
     }

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -43,6 +43,7 @@ export class WalletKeys {
    * Ethereum-compatible address used for EVM/Ethereum integrations tied to this wallet.
    */
   public ethereumAddress: string;
+  public readonly defaultEthereumAddress: string;
   public ethereumHdPrefixes: ISecurity['ethereumHdPrefixes'];
   public ethereumHdPath: `m/44'/60'/${string}`;
   public councilSignerEthereumHdPath: `m/44'/60'/${string}`;
@@ -63,7 +64,8 @@ export class WalletKeys {
     this.miningBotAddress = security.miningBotAddress;
     this.vaultingAddress = this.defaultArgonAddress;
     this.operationalAddress = security.operationalAddress;
-    this.ethereumAddress = security.ethereumAddress.toLowerCase();
+    this.defaultEthereumAddress = security.ethereumAddress.toLowerCase();
+    this.ethereumAddress = this.defaultEthereumAddress;
     this.ethereumHdPrefixes = security.ethereumHdPrefixes;
     this.ethereumHdPath = getEthereumHdPath(this.ethereumHdPrefixes.primary);
     this.councilSignerEthereumHdPath = getEthereumHdPath(this.ethereumHdPrefixes.councilSigner);
@@ -82,9 +84,7 @@ export class WalletKeys {
 
   public configureEthereumWallet(record?: IWalletRecord): void {
     this.activeEthereumWalletRecord = record;
-    if (record?.address) {
-      this.ethereumAddress = record.address.toLowerCase();
-    }
+    this.ethereumAddress = record?.address.toLowerCase() ?? this.defaultEthereumAddress;
   }
 
   public async exportMiningBidProxyAccountJson(passphrase: string): Promise<KeyringPair$Json> {

--- a/src-vue/navigation/WalletsMenu.vue
+++ b/src-vue/navigation/WalletsMenu.vue
@@ -93,7 +93,7 @@ async function openWallet(wallet: IWalletRecord) {
 
 function addWallet() {
   closeMenu();
-  basicEmitter.emit('openEthereumWalletImportOverlay');
+  basicEmitter.emit('openEthereumWalletImportOverlay', 'choice');
 }
 
 function onMouseEnter() {

--- a/src-vue/overlays/AboutOverlay.vue
+++ b/src-vue/overlays/AboutOverlay.vue
@@ -4,9 +4,7 @@
     <DialogPortal>
       <AnimatePresence>
         <DialogOverlay asChild>
-          <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
-          </Motion>
+          <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
         </DialogOverlay>
 
         <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">

--- a/src-vue/overlays/AppUpdatesOverlay.vue
+++ b/src-vue/overlays/AppUpdatesOverlay.vue
@@ -4,9 +4,7 @@
     <DialogPortal>
       <AnimatePresence>
         <DialogOverlay asChild>
-          <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
-          </Motion>
+          <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
         </DialogOverlay>
 
         <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">

--- a/src-vue/overlays/BootingOverlay.vue
+++ b/src-vue/overlays/BootingOverlay.vue
@@ -1,17 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <TransitionRoot class="absolute inset-0 pointer-events-none" :show="isOpen">
-    <TransitionChild
-      as="template"
-      enter="ease-out duration-300"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="ease-in duration-200"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
-    </TransitionChild>
+    <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
 
     <div
       class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"

--- a/src-vue/overlays/JurisdictionOverlay.vue
+++ b/src-vue/overlays/JurisdictionOverlay.vue
@@ -4,9 +4,7 @@
     <DialogPortal>
       <AnimatePresence>
         <DialogOverlay asChild>
-          <Motion asChild :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :exit="{ opacity: 0 }">
-            <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
-          </Motion>
+          <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="closeOverlay" />
         </DialogOverlay>
 
         <DialogContent asChild @escapeKeyDown="closeOverlay" :aria-describedby="undefined" :style="{ zIndex: overlayZIndex.contentZIndex }">

--- a/src-vue/overlays/MoveCapitalButton.vue
+++ b/src-vue/overlays/MoveCapitalButton.vue
@@ -3,7 +3,14 @@
   <PopoverRoot v-model:open="isOpen">
     <PopoverTrigger :asChild="true">
       <slot>
-        <button :class="twMerge('border-argon-600/50 text-argon-600/80 cursor-pointer rounded border px-3 font-bold', props.class)">
+        <button
+          :class="
+            twMerge(
+              'border-argon-600/50 text-argon-600/80 cursor-pointer rounded border px-3 font-bold',
+              props.class,
+            )
+          "
+        >
           Move
         </button>
       </slot>

--- a/src-vue/overlays/OverlayBase.vue
+++ b/src-vue/overlays/OverlayBase.vue
@@ -4,13 +4,7 @@
     <DialogPortal>
       <AnimatePresence>
         <DialogOverlay asChild v-if="showBg">
-          <Motion
-            asChild
-            :initial="disableOverlayMotion ? false : { opacity: 0 }"
-            :animate="{ opacity: 1 }"
-            :exit="{ opacity: 0 }">
-            <BgOverlay :enableTopBar="props.enableTopBar" :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="clickBackdrop" />
-          </Motion>
+          <BgOverlay :enableTopBar="props.enableTopBar" :style="{ zIndex: overlayZIndex.backdropZIndex }" @close="clickBackdrop" />
         </DialogOverlay>
 
         <DialogContent

--- a/src-vue/overlays/ProvisioningCompleteOverlay.vue
+++ b/src-vue/overlays/ProvisioningCompleteOverlay.vue
@@ -1,17 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <TransitionRoot class="absolute inset-0" :show="isOpen">
-    <TransitionChild
-      as="template"
-      enter="ease-out duration-300"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="ease-in duration-200"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
-    </TransitionChild>
+    <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
 
     <div
       class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"

--- a/src-vue/overlays/SecuritySettingsOverlay.vue
+++ b/src-vue/overlays/SecuritySettingsOverlay.vue
@@ -8,12 +8,18 @@
     </template>
 
     <div class="px-3 py-4">
-      <SecuritySettingsOverview v-if="currentScreen === 'overview'" @close="closeOverlay" @goTo="goTo" />
+      <SecuritySettingsOverview
+        v-if="currentScreen === 'overview'"
+        :hasDefaultEthereumWallet="!!defaultEthereumWallet"
+        @close="closeOverlay"
+        @goTo="goTo"
+      />
       <SecuritySettingsMnemonics v-if="currentScreen === 'mnemonics'" @close="closeOverlay" @goTo="goTo" />
       <SecuritySettingsSSHAccess v-if="currentScreen === 'ssh'" @close="closeOverlay" @goTo="goTo" />
       <SecuritySettingsEncrypt v-if="currentScreen === 'encrypt'" @close="closeOverlay" @goTo="goTo" />
       <SecuritySettingsExportEthereumPrivateKey
-        v-if="currentScreen === 'ethereum-export'"
+        v-if="currentScreen === 'ethereum-export' && defaultEthereumWallet"
+        :walletRecord="defaultEthereumWallet"
         @close="closeOverlay"
         @goTo="goTo"
       />
@@ -31,12 +37,17 @@ import SecuritySettingsMnemonics from './security-settings/Mnemonics.vue';
 import SecuritySettingsSSHAccess from './security-settings/SSHAccess.vue';
 import OverlayBase from './OverlayBase.vue';
 import { useBasics } from '../stores/basics.ts';
+import { useWallets } from '../stores/wallets.ts';
 
 const basics = useBasics();
+const wallets = useWallets();
 
 const isOpen = Vue.ref(false);
 const currentScreen = Vue.ref<'overview' | 'mnemonics' | 'ssh' | 'encrypt' | 'ethereum-export'>('overview');
 const overlayWidth = Vue.ref(640);
+const defaultEthereumWallet = Vue.computed(() =>
+  wallets.walletRecords.find(record => record.role === 'defaultEthereum'),
+);
 
 const title = Vue.computed(() => {
   if (currentScreen.value === 'overview') {
@@ -48,14 +59,24 @@ const title = Vue.computed(() => {
   } else if (currentScreen.value === 'mnemonics') {
     return 'Account Recovery Mnemonic';
   } else if (currentScreen.value === 'ethereum-export') {
-    return 'Export Ethereum Private Key';
+    return 'Export Default Ethereum Private Key';
   }
   throw new Error('Invalid screen name');
 });
 
 basicEmitter.on('openSecuritySettingsOverlay', async data => {
+  const requestedScreen = data?.screen ?? 'overview';
+  if (requestedScreen === 'ethereum-export' && !wallets.isLoaded) {
+    try {
+      await wallets.load();
+    } catch (error) {
+      console.error('Failed to load wallet records before opening the Default Ethereum export', error);
+    }
+  }
+
   isOpen.value = true;
-  currentScreen.value = data?.screen ?? 'overview';
+  currentScreen.value =
+    requestedScreen === 'ethereum-export' && !defaultEthereumWallet.value ? 'overview' : requestedScreen;
   basics.overlayIsOpen = true;
 });
 
@@ -69,6 +90,8 @@ function goBack() {
 }
 
 function goTo(screen: 'overview' | 'encrypt' | 'mnemonics' | 'ssh' | 'ethereum-export') {
+  if (screen === 'ethereum-export' && !defaultEthereumWallet.value) return;
+
   currentScreen.value = screen;
   if (screen === 'overview') {
     overlayWidth.value = 640;

--- a/src-vue/overlays/ServerRemoveOverlay.vue
+++ b/src-vue/overlays/ServerRemoveOverlay.vue
@@ -1,17 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <TransitionRoot class="absolute inset-0" :show="isOpen">
-    <TransitionChild
-      as="template"
-      enter="ease-out duration-300"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="ease-in duration-200"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
-    </TransitionChild>
+    <BgOverlay :style="{ zIndex: overlayZIndex.backdropZIndex }" />
 
     <div
       class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"

--- a/src-vue/overlays/SyncingOverlay.vue
+++ b/src-vue/overlays/SyncingOverlay.vue
@@ -1,17 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <TransitionRoot class="absolute inset-0 pointer-events-none" :show="isOpen">
-    <TransitionChild
-      as="template"
-      enter="ease-out duration-300"
-      enter-from="opacity-0"
-      enter-to="opacity-100"
-      leave="ease-in duration-200"
-      leave-from="opacity-100"
-      leave-to="opacity-0"
-    >
-      <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
-    </TransitionChild>
+    <BgOverlay :enableTopBar="true" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
 
     <div
       class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"

--- a/src-vue/overlays/security-settings/ExportEthereumPrivateKey.vue
+++ b/src-vue/overlays/security-settings/ExportEthereumPrivateKey.vue
@@ -3,14 +3,14 @@
   <div class="flex flex-col gap-5 px-3">
     <div class="flex flex-col gap-3 text-md leading-6 text-slate-500">
       <p>
-        This exports the private key for your default Ethereum wallet address. Any wallet that imports this key can
-        spend funds from that Ethereum account.
+        This exports the private key for your Default Ethereum wallet. Any wallet that imports this key can spend funds
+        from that Ethereum account.
       </p>
     </div>
 
     <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-      <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Ethereum address</div>
-      <div class="mt-2 break-all font-mono text-sm text-slate-900">{{ walletKeys.ethereumAddress }}</div>
+      <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Default Ethereum address</div>
+      <div class="mt-2 break-all font-mono text-sm text-slate-900">{{ props.walletRecord.address }}</div>
     </div>
 
     <div class="relative rounded-xl border border-red-200 bg-red-50 px-4 py-3">
@@ -47,6 +47,9 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { getWalletKeys } from '../../stores/wallets.ts';
+import type { IWalletRecord } from '../../lib/db/WalletsTable.ts';
+
+const props = defineProps<{ walletRecord: Pick<IWalletRecord, 'address'> }>();
 
 const walletKeys = getWalletKeys();
 

--- a/src-vue/overlays/security-settings/Overview.vue
+++ b/src-vue/overlays/security-settings/Overview.vue
@@ -31,14 +31,16 @@
       <EncryptionFileIcon class="w-5 h-5 mr-2 opacity-70 group-hover:text-argon-600" />
       Set Encryption Passphrase
     </li>
-    <li class="h-[1px] border-t border-slate-300 border-dashed my-4" />
-    <li
-      @click="goTo('ethereum-export')"
-      class="group flex flex-row items-center cursor-pointer hover:text-argon-600 hover:bg-gradient-to-r hover:from-transparent hover:to-argon-menu-hover/70 rounded-md py-4"
-    >
-      <ExportIcon class="w-5 h-5 mr-2 opacity-70 group-hover:text-argon-600" />
-      Export Ethereum Private Key
-    </li>
+    <template v-if="props.hasDefaultEthereumWallet">
+      <li class="h-[1px] border-t border-slate-300 border-dashed my-4" />
+      <li
+        @click="goTo('ethereum-export')"
+        class="group flex flex-row items-center cursor-pointer hover:text-argon-600 hover:bg-gradient-to-r hover:from-transparent hover:to-argon-menu-hover/70 rounded-md py-4"
+      >
+        <ExportIcon class="w-5 h-5 mr-2 opacity-70 group-hover:text-argon-600" />
+        Export Default Ethereum Private Key
+      </li>
+    </template>
   </ul>
 </template>
 
@@ -52,6 +54,7 @@ import { OperationalStepId, useCertificationController } from '../../stores/cert
 import ArrowCalloutButton from '../../components/ArrowCalloutButton.vue';
 
 const controller = useCertificationController();
+const props = defineProps<{ hasDefaultEthereumWallet: boolean }>();
 
 const emit = defineEmits(['close', 'goTo']);
 

--- a/src-vue/screens/OldWalletsScreen.vue
+++ b/src-vue/screens/OldWalletsScreen.vue
@@ -25,9 +25,9 @@
         class="mt-5 text-center text-lg leading-normal font-light text-slate-800/60"
         style="text-shadow: 1px 1px 0 white"
       >
-        Click any wallet below to open it. Drag any two open wallets
+        Click any wallet below to open it. Choose another wallet in
         <br />
-        together to create a jump portal between them.
+        an empty slot to view or transfer between them.
       </p>
 
       <ul
@@ -349,7 +349,7 @@ function reorderDraggedWallet() {
 }
 
 function openEthereumChoice() {
-  basicEmitter.emit('openEthereumWalletImportOverlay');
+  basicEmitter.emit('openEthereumWalletImportOverlay', 'choice');
 }
 
 Vue.onUnmounted(() => {

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -380,7 +380,7 @@ export const useFinancials = defineStore('financials', () => {
       UnitOfMeasurement.Microgon,
     );
     const otherTokenValue = wallets.ethereumWallet.otherTokens.reduce((totalValue, token) => {
-      return totalValue + currency.convertOtherToMicrogon(token as IOtherToken);
+      return totalValue + currency.convertOtherToMicrogon(token);
     }, 0n);
 
     return micronotValue + otherTokenValue;

--- a/src-vue/stores/wallets.ts
+++ b/src-vue/stores/wallets.ts
@@ -55,8 +55,8 @@ export const useWallets = defineStore('wallets', () => {
   const { promise: isLoadedPromise, resolve: isLoadedResolve, reject: isLoadedReject } = createDeferred<void>();
 
   const walletsForArgon = getWalletsForArgon();
-  let walletForEthereum: WalletForEthereum | undefined;
-  const walletForBase = new WalletForBase(walletKeys.ethereumAddress);
+  const ethereumWalletLoaders = new Map<number, WalletForEthereum>();
+  const walletForBase = new WalletForBase(walletKeys.defaultEthereumAddress);
   const walletRecords = Vue.ref<IWalletRecord[]>([]);
   const activeEthereumWalletRecordId = Vue.ref<number>();
 
@@ -110,7 +110,11 @@ export const useWallets = defineStore('wallets', () => {
   const miningBotWallet = Vue.reactive<IWallet>({ ...defaultWalletData, address: walletKeys.miningBotAddress });
   const operationalWallet = Vue.reactive<IWallet>({ ...defaultWalletData, address: walletKeys.operationalAddress });
 
-  const ethereumWallet = Vue.reactive<IWallet>({ ...defaultWalletData });
+  const emptyEthereumWallet = Vue.reactive<IWallet>({ ...defaultWalletData });
+  const ethereumWallet = Vue.computed(() => {
+    if (!activeEthereumWalletRecordId.value) return emptyEthereumWallet;
+    return ethereumWalletLoaders.get(activeEthereumWalletRecordId.value)?.data ?? emptyEthereumWallet;
+  });
   const baseWallet = Vue.reactive<IWallet>(walletForBase.data);
   walletForBase.data = baseWallet;
 
@@ -274,11 +278,11 @@ export const useWallets = defineStore('wallets', () => {
       try {
         await config.isLoadedPromise;
         await ensureWalletRecordsLoaded();
-        await ensureActiveEthereumWallet();
+        const activeEthereumWallet = await ensureActiveEthereumWallet();
 
         const loadPromises: Promise<unknown>[] = [walletsForArgon.load(), walletForBase.load()];
-        if (walletForEthereum) {
-          loadPromises.push(walletForEthereum.load());
+        if (activeEthereumWallet) {
+          loadPromises.push(activeEthereumWallet.load());
         }
         await Promise.all(loadPromises);
         await ensureLegacyMiningHoldCleanup().catch(error => {
@@ -352,9 +356,9 @@ export const useWallets = defineStore('wallets', () => {
     const db = await getDbPromise();
     const existingEthereumWallets = await db.walletsTable.fetchEthereumWallets();
     if (existingEthereumWallets.length) return;
-    if (!walletKeys.ethereumAddress) return;
+    if (!walletKeys.defaultEthereumAddress) return;
 
-    const legacyWallet = new WalletForEthereum(walletKeys.ethereumAddress);
+    const legacyWallet = new WalletForEthereum(walletKeys.defaultEthereumAddress);
     await legacyWallet.load().catch(error => {
       console.warn('Unable to inspect legacy default Ethereum wallet during wallet seeding', error);
     });
@@ -364,7 +368,7 @@ export const useWallets = defineStore('wallets', () => {
       legacyWallet.data.otherTokens.some(token => token.value > 0n)
     ) {
       await db.walletsTable.createDefaultEthereum({
-        address: walletKeys.ethereumAddress,
+        address: walletKeys.defaultEthereumAddress,
         derivationPath: DEFAULT_ETHEREUM_HD_PATH,
       });
     }
@@ -380,11 +384,7 @@ export const useWallets = defineStore('wallets', () => {
     const activeEthereum = preferredEthereum ?? defaultEthereum ?? ethereumWallets[0];
     activeEthereumWalletRecordId.value = activeEthereum?.id;
     walletKeys.configureEthereumWallet(activeEthereum);
-    walletForEthereum = activeEthereum ? new WalletForEthereum(activeEthereum.address) : undefined;
-    Object.assign(ethereumWallet, walletForEthereum?.data ?? { ...defaultWalletData });
-    if (walletForEthereum) {
-      walletForEthereum.data = ethereumWallet;
-    }
+    return activeEthereum ? ensureEthereumWalletLoader(activeEthereum) : undefined;
   }
 
   async function refreshWalletRecords() {
@@ -394,17 +394,18 @@ export const useWallets = defineStore('wallets', () => {
   }
 
   async function selectEthereumWalletRecord(recordId: number) {
-    await ensureActiveEthereumWallet(recordId);
-    await walletForEthereum?.load();
+    const selectedWallet = await ensureActiveEthereumWallet(recordId);
+    await selectedWallet?.load();
   }
 
   async function createDefaultEthereumWallet() {
     const db = await getDbPromise();
-    await db.walletsTable.createDefaultEthereum({
-      address: walletKeys.ethereumAddress,
+    const record = await db.walletsTable.createDefaultEthereum({
+      address: walletKeys.defaultEthereumAddress,
       derivationPath: DEFAULT_ETHEREUM_HD_PATH,
     });
     await refreshWalletRecords();
+    return record;
   }
 
   async function previewExternalEthereumMnemonic(mnemonic: string, count = 10) {
@@ -430,13 +431,14 @@ export const useWallets = defineStore('wallets', () => {
       invokeWithTimeout<string>('encrypt_wallet_secret', { secret: args.privateKey }, 60e3),
     ]);
     const db = await getDbPromise();
-    await db.walletsTable.importExternalEthereum({
+    const record = await db.walletsTable.importExternalEthereum({
       name: args.name,
       address,
       secretKind: 'privateKey',
       encryptedSecret,
     });
     await refreshWalletRecords();
+    return record;
   }
 
   async function importExternalEthereumMnemonic(args: {
@@ -447,7 +449,7 @@ export const useWallets = defineStore('wallets', () => {
   }) {
     const encryptedSecret = await invokeWithTimeout<string>('encrypt_wallet_secret', { secret: args.mnemonic }, 60e3);
     const db = await getDbPromise();
-    await db.walletsTable.importExternalEthereum({
+    const record = await db.walletsTable.importExternalEthereum({
       name: args.name,
       address: args.address,
       derivationPath: args.derivationPath,
@@ -455,6 +457,7 @@ export const useWallets = defineStore('wallets', () => {
       encryptedSecret,
     });
     await refreshWalletRecords();
+    return record;
   }
 
   async function scanEthereumWalletBalances(addresses: string[]) {
@@ -517,6 +520,26 @@ export const useWallets = defineStore('wallets', () => {
     await refreshWalletRecords();
   }
 
+  function getEthereumWalletRecord(recordId: number): IWallet {
+    const record = walletRecords.value.find(wallet => wallet.id === recordId && wallet.walletType === 'ethereum');
+    if (!record) {
+      throw new Error(`Ethereum wallet record not found: ${recordId}`);
+    }
+    return ensureEthereumWalletLoader(record).data;
+  }
+
+  function ensureEthereumWalletLoader(record: IWalletRecord) {
+    const existingWallet = ethereumWalletLoaders.get(record.id);
+    if (existingWallet?.address.toLowerCase() === record.address.toLowerCase()) {
+      return existingWallet;
+    }
+
+    const wallet = new WalletForEthereum(record.address);
+    wallet.data = Vue.reactive<IWallet>(wallet.data);
+    ethereumWalletLoaders.set(record.id, wallet);
+    return wallet;
+  }
+
   load().catch(error => {
     void handleFatalError.bind('useWallets')(error);
     isLoadedReject();
@@ -528,8 +551,10 @@ export const useWallets = defineStore('wallets', () => {
 
     load,
     walletRecords,
+    activeEthereumWalletRecordId,
     refreshWalletRecords,
     selectEthereumWalletRecord,
+    getEthereumWalletRecord,
     createDefaultEthereumWallet,
     previewExternalEthereumMnemonic,
     importExternalEthereumPrivateKey,

--- a/src-vue/wallets/EthereumWalletImportOverlay.vue
+++ b/src-vue/wallets/EthereumWalletImportOverlay.vue
@@ -143,9 +143,13 @@
 import * as Vue from 'vue';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import { useWallets } from '../stores/wallets.ts';
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 
 const wallets = useWallets();
-const emit = defineEmits<{ complete: [] }>();
+const emit = defineEmits<{
+  complete: [walletRecord: IWalletRecord];
+  cancel: [];
+}>();
 
 const ethereumImportStep = Vue.ref<'choice' | 'external' | 'mnemonicAccounts'>();
 const ethereumImportMode = Vue.ref<'privateKey' | 'mnemonic'>('privateKey');
@@ -158,19 +162,23 @@ const mnemonicAccounts = Vue.ref<{ address: string; derivationPath: string; bala
 const selectedMnemonicPath = Vue.ref('');
 const startedFromChoiceStep = Vue.ref(false);
 
-const hasDefaultEthereumWallet = Vue.computed(() =>
-  wallets.walletRecords.some(wallet => wallet.role === 'defaultEthereum'),
-);
+function openEthereumImport(step: 'choice' | 'external') {
+  const hasDefaultEthereumWallet = wallets.walletRecords.some(wallet => wallet.role === 'defaultEthereum');
+  const initialStep = step === 'choice' && hasDefaultEthereumWallet ? 'external' : step;
 
-function openEthereumImport() {
-  startedFromChoiceStep.value = !hasDefaultEthereumWallet.value;
-  ethereumImportStep.value = startedFromChoiceStep.value ? 'choice' : 'external';
+  startedFromChoiceStep.value = initialStep === 'choice';
+  ethereumImportStep.value = initialStep;
   ethereumImportMode.value = 'privateKey';
   ethereumWalletNameInput.value = '';
   ethereumImportError.value = '';
 }
 
 function closeEthereumImport() {
+  resetEthereumImport();
+  emit('cancel');
+}
+
+function resetEthereumImport() {
   ethereumImportStep.value = undefined;
   ethereumSecretInput.value = '';
   ethereumWalletNameInput.value = '';
@@ -181,9 +189,9 @@ function closeEthereumImport() {
 }
 
 async function createDefaultEthereum() {
-  await wallets.createDefaultEthereumWallet();
-  closeEthereumImport();
-  emit('complete');
+  const walletRecord = await wallets.createDefaultEthereumWallet();
+  resetEthereumImport();
+  emit('complete', walletRecord);
 }
 
 async function continueExternalImport() {
@@ -196,12 +204,12 @@ async function continueExternalImport() {
   isImportingEthereum.value = true;
   try {
     if (ethereumImportMode.value === 'privateKey') {
-      await wallets.importExternalEthereumPrivateKey({
+      const walletRecord = await wallets.importExternalEthereumPrivateKey({
         name: walletName,
         privateKey: ethereumSecretInput.value.trim(),
       });
-      closeEthereumImport();
-      emit('complete');
+      resetEthereumImport();
+      emit('complete', walletRecord);
       return;
     }
     mnemonicAccounts.value = await wallets.previewExternalEthereumMnemonic(ethereumSecretInput.value.trim());
@@ -247,14 +255,14 @@ async function importSelectedMnemonicAccount() {
   }
   isImportingEthereum.value = true;
   try {
-    await wallets.importExternalEthereumMnemonic({
+    const walletRecord = await wallets.importExternalEthereumMnemonic({
       name: walletName,
       mnemonic: ethereumSecretInput.value.trim(),
       address: account.address,
       derivationPath: account.derivationPath,
     });
-    closeEthereumImport();
-    emit('complete');
+    resetEthereumImport();
+    emit('complete', walletRecord);
   } catch (error) {
     ethereumImportError.value = error instanceof Error ? error.message : 'Unable to import Ethereum wallet.';
   } finally {

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -1,15 +1,18 @@
-<!-- prettier-ignore -->
 <template>
   <DialogRoot :open="true" :modal="true">
     <DialogPortal>
       <DialogOverlay asChild>
-        <BgOverlay :style="{ zIndex: getOverlayBackdropZIndex(props.zIndex) }" @close="closeOverlay" />
+        <BgOverlay
+          class="bg-black/30"
+          :style="{ zIndex: getOverlayBackdropZIndex(props.zIndex) }"
+          @close="emit('close')"
+        />
       </DialogOverlay>
       <DialogContent
         asChild
         :aria-describedby="undefined"
         :style="{ zIndex: props.zIndex }"
-        @escapeKeyDown.prevent="handlePressEsc"
+        @escapeKeyDown.prevent="emit('close')"
       >
         <div
           :ref="setWalletRef"
@@ -17,107 +20,143 @@
             top: `calc(50% + ${draggable.modalPosition.y}px)`,
             left: `calc(50% + ${draggable.modalPosition.x}px)`,
             transform: 'translate(-50%, -50%)',
-            cursor: draggable.isDragging ? 'grabbing' : 'default',
           }"
-          :class="[
-            isSyncMode ? 'w-220' : 'w-110',
-            'absolute flex min-h-140 flex-col overflow-visible rounded-lg bg-linear-to-b from-[#cccccc] to-[#9f9f9f] shadow-2xl focus:outline-none pointer-events-auto',
-          ]"
+          class="pointer-events-auto absolute flex min-h-140 flex-row gap-12 focus:outline-none"
           @mousedown="emit('focus')"
         >
-          <DialogTitle asChild>
+          <DialogTitle class="sr-only">Wallets</DialogTitle>
+
+          <section
+            class="flex min-h-140 w-110 shrink-0 flex-col rounded-lg"
+            :class="
+              props.leftWallet
+                ? 'overflow-visible border border-black/40 bg-white shadow-2xl'
+                : 'overflow-hidden border-2 border-dashed border-slate-400/80 bg-gray-200/95 inset-shadow-sm inset-shadow-slate-300/60'
+            "
+          >
             <h2
-              class="z-20 mx-2 flex shrink-0 select-none flex-row items-center justify-between gap-x-3 px-2 pb-2 pt-3 text-2xl font-bold text-slate-800/70"
-              @dblclick="handleHeaderDoubleClick"
-              @mousedown="startDrag"
+              :style="{ cursor: draggable.isDragging ? 'grabbing' : 'grab' }"
+              class="z-20 mx-2 flex shrink-0 flex-row items-center justify-between gap-x-3 px-2 pt-3 pb-2 text-2xl font-bold text-slate-800/70 select-none"
+              @mousedown="draggable.onMouseDown"
             >
-              <div class="flex grow flex-row items-center">
-                <div v-if="isSyncMode" class="w-1/2 flex flex-row pr-6">
-                  <NavHeader :key="secondWalletKey" :walletType="secondWalletOption.type" :wallet="getWallet(secondWalletOption)" :isSyncMode="isSyncMode" :options="secondWalletOptions" :selectedOption="secondWalletOption" :showClose="true" @selectOption="handleSelectSecondWallet" @triggerSyncMode="triggerSyncMode" @close="closeOverlay" />
-                </div>
-                <div v-if="isSyncMode" class="relative h-[34px] w-[44px]">
-                  <button
-                    data-testid="WalletOverlay.toggleSyncDirection()"
-                    type="button"
-                    class="absolute top-1/2 left-1/2 -translate-1/2 z-10 flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center rounded-full bg-white border border-slate-500/60 shadow-sm text-slate-500/60 hover:border-slate-500/60 hover:bg-[#f1f3f7] focus:outline-none"
-                    @click="toggleSyncDirection"
-                  >
-                    <PortalIcon class="h-8 w-8" />
-                  </button>
-                </div>
-                <div :class="[isSyncMode ? 'w-1/2 pl-4' : 'w-full']" class="flex flex-row">
-                  <NavHeader :key="firstWalletKey" :walletType="firstWalletOption.type" :wallet="getWallet(firstWalletOption)" :isSyncMode="isSyncMode" :options="firstWalletOptions" :selectedOption="firstWalletOption" :showClose="true" @selectOption="handleSelectFirstWallet" @triggerSyncMode="triggerSyncMode" @close="closeOverlay" />
-                </div>
-              </div>
+              <NavHeader
+                v-if="props.leftWallet"
+                :walletType="props.leftWallet.walletType"
+                :wallet="getWallet(props.leftWallet)"
+                :name="getWalletSelectionName(props.leftWallet)"
+                :canExportPrivateKey="canExportEthereumPrivateKey(props.leftWallet)"
+                :showClose="true"
+                closeSide="left"
+                @close="emit('closeLeft')"
+              />
+              <header v-else class="grow px-2 text-left text-xl font-bold text-slate-600">Choose a Wallet</header>
             </h2>
-          </DialogTitle>
+
+            <WalletPanel
+              v-if="props.leftWallet"
+              :selection="props.leftWallet"
+              :wallet="getWallet(props.leftWallet)"
+              :mode="props.rightWallet ? 'transfer' : 'chooser'"
+              :transferDirection="
+                props.rightWallet ? getTransferDirection(props.leftWallet, props.rightWallet) : undefined
+              "
+              :moveFrom="argonWalletMove?.moveFrom"
+              :moveTo="argonWalletMove?.moveTo"
+              :showGuidance="props.showGuidance"
+              :guidanceContext="props.guidanceContext"
+              class="grow"
+              @openTransferOverlay="
+                props.rightWallet && openTransferOverlay(props.leftWallet, props.rightWallet, $event)
+              "
+            />
+            <WalletChooser
+              v-else
+              :availableWallets="props.availableWallets"
+              :canAddDefaultEthereum="props.canAddDefaultEthereum"
+              class="grow border-t border-dashed border-slate-400/50"
+              @select="emit('selectLeftWallet', $event)"
+              @addDefaultEthereum="emit('addDefaultEthereum', 'left')"
+              @addExternalEthereum="emit('addExternalEthereum', 'left')"
+            />
+          </section>
+
+          <section
+            class="flex min-h-140 w-110 shrink-0 flex-col rounded-lg"
+            :class="
+              props.rightWallet
+                ? 'overflow-visible border border-black/40 bg-white shadow-2xl'
+                : 'overflow-hidden border-2 border-dashed border-slate-400/60 bg-slate-100/90 inset-shadow-sm inset-shadow-slate-300/60'
+            "
+          >
+            <h2
+              :style="{ cursor: draggable.isDragging ? 'grabbing' : 'grab' }"
+              class="z-20 mx-2 flex shrink-0 flex-row items-center justify-between gap-x-3 px-2 pt-3 pb-2 text-2xl font-bold text-slate-800/70 select-none"
+              @mousedown="draggable.onMouseDown"
+            >
+              <NavHeader
+                v-if="props.rightWallet"
+                :walletType="props.rightWallet.walletType"
+                :wallet="getWallet(props.rightWallet)"
+                :name="getWalletSelectionName(props.rightWallet)"
+                :canExportPrivateKey="canExportEthereumPrivateKey(props.rightWallet)"
+                :showClose="true"
+                closeSide="right"
+                @close="emit('closeRight')"
+              />
+              <header v-else class="grow px-2 text-left text-xl font-bold text-slate-600">Choose a Wallet</header>
+            </h2>
+
+            <WalletPanel
+              v-if="props.rightWallet"
+              :selection="props.rightWallet"
+              :wallet="getWallet(props.rightWallet)"
+              :mode="props.leftWallet ? 'transfer' : 'chooser'"
+              :showGuidance="props.showGuidance"
+              :guidanceContext="props.guidanceContext"
+              class="grow"
+            />
+            <WalletChooser
+              v-else
+              :availableWallets="props.availableWallets"
+              :canAddDefaultEthereum="props.canAddDefaultEthereum"
+              class="grow border-t border-dashed border-slate-400/50"
+              @select="emit('selectRightWallet', $event)"
+              @addDefaultEthereum="emit('addDefaultEthereum', 'right')"
+              @addExternalEthereum="emit('addExternalEthereum', 'right')"
+            />
+          </section>
 
           <div
-            :class="[isSyncMode ? 'w-1/2' : 'w-full']"
-            class="absolute left-0 top-0 z-[-1] h-full rounded-lg border border-black/40 bg-white"
-          />
-          <div
-            v-if="isSyncMode"
-            class="absolute right-0 top-0 z-[-1] h-full w-1/2 rounded-lg border border-black/40 bg-white"
-          />
-
-          <div class="flex w-full flex-row text-black/90 px-1 text-7xl font-bold text-center">
-            <div v-if="isSyncMode" class="w-1/2 border-t border-slate-300 px-4 py-6">
-              <FormattedMoney :value="getWallet(secondWalletOption).availableMicrogons" />
-            </div>
-            <div class="border-t border-slate-300 px-4 py-6" :class="[isSyncMode ? 'w-1/2' : 'w-full']">
-              <FormattedMoney :value="getWallet(firstWalletOption).availableMicrogons" />
-            </div>
-          </div>
-
-          <div class="relative flex w-full flex-row" :class="isSyncMode ? 'py-2' : ''">
-            <div v-if="isSyncMode" class="absolute -left-2 top-0 z-[-1] h-full w-[calc(100%+16px)] rounded-t-lg border border-black/30 bg-white shadow-md">
-              <WrapBehindEdge class="absolute bottom-0 right-0 h-2 w-2 translate-y-full" />
-              <WrapBehindEdge class="absolute bottom-0 left-0 h-2 w-2 translate-y-full scale-x-[-1]" />
-            </div>
-            <div v-if="isSyncMode" class="w-1/2 px-4">
-              <ArgonTokens
-                :microgons="getWallet(secondWalletOption).availableMicrogons"
-                :micronots="getWallet(secondWalletOption).availableMicronots"
-                :minimizedLines="true"
-                :moveDirection="getTransferDirection(secondWalletOption, firstWalletOption)"
-                :networkName="getExternalNetworkName(secondWalletOption, firstWalletOption)"
-                :feeTokenSymbol="getExternalFeeTokenSymbol(secondWalletOption, firstWalletOption)"
-                @openTransferOverlay="openTransferOverlay(secondWalletOption, firstWalletOption, $event.moveToken, $event.availableAmount)"
-              />
-            </div>
-            <div class="px-4" :class="[isSyncMode ? 'w-1/2' : 'w-full']">
-              <ArgonTokens
-                :microgons="getWallet(firstWalletOption).availableMicrogons"
-                :micronots="getWallet(firstWalletOption).availableMicronots"
-                :minimizedLines="isSyncMode"
-              />
-            </div>
-          </div>
-
-          <div class="flex w-full grow flex-row">
-            <div v-if="isSyncMode" class="flex w-1/2 flex-col px-4">
-              <ArgonBottom
-                v-if="isArgonWalletType(secondWalletOption.type)"
-                :isSyncMode="isSyncMode"
-                :showGuidance="props.showGuidance"
-                :guidanceContext="props.guidanceContext"
-                :walletType="secondWalletOption.type"
-                direction="to"
-              />
-              <EthereumBottom v-else-if="secondWalletOption.type === 'ethereum'" />
-            </div>
-            <div :class="[isSyncMode ? 'w-1/2' : 'w-full']" class="flex flex-col px-4" >
-              <ArgonBottom
-                v-if="isArgonWalletType(firstWalletOption.type)"
-                :isSyncMode="isSyncMode"
-                :showGuidance="props.showGuidance"
-                :guidanceContext="props.guidanceContext"
-                :walletType="firstWalletOption.type"
-                direction="from"
-              />
-              <EthereumBottom v-else-if="firstWalletOption.type === 'ethereum'" />
-            </div>
+            v-if="props.leftWallet && props.rightWallet"
+            class="absolute top-full left-1/2 mt-4 flex w-max max-w-4xl -translate-x-1/2 items-center gap-3 text-sm text-white drop-shadow-sm"
+          >
+            <button
+              data-testid="WalletOverlay.toggleSyncDirection()"
+              type="button"
+              class="flex shrink-0 cursor-pointer items-center gap-1.5 rounded border border-white/50 bg-white/10 px-3 py-1.5 font-semibold text-white hover:bg-white/20 focus:outline-none"
+              title="Switch direction"
+              @click="emit('flip')"
+            >
+              <ArrowsRightLeftIcon class="h-4 w-4 stroke-2" />
+              Switch direction
+            </button>
+            <p>
+              Use
+              <strong>{{ isCrosschainWalletPair() ? 'JUMP' : 'MOVE' }}</strong>
+              to transfer supported tokens from
+              <strong>{{ getWalletSelectionName(props.leftWallet) }}</strong>
+              to
+              <strong>{{ getWalletSelectionName(props.rightWallet) }}</strong>
+              .
+              <a
+                v-if="isCrosschainWalletPair()"
+                href="https://argon.network/documentation/transfer-guide"
+                target="_blank"
+                class="font-semibold underline"
+              >
+                Learn more
+              </a>
+            </p>
           </div>
 
           <WalletTransferOverlay :request="activeTransferOverlay" @close="activeTransferOverlay = undefined" />
@@ -129,56 +168,56 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
+import { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
+import { ArrowsRightLeftIcon } from '@heroicons/vue/24/outline';
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui';
-import BgOverlay from '../components/BgOverlay.vue';
-import Draggable from '../overlays/helpers/Draggable.ts';
-import { getOverlayBackdropZIndex, provideOverlayContentZIndex } from '../overlays/helpers/OverlayZIndex.ts';
-import ArgonBottom from './components/ArgonBottom.vue';
-import EthereumBottom from './components/EthereumBottom.vue';
-import NavHeader, { type IWalletOption } from './components/NavHeader.vue';
-import ArgonTokens from './components/ArgonTokens.vue';
-import ArgonIntro from './components/ArgonIntro.vue';
-import PortalIcon from '../assets/wallets/swap.svg';
-import WrapBehindEdge from '../assets/wrap-behind-edge.svg';
-import EthereumIntro from './components/EthereumIntro.vue';
-import WalletTransferOverlay from './components/WalletTransferOverlay.vue';
 import type { IArgonWalletType, IEthereumMoveToken } from '../interfaces/IEthereumInboundTransferTracker.ts';
 import { type IWallet, WalletType } from '../lib/Wallet.ts';
+import Draggable from '../overlays/helpers/Draggable.ts';
+import { getOverlayBackdropZIndex, provideOverlayContentZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 import { useWallets } from '../stores/wallets.ts';
 import type { IWalletGuidanceContext } from '../emitters/basicEmitter.ts';
-import FormattedMoney from '../components/FormattedMoney.vue';
+import BgOverlay from '../components/BgOverlay.vue';
+import NavHeader from './components/NavHeader.vue';
+import WalletChooser from './components/WalletChooser.vue';
+import WalletPanel from './components/WalletPanel.vue';
+import WalletTransferOverlay from './components/WalletTransferOverlay.vue';
+import {
+  getWalletSelectionKey,
+  getWalletSelectionName,
+  isEthereumWalletSelection,
+  type IWalletSelection,
+} from './walletOverlayState.ts';
 
 const props = withDefaults(
   defineProps<{
-    walletType: WalletType.defaultArgon | WalletType.ethereum;
-    pairedWalletType?: WalletType.defaultArgon | WalletType.ethereum;
+    leftWallet?: IWalletSelection;
+    rightWallet?: IWalletSelection;
+    availableWallets: IWalletSelection[];
+    canAddDefaultEthereum: boolean;
     showGuidance?: boolean;
     guidanceContext?: IWalletGuidanceContext;
     zIndex: number;
-    position?: { x: number; y: number };
   }>(),
   {
     showGuidance: false,
-    position: () => ({ x: 0, y: 0 }),
   },
 );
 
 const emit = defineEmits<{
-  (e: 'close'): void;
-  (e: 'focus'): void;
-  (e: 'unpair'): void;
-  (e: 'pair', pairedWalletType: WalletType.defaultArgon | WalletType.ethereum): void;
-  (e: 'dragMove', payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }): void;
-  (e: 'positionChange', payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }): void;
-  (e: 'dragEnd', payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }): void;
+  (event: 'focus'): void;
+  (event: 'selectLeftWallet', wallet: IWalletSelection): void;
+  (event: 'selectRightWallet', wallet: IWalletSelection): void;
+  (event: 'addDefaultEthereum', side: 'left' | 'right'): void;
+  (event: 'addExternalEthereum', side: 'left' | 'right'): void;
+  (event: 'flip'): void;
+  (event: 'closeLeft'): void;
+  (event: 'closeRight'): void;
+  (event: 'close'): void;
 }>();
 
 const walletStore = useWallets();
 const draggable = Vue.reactive(new Draggable({ constrainToViewport: false }));
-const walletRef = Vue.shallowRef<HTMLElement | null>(null);
-provideOverlayContentZIndex(Vue.computed(() => props.zIndex));
-
-const isSyncMode = Vue.computed(() => !!props.pairedWalletType);
 const activeTransferOverlay = Vue.ref<{
   direction: 'transferToArgon' | 'transferOutOfArgon';
   moveToken: IEthereumMoveToken;
@@ -187,250 +226,94 @@ const activeTransferOverlay = Vue.ref<{
   networkName: string;
   feeTokenSymbol: string;
 }>();
-const walletOptions = Vue.ref<IWalletOption[]>([
-  { type: WalletType.defaultArgon as const, name: 'Native Argon Wallet', isArgonNetwork: true },
-  { type: WalletType.ethereum as const, name: 'Native Ethereum Wallet', isArgonNetwork: false },
-]);
-const firstWalletOption = Vue.ref<IWalletOption>(getWalletOption(props.walletType));
-const secondWalletOption = Vue.ref<IWalletOption>(
-  props.pairedWalletType
-    ? getWalletOption(props.pairedWalletType)
-    : walletOptions.value[walletOptions.value.length - 1],
-);
-const firstWalletOptions = Vue.computed(() => getWalletOptionsForSide(secondWalletOption.value));
-const secondWalletOptions = Vue.computed(() => getWalletOptionsForSide(firstWalletOption.value));
-const firstWalletKey = Vue.computed(() => getWalletHeaderKey(firstWalletOption.value, firstWalletOptions.value));
-const secondWalletKey = Vue.computed(() => getWalletHeaderKey(secondWalletOption.value, secondWalletOptions.value));
-
-function isArgonWalletType(walletType: WalletType): walletType is WalletType.defaultArgon {
-  return walletType === WalletType.defaultArgon;
-}
-
-function getWalletOptionsForSide(oppositeOption: IWalletOption) {
-  if (!isSyncMode.value) return walletOptions.value;
-
-  return walletOptions.value.filter(wallet => wallet.isArgonNetwork !== oppositeOption.isArgonNetwork);
-}
-
-function getWalletHeaderKey(selectedOption: IWalletOption, options: IWalletOption[]) {
-  return `${selectedOption.type}:${options.map(wallet => wallet.type).join(',')}`;
-}
-
-function getWalletOption(walletType: WalletType) {
-  const walletOption = walletOptions.value.find(x => x.type === walletType);
-  if (!walletOption) {
-    throw new Error(`Wallet option not supported: ${walletType}`);
-  }
-  return walletOption;
-}
-
-function closeOverlay() {
-  activeTransferOverlay.value = undefined;
-  emit('close');
-}
-
-function handlePressEsc() {
-  if (!isSyncMode.value) {
-    closeOverlay();
+const argonWalletMove = Vue.computed(() => {
+  const sourceWallet = props.leftWallet;
+  const recipientWallet = props.rightWallet;
+  if (
+    !sourceWallet ||
+    !recipientWallet ||
+    isEthereumWalletSelection(sourceWallet) ||
+    isEthereumWalletSelection(recipientWallet)
+  ) {
     return;
   }
 
-  activeTransferOverlay.value = undefined;
-  emit('unpair');
-}
-
-function handleHeaderDoubleClick() {
-  if (!isSyncMode.value) return;
-  activeTransferOverlay.value = undefined;
-  emit('unpair');
-}
-
-function handleSelectFirstWallet(option: IWalletOption) {
-  if (option.type === secondWalletOption.value.type) {
-    secondWalletOption.value = firstWalletOption.value;
+  if (sourceWallet.walletType === WalletType.defaultArgon && recipientWallet.walletType === WalletType.miningBot) {
+    return { moveFrom: MoveFrom.DefaultArgon, moveTo: MoveTo.MiningBot };
   }
-  firstWalletOption.value = option;
-}
 
-function handleSelectSecondWallet(option: IWalletOption) {
-  if (option.type === firstWalletOption.value.type) {
-    firstWalletOption.value = secondWalletOption.value;
+  if (sourceWallet.walletType === WalletType.miningBot && recipientWallet.walletType === WalletType.defaultArgon) {
+    return { moveFrom: MoveFrom.MiningBot, moveTo: MoveTo.DefaultArgon };
   }
-  secondWalletOption.value = option;
-}
+});
 
-function toggleSyncDirection() {
-  activeTransferOverlay.value = undefined;
-  const nextSecondWallet = firstWalletOption.value;
-  firstWalletOption.value = secondWalletOption.value;
-  secondWalletOption.value = nextSecondWallet;
-}
+provideOverlayContentZIndex(Vue.computed(() => props.zIndex));
 
-function triggerSyncMode() {
-  if (isSyncMode.value) return;
-  emit('pair', firstWalletOption.value.isArgonNetwork ? WalletType.ethereum : getDefaultArgonWalletType());
-}
-
-function getDefaultArgonWalletType(): WalletType.defaultArgon {
-  return WalletType.defaultArgon;
-}
-
-function getWallet(option: IWalletOption): IWallet {
-  if (option.type === WalletType.ethereum) {
-    return walletStore.ethereumWallet;
-  } else if (option.type === WalletType.defaultArgon) {
-    return walletStore.defaultArgonWallet;
-  } else {
-    throw new Error(`Wallet not support: ${option.type}`);
+function getWallet(selection: IWalletSelection): IWallet {
+  if (isEthereumWalletSelection(selection)) {
+    return walletStore.getEthereumWalletRecord(selection.walletRecord.id);
   }
+
+  return selection.walletType === WalletType.miningBot ? walletStore.miningBotWallet : walletStore.defaultArgonWallet;
+}
+
+function canExportEthereumPrivateKey(selection: IWalletSelection) {
+  return isEthereumWalletSelection(selection) && selection.walletRecord.role === 'defaultEthereum';
+}
+
+function isCrosschainWalletPair() {
+  if (!props.leftWallet || !props.rightWallet) return false;
+
+  return isEthereumWalletSelection(props.leftWallet) !== isEthereumWalletSelection(props.rightWallet);
 }
 
 function getTransferDirection(
-  currentOption: IWalletOption,
-  oppositeOption: IWalletOption,
+  sourceWallet: IWalletSelection,
+  recipientWallet: IWalletSelection,
 ): 'transferToArgon' | 'transferOutOfArgon' | undefined {
-  if (currentOption.type === WalletType.ethereum && isArgonWalletType(oppositeOption.type)) {
+  if (isEthereumWalletSelection(sourceWallet) && !isEthereumWalletSelection(recipientWallet)) {
     return 'transferToArgon';
   }
 
-  if (oppositeOption.type === WalletType.ethereum && isArgonWalletType(currentOption.type)) {
+  if (!isEthereumWalletSelection(sourceWallet) && isEthereumWalletSelection(recipientWallet)) {
     return 'transferOutOfArgon';
   }
 }
 
-function getExternalNetworkName(currentOption: IWalletOption, oppositeOption: IWalletOption) {
-  if (currentOption.type === WalletType.ethereum) {
-    return currentOption.name.replace(/ Wallet$/, '');
-  }
-
-  if (oppositeOption.type === WalletType.ethereum) {
-    return oppositeOption.name.replace(/ Wallet$/, '');
-  }
-
-  return '';
-}
-
-function getExternalFeeTokenSymbol(currentOption: IWalletOption, oppositeOption: IWalletOption) {
-  if (currentOption.type === WalletType.ethereum || oppositeOption.type === WalletType.ethereum) {
-    return 'ETH';
-  }
-
-  return '';
-}
-
-function openTransferOverlay(
-  currentOption: IWalletOption,
-  oppositeOption: IWalletOption,
-  moveToken: IEthereumMoveToken,
-  availableAmount: bigint,
+async function openTransferOverlay(
+  sourceWallet: IWalletSelection,
+  recipientWallet: IWalletSelection,
+  transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint },
 ) {
-  if (currentOption.type === WalletType.ethereum && isArgonWalletType(oppositeOption.type)) {
-    activeTransferOverlay.value = {
-      direction: 'transferToArgon',
-      moveToken,
-      availableAmount,
-      walletType: oppositeOption.type,
-      networkName: currentOption.name.replace(/ Wallet$/, ''),
-      feeTokenSymbol: 'ETH',
-    };
-    return;
-  }
+  const direction = getTransferDirection(sourceWallet, recipientWallet);
+  if (!direction) return;
 
-  if (oppositeOption.type === WalletType.ethereum && isArgonWalletType(currentOption.type)) {
-    activeTransferOverlay.value = {
-      direction: 'transferOutOfArgon',
-      moveToken,
-      availableAmount,
-      walletType: currentOption.type,
-      networkName: oppositeOption.name.replace(/ Wallet$/, ''),
-      feeTokenSymbol: 'ETH',
-    };
-  }
-}
+  const ethereumWallet = isEthereumWalletSelection(sourceWallet) ? sourceWallet : recipientWallet;
+  const argonWallet = isEthereumWalletSelection(sourceWallet) ? recipientWallet : sourceWallet;
+  if (!isEthereumWalletSelection(ethereumWallet) || isEthereumWalletSelection(argonWallet)) return;
 
-Vue.onMounted(() => {
-  draggable.modalPosition.x = props.position.x;
-  draggable.modalPosition.y = props.position.y;
-  emitPosition();
-});
-
-Vue.watch(
-  () => props.position,
-  position => {
-    if (draggable.isDragging) return;
-    draggable.modalPosition.x = position.x;
-    draggable.modalPosition.y = position.y;
-  },
-  { deep: true },
-);
-
-Vue.watch(() => ({ ...draggable.modalPosition }), emitPosition);
-
-Vue.watch(
-  () => props.walletType,
-  walletType => {
-    firstWalletOption.value = getWalletOption(walletType);
-  },
-);
-
-Vue.watch(
-  () => props.pairedWalletType,
-  pairedWalletType => {
-    if (pairedWalletType) {
-      secondWalletOption.value = getWalletOption(pairedWalletType);
-    }
-  },
-);
-
-function setWalletRef(el: Element | Vue.ComponentPublicInstance | null) {
-  walletRef.value = ((el as any)?.$el || el) as HTMLElement | null;
-  draggable.setModalRef(el);
-}
-
-function startDrag(event: MouseEvent) {
-  draggable.onMouseDown(event);
-
-  if (!draggable.isDragging) return;
-
-  window.addEventListener('mousemove', handleWalletDragMove);
-  window.addEventListener('mouseup', handleWalletDragEnd, { once: true });
-}
-
-function handleWalletDragMove() {
-  const payload = getPositionPayload();
-  if (!payload) return;
-  emit('positionChange', payload);
-  emit('dragMove', payload);
-}
-
-function handleWalletDragEnd() {
-  window.removeEventListener('mousemove', handleWalletDragMove);
-  Vue.nextTick(() => {
-    const payload = getPositionPayload();
-    if (!payload) return;
-    emit('positionChange', payload);
-    emit('dragEnd', payload);
-  });
-}
-
-function emitPosition() {
-  Vue.nextTick(() => {
-    const payload = getPositionPayload();
-    if (payload) {
-      emit('positionChange', payload);
-    }
-  });
-}
-
-function getPositionPayload() {
-  if (!walletRef.value) return;
-  return {
-    position: { ...draggable.modalPosition },
-    rect: walletRef.value.getBoundingClientRect(),
+  await walletStore.selectEthereumWalletRecord(ethereumWallet.walletRecord.id);
+  activeTransferOverlay.value = {
+    direction,
+    moveToken: transfer.moveToken,
+    availableAmount: transfer.availableAmount,
+    walletType: argonWallet.walletType,
+    networkName: 'Ethereum',
+    feeTokenSymbol: 'ETH',
   };
 }
 
-Vue.onUnmounted(() => {
-  window.removeEventListener('mousemove', handleWalletDragMove);
-});
+function setWalletRef(element: Element | Vue.ComponentPublicInstance | null) {
+  draggable.setModalRef(element);
+}
+
+Vue.watch(
+  () => [
+    props.leftWallet ? getWalletSelectionKey(props.leftWallet) : undefined,
+    props.rightWallet ? getWalletSelectionKey(props.rightWallet) : undefined,
+  ],
+  () => {
+    activeTransferOverlay.value = undefined;
+  },
+);
 </script>

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -1,27 +1,27 @@
 <template>
-  <div
-    v-if="snapPreviewStyle"
-    class="border-argon-500/70 pointer-events-none fixed rounded-xl border-2 shadow-[0_0_0_4px_rgba(183,76,186,0.18),0_0_28px_rgba(183,76,186,0.45)]"
-    :style="snapPreviewStyle"
-  />
   <WalletDialog
-    v-for="wallet in openWallets"
-    :key="wallet.id"
-    :walletType="wallet.walletType"
-    :pairedWalletType="wallet.pairedWalletType"
-    :showGuidance="wallet.showGuidance"
-    :guidanceContext="wallet.guidanceContext"
-    :zIndex="wallet.zIndex"
-    :position="wallet.position"
-    @focus="focusWallet(wallet.id)"
-    @pair="pairWallet(wallet.id, $event)"
-    @unpair="unpairWallet(wallet.id)"
-    @positionChange="updateWalletGeometry(wallet.id, $event)"
-    @dragMove="handleDragMove(wallet.id, $event)"
-    @dragEnd="handleDragEnd(wallet.id, $event)"
-    @close="closeWallet(wallet.id)"
+    v-if="openWallet"
+    :rightWallet="openWallet.rightWallet"
+    :leftWallet="openWallet.leftWallet"
+    :availableWallets="availableWallets"
+    :canAddDefaultEthereum="canAddDefaultEthereum"
+    :showGuidance="openWallet.showGuidance"
+    :guidanceContext="openWallet.guidanceContext"
+    :zIndex="openWallet.zIndex"
+    @focus="focusWallet"
+    @selectLeftWallet="selectWallet('left', $event)"
+    @selectRightWallet="selectWallet('right', $event)"
+    @addDefaultEthereum="addDefaultEthereum"
+    @addExternalEthereum="addExternalEthereum"
+    @flip="flipWallets"
+    @closeLeft="closeWallet('left')"
+    @closeRight="closeWallet('right')"
+    @close="closeOverlay"
   />
-  <EthereumWalletImportOverlay @complete="completeEthereumWalletSetup" />
+  <EthereumWalletImportOverlay
+    @complete="completeEthereumWalletSetup"
+    @cancel="pendingEthereumWalletAction = undefined"
+  />
 </template>
 
 <script lang="ts">
@@ -33,311 +33,216 @@ export const openWalletOverlayCount = ref(0);
 <script setup lang="ts">
 import * as Vue from 'vue';
 import basicEmitter, { type IWalletGuidanceContext, type IWalletOverlayRequest } from '../emitters/basicEmitter.ts';
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 import { WalletType } from '../lib/Wallet.ts';
-import { useBasics } from '../stores/basics.ts';
-import { useWallets } from '../stores/wallets.ts';
 import { releaseOverlayZIndex, reserveOverlayZIndex } from '../overlays/helpers/OverlayZIndex.ts';
-import WalletDialog from './WalletDialog.vue';
+import { useBasics } from '../stores/basics.ts';
+import { getConfig } from '../stores/config.ts';
+import { useWallets } from '../stores/wallets.ts';
 import EthereumWalletImportOverlay from './EthereumWalletImportOverlay.vue';
+import WalletDialog from './WalletDialog.vue';
+import {
+  closeWalletOverlaySide,
+  flipWalletOverlay,
+  getAvailableWalletSelections,
+  getInitialWalletOverlayState,
+  getWalletSelectionKey,
+  isEthereumWalletSelection,
+  type IWalletOverlayState,
+  type IWalletSelection,
+} from './walletOverlayState.ts';
 
-type IOpenWallet = {
-  id: number;
-  walletType: WalletType.defaultArgon | WalletType.ethereum;
-  pairedWalletType?: WalletType.defaultArgon | WalletType.ethereum;
+type IOpenWallet = IWalletOverlayState & {
   showGuidance: boolean;
   guidanceContext?: IWalletGuidanceContext;
   zIndex: number;
-  position: { x: number; y: number };
-  rect?: DOMRectReadOnly;
 };
 
 const basics = useBasics();
+const config = getConfig();
 const walletStore = useWallets();
-const openWallets = Vue.ref<IOpenWallet[]>([]);
+const openWallet = Vue.ref<IOpenWallet>();
 const pendingEthereumWalletAction = Vue.ref<
-  | { type: 'open'; request: IWalletOverlayRequest }
-  | {
-      type: 'pair';
-      walletId: number;
-      pairedWalletType: WalletType.defaultArgon | WalletType.ethereum;
-    }
+  { type: 'open'; request: IWalletOverlayRequest } | { type: 'select'; side: 'left' | 'right' }
 >();
-const snapPreview = Vue.ref<{
-  draggedWalletId: number;
-  targetWalletId: number;
-  bounds: { top: number; left: number; width: number; height: number };
-}>();
-let nextWalletId = 1;
 
-function syncOverlayState() {
-  basics.overlayIsOpen = openWallets.value.length > 0;
-}
+const availableWallets = Vue.computed(() => {
+  if (!openWallet.value) return [];
 
-function focusWallet(id: number) {
-  const wallet = openWallets.value.find(x => x.id === id);
-  if (!wallet) return;
-  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
-}
-
-function closeWallet(id: number) {
-  const wallet = openWallets.value.find(x => x.id === id);
-  if (wallet) {
-    releaseOverlayZIndex(wallet.zIndex);
+  const loadedWallets: IWalletSelection[] = [];
+  if (openWallet.value.leftWallet) {
+    loadedWallets.push(openWallet.value.leftWallet);
+  }
+  if (openWallet.value.rightWallet) {
+    loadedWallets.push(openWallet.value.rightWallet);
   }
 
-  openWallets.value = openWallets.value.filter(wallet => wallet.id !== id);
-  if (snapPreview.value?.draggedWalletId === id || snapPreview.value?.targetWalletId === id) {
-    snapPreview.value = undefined;
-  }
-  syncOverlayState();
-}
-
-function pairWallet(id: number, pairedWalletType: WalletType.defaultArgon | WalletType.ethereum) {
-  const wallet = openWallets.value.find(x => x.id === id);
-  if (!wallet || wallet.pairedWalletType) return;
-
-  if (
-    (wallet.walletType === WalletType.ethereum || pairedWalletType === WalletType.ethereum) &&
-    !walletStore.walletRecords.some(record => record.walletType === 'ethereum')
-  ) {
-    pendingEthereumWalletAction.value = { type: 'pair', walletId: id, pairedWalletType };
-    basicEmitter.emit('openEthereumWalletImportOverlay');
-    return;
-  }
-
-  wallet.pairedWalletType = pairedWalletType;
-  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
-}
-
-function unpairWallet(id: number) {
-  const wallet = openWallets.value.find(x => x.id === id);
-  if (!wallet?.pairedWalletType) return;
-
-  const pairedWalletType = wallet.pairedWalletType;
-  const originalPosition = { ...wallet.position };
-  const singleWalletWidth = (wallet.rect?.width ?? window.innerWidth * (8 / 12)) * (5 / 8);
-  const centerOffset = (singleWalletWidth + 15) / 2;
-  wallet.pairedWalletType = undefined;
-  wallet.zIndex = reserveOverlayZIndex(wallet.zIndex);
-  wallet.position = {
-    x: originalPosition.x + centerOffset,
-    y: originalPosition.y,
-  };
-
-  openWallets.value.push({
-    id: nextWalletId++,
-    walletType: pairedWalletType,
-    showGuidance: false,
-    zIndex: reserveOverlayZIndex(),
-    position: {
-      x: originalPosition.x - centerOffset,
-      y: originalPosition.y,
-    },
-  });
-  syncOverlayState();
-}
-
-function updateWalletGeometry(id: number, payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }) {
-  const wallet = openWallets.value.find(x => x.id === id);
-  if (!wallet) return;
-
-  wallet.position = payload.position;
-  wallet.rect = payload.rect;
-}
-
-function handleDragMove(id: number, payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }) {
-  updateWalletGeometry(id, payload);
-
-  const draggedWallet = openWallets.value.find(wallet => wallet.id === id);
-  if (!draggedWallet || draggedWallet.pairedWalletType) {
-    snapPreview.value = undefined;
-    return;
-  }
-
-  const targetWallet = findSnapTarget(draggedWallet);
-  if (!targetWallet?.rect || !draggedWallet.rect) {
-    snapPreview.value = undefined;
-    return;
-  }
-
-  snapPreview.value = {
-    draggedWalletId: draggedWallet.id,
-    targetWalletId: targetWallet.id,
-    bounds: getCombinedBounds(draggedWallet.rect, targetWallet.rect),
-  };
-}
-
-function handleDragEnd(id: number, payload: { position: { x: number; y: number }; rect: DOMRectReadOnly }) {
-  updateWalletGeometry(id, payload);
-
-  const draggedWallet = openWallets.value.find(wallet => wallet.id === id);
-  if (!draggedWallet || draggedWallet.pairedWalletType) {
-    snapPreview.value = undefined;
-    return;
-  }
-
-  const previewTargetId = snapPreview.value?.draggedWalletId === id ? snapPreview.value.targetWalletId : undefined;
-  const targetWallet = previewTargetId
-    ? openWallets.value.find(wallet => wallet.id === previewTargetId)
-    : findSnapTarget(draggedWallet);
-  snapPreview.value = undefined;
-  if (!targetWallet || !targetWallet.rect) return;
-
-  const draggedIsLeft = payload.rect.left < targetWallet.rect.left;
-  const primaryWalletType = draggedIsLeft ? targetWallet.walletType : draggedWallet.walletType;
-  const pairedWalletType = draggedIsLeft ? draggedWallet.walletType : targetWallet.walletType;
-  const primaryShowGuidance = draggedIsLeft ? targetWallet.showGuidance : draggedWallet.showGuidance;
-
-  releaseOverlayZIndex(draggedWallet.zIndex);
-  releaseOverlayZIndex(targetWallet.zIndex);
-  openWallets.value = openWallets.value.filter(
-    wallet => wallet.id !== draggedWallet.id && wallet.id !== targetWallet.id,
-  );
-  openWallets.value.push({
-    id: draggedWallet.id,
-    walletType: primaryWalletType,
-    pairedWalletType,
-    showGuidance: primaryShowGuidance,
-    zIndex: reserveOverlayZIndex(),
-    position: {
-      x: (draggedWallet.position.x + targetWallet.position.x) / 2,
-      y: (draggedWallet.position.y + targetWallet.position.y) / 2,
-    },
-  });
-  syncOverlayState();
-}
-
-const snapPreviewStyle = Vue.computed(() => {
-  if (!snapPreview.value) return;
-
-  const padding = 8;
-  const bounds = snapPreview.value.bounds;
-  return {
-    top: `${bounds.top - padding}px`,
-    left: `${bounds.left - padding}px`,
-    width: `${bounds.width + padding * 2}px`,
-    height: `${bounds.height + padding * 2}px`,
-    zIndex: Math.max(...openWallets.value.map(wallet => wallet.zIndex), 0) + 1,
-  };
+  return getAvailableWalletSelections(walletStore.walletRecords, loadedWallets, config.hasExtensionOperations);
 });
 
-function getNextPosition() {
-  const offset = (openWallets.value.length % 5) * 32;
-  return { x: offset, y: offset };
+const canAddDefaultEthereum = Vue.computed(
+  () => !walletStore.walletRecords.some(record => record.role === 'defaultEthereum'),
+);
+
+function focusWallet() {
+  if (!openWallet.value) return;
+  openWallet.value.zIndex = reserveOverlayZIndex(openWallet.value.zIndex);
 }
 
-function findSnapTarget(draggedWallet: IOpenWallet) {
-  if (!draggedWallet.rect) return;
+async function selectWallet(side: 'left' | 'right', wallet: IWalletSelection) {
+  if (!openWallet.value) return;
 
-  return openWallets.value.find(candidate => {
-    if (candidate.id === draggedWallet.id || candidate.pairedWalletType || !candidate.rect) return false;
-    if (!canPairWallets(draggedWallet.walletType, candidate.walletType)) return false;
+  if (isEthereumWalletSelection(wallet)) {
+    await walletStore.selectEthereumWalletRecord(wallet.walletRecord.id);
+  }
 
-    const verticalDistance = Math.abs(getRectCenterY(draggedWallet.rect!) - getRectCenterY(candidate.rect));
-    if (verticalDistance > 120) return false;
+  if (side === 'left') {
+    openWallet.value.leftWallet = wallet;
+  } else {
+    openWallet.value.rightWallet = wallet;
+  }
 
-    const draggedIsLeft = draggedWallet.rect!.left < candidate.rect.left;
-    const horizontalGap = draggedIsLeft
-      ? candidate.rect.left - draggedWallet.rect!.right
-      : draggedWallet.rect!.left - candidate.rect.right;
-
-    return horizontalGap >= -10 && horizontalGap <= 10;
-  });
+  await syncActiveEthereumWallet();
 }
 
-function getRectCenterY(rect: DOMRectReadOnly) {
-  return rect.top + rect.height / 2;
+async function addDefaultEthereum(side: 'left' | 'right') {
+  const walletRecord = await walletStore.createDefaultEthereumWallet();
+  await selectWallet(side, { walletType: WalletType.ethereum, walletRecord });
 }
 
-function getCombinedBounds(first: DOMRectReadOnly, second: DOMRectReadOnly) {
-  const top = Math.min(first.top, second.top);
-  const left = Math.min(first.left, second.left);
-  const right = Math.max(first.right, second.right);
-  const bottom = Math.max(first.bottom, second.bottom);
-
-  return {
-    top,
-    left,
-    width: right - left,
-    height: bottom - top,
-  };
+function addExternalEthereum(side: 'left' | 'right') {
+  pendingEthereumWalletAction.value = { type: 'select', side };
+  basicEmitter.emit('openEthereumWalletImportOverlay', 'external');
 }
 
-function canPairWallets(
-  first: WalletType.defaultArgon | WalletType.ethereum,
-  second: WalletType.defaultArgon | WalletType.ethereum,
-) {
-  return isArgonWalletType(first) !== isArgonWalletType(second);
+function flipWallets() {
+  if (!openWallet.value?.leftWallet || !openWallet.value.rightWallet) return;
+
+  const nextState = flipWalletOverlay(openWallet.value);
+  openWallet.value.leftWallet = nextState.leftWallet;
+  openWallet.value.rightWallet = nextState.rightWallet;
+  void syncActiveEthereumWallet();
 }
 
-function isArgonWalletType(walletType: WalletType) {
-  return walletType === WalletType.defaultArgon;
+function closeWallet(side: 'left' | 'right') {
+  if (!openWallet.value) return;
+
+  const nextState = closeWalletOverlaySide(openWallet.value, side);
+  openWallet.value.leftWallet = nextState.leftWallet;
+  openWallet.value.rightWallet = nextState.rightWallet;
+  void syncActiveEthereumWallet();
 }
 
-const openWalletOverlay = async (payload: IWalletOverlayRequest) => {
+const openWalletOverlay = async (request: IWalletOverlayRequest, ethereumWalletRecord?: IWalletRecord) => {
   try {
     await walletStore.load();
   } catch (error) {
     console.error('Failed to refresh wallet balances before opening wallet overlay', error);
   }
 
-  if (
-    payload.walletType === WalletType.ethereum &&
-    !walletStore.walletRecords.some(record => record.walletType === 'ethereum')
-  ) {
-    pendingEthereumWalletAction.value = { type: 'open', request: payload };
-    basicEmitter.emit('openEthereumWalletImportOverlay');
+  const wallet = getRequestedWallet(request, ethereumWalletRecord);
+  if (!wallet) {
+    pendingEthereumWalletAction.value = { type: 'open', request };
+    basicEmitter.emit('openEthereumWalletImportOverlay', 'choice');
     return;
   }
 
-  const existingWallet = openWallets.value.find(
-    wallet => !wallet.pairedWalletType && wallet.walletType === payload.walletType,
-  );
-  if (existingWallet) {
-    existingWallet.showGuidance = payload.showGuidance || false;
-    existingWallet.guidanceContext = payload.guidanceContext;
-    focusWallet(existingWallet.id);
-    syncOverlayState();
+  if (isEthereumWalletSelection(wallet)) {
+    await walletStore.selectEthereumWalletRecord(wallet.walletRecord.id);
+  }
+
+  if (openWallet.value) {
+    const walletKey = getWalletSelectionKey(wallet);
+    const isAlreadyOpen = [openWallet.value.leftWallet, openWallet.value.rightWallet].some(
+      currentWallet => currentWallet && getWalletSelectionKey(currentWallet) === walletKey,
+    );
+    if (!isAlreadyOpen) {
+      if (!openWallet.value.rightWallet) {
+        openWallet.value.rightWallet = wallet;
+      } else if (!openWallet.value.leftWallet) {
+        openWallet.value.leftWallet = wallet;
+      }
+    }
+    openWallet.value.showGuidance = request.showGuidance ?? false;
+    openWallet.value.guidanceContext = request.guidanceContext;
+    focusWallet();
+    await syncActiveEthereumWallet();
     return;
   }
 
-  openWallets.value.push({
-    id: nextWalletId++,
-    walletType: payload.walletType,
-    showGuidance: payload.showGuidance || false,
-    guidanceContext: payload.guidanceContext,
+  openWallet.value = {
+    ...getInitialWalletOverlayState(wallet),
+    showGuidance: request.showGuidance ?? false,
+    guidanceContext: request.guidanceContext,
     zIndex: reserveOverlayZIndex(),
-    position: getNextPosition(),
-  });
+  };
   syncOverlayState();
 };
 
-async function completeEthereumWalletSetup() {
+async function completeEthereumWalletSetup(walletRecord: IWalletRecord) {
   const action = pendingEthereumWalletAction.value;
   pendingEthereumWalletAction.value = undefined;
   if (!action) return;
 
   if (action.type === 'open') {
-    await openWalletOverlay(action.request);
+    await openWalletOverlay(action.request, walletRecord);
     return;
   }
 
-  pairWallet(action.walletId, action.pairedWalletType);
+  await selectWallet(action.side, { walletType: WalletType.ethereum, walletRecord });
+}
+
+function getRequestedWallet(
+  request: IWalletOverlayRequest,
+  ethereumWalletRecord?: IWalletRecord,
+): IWalletSelection | undefined {
+  if (request.walletType === WalletType.defaultArgon) {
+    return { walletType: WalletType.defaultArgon };
+  }
+
+  const activeWalletRecord = walletStore.walletRecords.find(
+    record => record.id === walletStore.activeEthereumWalletRecordId,
+  );
+  const walletRecord =
+    ethereumWalletRecord ??
+    activeWalletRecord ??
+    walletStore.walletRecords.find(record => record.walletType === 'ethereum');
+  return walletRecord ? { walletType: WalletType.ethereum, walletRecord } : undefined;
+}
+
+async function syncActiveEthereumWallet() {
+  if (!openWallet.value) return;
+
+  const ethereumWallets = [openWallet.value.leftWallet, openWallet.value.rightWallet].filter(
+    (wallet): wallet is Extract<IWalletSelection, { walletType: WalletType.ethereum }> =>
+      !!wallet && isEthereumWalletSelection(wallet),
+  );
+  if (ethereumWallets.length !== 1) return;
+
+  const recordId = ethereumWallets[0].walletRecord.id;
+  if (walletStore.activeEthereumWalletRecordId !== recordId) {
+    await walletStore.selectEthereumWalletRecord(recordId);
+  }
+}
+
+function closeOverlay() {
+  if (openWallet.value) {
+    releaseOverlayZIndex(openWallet.value.zIndex);
+  }
+  openWallet.value = undefined;
+  syncOverlayState();
+}
+
+function syncOverlayState() {
+  const count = openWallet.value ? 1 : 0;
+  basics.overlayIsOpen = count > 0;
+  openWalletOverlayCount.value = count;
 }
 
 basicEmitter.on('openWalletOverlay', openWalletOverlay);
 
-Vue.watch(
-  () => openWallets.value.length,
-  count => {
-    openWalletOverlayCount.value = count;
-  },
-  { immediate: true },
-);
-
 Vue.onUnmounted(() => {
   basicEmitter.off('openWalletOverlay', openWalletOverlay);
-  openWallets.value.forEach(wallet => releaseOverlayZIndex(wallet.zIndex));
-  openWalletOverlayCount.value = 0;
+  closeOverlay();
 });
 </script>

--- a/src-vue/wallets/components/ArgonBottom.vue
+++ b/src-vue/wallets/components/ArgonBottom.vue
@@ -1,20 +1,9 @@
 <template>
   <div class="flex grow flex-col py-4">
     <div class="flex grow flex-col items-center justify-center pb-[5%]">
-      <p v-if="props.isSyncMode" class="text-argon-600/80 mt-5 text-center font-light">
-        Click the Move arrow to transfer tokens {{ props.direction }} the
-        <br />
-        Ethereum Network.
-        <a href="https://argon.network/" target="_blank" class="text-argon-600 underline">Learn more</a>
-        .
-      </p>
-      <div v-else class="mt-5 text-center">
-        <p class="font-light">
-          Click the transfer icon above (
-          <PortalIcon class="relative -top-px inline-block w-4" />
-          ) to move
-          <br />
-          tokens between Argon and Ethereum.
+      <div v-if="props.mode === 'chooser'" class="mt-5 text-center">
+        <p class="text-argon-600/80 font-light">
+          Choose another wallet in the empty slot to view them together or move supported tokens.
         </p>
         <AlertCalloutButton
           v-if="
@@ -169,7 +158,6 @@ import { MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { open as tauriOpen } from '@tauri-apps/plugin-shell';
 import { CheckBadgeIcon } from '@heroicons/vue/24/outline';
 import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui';
-import PortalIcon from '../../assets/wallets/swap.svg';
 import ReceiptIcon from '../../assets/receipt.svg';
 import ExternalIcon from '../../assets/external.svg';
 import { IWallet, WalletType } from '../../lib/Wallet.ts';
@@ -189,9 +177,8 @@ import type { IWalletGuidanceContext } from '../../emitters/basicEmitter.ts';
 import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
 
 const props = defineProps<{
-  direction: 'from' | 'to';
   walletType: WalletType;
-  isSyncMode?: boolean;
+  mode: 'chooser' | 'transfer';
   showGuidance?: boolean;
   guidanceContext?: IWalletGuidanceContext;
 }>();

--- a/src-vue/wallets/components/ArgonTokens.vue
+++ b/src-vue/wallets/components/ArgonTokens.vue
@@ -1,9 +1,6 @@
 <template>
-  <ul :class="minimizedLines ? '' : 'border-b border-slate-400/50'">
-    <li
-      :class="[minimizedLines ? '' : 'border-t', hasMoveButton ? 'pr-14' : '']"
-      class="relative flex flex-row gap-x-2 border-slate-400/50 py-2"
-    >
+  <ul>
+    <li class="relative flex flex-row gap-x-2 border-slate-400/50 py-2">
       <ArgonIcon class="h-6 w-6" />
       <div class="grow">{{ microgonToArgonNm(props.microgons).format('0,0.[00]') }} ARGN</div>
       <div>{{ currency.symbol }}{{ microgonToMoneyNm(props.microgons).format('0,0.00') }}</div>
@@ -16,11 +13,16 @@
         :feeTokenSymbol="props.feeTokenSymbol"
         @openTransferOverlay="openTransferOverlay(MoveToken.ARGN, props.microgons)"
       />
+      <MoveCapitalButton
+        v-else-if="props.moveFrom !== undefined && props.moveTo !== undefined"
+        :moveFrom="props.moveFrom"
+        :moveTo="props.moveTo"
+        :moveToken="MoveToken.ARGN"
+        side="top"
+        class="absolute top-1/2 left-[calc(100%+40px)] z-30 -translate-x-1/2 -translate-y-1/2 bg-white py-1 text-xs"
+      />
     </li>
-    <li
-      :class="[hasMoveButton ? 'pr-14' : '']"
-      class="relative flex flex-row gap-x-2 border-t border-slate-400/50 py-2"
-    >
+    <li class="relative flex flex-row gap-x-2 border-t border-slate-400/50 py-2">
       <ArgonotIcon class="h-6 w-6" />
       <div class="grow">{{ micronotToArgonotNm(props.micronots).format('0,0.[00]') }} ARGNOT</div>
       <div>{{ currency.symbol }}{{ micronotToMoneyNm(props.micronots).format('0,0.00') }}</div>
@@ -33,17 +35,26 @@
         :feeTokenSymbol="props.feeTokenSymbol"
         @openTransferOverlay="openTransferOverlay(MoveToken.ARGNOT, props.micronots)"
       />
+      <MoveCapitalButton
+        v-else-if="props.moveFrom !== undefined && props.moveTo !== undefined"
+        :moveFrom="props.moveFrom"
+        :moveTo="props.moveTo"
+        :moveToken="MoveToken.ARGNOT"
+        side="top"
+        class="absolute top-1/2 left-[calc(100%+40px)] z-30 -translate-x-1/2 -translate-y-1/2 bg-white py-1 text-xs"
+      />
     </li>
   </ul>
 </template>
 <script setup lang="ts">
-import * as Vue from 'vue';
 import { MoveToken } from '@argonprotocol/apps-core';
+import type { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
 import ArgonotIcon from '../../assets/resources/argonot.svg';
 import ArgonIcon from '../../assets/resources/argon.svg';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import CrosschainMoveButton from './CrosschainMoveButton.vue';
+import MoveCapitalButton from '../../overlays/MoveCapitalButton.vue';
 
 const currency = getCurrency();
 
@@ -53,8 +64,9 @@ const props = withDefaults(
   defineProps<{
     microgons?: bigint;
     micronots?: bigint;
-    minimizedLines?: boolean;
     moveDirection?: 'transferToArgon' | 'transferOutOfArgon';
+    moveFrom?: MoveFrom;
+    moveTo?: MoveTo;
     networkName?: string;
     feeTokenSymbol?: string;
   }>(),
@@ -75,8 +87,6 @@ const emit = defineEmits<{
     },
   ): void;
 }>();
-
-const hasMoveButton = Vue.computed(() => !!props.moveDirection);
 
 function openTransferOverlay(moveToken: MoveToken.ARGN | MoveToken.ARGNOT, availableAmount: bigint) {
   if (!props.moveDirection) {

--- a/src-vue/wallets/components/CrosschainMoveButton.vue
+++ b/src-vue/wallets/components/CrosschainMoveButton.vue
@@ -4,15 +4,17 @@
       <button
         :data-testid="getMoveButtonTestId()"
         type="button"
-        :disabled="isMoveDisabled"
-        class="absolute top-1/2 -right-6 h-10 -translate-y-1/2 cursor-pointer disabled:cursor-default disabled:opacity-40"
+        :aria-disabled="isMoveDisabled"
+        :title="isMoveDisabled ? `No ${props.moveToken} available to jump` : `Jump ${props.moveToken}`"
+        class="absolute top-1/2 left-[calc(100%+40px)] z-30 h-10 -translate-x-1/2 -translate-y-1/2 cursor-pointer"
         @mouseenter="isHovered = true"
         @mouseleave="isHovered = false"
         @click="openTransferOverlay"
       >
-        <div class="absolute top-0 left-0 h-full w-9/12 bg-gradient-to-r from-white to-transparent" />
         <div v-if="hasPendingTransfer" spinner class="absolute top-1/2 right-4 h-5 w-5 -translate-y-1/2 border-3" />
-        <div v-else class="text-argon-600 absolute top-1/2 right-4 -translate-y-1/2 text-sm font-bold">MOVE</div>
+        <div v-else class="text-argon-600 absolute inset-0 flex items-center justify-center text-sm font-bold">
+          <span class="relative right-1.5">{{ WALLET_JUMP_LABEL }}</span>
+        </div>
         <MoveArrow class="pointer-events-none h-full" />
       </button>
     </HoverCardTrigger>
@@ -131,6 +133,7 @@ import { getCurrency } from '../../stores/currency.ts';
 import { getEthereumMoveTracker } from '../../stores/moveFromEthereum.ts';
 import { getEthereumOutboundTransferTracker } from '../../stores/moveToEthereum.ts';
 import { loadEthereumChainConfig } from '../../lib/EthereumClient.ts';
+import { WALLET_JUMP_LABEL } from '../walletOverlayState.ts';
 import {
   getCrosschainTransferProgressView,
   isCrosschainTransferVisible,
@@ -249,6 +252,10 @@ Vue.onMounted(() => {
 });
 
 function openTransferOverlay() {
+  if (isMoveDisabled.value) {
+    return;
+  }
+
   isHovered.value = false;
   emit('openTransferOverlay');
 }

--- a/src-vue/wallets/components/EthereumBottom.vue
+++ b/src-vue/wallets/components/EthereumBottom.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col gap-4">
     <div
-      v-if="hasBaseAlert || baseWallet.fetchErrorMsg"
+      v-if="isBaseWalletAddress && (hasBaseAlert || baseWallet.fetchErrorMsg)"
       class="text-md flex flex-row items-start gap-x-3 rounded-lg border border-amber-300 bg-amber-50 p-2 leading-6"
     >
       <AlertIcon class="relative top-1 w-10 text-amber-600" />
@@ -16,9 +16,9 @@
     <!--    <p class="font-light">The following is a list of your non-argon tokens.</p>-->
 
     <div class="pb-1">
-      <OtherTokens :tokens="ethereumWallet.otherTokens" />
-      <p v-if="ethereumWallet.fetchErrorMsg" class="mt-3 text-sm leading-6 text-red-600">
-        {{ ethereumWallet.fetchErrorMsg }}
+      <OtherTokens :tokens="props.wallet.otherTokens" />
+      <p v-if="props.wallet.fetchErrorMsg" class="mt-3 text-sm leading-6 text-red-600">
+        {{ props.wallet.fetchErrorMsg }}
       </p>
     </div>
   </div>
@@ -29,11 +29,15 @@ import * as Vue from 'vue';
 import OtherTokens from './OtherTokens.vue';
 import AlertIcon from '../../assets/alert.svg';
 import { useWallets } from '../../stores/wallets.ts';
+import type { IWallet } from '../../lib/Wallet.ts';
+
+const props = defineProps<{ wallet: IWallet }>();
 
 const wallets = useWallets();
 
-const ethereumWallet = wallets.ethereumWallet;
 const baseWallet = wallets.baseWallet;
+
+const isBaseWalletAddress = Vue.computed(() => props.wallet.address.toLowerCase() === baseWallet.address.toLowerCase());
 
 const hasBaseAlert = Vue.computed(() => {
   const tokensWithValue = baseWallet.otherTokens.filter(x => x.value > 0n);

--- a/src-vue/wallets/components/ExtraMenu.vue
+++ b/src-vue/wallets/components/ExtraMenu.vue
@@ -64,6 +64,15 @@
                 <ShieldCheckIcon class="w-4 h-4" />
               </div>
             </DropdownMenuItem>
+            <template v-if="props.canExportPrivateKey">
+              <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
+              <DropdownMenuItem MenuItem @click="openEthereumPrivateKeyExport">
+                <div ItemWrapper>
+                  <header>Export Private Key</header>
+                  <KeyIcon class="w-4 h-4" />
+                </div>
+              </DropdownMenuItem>
+            </template>
             <template v-if="walletType !== WalletType.defaultArgon">
               <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
               <DropdownMenuItem MenuItem @click="() => disconnectWallet()">
@@ -94,7 +103,7 @@ import {
 import type { PointerDownOutsideEvent } from 'reka-ui';
 import basicEmitter from '../../emitters/basicEmitter.ts';
 import { WalletType } from '../../lib/Wallet.ts';
-import { WindowIcon, QrCodeIcon, ShieldCheckIcon } from '@heroicons/vue/24/outline';
+import { KeyIcon, WindowIcon, QrCodeIcon, ShieldCheckIcon } from '@heroicons/vue/24/outline';
 import CopyIcon from '../../assets/copy.svg';
 import QRCode from 'qrcode';
 import CopyToClipboard from '../../components/CopyToClipboard.vue';
@@ -105,10 +114,12 @@ const props = withDefaults(
     wallet: { address: string };
     walletType: WalletType;
     walletIsOpen?: boolean;
+    canExportPrivateKey?: boolean;
     showBorders?: boolean;
   }>(),
   {
     walletIsOpen: false,
+    canExportPrivateKey: false,
     showBorders: true,
   },
 );
@@ -145,6 +156,10 @@ function disconnectWallet() {}
 
 function openRecovery() {
   basicEmitter.emit('openSecuritySettingsOverlay', { screen: 'mnemonics' });
+}
+
+function openEthereumPrivateKeyExport() {
+  basicEmitter.emit('openSecuritySettingsOverlay', { screen: 'ethereum-export' });
 }
 
 function openWallet(walletType: WalletType) {

--- a/src-vue/wallets/components/NavHeader.vue
+++ b/src-vue/wallets/components/NavHeader.vue
@@ -1,71 +1,50 @@
 <template>
   <div class="flex grow flex-row items-center gap-x-2">
     <header class="grow px-2 text-left text-xl font-bold text-slate-800/70">
-      {{ props.selectedOption.name }}
+      {{ props.name }}
     </header>
-    <div
-      v-if="!isSyncMode"
-      NotDraggable
-      @click="triggerSyncMode"
-      class="z-10 flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-sm/6 font-semibold hover:border-slate-500/60 hover:bg-[#f1f3f7] focus:outline-none"
-    >
-      <PortalIcon class="pointer-events-none h-5 w-5 text-slate-500/60" />
-    </div>
     <ExtraMenu
       :walletType="walletType"
       :wallet="props.wallet"
       :walletIsOpen="true"
+      :canExportPrivateKey="props.canExportPrivateKey"
       @click.stop
       @pointerdown.stop
       @mousedown.stop
     />
-    <DialogClose
+    <button
       v-if="showClose"
       NotDraggable
+      type="button"
       @click="close"
-      class="z-10 flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-sm/6 font-semibold hover:border-slate-500/60 hover:bg-[#f1f3f7] focus:outline-none"
+      class="relative z-10 flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-sm/6 font-semibold hover:border-slate-500/60 hover:bg-[#f1f3f7] focus:outline-none"
     >
+      <span v-if="props.closeSide === 'left'" data-testid="WalletOverlay.closeLeft()" class="absolute inset-0 z-10" />
+      <span v-else data-testid="WalletOverlay.closeRight()" class="absolute inset-0 z-10" />
       <XMarkIcon class="pointer-events-none h-5 w-5 stroke-2 text-slate-500/60" />
-    </DialogClose>
+    </button>
   </div>
 </template>
 
-<script lang="ts">
-import { WalletType } from '../../lib/Wallet.ts';
-
-export interface IWalletOption {
-  type: WalletType.defaultArgon | WalletType.ethereum;
-  name: string;
-  isArgonNetwork: boolean;
-}
-</script>
-
 <script setup lang="ts">
-import { DialogClose } from 'reka-ui';
 import { XMarkIcon } from '@heroicons/vue/24/outline';
 import ExtraMenu from './ExtraMenu.vue';
-import PortalIcon from '../../assets/wallets/swap.svg';
+import { type IWallet, WalletType } from '../../lib/Wallet.ts';
 
 const emit = defineEmits<{
   (e: 'close'): void;
-  (e: 'selectOption', option: IWalletOption): void;
-  (e: 'triggerSyncMode'): void;
 }>();
 
 const props = defineProps<{
-  wallet: { address: string };
+  wallet: IWallet;
   walletType: WalletType;
-  options: IWalletOption[];
-  selectedOption: IWalletOption;
-  isSyncMode?: boolean;
+  name: string;
+  canExportPrivateKey?: boolean;
   showClose?: boolean;
+  closeSide: 'left' | 'right';
 }>();
 
 function close() {
   emit('close');
-}
-
-function triggerSyncMode() {
-  emit('triggerSyncMode');
 }
 </script>

--- a/src-vue/wallets/components/WalletChooser.vue
+++ b/src-vue/wallets/components/WalletChooser.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="flex h-full flex-col px-4 pt-3 pb-5 text-left">
+    <div class="mt-3 flex max-h-80 flex-col gap-2 overflow-y-auto pr-1">
+      <button
+        v-for="wallet in props.availableWallets"
+        :key="getWalletSelectionKey(wallet)"
+        :data-wallet-key="getWalletSelectionKey(wallet)"
+        type="button"
+        class="relative flex min-h-16 w-full cursor-pointer items-center rounded-md border border-slate-300 bg-white/80 px-3 py-2 text-left shadow-sm hover:border-slate-400 hover:bg-white"
+        @click="emit('select', wallet)"
+      >
+        <span
+          v-if="isEthereumWalletSelection(wallet) && wallet.walletRecord.id === wallets.activeEthereumWalletRecordId"
+          data-testid="WalletOverlay.chooseEthereumWallet()"
+          class="absolute inset-0 z-10"
+        />
+        <span v-else-if="isEthereumWalletSelection(wallet)" class="absolute inset-0 z-10" />
+        <span
+          v-else-if="wallet.walletType === WalletType.miningBot"
+          data-testid="WalletOverlay.chooseMiningWallet()"
+          class="absolute inset-0 z-10"
+        />
+        <span v-else data-testid="WalletOverlay.chooseDefaultArgonWallet()" class="absolute inset-0 z-10" />
+        <EthereumLogo v-if="isEthereumWalletSelection(wallet)" class="h-8 w-8 shrink-0" />
+        <ArgonLogo v-else class="h-8 w-8 shrink-0" />
+        <span class="ml-3 min-w-0">
+          <strong class="block truncate text-sm text-slate-800">{{ getWalletSelectionName(wallet) }}</strong>
+          <span class="block truncate text-xs text-slate-500">{{ getWalletAddress(wallet) }}</span>
+        </span>
+      </button>
+    </div>
+
+    <div class="mt-auto grid gap-2 pt-4">
+      <button
+        v-if="props.canAddDefaultEthereum"
+        data-testid="WalletOverlay.addDefaultEthereum()"
+        type="button"
+        class="rounded-md border border-slate-400/60 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:border-slate-500/60 hover:bg-slate-200/60"
+        @click="emit('addDefaultEthereum')"
+      >
+        Add Default Ethereum
+      </button>
+      <button
+        data-testid="WalletOverlay.addExternalEthereum()"
+        type="button"
+        class="rounded-md border border-slate-400/60 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:border-slate-500/60 hover:bg-slate-200/60"
+        @click="emit('addExternalEthereum')"
+      >
+        Add External Ethereum
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { abbreviateAddress } from '../../lib/Utils.ts';
+import { WalletType } from '../../lib/Wallet.ts';
+import { useWallets } from '../../stores/wallets.ts';
+import EthereumLogo from '../../assets/wallets/networks/ethereum.svg?component';
+import ArgonLogo from '../../assets/wallets/networks/argon.svg?component';
+import {
+  getWalletSelectionKey,
+  getWalletSelectionName,
+  isEthereumWalletSelection,
+  type IWalletSelection,
+} from '../walletOverlayState.ts';
+
+const props = defineProps<{
+  availableWallets: IWalletSelection[];
+  canAddDefaultEthereum: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'select', wallet: IWalletSelection): void;
+  (event: 'addDefaultEthereum'): void;
+  (event: 'addExternalEthereum'): void;
+}>();
+
+const wallets = useWallets();
+
+function getWalletAddress(wallet: IWalletSelection) {
+  let address = wallets.defaultArgonWallet.address;
+  if (wallet.walletType === WalletType.miningBot) {
+    address = wallets.miningBotWallet.address;
+  } else if (isEthereumWalletSelection(wallet)) {
+    address = wallet.walletRecord.address;
+  }
+
+  return abbreviateAddress(address, 8);
+}
+</script>

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="flex h-full flex-col text-black/90">
+    <div class="mx-1 border-t border-slate-300 px-4 py-6 text-center text-7xl font-bold">
+      <FormattedMoney :value="props.wallet.availableMicrogons" />
+    </div>
+
+    <div class="relative py-2">
+      <div
+        class="absolute top-0 -left-2 h-full w-[calc(100%+16px)] rounded-t-lg border border-black/30 bg-white shadow-md"
+      >
+        <WrapBehindEdge class="absolute right-0 bottom-0 h-2 w-2 translate-y-full" />
+        <WrapBehindEdge class="absolute bottom-0 left-0 h-2 w-2 translate-y-full scale-x-[-1]" />
+      </div>
+      <div class="relative px-4">
+        <ArgonTokens
+          :microgons="props.wallet.availableMicrogons"
+          :micronots="props.wallet.availableMicronots"
+          :moveDirection="props.transferDirection"
+          :moveFrom="props.moveFrom"
+          :moveTo="props.moveTo"
+          :networkName="props.transferDirection ? 'Ethereum' : ''"
+          :feeTokenSymbol="props.transferDirection ? 'ETH' : ''"
+          @openTransferOverlay="emit('openTransferOverlay', $event)"
+        />
+      </div>
+    </div>
+
+    <div class="flex grow flex-col px-4">
+      <ArgonBottom
+        v-if="props.selection.walletType !== WalletType.ethereum"
+        :mode="props.mode"
+        :showGuidance="props.showGuidance"
+        :guidanceContext="props.guidanceContext"
+        :walletType="props.selection.walletType"
+      />
+      <EthereumBottom v-else :wallet="props.wallet" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
+import type { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
+import { type IWallet, WalletType } from '../../lib/Wallet.ts';
+import type { IWalletGuidanceContext } from '../../emitters/basicEmitter.ts';
+import FormattedMoney from '../../components/FormattedMoney.vue';
+import WrapBehindEdge from '../../assets/wrap-behind-edge.svg';
+import ArgonBottom from './ArgonBottom.vue';
+import ArgonTokens from './ArgonTokens.vue';
+import EthereumBottom from './EthereumBottom.vue';
+import type { IWalletSelection } from '../walletOverlayState.ts';
+
+const props = defineProps<{
+  selection: IWalletSelection;
+  wallet: IWallet;
+  mode: 'chooser' | 'transfer';
+  transferDirection?: 'transferToArgon' | 'transferOutOfArgon';
+  moveFrom?: MoveFrom;
+  moveTo?: MoveTo;
+  showGuidance?: boolean;
+  guidanceContext?: IWalletGuidanceContext;
+}>();
+
+const emit = defineEmits<{
+  (event: 'openTransferOverlay', transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint }): void;
+}>();
+</script>

--- a/src-vue/wallets/components/WalletTransferOverlay.vue
+++ b/src-vue/wallets/components/WalletTransferOverlay.vue
@@ -229,6 +229,7 @@
 import * as Vue from 'vue';
 import { bigIntMax, MoveToken } from '@argonprotocol/apps-core';
 import { EvmContracts } from '@argonprotocol/mainchain';
+import { WalletType } from '../../lib/Wallet.ts';
 import InputToken from '../../components/InputToken.vue';
 import ProgressBar from '../../components/ProgressBar.vue';
 import type { IArgonWalletType, IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
@@ -634,8 +635,10 @@ function formatTokenAmount(value: bigint) {
 
 function getArgonWalletLabel(walletType?: IArgonWalletType) {
   switch (walletType) {
-    case 'defaultArgon':
+    case WalletType.defaultArgon:
       return 'Argon wallet';
+    case WalletType.miningBot:
+      return 'Mining wallet';
     default:
       return 'selected wallet';
   }

--- a/src-vue/wallets/walletOverlayState.ts
+++ b/src-vue/wallets/walletOverlayState.ts
@@ -1,0 +1,80 @@
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
+import { WalletType } from '../lib/Wallet.ts';
+
+export const WALLET_JUMP_LABEL = 'JUMP';
+
+export type IWalletSelection =
+  | { walletType: WalletType.defaultArgon | WalletType.miningBot }
+  | { walletType: WalletType.ethereum; walletRecord: IWalletRecord };
+
+export type IWalletOverlayState = {
+  leftWallet?: IWalletSelection;
+  rightWallet?: IWalletSelection;
+};
+
+export function getAvailableWalletSelections(
+  walletRecords: IWalletRecord[],
+  openWallets: IWalletSelection[],
+  includeMiningWallet: boolean,
+): IWalletSelection[] {
+  const openWalletKeys = new Set(openWallets.map(getWalletSelectionKey));
+  const availableWallets: IWalletSelection[] = [{ walletType: WalletType.defaultArgon }];
+  if (includeMiningWallet) {
+    availableWallets.push({ walletType: WalletType.miningBot });
+  }
+  availableWallets.push(
+    ...walletRecords
+      .filter(record => record.walletType === 'ethereum')
+      .map<IWalletSelection>(walletRecord => ({ walletType: WalletType.ethereum, walletRecord })),
+  );
+
+  return availableWallets.filter(wallet => !openWalletKeys.has(getWalletSelectionKey(wallet)));
+}
+
+export function getInitialWalletOverlayState(requestedWallet: IWalletSelection): IWalletOverlayState {
+  const rightWallet: IWalletSelection = { walletType: WalletType.defaultArgon };
+  if (requestedWallet.walletType === WalletType.defaultArgon) {
+    return { rightWallet };
+  }
+
+  return { leftWallet: requestedWallet, rightWallet };
+}
+
+export function flipWalletOverlay(state: IWalletOverlayState): IWalletOverlayState {
+  if (!state.leftWallet || !state.rightWallet) return state;
+
+  return {
+    leftWallet: state.rightWallet,
+    rightWallet: state.leftWallet,
+  };
+}
+
+export function closeWalletOverlaySide(state: IWalletOverlayState, side: 'left' | 'right'): IWalletOverlayState {
+  if (side === 'left') {
+    return state.rightWallet ? { rightWallet: state.rightWallet } : {};
+  }
+
+  return state.leftWallet ? { leftWallet: state.leftWallet } : {};
+}
+
+export function getWalletSelectionKey(wallet: IWalletSelection): string {
+  if (wallet.walletType === WalletType.ethereum) {
+    return `ethereum:${wallet.walletRecord.id}`;
+  }
+
+  return wallet.walletType;
+}
+
+export function getWalletSelectionName(wallet: IWalletSelection): string {
+  if (wallet.walletType === WalletType.ethereum) {
+    return wallet.walletRecord.name;
+  }
+
+  return wallet.walletType === WalletType.miningBot ? 'Mining Wallet' : 'Native Argon Wallet';
+}
+
+export function isEthereumWalletSelection(
+  wallet: IWalletSelection,
+): wallet is Extract<IWalletSelection, { walletType: WalletType.ethereum }> {
+  return wallet.walletType === WalletType.ethereum;
+}


### PR DESCRIPTION
## Summary

The wallet overlay now opens as a draggable two-slot workspace instead of requiring wallet windows to be snapped together. The right slot starts with the default Argon wallet, while either slot can choose any available Argon, operations, or saved Ethereum wallet without duplicating an open wallet.

Same-network transfers use Move, cross-network transfers use JUMP, and direction controls stay together beneath the wallet pair. Default Ethereum creation and private-key export now follow the saved default wallet record, while imported wallets remain selectable without exposing an export action.

Overlay backdrops are consistently dimmed and lightly blurred without delaying the blur behind content animations.

## Validation

- `yarn vue-tsc --noEmit`
- Repository commit checks
