### PR TITLE
fix(bot): recover from pending beacon transactions

### DIFF
--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -510,6 +510,42 @@ describe('EthereumBeaconSyncService', () => {
     expect(service.state().lastError).toBeUndefined();
   });
 
+  it('waits for the next sweep when an equal-priority transaction is already pending', async () => {
+    const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
+    const client = createClient(12);
+
+    mainchainMock.getEthereumBeaconSyncState.mockResolvedValue({
+      isBootstrapped: true,
+      hasNextSyncCommittee: true,
+      latestFinalizedBlockRoot: '0xabc',
+      latestFinalizedSlot: 800n,
+      nextRecommendedFinalizedSlot: 832n,
+      latestSyncCommitteeUpdatePeriod: 12n,
+      headerInterval: 32n,
+    });
+    mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue(txs);
+    submissionMock.submitWithTerminalStatusWatch.mockRejectedValue(
+      new Error(
+        '1014: Priority is too low: (115 vs 115): The transaction has too low priority to replace another transaction already in the pool.',
+      ),
+    );
+
+    const service = new EthereumBeaconSyncService(client, {
+      beaconApiUrl: 'https://beacon.example',
+      submitLane: createSubmitLane(client),
+    });
+
+    await service.runOnce();
+
+    expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
+    expect(service.state()).toMatchObject({
+      latestFinalizedSlot: 800n,
+      latestSyncCommitteeUpdatePeriod: 12n,
+      mode: 'idle',
+    });
+    expect(service.state().lastError).toBeUndefined();
+  });
+
   it('continues when the submit error is retryable after the node drops it', async () => {
     const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
     const droppedError = new TxSubmissionError(

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -255,10 +255,26 @@ export class EthereumBeaconSyncService {
 
       try {
         const result = await submitLane.runExclusive(async (client, getNonce) => {
-          return await new TxSubmitter(client, tx, submitLane.keypair).submit({
-            nonce: await getNonce(),
-          });
+          try {
+            return await new TxSubmitter(client, tx, submitLane.keypair).submit({
+              nonce: await getNonce(),
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (message.includes('Priority is too low')) {
+              console.warn(
+                `[EthereumBeaconSyncService] Beacon sync tx already pending in pool; waiting for next sweep: ${message}`,
+              );
+              submitLane.invalidateNonce();
+              return;
+            }
+            throw error;
+          }
         });
+        if (!result) {
+          this.stateData.mode = 'idle';
+          return;
+        }
         this.stateData.lastSubmittedTxHash = result.extrinsic.signedHash;
         const inclusionTimeoutMs = NetworkConfig.tickMillis * SUBMISSION_INCLUSION_BLOCKS;
         const observedInFirstBlock = await raceWithTimeout(


### PR DESCRIPTION
Beacon sync now treats equal-priority pool rejections as pending work instead of entering an error loop. It refreshes the delegate nonce, stops the current batch, and retries on the next sweep so later headers are not submitted with a conflicting nonce.

Validated with the focused beacon and gateway tests plus bot type, lint, and formatting checks.
