### PR TITLE
feat(wallets): refine vault selection and account metrics

### DIFF
--- a/src-vue/overlays/BitcoinLockingOverlay.vue
+++ b/src-vue/overlays/BitcoinLockingOverlay.vue
@@ -179,9 +179,11 @@
     </div>
     <LockStart
       v-else-if="lockStep === LockStep.Start"
+      :canChangeVault="canChangeVault"
       :coupon="props.coupon"
       :currentTick="props.currentTick"
       :vault="vault as Vault"
+      @changeVault="changeVault"
       @close="closeOverlay"
       @lockCreated="onLockCreated" />
     <LockIsProcessingOnArgon v-else-if="lockStep === LockStep.IsProcessingOnArgon" :personalLock="personalLock!" />
@@ -246,11 +248,15 @@ import BitcoinIcon from '../assets/wallets/bitcoin.svg?component';
 import Arrows from '../assets/arrows.svg?component';
 import RoundCap from './bitcoin-locking/components/RoundCap.vue';
 import { getBitcoinLocks } from '../stores/bitcoin.ts';
+import { getConfig } from '../stores/config.ts';
+import { getMyVault } from '../stores/vaults.ts';
 import { Vault } from '@argonprotocol/mainchain';
 import type { IBitcoinLockCouponStatus } from '@argonprotocol/apps-router';
 import SelectAVault from '../components/SelectAVault.vue';
 
 const bitcoinLocks = getBitcoinLocks();
+const config = getConfig();
+const myVault = getMyVault();
 
 const props = defineProps<{
   coupon?: IBitcoinLockCouponStatus;
@@ -305,6 +311,12 @@ const lockProcessingDetails = Vue.ref({
 const mismatchView = Vue.computed(() => {
   if (!personalLock.value) return undefined;
   return bitcoinLocks.getMismatchViewState(personalLock.value);
+});
+
+const canChangeVault = Vue.computed(() => {
+  const ownVaultId = myVault.vaultId;
+  const upstreamVaultId = config.upstreamOperator?.vaultId;
+  return !personalLock.value && ownVaultId != null && upstreamVaultId != null && ownVaultId !== upstreamVaultId;
 });
 
 const lockStep = Vue.computed<LockStep>(() => {
@@ -439,6 +451,10 @@ function handleVaultSelected(v: Vault) {
 
 function finalizeVaultSelection() {
   vault.value = tmpVault.value;
+}
+
+function changeVault() {
+  vault.value = undefined;
 }
 
 Vue.onMounted(() => {

--- a/src-vue/overlays/BuyBondsOverlay.vue
+++ b/src-vue/overlays/BuyBondsOverlay.vue
@@ -51,6 +51,7 @@ import SelectAVault from '../components/SelectAVault.vue';
 import { Vault } from '@argonprotocol/mainchain';
 import type { BondLot } from '@argonprotocol/apps-core';
 import { getConfig } from '../stores/config.ts';
+import { getMyVault } from '../stores/vaults.ts';
 import { useWallets } from '../stores/wallets.ts';
 
 const { programType = 'Vault' } = defineProps<{
@@ -63,16 +64,21 @@ const emit = defineEmits<{
 }>();
 
 const config = getConfig();
+const myVault = getMyVault();
 const wallets = useWallets();
 
-const tmpVaultId = Vue.ref();
-const vaultId = Vue.ref(programType === 'Vault' ? config.upstreamOperator?.vaultId : undefined);
+const tmpVaultId = Vue.ref<number>();
+const selectedVaultId = Vue.ref<number>();
+const vaultId = Vue.computed(() => {
+  if (programType !== 'Vault') return;
+  return selectedVaultId.value ?? myVault.vaultId ?? config.upstreamOperator?.vaultId;
+});
 
 function handleVaultSelected(v: Vault) {
   tmpVaultId.value = v.vaultId;
 }
 
 function selectVault() {
-  vaultId.value = tmpVaultId.value;
+  selectedVaultId.value = tmpVaultId.value;
 }
 </script>

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -109,6 +109,15 @@
 
     <div class="mt-16 flex flex-row items-center justify-end gap-x-3 border-t border-black/20 pt-4 pr-4">
       <button
+        v-if="props.canChangeVault"
+        data-testid="LockStart.changeVault()"
+        class="text-argon-600 hover:text-argon-700 mr-auto cursor-pointer px-2 py-2 text-sm font-semibold disabled:opacity-40"
+        @click="emit('changeVault')"
+        :disabled="isSaving"
+      >
+        Choose Different Vault
+      </button>
+      <button
         class="border-argon-600/20 cursor-pointer rounded-lg border bg-gray-200 px-10 py-1 text-lg text-black hover:bg-gray-300"
         @click="closeOverlay"
         :disabled="isSaving"
@@ -150,12 +159,14 @@ import { getWalletKeys, useWallets } from '../../stores/wallets.ts';
 import type { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
 
 const props = defineProps<{
+  canChangeVault?: boolean;
   coupon?: IBitcoinLockCouponStatus;
   currentTick?: number;
   vault: Vault;
 }>();
 
 const emit = defineEmits<{
+  (e: 'changeVault'): void;
   (e: 'close'): void;
   (e: 'lockCreated', lock: IBitcoinLockRecord): void;
 }>();

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -158,7 +158,7 @@
       :coupon="bitcoinLockCoupons.currentCoupon"
       :currentTick="currentTick"
       :personalLock="selectedLock?.record"
-      :vault="couponVault"
+      :vault="defaultVault"
       @close="closeLockingOverlay"
     />
 
@@ -202,7 +202,7 @@ import BitcoinRatchetingOverlay from '../overlays/BitcoinRatchetingOverlay.vue';
 import FormattedMoney from '../components/FormattedMoney.vue';
 import { UnitOfMeasurement } from '@argonprotocol/apps-core';
 import { useFinancials, type ILockSummary } from '../stores/financials.ts';
-import { getVaults } from '../stores/vaults.ts';
+import { getMyVault, getVaults } from '../stores/vaults.ts';
 import BitcoinRecord from './treasury-screens/components/BitcoinRecord.vue';
 
 const config = getConfig();
@@ -211,6 +211,7 @@ const financials = useFinancials();
 const bitcoinLocks = getBitcoinLocks();
 const bitcoinLockCoupons = getBitcoinLockCoupons();
 const miningFrames = getMiningFrames();
+const myVault = getMyVault();
 const vaults = getVaults();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
@@ -222,9 +223,14 @@ const showUnlockingOverlay = Vue.ref(false);
 const showRatchetingOverlay = Vue.ref(false);
 const selectedLock = Vue.ref<ILockSummary | undefined>();
 const couponProviderLabel = config.upstreamOperator?.name || 'The vault operator';
-const couponVault = Vue.computed(() => {
-  const vaultId = bitcoinLockCoupons.currentCoupon?.coupon.vaultId;
-  return vaultId ? vaults.vaultsById[vaultId] : undefined;
+const defaultVault = Vue.computed(() => {
+  const vaultId = myVault.vaultId;
+  if (vaultId) {
+    return myVault.createdVault ?? vaults.vaultsById[vaultId];
+  }
+
+  const couponVaultId = bitcoinLockCoupons.currentCoupon?.coupon.vaultId;
+  return couponVaultId ? vaults.vaultsById[couponVaultId] : undefined;
 });
 
 const canStartLocking = Vue.computed(() => {

--- a/src-vue/screens/Dashboard.vue
+++ b/src-vue/screens/Dashboard.vue
@@ -3,13 +3,41 @@
     <div class="relative w-full px-4 py-3">
       <div class="text-argon-600/60 relative z-20 flex flex-row">
         <div class="w-1/3 grow text-left">
-          +{{ numeral(financials.savingsAllTimeReturn).format('0,0.[00]') }}% Buying Power vs
+          <template v-if="financials.savingsIsLoaded">
+            +{{ numeral(financials.savingsAllTimeReturn).format('0,0.[00]') }}%
+          </template>
+          <template v-else>--</template>
+          Buying Power vs
           {{ financials.savingsAllTimeFiatKey }}
         </div>
-        <div class="w-1/3 grow text-center">Argon Is 0.002 UNDER $1.06 Target</div>
+        <div class="w-1/3 grow text-center">
+          <template
+            v-if="
+              currency.priceIndex.argonUsdPrice?.isZero() === false &&
+              currency.priceIndex.argonUsdTargetPrice?.isZero() === false
+            "
+          >
+            <template v-if="currency.targetOffset">
+              Argon Is {{ targetCurrency.symbol
+              }}{{ microgonToNm(targetDiff, UnitOfMeasurement.USD).format('0.00[0]') }}
+              <template v-if="currency.targetOffset > 0">ABOVE</template>
+              <template v-else>BELOW</template>
+              {{ targetCurrency.symbol }}{{ microgonToNm(oneArgon, UnitOfMeasurement.USD).format('0.00') }} Target
+            </template>
+            <template v-else>
+              Argon Is At Its {{ targetCurrency.symbol
+              }}{{ microgonToNm(oneArgon, UnitOfMeasurement.USD).format('0.00') }} Target
+            </template>
+          </template>
+          <template v-else-if="!currency.isLoaded">Loading Argon Price</template>
+          <template v-else>Argon Price Unavailable</template>
+        </div>
         <div class="w-1/3 grow text-right">
-          {{ numeral(financials.savingsRestabilizationPower).formatIfElse('< 10', '0,0.[0]', '0,0') }}:1 Restabilization
-          Power
+          <template v-if="financials.savingsIsLoaded">
+            {{ numeral(financials.savingsRestabilizationPower).formatIfElse('< 10', '0,0.[0]', '0,0') }}:1
+          </template>
+          <template v-else>--</template>
+          Restabilization Power
         </div>
       </div>
       <div
@@ -75,11 +103,12 @@
 </template>
 
 <script setup lang="ts">
+import * as Vue from 'vue';
+import { bigIntAbs, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { getCurrency } from '../stores/currency.ts';
-import MoreIcon from '../assets/more.svg';
-import InfoIcon from '../assets/info-outline.svg';
 import { WalletType } from '../lib/Wallet.ts';
-import numeral from '../lib/numeral.ts';
+import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import FormattedMoney from '../components/FormattedMoney.vue';
 import ArrowIcon from '../assets/arrow.svg';
@@ -87,6 +116,15 @@ import { useFinancials } from '../stores/financials.ts';
 
 const financials = useFinancials();
 const currency = getCurrency();
+
+const oneArgon = BigInt(MICROGONS_PER_ARGON);
+const targetCurrency = currency.recordsByKey[UnitOfMeasurement.USD];
+const { microgonToNm } = createNumeralHelpers(currency);
+
+const targetDiff = Vue.computed(() => {
+  const adjusted = currency.adjustByTargetOffset(oneArgon);
+  return bigIntAbs(adjusted - oneArgon);
+});
 
 function openArgonWallet() {
   basicEmitter.emit('openWalletOverlay', { walletType: WalletType.defaultArgon });

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -7,12 +7,13 @@ import { useMyBonds } from './myBonds.ts';
 import { calculatePerformanceReturn, IPerformanceReturnInput } from '../lib/PerformanceReturn.ts';
 import { getMiningFrames } from './mainchain.ts';
 import { BitcoinLockStatus, IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
-import { bigIntMax, GlobalVaultingStats, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { bigIntMax, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import BigNumber from 'bignumber.js';
 import { BitcoinLock, MICROGONS_PER_ARGON, Vault } from '@argonprotocol/mainchain';
 import { getVaults } from './vaults.ts';
 import type { IOtherToken } from '../lib/Wallet.ts';
 import { IBitcoinLockProcessingDetails } from '../lib/BitcoinLocks.ts';
+import { useVaultingStats } from './vaultingStats.ts';
 
 export interface ILockSummary {
   uuid: string;
@@ -48,8 +49,7 @@ export const useFinancials = defineStore('financials', () => {
   const miningFrames = getMiningFrames();
   const currency = getCurrency();
   const vaultStore = getVaults();
-
-  const stats = new GlobalVaultingStats(vaultStore, currency);
+  const vaultingStats = useVaultingStats();
 
   const isLoaded = Vue.ref(false);
 
@@ -91,39 +91,30 @@ export const useFinancials = defineStore('financials', () => {
       return sum + ratchets.reduce((s, r) => s + (r.mintPending ?? 0n), 0n);
     }, 0n);
   });
-  const savingsTotalReadyToUse = Vue.ref(0n);
+  const savingsTotalReadyToUse = Vue.computed(() => wallets.defaultArgonWallet.availableMicrogons);
   const savingsTotalValue = Vue.computed(() => {
     return savingsTotalPending.value + savingsTotalReadyToUse.value;
   });
 
   const savingsInvestments = Vue.ref<IPerformanceReturnInput[]>([]);
   const savingsAllTimeFiatKey = Vue.ref(UnitOfMeasurement.USD);
-  const savingsAllTimeReturn = Vue.ref(0);
-
-  const savingsRestabilizationPower = Vue.ref(1);
-
-  const savingsIsLoaded = Vue.ref(false);
-
-  function loadSavings() {
-    savingsTotalReadyToUse.value = wallets.defaultArgonWallet.availableMicrogons;
-
+  const savingsAllTimeReturn = Vue.computed(() => {
+    if (!currency.usdTarget) return 0;
     const savingsReturnBn = BigNumber(currency.usdTarget - 1)
       .dividedBy(1)
       .multipliedBy(100);
-    savingsAllTimeReturn.value = savingsReturnBn.toNumber();
-
-    void stats.load().then(() => {
-      const microgonValueInVaults = stats.microgonValueOfVaultedBitcoins;
-      const microgonBurnCapacity = BigInt(Math.round(stats.argonBurnCapacity * MICROGONS_PER_ARGON));
-      savingsRestabilizationPower.value = BigNumber(microgonBurnCapacity).dividedBy(microgonValueInVaults).toNumber();
-    });
-
-    savingsIsLoaded.value = true;
-  }
-
-  Vue.watch([wallets.defaultArgonWallet], () => {
-    loadSavings();
+    return savingsReturnBn.toNumber();
   });
+
+  const savingsRestabilizationPower = Vue.computed(() => {
+    const microgonValueInVaults = vaultingStats.microgonValueInVaults;
+    if (!microgonValueInVaults) return 0;
+
+    const microgonBurnCapacity = BigInt(Math.round(vaultingStats.argonBurnCapacity * MICROGONS_PER_ARGON));
+    return BigNumber(microgonBurnCapacity).dividedBy(microgonValueInVaults).toNumber();
+  });
+
+  const savingsIsLoaded = Vue.ref(false);
 
   // Argon Bonds ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -402,9 +393,17 @@ export const useFinancials = defineStore('financials', () => {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   async function load() {
-    await Promise.all([myBonds.load(), bitcoinLocks.load(), currency.fetchMainchainRates(), vaultStore.load()]);
+    await Promise.all([
+      myBonds.load(),
+      bitcoinLocks.load(),
+      wallets.isLoadedPromise,
+      currency.fetchMainchainRates(),
+      vaultStore.load(),
+      vaultingStats.isLoadedPromise,
+    ]);
 
-    loadSavings();
+    savingsIsLoaded.value = true;
+
     await Promise.all([loadVaults(), loadLocks()]);
     startLockSummaryProgressRefresh();
 

--- a/src-vue/wallets/components/ArgonTokens.vue
+++ b/src-vue/wallets/components/ArgonTokens.vue
@@ -19,8 +19,22 @@
         :moveTo="props.moveTo"
         :moveToken="MoveToken.ARGN"
         side="top"
-        class="absolute top-1/2 left-[calc(100%+40px)] z-30 -translate-x-1/2 -translate-y-1/2 bg-white py-1 text-xs"
-      />
+      >
+        <button
+          type="button"
+          :disabled="!props.microgons"
+          :title="!props.microgons ? 'No ARGN available to move' : 'Move ARGN'"
+          class="absolute top-1/2 left-[calc(100%+40px)] z-30 h-10 -translate-x-1/2 -translate-y-1/2 cursor-pointer disabled:cursor-default"
+        >
+          <div
+            :class="!props.microgons ? 'text-argon-600/40' : 'text-argon-600'"
+            class="absolute inset-0 flex items-center justify-center text-sm font-bold"
+          >
+            <span class="relative right-1.5">MOVE</span>
+          </div>
+          <MoveArrow class="pointer-events-none h-full" />
+        </button>
+      </MoveCapitalButton>
     </li>
     <li class="relative flex flex-row gap-x-2 border-t border-slate-400/50 py-2">
       <ArgonotIcon class="h-6 w-6" />
@@ -41,8 +55,22 @@
         :moveTo="props.moveTo"
         :moveToken="MoveToken.ARGNOT"
         side="top"
-        class="absolute top-1/2 left-[calc(100%+40px)] z-30 -translate-x-1/2 -translate-y-1/2 bg-white py-1 text-xs"
-      />
+      >
+        <button
+          type="button"
+          :disabled="!props.micronots"
+          :title="!props.micronots ? 'No ARGNOT available to move' : 'Move ARGNOT'"
+          class="absolute top-1/2 left-[calc(100%+40px)] z-30 h-10 -translate-x-1/2 -translate-y-1/2 cursor-pointer disabled:cursor-default"
+        >
+          <div
+            :class="!props.micronots ? 'text-argon-600/40' : 'text-argon-600'"
+            class="absolute inset-0 flex items-center justify-center text-sm font-bold"
+          >
+            <span class="relative right-1.5">MOVE</span>
+          </div>
+          <MoveArrow class="pointer-events-none h-full" />
+        </button>
+      </MoveCapitalButton>
     </li>
   </ul>
 </template>
@@ -55,6 +83,7 @@ import { createNumeralHelpers } from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import CrosschainMoveButton from './CrosschainMoveButton.vue';
 import MoveCapitalButton from '../../overlays/MoveCapitalButton.vue';
+import MoveArrow from '../../assets/move-arrow.svg';
 
 const currency = getCurrency();
 


### PR DESCRIPTION
## Summary

Users with a personal vault now start new bonds and Bitcoin locks in that vault by default. The Bitcoin lock flow retains the ability to switch to an upstream vault.

The account dashboard now shows live buying power, Argon target position, and restabilization power instead of stale or hard-coded values. Same-network wallet transfers keep the arrow affordance and clearly disable MOVE when the selected token balance is empty.