### PR TITLE
fix(app): stabilize desktop and e2e startup

### DIFF
--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -359,6 +359,46 @@ describe('BlockWatch archive recovery', () => {
     expect(blockWatch.finalizedBlockHeader).toBe(finalizedHeader);
   });
 
+  it('keeps concurrent startup callers attached when the pruned client connects', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    try {
+      const finalizedHeader = createHeaderInfo(100, '0x100', '0x099');
+      const finalizedHead = createDeferredPromise<string>();
+      const archiveClient = createSubscriptionClient(finalizedHeader);
+      archiveClient.rpc.chain.getFinalizedHead.mockImplementation(() => finalizedHead.promise);
+      const prunedClient = createSubscriptionClient(finalizedHeader);
+      let onPrunedClient!: () => void;
+      const clients = {
+        prunedClientPromise: Promise.resolve(prunedClient),
+        archiveClientPromise: Promise.resolve(archiveClient),
+        events: {
+          on: vi.fn((event: string, callback: () => void) => {
+            if (event === 'on-pruned-client') {
+              onPrunedClient = callback;
+            }
+            return () => undefined;
+          }),
+        },
+      };
+      const blockWatch = new BlockWatch(clients as any);
+
+      const firstStart = blockWatch.start('archive');
+      const concurrentStart = blockWatch.start('archive');
+      await vi.waitFor(() => expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce());
+
+      onPrunedClient();
+      await vi.advanceTimersByTimeAsync(250);
+      finalizedHead.resolve(finalizedHeader.blockHash);
+
+      await expect(Promise.all([firstStart, concurrentStart])).resolves.toEqual([undefined, undefined]);
+      expect(prunedClient.rpc.chain.getFinalizedHead).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('continues the current subscription after an unreadable new-head ancestry', async () => {
     vi.useFakeTimers();
     vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);

--- a/core/__test__/helpers/sudoFundWallet.ts
+++ b/core/__test__/helpers/sudoFundWallet.ts
@@ -1,4 +1,10 @@
-import { getClient, type ArgonClient } from '@argonprotocol/mainchain';
+import {
+  getClient,
+  type ArgonClient,
+  isOutdatedTransactionError,
+  isTxSubmissionError,
+  TxSubmissionErrorCode,
+} from '@argonprotocol/mainchain';
 import { sudo } from '@argonprotocol/testing';
 import { NetworkConfigSettings } from '../../src/NetworkConfig.ts';
 import { submitAndFinalize } from './mainchain.ts';
@@ -23,16 +29,38 @@ export async function sudoFundWallet(input: ISudoFundWalletInput): Promise<ISudo
   const client = input.client ?? (await getClient(resolveArchiveUrl(input.archiveUrl)));
   const ownsClient = !input.client;
   try {
-    const tx = client.tx.sudo.sudo(
-      client.tx.utility.batch([
-        client.tx.balances.forceSetBalance(input.address, input.microgons),
-        client.tx.ownership.forceSetBalance(input.address, input.micronots),
-      ]),
-    );
-    const result = await submitAndFinalize(client, tx, sudo());
+    for (let attempt = 1; ; attempt += 1) {
+      const tx = client.tx.sudo.sudo(
+        client.tx.utility.batch([
+          client.tx.balances.forceSetBalance(input.address, input.microgons),
+          client.tx.ownership.forceSetBalance(input.address, input.micronots),
+        ]),
+      );
 
-    if (result.extrinsicError) {
-      throw result.extrinsicError;
+      try {
+        const result = await submitAndFinalize(client, tx, sudo(), { useLatestNonce: true });
+        if (result.extrinsicError) {
+          throw result.extrinsicError;
+        }
+        break;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const isConcurrentSubmission =
+          isOutdatedTransactionError(error) ||
+          isTxSubmissionError(
+            error,
+            TxSubmissionErrorCode.Dropped,
+            TxSubmissionErrorCode.Invalid,
+            TxSubmissionErrorCode.Usurped,
+          ) ||
+          message.includes('Priority is too low') ||
+          message.includes('Already imported');
+        if (!isConcurrentSubmission || attempt >= 3) {
+          throw error;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, attempt * 500));
+      }
     }
 
     const startedAt = Date.now();

--- a/core/__test__/startArgonTestNetwork.ts
+++ b/core/__test__/startArgonTestNetwork.ts
@@ -178,6 +178,11 @@ export async function startArgonTestNetwork(
     cwd: COMPOSE_DIR,
     env: composeEnv,
   });
+  const archiveRpcPortResult = await docker.port('archive-rpc', '9944', {
+    config: COMPOSE_CONFIG,
+    cwd: COMPOSE_DIR,
+    env: composeEnv,
+  });
   const esploraPortResult = await docker.port('bitcoin-electrs', '3002', {
     config: COMPOSE_CONFIG,
     cwd: COMPOSE_DIR,
@@ -197,6 +202,7 @@ export async function startArgonTestNetwork(
   });
   const port = portResult.data.port;
   const archiveUrl = `ws://127.0.0.1:${port}`;
+  const archiveRpcUrl = `ws://127.0.0.1:${archiveRpcPortResult.data.port}`;
   const client = await getClient(archiveUrl);
   await waitForFirstMainchainBlock(client, archiveUrl, {
     timeoutMs: Number.isFinite(options.chainStartTimeoutMs ?? NaN)
@@ -208,6 +214,11 @@ export async function startArgonTestNetwork(
     composeProjectName:
       options.composeProjectName ??
       toComposeProjectName(uniqueTestName, process.env.ARGON_NETWORK_NAME ?? 'dev-docker'),
+  });
+  await waitForQueryableClient(archiveRpcUrl, {
+    timeoutMs: options.chainStartTimeoutMs ?? DEFAULT_CHAIN_START_TIMEOUT_MS,
+    pollMs: options.chainStartPollMs ?? DEFAULT_CHAIN_START_POLL_MS,
+    label: `archive RPC ${archiveRpcUrl}`,
   });
 
   try {
@@ -227,7 +238,7 @@ export async function startArgonTestNetwork(
     return {
       archiveUrl,
       networkConfigOverride: {
-        archiveUrl,
+        archiveUrl: archiveRpcUrl,
         bitcoinBlockMillis: updatedConfig.bitcoinBlockMillis as number,
         esploraHost: updatedConfig.esploraHost as string,
         ...(updatedConfig.indexerHost ? { indexerHost: updatedConfig.indexerHost as string } : {}),

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -84,6 +84,9 @@ export class BlockWatch {
       }),
 
       this.clients.events.on('working', (_path, clientType) => {
+        if (!this.isLoaded.isSettled || this.isRestarting) {
+          return;
+        }
         if (clientType !== 'pruned' || this.forcePrunedClientSubscriptions || this.activeSource !== 'archive') {
           return;
         }
@@ -94,7 +97,12 @@ export class BlockWatch {
       }),
 
       this.clients.events.on('on-pruned-client', () => {
-        if (this.forcePrunedClientSubscriptions || this.activeSource === 'pruned') {
+        if (
+          !this.isLoaded.isSettled ||
+          this.isRestarting ||
+          this.forcePrunedClientSubscriptions ||
+          this.activeSource === 'pruned'
+        ) {
           return;
         }
         this.scheduleRestart('pruned', 'Switched to pruned client');

--- a/e2e/flows/operations/App.op.prepareAccess.ts
+++ b/e2e/flows/operations/App.op.prepareAccess.ts
@@ -63,7 +63,7 @@ export default new Operation<IAppFlowContext, IPrepareAccessState>(import.meta, 
         } catch (error) {
           if (isRetryableAppConnectionError(error)) {
             sawReloadError = true;
-            return false;
+            return true;
           }
           throw error;
         }

--- a/e2e/flows/operations/Bitcoin.op.acceptMismatch.ts
+++ b/e2e/flows/operations/Bitcoin.op.acceptMismatch.ts
@@ -4,6 +4,7 @@ import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts'
 import bitcoinEnsureMismatchActionPanel, {
   type IEnsureMismatchActionPanelState,
 } from './Bitcoin.op.ensureMismatchActionPanel.ts';
+import { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 import { Operation } from './index.ts';
 
 type IAcceptMismatchChainState = IEnsureMismatchActionPanelState['chainState'];
@@ -73,7 +74,7 @@ export default new Operation<IBitcoinFlowContext, IAcceptMismatchState>(import.m
       throw new Error(`${flowName}: mismatch accept action remained disabled after readiness polling.`);
     }
     if (!panelState.mismatchPanelVisible) {
-      await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+      await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
     }
     await flow.click('LockFundingMismatch.acceptMismatch()', { timeoutMs: 60_000 });
     await flow.poll(
@@ -93,13 +94,9 @@ export default new Operation<IBitcoinFlowContext, IAcceptMismatchState>(import.m
   },
 });
 
-async function clickDashboardLockEntry(
+async function clickBitcoinLockEntry(
   flow: IBitcoinFlowContext['flow'],
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  return await clickIfVisible(
-    flow,
-    { selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 },
-    options,
-  );
+  return await clickIfVisible(flow, { selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 }, options);
 }

--- a/e2e/flows/operations/Bitcoin.op.activateTab.ts
+++ b/e2e/flows/operations/Bitcoin.op.activateTab.ts
@@ -1,0 +1,72 @@
+import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
+import { Operation } from './index.ts';
+import appPrepareAccess from './App.op.prepareAccess.ts';
+import type { IE2EOperationInspectState } from '../types.ts';
+import { clickIfVisible, dismissOpenLockingOverlay } from '../helpers/utils.ts';
+
+type IActivateTabUiState = {
+  activeTabVisible: boolean;
+  welcomeOverlayVisible: boolean;
+  walletFundingOverlayVisible: boolean;
+  bitcoinLockingDialogVisible: boolean;
+};
+
+type IActivateTabState = IE2EOperationInspectState<Record<string, never>, IActivateTabUiState>;
+
+const OPEN_LOCKING_DIALOG_SELECTOR = '[role="dialog"][data-state="open"].BitcoinLockingOverlay';
+export const BITCOIN_LOCK_ENTRY_SELECTOR = '[data-testid^="BitcoinLocks.lockEntry."]';
+
+export default new Operation<IBitcoinFlowContext, IActivateTabState>(import.meta, {
+  async inspect({ flow }) {
+    const [activeTab, prepareAccessState, walletFundingOverlay, openBitcoinLockingDialogs] = await Promise.all([
+      flow.isVisible('BitcoinLocksScreen'),
+      flow.inspect(appPrepareAccess),
+      flow.isVisible('WalletFundingReceivedOverlay.closeOverlay()'),
+      flow.count({ selector: OPEN_LOCKING_DIALOG_SELECTOR }).catch(() => 0),
+    ]);
+    const activeTabVisible = activeTab.visible;
+    const welcomeOverlayVisible = prepareAccessState.state === 'runnable';
+    const walletFundingOverlayVisible = walletFundingOverlay.visible;
+    const bitcoinLockingDialogVisible = openBitcoinLockingDialogs > 0;
+    const hasBlockingOverlays = welcomeOverlayVisible || walletFundingOverlayVisible || bitcoinLockingDialogVisible;
+    const isComplete = activeTabVisible && !hasBlockingOverlays;
+
+    return {
+      chainState: {},
+      uiState: {
+        activeTabVisible,
+        welcomeOverlayVisible,
+        walletFundingOverlayVisible,
+        bitcoinLockingDialogVisible,
+      },
+      state: isComplete ? 'complete' : 'runnable',
+      blockers: [],
+    };
+  },
+  async run({ flow, flowName }) {
+    await flow.run(appPrepareAccess);
+    await clickIfVisible(flow, 'WalletFundingReceivedOverlay.closeOverlay()', { timeoutMs: 5_000 });
+
+    if ((await flow.count({ selector: OPEN_LOCKING_DIALOG_SELECTOR }).catch(() => 0)) > 0) {
+      let dismissed = await dismissOpenLockingOverlay(flow, 'LockMinting.closeOverlay()');
+      if (!dismissed) {
+        dismissed = await dismissOpenLockingOverlay(flow, 'LockStart.closeOverlay()');
+      }
+      if (!dismissed) {
+        throw new Error(`${flowName}: blocking bitcoin locking dialog is still open.`);
+      }
+    }
+
+    if ((await flow.count({ selector: OPEN_LOCKING_DIALOG_SELECTOR }).catch(() => 0)) > 0) {
+      throw new Error(`${flowName}: blocking bitcoin locking dialog is still open.`);
+    }
+
+    const activeTab = await flow.isVisible('BitcoinLocksScreen');
+    if (activeTab.visible) {
+      return;
+    }
+
+    await flow.click('LeftBar.goto(TopTab.BitcoinLocks)', { timeoutMs: 10_000 });
+    await flow.waitFor('BitcoinLocksScreen', { timeoutMs: 10_000 });
+  },
+});

--- a/e2e/flows/operations/Bitcoin.op.ensureMismatchActionPanel.ts
+++ b/e2e/flows/operations/Bitcoin.op.ensureMismatchActionPanel.ts
@@ -3,7 +3,7 @@ import { clickIfVisible } from '../helpers/utils.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import { Operation } from './index.ts';
-import vaultingActivateTab from './Vaulting.op.activateTab.ts';
+import bitcoinActivateTab, { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 
 const MISMATCH_INSPECT_TIMEOUT_MS = 20_000;
 type IMismatchChainState = IBitcoinVaultMismatchState;
@@ -80,7 +80,7 @@ export default new Operation<IBitcoinFlowContext, IEnsureMismatchActionPanelStat
         },
       ),
       flow.isVisible('LockFundingMismatch.actionError'),
-      hasDashboardLockEntry(flow),
+      hasBitcoinLockEntry(flow),
       flow.isVisible('LockFundingMismatch'),
       flow.isVisible('LockFundingMismatch.acceptMismatch()'),
       flow.isVisible('LockFundingMismatch.returnDestination'),
@@ -164,29 +164,24 @@ export default new Operation<IBitcoinFlowContext, IEnsureMismatchActionPanelStat
   async run({ flow }, state) {
     if (state.state === 'complete') return;
 
-    const onVaultingScreen = await flow.isVisible('VaultingScreen');
+    const onBitcoinLocksScreen = await flow.isVisible('BitcoinLocksScreen');
     const hasVisibleMismatchUi = state.mismatchPanelVisible || state.lockingEntryVisible || state.returnPanelVisible;
-    if (!onVaultingScreen.visible && !hasVisibleMismatchUi) {
-      await flow.run(vaultingActivateTab).catch(() => undefined);
+    if (!onBitcoinLocksScreen.visible && !hasVisibleMismatchUi) {
+      await flow.run(bitcoinActivateTab).catch(() => undefined);
     }
     if (!state.mismatchPanelVisible && !state.returnPanelVisible) {
-      await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+      await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
     }
   },
 });
 
-async function hasDashboardLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
-  return (await flow.isVisible({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 }))
-    .visible;
+async function hasBitcoinLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
+  return (await flow.isVisible({ selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 })).visible;
 }
 
-async function clickDashboardLockEntry(
+async function clickBitcoinLockEntry(
   flow: IBitcoinFlowContext['flow'],
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  return await clickIfVisible(
-    flow,
-    { selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 },
-    options,
-  );
+  return await clickIfVisible(flow, { selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 }, options);
 }

--- a/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
+++ b/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
@@ -9,6 +9,7 @@ import { Operation } from './index.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
+import { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 
 type IFundLockExactChainState = IBitcoinVaultMismatchState;
 
@@ -27,7 +28,7 @@ function createBitcoinFundLockExactOperation(): Operation<IBitcoinFlowContext, I
     async inspect({ flow }) {
       const [panelState, lockingEntryVisible, lockOverlay, fundingBip21] = await Promise.all([
         flow.inspect(bitcoinEnsureMismatchActionPanel),
-        hasDashboardLockEntry(flow),
+        hasBitcoinLockEntry(flow),
         flow.isVisible('BitcoinLockingOverlay'),
         flow.isVisible('fundingBip21.copyContent()'),
       ]);
@@ -125,7 +126,6 @@ function createBitcoinFundLockExactOperation(): Operation<IBitcoinFlowContext, I
   return operation;
 }
 
-async function hasDashboardLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
-  return (await flow.isVisible({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 }))
-    .visible;
+async function hasBitcoinLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
+  return (await flow.isVisible({ selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 })).visible;
 }

--- a/e2e/flows/operations/Bitcoin.op.fundLockMismatch.ts
+++ b/e2e/flows/operations/Bitcoin.op.fundLockMismatch.ts
@@ -9,6 +9,7 @@ import { Operation } from './index.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EFlowRuntime, IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
+import { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 
 const DEFAULT_MISMATCH_OFFSET_SATOSHIS = 25_000n;
 const LOCK_VARIANCE_INSPECT_TIMEOUT_MS = 20_000;
@@ -137,7 +138,7 @@ async function readFundLockMismatchUiState(flow: IE2EFlowRuntime): Promise<{
   mismatchPanelVisible: boolean;
 }> {
   const [lockingEntryVisible, lockOverlay, fundingBip21, mismatchPanel] = await Promise.all([
-    hasDashboardLockEntry(flow),
+    hasBitcoinLockEntry(flow),
     flow.isVisible('BitcoinLockingOverlay'),
     flow.isVisible('fundingBip21.copyContent()'),
     flow.isVisible('LockFundingMismatch'),
@@ -180,7 +181,6 @@ function calculateMismatchedAmount(
   return lowerAmount > 0n ? lowerAmount : expectedAmountSatoshis + mismatchOffsetSatoshis;
 }
 
-async function hasDashboardLockEntry(flow: IE2EFlowRuntime): Promise<boolean> {
-  return (await flow.isVisible({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 }))
-    .visible;
+async function hasBitcoinLockEntry(flow: IE2EFlowRuntime): Promise<boolean> {
+  return (await flow.isVisible({ selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 })).visible;
 }

--- a/e2e/flows/operations/Bitcoin.op.openLockFundingOverlay.ts
+++ b/e2e/flows/operations/Bitcoin.op.openLockFundingOverlay.ts
@@ -3,7 +3,7 @@ import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
 import { Operation } from './index.ts';
-import vaultingActivateTab from './Vaulting.op.activateTab.ts';
+import bitcoinActivateTab, { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 import { clickIfVisible, sleep } from '../helpers/utils.ts';
 
 type IOpenLockFundingOverlayUiState = {
@@ -82,10 +82,10 @@ export default new Operation<IBitcoinFlowContext, IOpenLockFundingOverlayState>(
     if (state.state === 'complete') return;
 
     if (!state.uiState.lockOverlayVisible && !state.uiState.lockingEntryVisible) {
-      await flow.run(vaultingActivateTab);
+      await flow.run(bitcoinActivateTab);
     }
     if (!state.uiState.lockOverlayVisible) {
-      const opened = await clickDashboardLockEntry(flow, { timeoutMs: 15_000 });
+      const opened = await clickBitcoinLockEntry(flow, { timeoutMs: 15_000 });
       if (!opened) {
         throw new Error('Lock funding overlay entry point is not clickable.');
       }
@@ -108,13 +108,9 @@ export default new Operation<IBitcoinFlowContext, IOpenLockFundingOverlayState>(
   },
 });
 
-async function clickDashboardLockEntry(
+async function clickBitcoinLockEntry(
   flow: IBitcoinFlowContext['flow'],
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  return await clickIfVisible(
-    flow,
-    { selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 },
-    options,
-  );
+  return await clickIfVisible(flow, { selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 }, options);
 }

--- a/e2e/flows/operations/Bitcoin.op.returnMismatchAndResume.ts
+++ b/e2e/flows/operations/Bitcoin.op.returnMismatchAndResume.ts
@@ -1,5 +1,6 @@
 import { createBitcoinAddress, mineBitcoinSingleBlock } from '@argonprotocol/apps-core/__test__/helpers/bitcoinCli.ts';
 import { clickIfVisible } from '../helpers/utils.ts';
+import { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel, {
@@ -104,7 +105,7 @@ export default new Operation<IBitcoinFlowContext, IReturnMismatchAndResumeState>
                 }
                 return true;
               }
-              await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+              await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
               mineBitcoinSingleBlock(minerAddress);
               return false;
             },
@@ -128,7 +129,7 @@ export default new Operation<IBitcoinFlowContext, IReturnMismatchAndResumeState>
               return true;
             }
             if (!latest.returnPanelVisible) {
-              await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+              await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
             }
             mineBitcoinSingleBlock(minerAddress);
             return false;
@@ -156,14 +157,14 @@ export default new Operation<IBitcoinFlowContext, IReturnMismatchAndResumeState>
         }
         if (latest.resumeReady) {
           if (!latest.resumeVisible) {
-            await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+            await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
             await flow.waitFor('LockFundingMismatch.resumeFunding()', { timeoutMs: 5_000 });
           }
           return true;
         }
         if (['returningOnArgon', 'returningOnBitcoin', 'returned'].includes(latest.chainState.phase)) {
           if (!latest.mismatchPanelVisible) {
-            await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+            await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
             await flow.waitFor('LockFundingMismatch', { timeoutMs: 5_000 });
           }
         }
@@ -179,7 +180,7 @@ export default new Operation<IBitcoinFlowContext, IReturnMismatchAndResumeState>
 
     const latest = await flow.inspect(bitcoinEnsureMismatchActionPanel);
     if (!latest.resumeVisible) {
-      await clickDashboardLockEntry(flow, { timeoutMs: 5_000 });
+      await clickBitcoinLockEntry(flow, { timeoutMs: 5_000 });
       await flow.waitFor('LockFundingMismatch.resumeFunding()', { timeoutMs: 5_000 });
     }
     await flow.click('LockFundingMismatch.resumeFunding()', { timeoutMs: 60_000 });
@@ -200,13 +201,9 @@ export default new Operation<IBitcoinFlowContext, IReturnMismatchAndResumeState>
   },
 });
 
-async function clickDashboardLockEntry(
+async function clickBitcoinLockEntry(
   flow: IBitcoinFlowContext['flow'],
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  return await clickIfVisible(
-    flow,
-    { selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 },
-    options,
-  );
+  return await clickIfVisible(flow, { selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 }, options);
 }

--- a/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
+++ b/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
@@ -5,11 +5,12 @@ import { clickIfVisible, formatUnitsToDecimal, pollEvery, sleep } from '../helpe
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
 import { Operation } from './index.ts';
-import vaultingActivateTab from './Vaulting.op.activateTab.ts';
+import bitcoinActivateTab from './Bitcoin.op.activateTab.ts';
 
 const SATOSHIS_PER_BTC = 100_000_000n;
 
 type IStartBitcoinLockUiState = {
+  bitcoinLocksScreenVisible: boolean;
   lockStartEntryVisible: boolean;
   lockOverlayVisible: boolean;
   lockOverlayState: string | null;
@@ -22,12 +23,14 @@ type IStartBitcoinLockState = IE2EOperationInspectState<IBitcoinVaultMismatchSta
 export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import.meta, {
   async inspect({ flow }) {
     const panelState = await flow.inspect(bitcoinEnsureMismatchActionPanel);
-    const [lockStartEntry, lockOverlay, lockStart, fundingBip21] = await Promise.all([
-      flow.isVisible({ selector: '[bitcoinmap] .treemap__tile--remainder' }),
+    const [bitcoinLocksScreen, lockStartEntry, lockOverlay, lockStart, fundingBip21] = await Promise.all([
+      flow.isVisible('BitcoinLocksScreen'),
+      flow.isVisible('BitcoinLocks.openLockingOverlay()'),
       flow.isVisible('BitcoinLockingOverlay'),
       flow.isVisible('LockStart.submitLiquidLock()'),
       flow.isVisible('fundingBip21.copyContent()'),
     ]);
+    const bitcoinLocksScreenVisible = bitcoinLocksScreen.visible;
     const lockStartEntryVisible = lockStartEntry.visible;
     const lockOverlayVisible = lockOverlay.visible;
     const lockOverlayState = lockOverlay.visible
@@ -39,7 +42,7 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
     const canRun =
       !isComplete &&
       !panelState.chainState.hasActiveLock &&
-      (lockStartEntryVisible || lockOverlayVisible || lockStartVisible);
+      (!bitcoinLocksScreenVisible || lockStartEntryVisible || lockOverlayVisible || lockStartVisible);
     let operationState: IE2EOperationState = 'processing';
     if (isComplete) {
       operationState = 'complete';
@@ -59,6 +62,7 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
     return {
       chainState: panelState.chainState,
       uiState: {
+        bitcoinLocksScreenVisible,
         lockStartEntryVisible,
         lockOverlayVisible,
         lockOverlayState,
@@ -80,10 +84,10 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
     if (state.state === 'complete') return;
 
     if (!state.uiState.lockOverlayVisible && !state.uiState.lockStartVisible) {
-      await flow.run(vaultingActivateTab);
-      const opened = await clickDashboardBitcoinRemainder(flow, { timeoutMs: 5_000 });
+      await flow.run(bitcoinActivateTab);
+      const opened = await clickBitcoinLockStart(flow, { timeoutMs: 5_000 });
       if (!opened) {
-        throw new Error(`${flowName}: Bitcoin lock entry point is not clickable on the vault dashboard.`);
+        throw new Error(`${flowName}: Bitcoin lock entry point is not clickable on the Bitcoin Locks tab.`);
       }
     }
     await flow.waitFor('LockStart.submitLiquidLock()', { state: 'enabled', timeoutMs: 10_000 });
@@ -137,9 +141,9 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
   },
 });
 
-async function clickDashboardBitcoinRemainder(
+async function clickBitcoinLockStart(
   flow: IBitcoinFlowContext['flow'],
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  return await clickIfVisible(flow, { selector: '[bitcoinmap] .treemap__tile--remainder' }, options);
+  return await clickIfVisible(flow, 'BitcoinLocks.openLockingOverlay()', options);
 }

--- a/e2e/flows/operations/Bitcoin.op.unlockBitcoin.ts
+++ b/e2e/flows/operations/Bitcoin.op.unlockBitcoin.ts
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict';
 import { createBitcoinAddress, mineBitcoinSingleBlock } from '@argonprotocol/apps-core/__test__/helpers/bitcoinCli.ts';
 import type { IBitcoinUnlockReleaseState } from '../types/srcVue.ts';
 import { clickIfVisible, pollEvery, sleep } from '../helpers/utils.ts';
+import bitcoinActivateTab, { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EFlowRuntime, IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import appPrepareAccess from './App.op.prepareAccess.ts';
 import { Operation } from './index.ts';
-import vaultingActivateTab from './Vaulting.op.activateTab.ts';
 
 type IUnlockBitcoinUiState = {
   detailOverlayVisible: boolean;
@@ -99,11 +99,7 @@ export default new Operation<IBitcoinFlowContext, IUnlockBitcoinState>(import.me
   },
   async run({ flow, flowName }, state) {
     const latestChainState = await readUnlockBackendReleaseState(flow).catch(() => state.chainState);
-    if (
-      !latestChainState.hasActiveLock &&
-      !(await hasDashboardLockEntry(flow)) &&
-      !state.uiState.detailOverlayVisible
-    ) {
+    if (!latestChainState.hasActiveLock && !(await hasBitcoinLockEntry(flow)) && !state.uiState.detailOverlayVisible) {
       return;
     }
 
@@ -125,9 +121,9 @@ export default new Operation<IBitcoinFlowContext, IUnlockBitcoinState>(import.me
         await flow.run(appPrepareAccess);
         await clickIfVisible(flow, 'WalletFundingReceivedOverlay.closeOverlay()', { timeoutMs: 1_000 });
 
-        const activeTab = await flow.isVisible('VaultingScreen');
+        const activeTab = await flow.isVisible('BitcoinLocksScreen');
         if (!activeTab.visible && !latest.uiState.detailOverlayVisible && !latest.uiState.lockEntryVisible) {
-          await flow.run(vaultingActivateTab).catch(() => undefined);
+          await flow.run(bitcoinActivateTab).catch(() => undefined);
         }
 
         if (latest.uiState.detailOverlayVisible) {
@@ -139,7 +135,7 @@ export default new Operation<IBitcoinFlowContext, IUnlockBitcoinState>(import.me
           return false;
         }
 
-        if (latest.uiState.lockEntryVisible && (await clickDashboardLockEntry(flow, { timeoutMs: 1_000 }))) {
+        if (latest.uiState.lockEntryVisible && (await clickBitcoinLockEntry(flow, { timeoutMs: 1_000 }))) {
           const afterClick = await flow.inspect<IUnlockBitcoinState>();
           if (afterClick.uiState.unlockingOverlayState === 'Start') {
             return true;
@@ -202,7 +198,7 @@ export default new Operation<IBitcoinFlowContext, IUnlockBitcoinState>(import.me
         .getText({ selector: '[role="dialog"][data-state="open"]' }, { timeoutMs: 1_000 })
         .then(text => text.slice(0, 240))
         .catch(() => null),
-      countDashboardLockEntries(flow).catch(() => -1),
+      countBitcoinLockEntries(flow).catch(() => -1),
     ]);
 
     console.error(
@@ -229,7 +225,7 @@ export default new Operation<IBitcoinFlowContext, IUnlockBitcoinState>(import.me
 
 async function readUnlockUiState(flow: IE2EFlowRuntime): Promise<IUnlockBitcoinUiState> {
   const [lockEntryVisible, detailOverlay] = await Promise.all([
-    hasDashboardLockEntry(flow),
+    hasBitcoinLockEntry(flow),
     flow.isVisible('BitcoinLockDetailOverlay'),
   ]);
 
@@ -257,7 +253,7 @@ async function waitForUnlockRequestAccepted(flow: IBitcoinFlowContext['flow']): 
 
     const unlockState = await flow.inspect<IUnlockBitcoinState>();
     const backendRelease = await readUnlockBackendReleaseState(flow);
-    const lockEntryCount = await countDashboardLockEntries(flow);
+    const lockEntryCount = await countBitcoinLockEntries(flow);
 
     if (
       unlockState.uiState.unlockingOverlayState === 'IsProcessing' ||
@@ -313,19 +309,14 @@ export async function readUnlockBackendReleaseState(flow: IE2EFlowRuntime): Prom
   };
 }
 
-async function hasDashboardLockEntry(flow: IE2EFlowRuntime): Promise<boolean> {
-  return (await flow.isVisible({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 }))
-    .visible;
+async function hasBitcoinLockEntry(flow: IE2EFlowRuntime): Promise<boolean> {
+  return (await flow.isVisible({ selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 })).visible;
 }
 
-async function countDashboardLockEntries(flow: IE2EFlowRuntime): Promise<number> {
-  return await flow.count({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)' });
+async function countBitcoinLockEntries(flow: IE2EFlowRuntime): Promise<number> {
+  return await flow.count({ selector: BITCOIN_LOCK_ENTRY_SELECTOR });
 }
 
-async function clickDashboardLockEntry(flow: IE2EFlowRuntime, options: { timeoutMs?: number } = {}): Promise<boolean> {
-  return await clickIfVisible(
-    flow,
-    { selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 },
-    options,
-  );
+async function clickBitcoinLockEntry(flow: IE2EFlowRuntime, options: { timeoutMs?: number } = {}): Promise<boolean> {
+  return await clickIfVisible(flow, { selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 }, options);
 }

--- a/e2e/flows/operations/Bitcoin.op.waitUnlockReady.ts
+++ b/e2e/flows/operations/Bitcoin.op.waitUnlockReady.ts
@@ -4,7 +4,7 @@ import { pollEvery } from '../helpers/utils.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EFlowRuntime, IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import { Operation } from './index.ts';
-import vaultingActivateTab from './Vaulting.op.activateTab.ts';
+import bitcoinActivateTab, { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 import { readUnlockBackendReleaseState } from './Bitcoin.op.unlockBitcoin.ts';
 
 type IWaitUnlockReadyUiState = {
@@ -17,7 +17,7 @@ type IWaitUnlockReadyState = IE2EOperationInspectState<IBitcoinUnlockReleaseStat
 export default new Operation<IBitcoinFlowContext, IWaitUnlockReadyState>(import.meta, {
   async inspect({ flow }) {
     const [lockEntryVisible, chainState, lockingOverlay] = await Promise.all([
-      hasDashboardLockEntry(flow),
+      hasBitcoinLockEntry(flow),
       readUnlockBackendReleaseState(flow),
       flow.isVisible('BitcoinLockingOverlay'),
     ]);
@@ -64,9 +64,9 @@ export default new Operation<IBitcoinFlowContext, IWaitUnlockReadyState>(import.
     await pollEvery(
       1_000,
       async () => {
-        const activeTab = await flow.isVisible('VaultingScreen');
+        const activeTab = await flow.isVisible('BitcoinLocksScreen');
         if (!activeTab.visible) {
-          await flow.run(vaultingActivateTab).catch(() => undefined);
+          await flow.run(bitcoinActivateTab).catch(() => undefined);
         }
 
         const latest = await flow.inspect<IWaitUnlockReadyState>();
@@ -124,7 +124,6 @@ async function readWaitUnlockDebugState(flow: IE2EFlowRuntime): Promise<IBitcoin
   );
 }
 
-async function hasDashboardLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
-  return (await flow.isVisible({ selector: '[bitcoinmap] .treemap__tile:not(.treemap__tile--remainder)', index: 0 }))
-    .visible;
+async function hasBitcoinLockEntry(flow: IBitcoinFlowContext['flow']): Promise<boolean> {
+  return (await flow.isVisible({ selector: BITCOIN_LOCK_ENTRY_SELECTOR, index: 0 })).visible;
 }

--- a/e2e/flows/operations/Mining.op.fundWallet.ts
+++ b/e2e/flows/operations/Mining.op.fundWallet.ts
@@ -73,8 +73,8 @@ export default new Operation<IMiningFlowContext, IFundWalletState>(import.meta, 
     }
 
     await flow.click('SetupChecklist.openFundMiningAccountOverlay()');
-    await flow.waitFor('WalletOverlay.micronotsNeeded');
-    await flow.waitFor('WalletOverlay.microgonsNeeded');
+    await flow.waitFor('WalletOverlay.micronotsNeeded', { state: 'exists' });
+    await flow.waitFor('WalletOverlay.microgonsNeeded', { state: 'exists' });
 
     const microgonsNeededRaw = await flow.getAttribute('WalletOverlay.microgonsNeeded', 'data-value');
     const micronotsNeededRaw = await flow
@@ -105,7 +105,7 @@ export default new Operation<IMiningFlowContext, IFundWalletState>(import.meta, 
     };
     const fundingNeeded = requiredFunding.microgons > 0n || requiredFunding.micronots > 0n;
     const funding = fundingNeeded ? deriveMiningFunding(flowName, requiredFunding, input.fundingArgons) : undefined;
-    await flow.click('OverlayBase.clickClose()', { timeoutMs: 8_000 });
+    await flow.click('NavHeader.close()', { timeoutMs: 8_000 });
     await pollEvery(250, async () => !(await flow.inspect(this)).uiState.walletOverlayVisible, {
       timeoutMs: 20_000,
       timeoutMessage: `${flowName}: mining wallet overlay did not close after funding.`,

--- a/e2e/flows/operations/Vaulting.op.fundWallet.ts
+++ b/e2e/flows/operations/Vaulting.op.fundWallet.ts
@@ -106,8 +106,8 @@ export default new Operation<IVaultingFlowContext, IFundVaultingWalletState>(imp
     }
 
     await flow.click('SetupChecklist.openFundVaultingAccountOverlay()');
-    await flow.waitFor('WalletOverlay.micronotsNeeded');
-    await flow.waitFor('WalletOverlay.microgonsNeeded');
+    await flow.waitFor('WalletOverlay.micronotsNeeded', { state: 'exists' });
+    await flow.waitFor('WalletOverlay.microgonsNeeded', { state: 'exists' });
 
     const microgonsNeededRaw = await flow.getAttribute('WalletOverlay.microgonsNeeded', 'data-value');
     const micronotsNeededRaw = await flow
@@ -133,7 +133,7 @@ export default new Operation<IVaultingFlowContext, IFundVaultingWalletState>(imp
     const requiredMicronots = BigInt(micronotsNeededRaw ?? '0');
     const fundingNeeded = requiredMicrogons > 0n || requiredMicronots > 0n;
 
-    await flow.click('OverlayBase.clickClose()', { timeoutMs: 8_000 });
+    await flow.click('NavHeader.close()', { timeoutMs: 8_000 });
     await pollEvery(250, async () => !(await flow.inspect(this)).uiState.walletOverlayVisible, {
       timeoutMs: 20_000,
       timeoutMessage: `${flowName}: vaulting wallet overlay did not close after funding.`,

--- a/e2e/flows/session.ts
+++ b/e2e/flows/session.ts
@@ -88,6 +88,7 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
     ...commandEnv,
     ARGON_DRIVER_WS: driverServer.url,
     ARGON_E2E_HEADLESS: process.env.ARGON_E2E_HEADLESS?.trim() || '0',
+    E2E_USE_TEST_NETWORK: useTestNetwork ? '1' : '0',
     ARGON_APP_ENABLE_AUTOUPDATE: '0',
     ...options.appEnv,
   };
@@ -108,7 +109,7 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
         registerTeardown: false,
         composeProjectName,
       });
-      sessionData.sessionArchiveUrl = testNetwork.archiveUrl;
+      sessionData.sessionArchiveUrl = testNetwork.networkConfigOverride.archiveUrl;
       tauriEnv.ARGON_NETWORK_CONFIG_OVERRIDE = JSON.stringify(testNetwork.networkConfigOverride);
       process.env.ARGON_NETWORK_CONFIG_OVERRIDE = tauriEnv.ARGON_NETWORK_CONFIG_OVERRIDE;
       const composeEnv = testNetwork.composeEnv;
@@ -721,7 +722,7 @@ async function printSessionStartupDiagnostics(options: ISessionStartupDiagnostic
 
   if (options.testNetwork) {
     console.error(
-      `[E2E] Test network endpoints: archive=${options.testNetwork.archiveUrl} notary=${options.testNetwork.notaryUrl} esplora=${options.testNetwork.networkConfigOverride.esploraHost} indexer=${options.testNetwork.networkConfigOverride.indexerHost ?? 'n/a'}`,
+      `[E2E] Test network endpoints: archive-node=${options.testNetwork.archiveUrl} app-rpc=${options.testNetwork.networkConfigOverride.archiveUrl} notary=${options.testNetwork.notaryUrl} esplora=${options.testNetwork.networkConfigOverride.esploraHost} indexer=${options.testNetwork.networkConfigOverride.indexerHost ?? 'n/a'}`,
     );
   } else {
     console.error('[E2E] No test network handle available for this startup failure.');

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -30,8 +30,8 @@ export const DEV_DOCKER_COMPOSE_FILES = [
   'miners.docker-compose.yml',
   'upstream-server.docker-compose.yml',
   'indexer.docker-compose.yml',
-  'chainspec.docker-compose.yml',
 ] as const;
+const CHAIN_SPEC_COMPOSE_FILE = 'chainspec.docker-compose.yml';
 
 const DEFAULT_COMPOSE_PROFILES = ['all'] as const;
 const UPSTREAM_COMPOSE_PROFILES = ['all', 'upstream'] as const;
@@ -313,11 +313,16 @@ export function readComposeContainerId(args: { context?: DevDockerComposeContext
 }
 
 function getComposeArgs(context: DevDockerComposeContext): string[] {
+  const useChainspec =
+    context.composeEnv.E2E_USE_TEST_NETWORK?.trim() !== '1' ||
+    context.composeEnv.ARGON_CHAIN?.trim() === '/chainspec.raw.json';
+  const composeFiles = useChainspec ? [...DEV_DOCKER_COMPOSE_FILES, CHAIN_SPEC_COMPOSE_FILE] : DEV_DOCKER_COMPOSE_FILES;
+
   return [
     'compose',
     ...context.profiles.flatMap(profile => ['--profile', profile]),
     ...(context.composeProjectName ? ['--project-name', context.composeProjectName] : []),
-    ...DEV_DOCKER_COMPOSE_FILES.flatMap(file => ['-f', file]),
+    ...composeFiles.flatMap(file => ['-f', file]),
   ];
 }
 

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -326,6 +326,7 @@ type RuntimeNetworkConfigOverride = INetworkConfigOverride;
 
 interface DevDockerComposePorts {
   archivePort: string;
+  archiveRpcPort: string;
   archiveP2pPort: string;
   bitcoinP2pPort: string;
   esploraPort: string;
@@ -337,6 +338,7 @@ interface DevDockerComposePorts {
 async function resolveDevDockerComposePorts(): Promise<DevDockerComposePorts | null> {
   const context = getDevDockerComposeContext();
   let archivePort: string;
+  let archiveRpcPort: string;
   let archiveP2pPort: string;
   let bitcoinP2pPort: string;
   let esploraPort: string;
@@ -348,6 +350,11 @@ async function resolveDevDockerComposePorts(): Promise<DevDockerComposePorts | n
     archivePort = (await readComposePortWithRetry({
       context,
       service: 'archive-node',
+      port: 9944,
+    }))!;
+    archiveRpcPort = (await readComposePortWithRetry({
+      context,
+      service: 'archive-rpc',
       port: 9944,
     }))!;
     archiveP2pPort = (await readComposePortWithRetry({
@@ -399,6 +406,7 @@ async function resolveDevDockerComposePorts(): Promise<DevDockerComposePorts | n
 
   return {
     archivePort,
+    archiveRpcPort,
     archiveP2pPort,
     bitcoinP2pPort,
     esploraPort,
@@ -451,6 +459,7 @@ async function resolveDevDockerNetworkConfigOverride(
   usdcTokenAddress?: string,
 ): Promise<RuntimeNetworkConfigOverride | null> {
   const archiveUrl = `ws://127.0.0.1:${ports.archivePort}`;
+  const archiveRpcUrl = `ws://127.0.0.1:${ports.archiveRpcPort}`;
   let runtimeConfig: RuntimeChainConfig;
   try {
     console.log(`[tauri-dev] Loading runtime chain config from ${archiveUrl}`);
@@ -462,7 +471,7 @@ async function resolveDevDockerNetworkConfigOverride(
 
   const override: RuntimeNetworkConfigOverride = {
     ...runtimeConfig,
-    archiveUrl,
+    archiveUrl: archiveRpcUrl,
     bitcoinBlockMillis: runtimeConfig.tickMillis * 10,
     esploraHost: `http://localhost:${ports.esploraPort}`,
     baseNetwork: {
@@ -553,15 +562,15 @@ function mergeNetworkConfigOverrides(
   }
 
   return {
-    ...inheritedOverride,
     ...dynamicOverride,
+    ...inheritedOverride,
     ethereumNetwork: {
-      ...inheritedOverride.ethereumNetwork,
       ...dynamicOverride.ethereumNetwork,
+      ...inheritedOverride.ethereumNetwork,
     },
     baseNetwork: {
-      ...inheritedOverride.baseNetwork,
       ...dynamicOverride.baseNetwork,
+      ...inheritedOverride.baseNetwork,
     },
   };
 }

--- a/src-vue/__test__/E2eInit.test.ts
+++ b/src-vue/__test__/E2eInit.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { BootstrapType, type IConfig } from '../interfaces/IConfig.ts';
+
+const mocks = vi.hoisted(() => ({
+  config: {
+    isLoadedPromise: Promise.resolve(),
+    showWelcomeOverlay: false,
+    bootstrapDetails: undefined as IConfig['bootstrapDetails'],
+    hasExtensionTreasury: false,
+    hasExtensionOperations: false,
+    save: vi.fn(),
+  },
+}));
+
+vi.mock('../e2e/commands', () => ({
+  LOGGABLE_ARG_KEYS: [],
+  runCommand: vi.fn(),
+}));
+
+vi.mock('../stores/config', () => ({
+  getConfig: () => mocks.config,
+}));
+
+import { initializeE2EState } from '../e2e/init.ts';
+
+beforeEach(() => {
+  mocks.config.showWelcomeOverlay = false;
+  mocks.config.bootstrapDetails = undefined;
+  mocks.config.hasExtensionTreasury = false;
+  mocks.config.hasExtensionOperations = false;
+  mocks.config.save.mockClear();
+});
+
+it('activates E2E extensions after access is available', async () => {
+  await initializeE2EState();
+
+  expect(mocks.config.hasExtensionTreasury).toBe(true);
+  expect(mocks.config.hasExtensionOperations).toBe(true);
+  expect(mocks.config.save).toHaveBeenCalledOnce();
+});
+
+it('keeps E2E extensions disabled while the first-run welcome overlay is shown', async () => {
+  mocks.config.showWelcomeOverlay = true;
+
+  await initializeE2EState();
+
+  expect(mocks.config.hasExtensionTreasury).toBe(false);
+  expect(mocks.config.hasExtensionOperations).toBe(false);
+  expect(mocks.config.save).not.toHaveBeenCalled();
+});
+
+it('activates E2E extensions after account import recreates the config database', async () => {
+  mocks.config.showWelcomeOverlay = true;
+  mocks.config.bootstrapDetails = { type: BootstrapType.Public, routerHost: '127.0.0.1' };
+
+  await initializeE2EState();
+
+  expect(mocks.config.showWelcomeOverlay).toBe(false);
+  expect(mocks.config.hasExtensionTreasury).toBe(true);
+  expect(mocks.config.hasExtensionOperations).toBe(true);
+  expect(mocks.config.save).toHaveBeenCalledOnce();
+});

--- a/src-vue/e2e/init.ts
+++ b/src-vue/e2e/init.ts
@@ -1,4 +1,5 @@
 import { LOGGABLE_ARG_KEYS, runCommand } from './commands';
+import { getConfig } from '../stores/config';
 
 const ALLOWED_DRIVER_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
 
@@ -48,6 +49,18 @@ function installClipboardShim(): void {
   };
 
   e2eWindow.__ARGON_E2E_CLIPBOARD_PATCHED__ = true;
+}
+
+export async function initializeE2EState(): Promise<void> {
+  const config = getConfig();
+  await config.isLoadedPromise;
+  // Account import recreates the config database and leaves bootstrapDetails as the onboarding marker.
+  if (!config.showWelcomeOverlay || config.bootstrapDetails) {
+    config.showWelcomeOverlay = false;
+    config.hasExtensionTreasury = true;
+    config.hasExtensionOperations = true;
+    await config.save();
+  }
 }
 
 function parseDriverUrl(raw: string): URL | null {
@@ -210,7 +223,7 @@ async function onDriverMessage(socket: WebSocket, data: string, session: string)
   }
 }
 
-export function initE2EClient(): void {
+export async function initE2EClient(): Promise<void> {
   const driverUrl = parseDriverUrl(__ARGON_DRIVER_WS__);
   if (!driverUrl) return;
 
@@ -226,6 +239,7 @@ export function initE2EClient(): void {
   const session = driverUrl.searchParams.get('session');
   if (!session) return;
 
+  await initializeE2EState();
   installClipboardShim();
 
   const socket = new WebSocket(driverUrl.toString());

--- a/src-vue/main.ts
+++ b/src-vue/main.ts
@@ -64,7 +64,7 @@ if (isE2E) {
   void import('./e2e/init')
     .then(({ initE2EClient }) => {
       console.info('[E2E] Driver client module loaded');
-      initE2EClient();
+      return initE2EClient();
     })
     .catch(error => {
       console.error('[E2E] Failed to initialize driver client', error);

--- a/src-vue/screens/ArgonBonds.vue
+++ b/src-vue/screens/ArgonBonds.vue
@@ -1,5 +1,5 @@
 <template>
-  <div DashBox class="flex h-full min-h-0 grow flex-col">
+  <div DashBox data-testid="ArgonBondsScreen" class="flex h-full min-h-0 grow flex-col">
     <div v-if="!isLoaded" class="flex grow items-center justify-center text-slate-500">Loading…</div>
 
     <!-- Blank state -->

--- a/src-vue/screens/ArgonotBonds.vue
+++ b/src-vue/screens/ArgonotBonds.vue
@@ -1,5 +1,5 @@
 <template>
-  <div DashBox class="flex h-full min-h-0 grow flex-col">
+  <div DashBox data-testid="ArgonotBondsScreen" class="flex h-full min-h-0 grow flex-col">
     <div v-if="!isLoaded" class="flex grow items-center justify-center text-slate-500">Loading…</div>
 
     <!-- Blank state -->

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div DashBox class="flex h-full min-h-0 grow flex-col">
+  <div DashBox data-testid="BitcoinLocksScreen" class="flex h-full min-h-0 grow flex-col">
     <div v-if="!isLoaded" class="flex grow items-center justify-center text-slate-500">Loading...</div>
 
     <!-- Blank state -->
@@ -125,7 +125,7 @@
               }}...
             </span>
             <div class="flex flex-row items-stretch gap-x-3">
-              <button @click="showLockingOverlay = true" class="text-md text-argon-600 cursor-pointer">
+              <button @click="openLockingOverlay" class="text-md text-argon-600 cursor-pointer">
                 Lock Another Bitcoin
               </button>
               <div class="w-px bg-slate-400/50" />
@@ -137,6 +137,7 @@
 
           <section class="mt-4 flex grow flex-col gap-y-3 px-9 pb-10">
             <BitcoinRecord
+              :data-testid="`BitcoinLocks.lockEntry.${lockSummary.uuid}`"
               v-for="lockSummary in financials.liquidVisibleRecords"
               :key="lockSummary.uuid ?? lockSummary.utxoId"
               :lockSummary="lockSummary"

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -16,6 +16,7 @@
       >
         <div
           :ref="setWalletRef"
+          data-testid="WalletOverlay"
           :style="{
             top: `calc(50% + ${draggable.modalPosition.y}px)`,
             left: `calc(50% + ${draggable.modalPosition.x}px)`,


### PR DESCRIPTION
## Summary

Restores E2E coverage across the redesigned wallet, treasury, operations, and Bitcoin surfaces while making local and isolated test sessions follow the same RPC topology as the desktop app.

- Bitcoin flows now enter through the Bitcoin Locks tab and operate on lock records instead of relying on vault treemaps. Mining and vault funding use the redesigned wallet overlay, and E2E startup activates the Treasury and Operations extensions after onboarding access is available.
- Dev and test-network sessions send app traffic through `archive-rpc` while retaining the raw archive node for runtime configuration. Isolated test networks avoid mounting the normal chainspec, and concurrent sudo funding submissions retry with a fresh nonce.
- BlockWatch waits for its initial subscription to settle before promoting a newly available upstream pruned client. This prevents concurrent startup callers from being stranded and leaving wallets or mining pages loading indefinitely when the upstream vault starts.

## Validation

- Selector and operation rules pass.
- BlockWatch and E2E initialization tests pass (21 tests).
- In the running Docker dev stack, wallet synchronization resumed from block 114 and continued advancing after the upstream pruned client connected.
