### PR TITLE
fix(router): track Argon fast sync progress

### DIFF
--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -1,16 +1,13 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { NetworkConfig, raceWithTimeout, SingleFileQueue, type IEthereumSyncStatus } from '@argonprotocol/apps-core';
 import {
-  dispatchErrorToString,
   type ArgonClient,
   ExtrinsicError,
-  getEthereumBeaconSyncBootstrapTx,
   getEthereumBeaconSyncState,
   getLatestArgonFinalizedExecutionHeader,
   getNextEthereumBeaconSyncTxs,
   isOutdatedTransactionError,
   isTxSubmissionError,
-  type KeyringPair,
   TxSubmitter,
 } from '@argonprotocol/mainchain';
 import { createPublicClient, http } from 'viem';
@@ -20,13 +17,6 @@ type IEthereumBeaconSyncServiceOptions = {
   beaconApiUrl?: string;
   pollMs?: number;
   submitLane: DelegateSubmitLane;
-};
-
-type IEthereumBeaconBootstrapOptions = {
-  timeoutMs?: number;
-  pollMs?: number;
-  minimumExecutionBlockNumber?: bigint;
-  minimumFinalizedSlot?: bigint;
 };
 
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5 * 60_000;
@@ -88,85 +78,6 @@ export class EthereumBeaconSyncService {
         this.stateData.lastUpdatedAt = new Date();
       }
     }).promise;
-  }
-
-  public static async ensureBootstrapped(
-    client: ArgonClient,
-    beaconApiUrl: string,
-    sudoKeypair: KeyringPair,
-    options: IEthereumBeaconBootstrapOptions = {},
-  ): Promise<void> {
-    const startedAt = Date.now();
-    console.log('[EthereumBeaconSyncService] Checking bootstrap state');
-    const state = await getEthereumBeaconSyncState(client);
-    if (state.isBootstrapped) {
-      console.log(`[EthereumBeaconSyncService] Bootstrap already present after ${Date.now() - startedAt}ms`);
-      return;
-    }
-
-    const timeoutMs = options.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
-    const pollMs = options.pollMs ?? DEFAULT_BOOTSTRAP_POLL_MS;
-    const minimumExecutionBlockNumber = options.minimumExecutionBlockNumber ?? 1n;
-    const minimumFinalizedSlot = options.minimumFinalizedSlot ?? 0n;
-
-    console.log(
-      `[EthereumBeaconSyncService] Waiting for finalized beacon execution block >= ${minimumExecutionBlockNumber} and slot >= ${minimumFinalizedSlot}`,
-    );
-    await waitForFinalizedBeaconExecutionAtOrAbove(beaconApiUrl, minimumExecutionBlockNumber, {
-      timeoutMs,
-      pollMs,
-      minimumFinalizedSlot,
-    });
-    console.log(`[EthereumBeaconSyncService] Finalized beacon execution is ready after ${Date.now() - startedAt}ms`);
-
-    const bootstrapTxStartedAt = Date.now();
-    let bootstrapTx;
-    let lastBootstrapError: Error | undefined;
-
-    while (Date.now() - bootstrapTxStartedAt < timeoutMs) {
-      try {
-        bootstrapTx = await getEthereumBeaconSyncBootstrapTx(client, beaconApiUrl);
-        console.log(
-          `[EthereumBeaconSyncService] Built beacon bootstrap transaction after ${Date.now() - bootstrapTxStartedAt}ms`,
-        );
-        break;
-      } catch (error) {
-        if (!(error instanceof Error)) {
-          throw error;
-        }
-
-        lastBootstrapError = error;
-        if (!isBootstrapEndpointNotReady(error.message)) {
-          throw error;
-        }
-        await sleep(pollMs);
-      }
-    }
-
-    if (!bootstrapTx) {
-      const lastErrorSuffix = lastBootstrapError ? ` Last error: ${lastBootstrapError.message}` : '';
-      throw new Error(
-        `Ethereum beacon light-client bootstrap endpoint did not become ready within ${Math.floor(timeoutMs / 1000)}s.${lastErrorSuffix}`,
-      );
-    }
-
-    console.log('[EthereumBeaconSyncService] Submitting beacon bootstrap sudo transaction');
-    const result = await new TxSubmitter(client, client.tx.sudo.sudo(bootstrapTx), sudoKeypair).submit();
-    console.log('[EthereumBeaconSyncService] Waiting for beacon bootstrap transaction to enter a block');
-    await result.waitForInFirstBlock;
-    console.log(
-      `[EthereumBeaconSyncService] Beacon bootstrap transaction entered a block after ${Date.now() - startedAt}ms`,
-    );
-
-    const sudoResultEvent = result.events.find(event => client.events.sudo.Sudid.is(event));
-    if (!sudoResultEvent || !client.events.sudo.Sudid.is(sudoResultEvent)) {
-      throw new Error('Bootstrap transaction did not emit sudo.Sudid.');
-    }
-    if (sudoResultEvent.data.sudoResult.isErr) {
-      throw new Error(`Bootstrap failed: ${dispatchErrorToString(client, sudoResultEvent.data.sudoResult.asErr)}`);
-    }
-
-    console.log(`[EthereumBeaconSyncService] Beacon bootstrap completed successfully in ${Date.now() - startedAt}ms`);
   }
 
   private get isEnabled(): boolean {
@@ -442,10 +353,6 @@ export async function waitForFinalizedBeaconExecutionAtOrAbove(
   throw new Error(
     `finalized beacon execution block did not reach block >= ${minimumExecutionBlockNumber} and slot >= ${minimumFinalizedSlot} within ${Math.floor(timeoutMs / 1000)}s${lastErrorSuffix}`,
   );
-}
-
-function isBootstrapEndpointNotReady(message: string): boolean {
-  return message.includes('/eth/v1/beacon/light_client/bootstrap/') && message.includes('404');
 }
 
 function isLightClientFinalityUpdateNotReady(error: unknown): boolean {

--- a/e2e/argon/argon-rpc.dev.yml
+++ b/e2e/argon/argon-rpc.dev.yml
@@ -1,0 +1,48 @@
+extensions:
+  client:
+    endpoints: ${ARGON_RPC_ENDPOINTS:-["ws://archive-node:9944"]}
+    request_timeout_seconds: ${ARGON_RPC_UPSTREAM_REQUEST_TIMEOUT_SECONDS:-20}
+    connection_timeout_seconds: ${ARGON_RPC_UPSTREAM_CONNECTION_TIMEOUT_SECONDS:-5}
+    retries: ${ARGON_RPC_UPSTREAM_RETRIES:-1}
+  event_bus:
+  substrate_api:
+    stale_timeout_seconds: ${ARGON_RPC_STALE_TIMEOUT_SECONDS:-180}
+  telemetry:
+    provider: none
+  merge_subscription:
+    keep_alive_seconds: ${ARGON_RPC_KEEP_ALIVE_SECONDS:-60}
+  server:
+    port: 9944
+    listen_address: '0.0.0.0'
+    max_connections: ${ARGON_RPC_MAX_CONNECTIONS:-2000}
+    max_batch_size: ${ARGON_RPC_MAX_BATCH_SIZE:-10}
+    http_methods:
+      - path: /health
+        method: system_health
+      - path: /liveness
+        method: chain_getBlockHash
+    cors: all
+  rate_limit:
+    connection:
+      burst: ${ARGON_RPC_CONNECTION_BURST:-20}
+      period_secs: ${ARGON_RPC_CONNECTION_PERIOD_SECS:-1}
+    ip:
+      burst: ${ARGON_RPC_IP_BURST:-500}
+      period_secs: ${ARGON_RPC_IP_PERIOD_SECS:-10}
+    use_xff: ${ARGON_RPC_USE_XFF:-true}
+  prometheus:
+    port: 9616
+    listen_address: '0.0.0.0'
+    label: '${ARGON_RPC_PROMETHEUS_LABEL:-argon-rpc}'
+
+middlewares:
+  methods:
+    - delay
+    - response
+    - inject_params
+    - upstream
+  subscriptions:
+    - merge_subscription
+    - upstream
+
+rpcs: /config/rpcs.yml

--- a/e2e/argon/indexer.docker-compose.yml
+++ b/e2e/argon/indexer.docker-compose.yml
@@ -1,5 +1,15 @@
 ---
 services:
+  archive-rpc:
+    entrypoint:
+      - /usr/bin/tini
+      - --
+      - /usr/local/bin/subway
+      - --config
+      - /config/argon-rpc-dev.yml
+    volumes:
+      - ./argon-rpc.dev.yml:/config/argon-rpc-dev.yml:ro
+
   indexer:
     build:
       context: ../../indexer

--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -29,9 +29,9 @@ import {
   type TransactionReceipt,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { EthereumBeaconSyncService } from '../bot/src/EthereumBeaconSyncService.ts';
 import { waitForQueryableClient } from '../core/__test__/startArgonTestNetwork.ts';
 import {
+  ensureDevEthereumBeaconBootstrapped,
   loadDevEthereumActivationRepaymentPricing,
   syncEthereumGatewayActiveCouncilToArgon,
 } from './devEthereumRuntimeSetup.ts';
@@ -356,7 +356,7 @@ async function ensureDevEthereumBeaconBootstrap(
       console.log(
         `[tauri-dev] Ethereum verifier bootstrap attempt ${attemptNumber}/3: waiting for beacon bootstrap inputs from ${beaconApiUrl}`,
       );
-      await EthereumBeaconSyncService.ensureBootstrapped(client, beaconApiUrl, sudoKeypair, {
+      await ensureDevEthereumBeaconBootstrapped(client, beaconApiUrl, sudoKeypair, {
         minimumFinalizedSlot: MINIMUM_BOOTSTRAP_FINALIZED_SLOT_BY_PRESET[beaconPreset],
       });
       console.log(
@@ -365,10 +365,10 @@ async function ensureDevEthereumBeaconBootstrap(
       return;
     } catch (error) {
       lastError = error as Error;
-      if (attempt === 2 || !isRetryableArchiveBootstrapError(lastError)) {
+      if (attempt === 2 || !isRetryableBootstrapError(lastError)) {
         throw error;
       }
-      console.warn(`[tauri-dev] Retrying Ethereum verifier bootstrap after archive disconnect (${lastError.message})`);
+      console.warn(`[tauri-dev] Retrying Ethereum verifier bootstrap (${lastError.message})`);
       await delay(1_000);
       await waitForQueryableClient(archiveUrl, {
         timeoutMs: 120_000,
@@ -746,9 +746,10 @@ async function delay(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function isRetryableArchiveBootstrapError(error: Error): boolean {
+function isRetryableBootstrapError(error: Error): boolean {
   const message = error.message.toLowerCase();
   return (
+    message.includes('priority is too low') ||
     message.includes('fetch failed') ||
     message.includes('disconnected from ws://') ||
     message.includes('abnormal closure')

--- a/e2e/devEthereumRuntimeSetup.ts
+++ b/e2e/devEthereumRuntimeSetup.ts
@@ -1,5 +1,16 @@
-import { EvmContracts, MICROGONS_PER_ARGON, type IArgonQueryable } from '@argonprotocol/mainchain';
+import {
+  dispatchErrorToString,
+  type ArgonClient,
+  EvmContracts,
+  getEthereumBeaconSyncBootstrapTx,
+  getEthereumBeaconSyncState,
+  type IArgonQueryable,
+  type KeyringPair,
+  MICROGONS_PER_ARGON,
+  TxSubmitter,
+} from '@argonprotocol/mainchain';
 import { createPublicClient, getAddress, http, type Address, type Hex, type PublicClient } from 'viem';
+import { waitForFinalizedBeaconExecutionAtOrAbove } from '../bot/src/EthereumBeaconSyncService.ts';
 
 // Measured in the mainchain deploy gas harness:
 // `yarn workspace @argonprotocol/ethereum-deploy gas:measure`
@@ -11,6 +22,84 @@ const MIN_DEV_ETHEREUM_WEI_PER_GAS = 1_000_000_000n;
 // Keep isolated e2e deterministic/offline with the same explicit estimate used in
 // mainchain's Ethereum proof e2e.
 const FALLBACK_DEV_ETHEREUM_ESTIMATED_MICROGONS_PER_ETH = 1_000_000n;
+
+export async function ensureDevEthereumBeaconBootstrapped(
+  client: ArgonClient,
+  beaconApiUrl: string,
+  sudoKeypair: KeyringPair,
+  options: {
+    timeoutMs?: number;
+    pollMs?: number;
+    minimumExecutionBlockNumber?: bigint;
+    minimumFinalizedSlot?: bigint;
+  } = {},
+): Promise<void> {
+  const startedAt = Date.now();
+  console.log('[dev-ethereum] Checking beacon bootstrap state');
+  const state = await getEthereumBeaconSyncState(client);
+  if (state.isBootstrapped) {
+    console.log(`[dev-ethereum] Beacon bootstrap already present after ${Date.now() - startedAt}ms`);
+    return;
+  }
+
+  const timeoutMs = options.timeoutMs ?? 5 * 60_000;
+  const pollMs = options.pollMs ?? 1_000;
+  const minimumExecutionBlockNumber = options.minimumExecutionBlockNumber ?? 1n;
+  const minimumFinalizedSlot = options.minimumFinalizedSlot ?? 0n;
+
+  console.log(
+    `[dev-ethereum] Waiting for finalized beacon execution block >= ${minimumExecutionBlockNumber} and slot >= ${minimumFinalizedSlot}`,
+  );
+  await waitForFinalizedBeaconExecutionAtOrAbove(beaconApiUrl, minimumExecutionBlockNumber, {
+    timeoutMs,
+    pollMs,
+    minimumFinalizedSlot,
+  });
+  console.log(`[dev-ethereum] Finalized beacon execution is ready after ${Date.now() - startedAt}ms`);
+
+  const bootstrapTxStartedAt = Date.now();
+  let bootstrapTx;
+  let lastBootstrapError: Error | undefined;
+
+  while (Date.now() - bootstrapTxStartedAt < timeoutMs) {
+    try {
+      bootstrapTx = await getEthereumBeaconSyncBootstrapTx(client, beaconApiUrl);
+      console.log(`[dev-ethereum] Built beacon bootstrap transaction after ${Date.now() - bootstrapTxStartedAt}ms`);
+      break;
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+
+      lastBootstrapError = error;
+      if (!error.message.includes('/eth/v1/beacon/light_client/bootstrap/') || !error.message.includes('404')) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+  }
+
+  if (!bootstrapTx) {
+    const lastErrorSuffix = lastBootstrapError ? ` Last error: ${lastBootstrapError.message}` : '';
+    throw new Error(
+      `Ethereum beacon light-client bootstrap endpoint did not become ready within ${Math.floor(timeoutMs / 1000)}s.${lastErrorSuffix}`,
+    );
+  }
+
+  console.log('[dev-ethereum] Submitting beacon bootstrap sudo transaction');
+  const result = await new TxSubmitter(client, client.tx.sudo.sudo(bootstrapTx), sudoKeypair).submit();
+  await result.waitForInFirstBlock;
+
+  const sudoResultEvent = result.events.find(event => client.events.sudo.Sudid.is(event));
+  if (!sudoResultEvent || !client.events.sudo.Sudid.is(sudoResultEvent)) {
+    throw new Error('Bootstrap transaction did not emit sudo.Sudid.');
+  }
+  if (sudoResultEvent.data.sudoResult.isErr) {
+    throw new Error(`Bootstrap failed: ${dispatchErrorToString(client, sudoResultEvent.data.sudoResult.asErr)}`);
+  }
+
+  console.log(`[dev-ethereum] Beacon bootstrap completed successfully in ${Date.now() - startedAt}ms`);
+}
 
 export async function loadDevEthereumActivationRepaymentPricing(args: {
   finalizedClient: IArgonQueryable;

--- a/e2e/flows/helpers/fundDevEthereumWallet.ts
+++ b/e2e/flows/helpers/fundDevEthereumWallet.ts
@@ -7,6 +7,7 @@ const MIN_DEV_ETHEREUM_GAS_WEI = 10n ** 17n;
 export async function fundDevEthereumWallet(args: {
   to: string;
   archiveUrl?: string;
+  ethereumRpcUrl?: string;
   microgons?: bigint;
   micronots?: bigint;
   minGasWei?: bigint;
@@ -19,6 +20,7 @@ export async function fundDevEthereumWallet(args: {
     const result = await mintDevEthereumTokens({
       to,
       archiveUrl,
+      rpcUrl: args.ethereumRpcUrl,
       argnRuntimeAmount: microgons,
       argnotRuntimeAmount: micronots,
     });

--- a/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
+++ b/e2e/flows/operations/App.op.fundWalletFromEthereum.ts
@@ -10,6 +10,7 @@ const ETHEREUM_MOVE_TIMEOUT_MS = 6 * 60_000;
 const EMPTY_FUNDING_STATE = {
   ethereumAddress: '',
   archiveUrl: '',
+  ethereumRpcUrl: '',
   ethereumChainConfigReady: false,
   ethereumFetchErrorMsg: '',
   ethereumMicrogons: 0n,
@@ -116,6 +117,7 @@ export default new Operation<IAppFundWalletFromEthereumContext, IAppFundWalletFr
       await fundDevEthereumWallet({
         to: initialState.chainState.ethereumAddress,
         archiveUrl: initialState.chainState.archiveUrl,
+        ethereumRpcUrl: initialState.chainState.ethereumRpcUrl,
         microgons: requiredMicrogons > 0n ? requiredMicrogons : undefined,
         micronots: requiredMicronots > 0n ? requiredMicronots : undefined,
       });
@@ -231,6 +233,7 @@ async function readEthereumFundingState(flow: IE2EFlowRuntime, targetWalletType:
       return {
         ethereumAddress: refs.wallets.ethereumWallet.address,
         archiveUrl,
+        ethereumRpcUrl: refs.getEthereumOutboundTransferTracker().executionRpcUrl ?? '',
         ethereumChainConfigReady,
         ethereumFetchErrorMsg: refs.wallets.ethereumWallet.fetchErrorMsg,
         ethereumMicrogons: refs.wallets.ethereumWallet.availableMicrogons.toString(),
@@ -266,6 +269,7 @@ async function readEthereumFundingState(flow: IE2EFlowRuntime, targetWalletType:
   return {
     ethereumAddress: state.ethereumAddress,
     archiveUrl: state.archiveUrl,
+    ethereumRpcUrl: state.ethereumRpcUrl,
     ethereumChainConfigReady: state.ethereumChainConfigReady,
     ethereumFetchErrorMsg: state.ethereumFetchErrorMsg,
     ethereumMicrogons: BigInt(state.ethereumMicrogons),

--- a/e2e/flows/operations/Mining.op.completeChecklist.ts
+++ b/e2e/flows/operations/Mining.op.completeChecklist.ts
@@ -5,6 +5,7 @@ import type { IMiningFlowContext } from '../contexts/miningContext.ts';
 
 type ICompleteChecklistUiState = {
   checklistVisible: boolean;
+  checklistClickable: boolean;
   botConfigured: boolean;
 };
 
@@ -21,7 +22,7 @@ export default new Operation<IMiningFlowContext, ICompleteChecklistState>(import
     ]);
     const botConfigured = botConfigState?.hasSavedBiddingRules ?? false;
     const isComplete = botConfigured;
-    const canRun = checklistEntry.visible && !botConfigured;
+    const canRun = checklistEntry.clickable && !botConfigured;
     let operationState: 'complete' | 'runnable' | 'processing' = 'processing';
     if (isComplete) {
       operationState = 'complete';
@@ -31,10 +32,14 @@ export default new Operation<IMiningFlowContext, ICompleteChecklistState>(import
 
     const blockers: string[] = [];
     if (!isComplete && !checklistEntry.visible) blockers.push('Mining checklist is not visible.');
+    if (!isComplete && checklistEntry.visible && !checklistEntry.clickable) {
+      blockers.push('Mining checklist is still loading.');
+    }
     return {
       chainState: {},
       uiState: {
         checklistVisible: checklistEntry.visible,
+        checklistClickable: checklistEntry.clickable,
         botConfigured,
       },
       state: operationState,

--- a/e2e/flows/operations/Mining.op.fundWallet.ts
+++ b/e2e/flows/operations/Mining.op.fundWallet.ts
@@ -83,8 +83,11 @@ export default new Operation<IMiningFlowContext, IFundWalletState>(import.meta, 
     const walletAddress = await readClipboardWithRetries(
       flow,
       async () => {
-        await flow.click('defaultArgonWalletAddress.openMenu()', { timeoutMs: 5_000 });
-        await flow.waitFor('defaultArgonWalletAddress.copyContent()', { timeoutMs: 5_000 });
+        const copyAction = await flow.isVisible('defaultArgonWalletAddress.copyContent()');
+        if (!copyAction.clickable) {
+          await flow.click('defaultArgonWalletAddress.openMenu()', { timeoutMs: 5_000 });
+          await flow.waitFor('defaultArgonWalletAddress.copyContent()', { timeoutMs: 5_000 });
+        }
         await flow.click('defaultArgonWalletAddress.copyContent()', { timeoutMs: 5_000 });
       },
       value => isAddress(value),
@@ -105,7 +108,7 @@ export default new Operation<IMiningFlowContext, IFundWalletState>(import.meta, 
     };
     const fundingNeeded = requiredFunding.microgons > 0n || requiredFunding.micronots > 0n;
     const funding = fundingNeeded ? deriveMiningFunding(flowName, requiredFunding, input.fundingArgons) : undefined;
-    await flow.click('NavHeader.close()', { timeoutMs: 8_000 });
+    await flow.click('BgOverlay.close()', { timeoutMs: 8_000 });
     await pollEvery(250, async () => !(await flow.inspect(this)).uiState.walletOverlayVisible, {
       timeoutMs: 20_000,
       timeoutMessage: `${flowName}: mining wallet overlay did not close after funding.`,

--- a/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
@@ -5,7 +5,7 @@ import { fundDevEthereumAccount } from '../../scripts/fundDevEthereumAccount.ts'
 import { clickIfVisible } from '../helpers/utils.ts';
 import vaultingOnboarding from './Vaulting.flow.onboarding.ts';
 import vaultingActivateTab from './Vaulting.op.activateTab.ts';
-import vaultingTransferOutToEthereum from './Vaulting.op.transferOutToEthereum.ts';
+import vaultingTransferOutToEthereum, { openVaultingWalletOverlay } from './Vaulting.op.transferOutToEthereum.ts';
 import { OperationalFlow } from './index.ts';
 import type { IE2EOperationInspectState } from '../types.ts';
 
@@ -42,20 +42,56 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
     }
 
     await flow.run(vaultingOnboarding);
-    const { ethereumAddress, executionRpcUrl } = (await flow.queryApp(
-      async refs => {
-        await refs.wallets.load().catch(() => undefined);
-        const tracker = refs.getEthereumOutboundTransferTracker() as any;
+    await openVaultingWalletOverlay(flow);
 
-        return {
-          ethereumAddress: refs.wallets.ethereumWallet.address,
-          executionRpcUrl: tracker.ethereumClient.executionRpcUrl,
-        };
+    let requestedDefaultEthereumWallet = false;
+    const ethereumConnection = await waitFor(
+      15_000,
+      `${context.flowName}: default Ethereum wallet`,
+      async () => {
+        const connection = await flow.queryApp(
+          async refs => {
+            if (!refs.wallets.isLoaded) {
+              await refs.wallets.load().catch(() => undefined);
+            }
+            const tracker = refs.getEthereumOutboundTransferTracker();
+
+            return {
+              ethereumAddress: refs.wallets.ethereumWallet.address,
+              executionRpcUrl: tracker.executionRpcUrl,
+            };
+          },
+          {
+            timeoutMs: 15_000,
+          },
+        );
+
+        if (connection?.ethereumAddress) {
+          return connection;
+        }
+
+        if (!requestedDefaultEthereumWallet) {
+          const addDefaultEthereum = await flow.isVisible('WalletOverlay.addDefaultEthereum()');
+          if (addDefaultEthereum.clickable) {
+            requestedDefaultEthereumWallet = true;
+            await flow.click('WalletOverlay.addDefaultEthereum()', { timeoutMs: 15_000 });
+          }
+        }
       },
       {
-        timeoutMs: 15_000,
+        pollMs: 250,
+        timeoutMessage: `${context.flowName}: missing default Ethereum wallet address.`,
       },
-    )) as { ethereumAddress: string; executionRpcUrl: string };
+    );
+
+    if (!ethereumConnection.executionRpcUrl) {
+      throw new Error(`${context.flowName}: missing Ethereum execution RPC URL.`);
+    }
+    const { ethereumAddress, executionRpcUrl } = ethereumConnection;
+    console.info(`[E2E] ${context.flowName} prepared Ethereum destination`, {
+      ethereumAddress,
+      executionRpcUrl,
+    });
 
     await waitFor(
       DEV_ETHEREUM_BACKEND_MINTING_AUTHORITY_READY_TIMEOUT_MS,

--- a/e2e/flows/operations/Vaulting.op.fundWallet.ts
+++ b/e2e/flows/operations/Vaulting.op.fundWallet.ts
@@ -106,8 +106,7 @@ export default new Operation<IVaultingFlowContext, IFundVaultingWalletState>(imp
     }
 
     await flow.click('SetupChecklist.openFundVaultingAccountOverlay()');
-    await flow.waitFor('WalletOverlay.micronotsNeeded', { state: 'exists' });
-    await flow.waitFor('WalletOverlay.microgonsNeeded', { state: 'exists' });
+    await flow.waitFor('WalletOverlay.microgonsNeeded', { state: 'exists', timeoutMs: 30_000 });
 
     const microgonsNeededRaw = await flow.getAttribute('WalletOverlay.microgonsNeeded', 'data-value');
     const micronotsNeededRaw = await flow
@@ -133,7 +132,7 @@ export default new Operation<IVaultingFlowContext, IFundVaultingWalletState>(imp
     const requiredMicronots = BigInt(micronotsNeededRaw ?? '0');
     const fundingNeeded = requiredMicrogons > 0n || requiredMicronots > 0n;
 
-    await flow.click('NavHeader.close()', { timeoutMs: 8_000 });
+    await flow.click('WalletOverlay.closeRight()', { timeoutMs: 8_000 });
     await pollEvery(250, async () => !(await flow.inspect(this)).uiState.walletOverlayVisible, {
       timeoutMs: 20_000,
       timeoutMessage: `${flowName}: vaulting wallet overlay did not close after funding.`,
@@ -144,6 +143,7 @@ export default new Operation<IVaultingFlowContext, IFundVaultingWalletState>(imp
         address: walletAddress,
         microgons: requiredMicrogons + extraMicrogons,
         micronots: requiredMicronots,
+        archiveUrl: flow.getData<string>('sessionArchiveUrl'),
       });
 
       console.info(`[E2E] ${flowName} funded wallet`, {

--- a/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
@@ -273,7 +273,7 @@ async function readOutboundTransferState(flow: IVaultingFlowContext['flow']) {
   };
 }
 
-async function openVaultingWalletOverlay(flow: IVaultingFlowContext['flow']) {
+export async function openVaultingWalletOverlay(flow: IVaultingFlowContext['flow']) {
   await flow.queryApp(
     (refs, args: { walletType: WalletType.defaultArgon }) => {
       refs.openWalletOverlay(args.walletType);

--- a/router/__test__/ArgonApis.test.ts
+++ b/router/__test__/ArgonApis.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callArgonRpc: vi.fn(),
+  readTextFileOrDefault: vi.fn().mockResolvedValue('100'),
+}));
+
+vi.mock('../src/env.ts', () => ({
+  LOCAL_NODE_URL: 'http://argon-miner:9944',
+  LOGS_DIR: '/tmp',
+  MAIN_NODE_URL: 'https://archive.argon.network',
+}));
+
+vi.mock('../src/utils.ts', async importOriginal => ({
+  ...(await importOriginal()),
+  callArgonRpc: mocks.callArgonRpc,
+  readTextFileOrDefault: mocks.readTextFileOrDefault,
+}));
+
+import { ArgonApis } from '../src/ArgonApis.ts';
+
+describe('ArgonApis sync status', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.callArgonRpc.mockReset();
+    mocks.readTextFileOrDefault.mockResolvedValue('100');
+  });
+
+  it('uses state sync progress in the final third of fast sync', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 0,
+        currentBlock: 10,
+        state: 'downloading',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: {
+          percentage: 65,
+          phase: 'downloadingState',
+        },
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 89.6,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+    expect(mocks.callArgonRpc).toHaveBeenCalledWith('http://argon-miner:9944', 'system_syncStatus');
+  });
+
+  it('measures ordinary block sync from the node startup height', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 100,
+        currentBlock: 550,
+        state: 'downloading',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: null,
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 46.6,
+      localNodeBlockNumber: 550,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('hands header progress into state download without moving backward', async () => {
+    mocks.callArgonRpc
+      .mockResolvedValueOnce({
+        result: {
+          startingBlock: 100,
+          currentBlock: 1_000,
+          state: 'downloading',
+          targetBlock: 1_000,
+          bestSeenBlock: 1_000,
+          numPeers: 3,
+          stateSync: null,
+          warpSync: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          startingBlock: 100,
+          currentBlock: 1_000,
+          state: 'downloading',
+          targetBlock: 1_000,
+          bestSeenBlock: 1_000,
+          numPeers: 3,
+          stateSync: {
+            percentage: 0,
+            phase: 'downloadingState',
+          },
+          warpSync: null,
+        },
+      });
+
+    const headersComplete = await ArgonApis.syncStatus();
+    const stateStarted = await ArgonApis.syncStatus();
+
+    expect(headersComplete.syncPercent).toBe(73.3);
+    expect(stateStarted.syncPercent).toBe(headersComplete.syncPercent);
+  });
+
+  it('holds progress at the state import checkpoint until import completes', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 0,
+        currentBlock: 10,
+        state: 'idle',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: {
+          percentage: 100,
+          phase: 'importingState',
+        },
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 99.2,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('finishes idle sync when the best seen block remains ahead', async () => {
+    mocks.callArgonRpc.mockImplementation(async (_url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return {
+          result: {
+            startingBlock: 0,
+            currentBlock: 999,
+            state: 'idle',
+            targetBlock: null,
+            bestSeenBlock: 1_000,
+            numPeers: 3,
+            stateSync: null,
+            warpSync: null,
+          },
+        };
+      }
+
+      if (method === 'state_getRuntimeVersion') {
+        return { result: { specVersion: 1 } };
+      }
+
+      return { result: { isSyncing: false, peers: 3 } };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 100,
+      localNodeBlockNumber: 999,
+      mainNodeBlockNumber: 999,
+    });
+  });
+
+  it('does not report warp proof download as completed block sync', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 10,
+        currentBlock: 10,
+        state: 'idle',
+        targetBlock: null,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: null,
+        warpSync: {
+          phase: 'downloadingWarpProofs',
+        },
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 20,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('falls back to archive height progress for nodes without the sync status rpc', async () => {
+    mocks.callArgonRpc.mockImplementation(async (url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return { error: { code: -32601, message: 'Method not found' } };
+      }
+
+      return {
+        result: {
+          number: url === 'http://argon-miner:9944' ? '0x32' : '0x64',
+        },
+      };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 60,
+      localNodeBlockNumber: 50,
+      mainNodeBlockNumber: 100,
+    });
+  });
+});

--- a/router/src/ArgonApis.ts
+++ b/router/src/ArgonApis.ts
@@ -2,6 +2,28 @@ import type { IBlockNumbers } from './interfaces/IBlockNumbers';
 import { LOCAL_NODE_URL, LOGS_DIR, MAIN_NODE_URL } from './env';
 import { callArgonRpc, getRoundedPercent, readTextFileOrDefault } from './utils';
 
+// Returned by the custom system_syncStatus RPC in mainchain/node/src/rpc.rs.
+interface IArgonNodeSyncStatus {
+  startingBlock: number;
+  currentBlock: number;
+  state: 'idle' | 'downloading' | 'importing';
+  targetBlock?: number | null;
+  bestSeenBlock?: number | null;
+  numPeers: number;
+  stateSync?: {
+    percentage: number;
+    phase: 'downloadingState' | 'importingState';
+  } | null;
+  warpSync?: {
+    phase: string;
+  } | null;
+}
+
+// Fast sync spends roughly two-thirds of its time downloading headers and one-third syncing state.
+const HEADER_SYNC_PERCENT = (2 / 3) * 100;
+const STATE_DOWNLOAD_COMPLETE_PERCENT = 98;
+const STATE_IMPORT_PERCENT = 99;
+
 let cache: null | {
   latestBlocks: IBlockNumbers;
   timestamp: number;
@@ -59,17 +81,61 @@ export class ArgonApis {
 
   public static async syncStatus(): Promise<{ syncPercent: number } & IBlockNumbers> {
     let dockerPercent = await this.dockerPercentComplete().catch(() => 0);
-    const { localNodeBlockNumber, mainNodeBlockNumber } = await this.latestBlocks().catch(() => ({
-      localNodeBlockNumber: 0,
-      mainNodeBlockNumber: 0,
-    }));
+    const response = LOCAL_NODE_URL
+      ? await callArgonRpc<IArgonNodeSyncStatus>(LOCAL_NODE_URL, 'system_syncStatus').catch(() => null)
+      : null;
+    const nodeSyncStatus = response?.result;
+
+    let localNodeBlockNumber = nodeSyncStatus?.currentBlock ?? 0;
+    let mainNodeBlockNumber = nodeSyncStatus?.currentBlock ?? 0;
+    const hasActiveStateSync = Boolean(nodeSyncStatus?.stateSync);
+    const hasActiveWarpSync = Boolean(nodeSyncStatus?.warpSync && nodeSyncStatus.warpSync.phase !== 'complete');
+    if (nodeSyncStatus && (nodeSyncStatus.state !== 'idle' || hasActiveStateSync || hasActiveWarpSync)) {
+      mainNodeBlockNumber = nodeSyncStatus.targetBlock ?? nodeSyncStatus.bestSeenBlock ?? localNodeBlockNumber;
+    }
+    let nodeSyncPercent = 0;
+
+    if (nodeSyncStatus) {
+      const stateSync = nodeSyncStatus.stateSync;
+      const warpPhase = nodeSyncStatus.warpSync?.phase;
+
+      if (stateSync?.phase === 'downloadingState') {
+        const stateDownloadPercent = Math.min(Math.max(stateSync.percentage, 0), 100);
+        const stateDownloadSpan = STATE_DOWNLOAD_COMPLETE_PERCENT - HEADER_SYNC_PERCENT;
+        nodeSyncPercent = HEADER_SYNC_PERCENT + (stateDownloadPercent / 100) * stateDownloadSpan;
+      } else if (stateSync?.phase === 'importingState' || warpPhase === 'importingState') {
+        nodeSyncPercent = STATE_IMPORT_PERCENT;
+      } else if (warpPhase === 'complete') {
+        nodeSyncPercent = 100;
+      } else if (warpPhase === 'downloadingState') {
+        nodeSyncPercent = HEADER_SYNC_PERCENT;
+      } else if (!warpPhase || warpPhase === 'downloadingBlocks') {
+        const blocksToSync = mainNodeBlockNumber - nodeSyncStatus.startingBlock;
+        const blocksSynced = Math.max(localNodeBlockNumber - nodeSyncStatus.startingBlock, 0);
+
+        if (localNodeBlockNumber > 0 && nodeSyncStatus.state === 'idle' && nodeSyncStatus.numPeers > 0) {
+          nodeSyncPercent = 100;
+        } else if (blocksToSync > 0) {
+          const headerDownloadRatio = Math.min(blocksSynced / blocksToSync, 1);
+          nodeSyncPercent = headerDownloadRatio * HEADER_SYNC_PERCENT;
+        }
+      }
+    } else {
+      const latestBlocks = await this.latestBlocks().catch(() => ({
+        localNodeBlockNumber: 0,
+        mainNodeBlockNumber: 0,
+      }));
+      localNodeBlockNumber = latestBlocks.localNodeBlockNumber;
+      mainNodeBlockNumber = latestBlocks.mainNodeBlockNumber;
+      nodeSyncPercent = mainNodeBlockNumber ? getRoundedPercent(localNodeBlockNumber / mainNodeBlockNumber) : 0;
+    }
+
     // if we have any blocks, docker is definitely done
     if (localNodeBlockNumber > 0) {
       dockerPercent = 100;
     }
 
-    const blockSyncPercent = mainNodeBlockNumber ? getRoundedPercent(localNodeBlockNumber / mainNodeBlockNumber) : 0;
-    let syncPercent = getRoundedPercent((dockerPercent * 0.2 + blockSyncPercent * 0.8) / 100, 1);
+    let syncPercent = getRoundedPercent((dockerPercent * 0.2 + nodeSyncPercent * 0.8) / 100, 1);
     // if we're not all the way synced, don't report 100%
     if (syncPercent >= 100) {
       if (localNodeBlockNumber < mainNodeBlockNumber) {

--- a/src-vue/__test__/EthereumCrosschain.integration.test.ts
+++ b/src-vue/__test__/EthereumCrosschain.integration.test.ts
@@ -54,6 +54,7 @@ import { setMainchainClients } from '../stores/mainchain.ts';
 import { createTestDb } from './helpers/db.ts';
 import { createMockWalletKeys } from './helpers/wallet.ts';
 import {
+  ensureDevEthereumBeaconBootstrapped,
   loadDevEthereumActivationRepaymentPricing,
   syncEthereumGatewayActiveCouncilToArgon,
 } from '../../e2e/devEthereumRuntimeSetup.ts';
@@ -208,7 +209,7 @@ describe.skipIf(skipE2E || !TestEthereum.isInstalled())('EthereumCrosschain inte
       ),
       sudo(),
     );
-    await EthereumBeaconSyncService.ensureBootstrapped(mainchainClient, endpoints.beaconApiUrl, sudo(), {
+    await ensureDevEthereumBeaconBootstrapped(mainchainClient, endpoints.beaconApiUrl, sudo(), {
       minimumFinalizedSlot: 64n,
     });
 
@@ -217,15 +218,10 @@ describe.skipIf(skipE2E || !TestEthereum.isInstalled())('EthereumCrosschain inte
 
     await sudoFundWallet({
       client,
-      address: walletKeys.vaultingAddress,
+      // The collapsed wallet model uses the default Argon account for vaulting.
+      address: walletKeys.defaultArgonAddress,
       microgons: 100_000_000n,
       micronots: 10_000_000n,
-    });
-    await sudoFundWallet({
-      client,
-      address: walletKeys.defaultArgonAddress,
-      microgons: client.consts.balances.existentialDeposit.toBigInt(),
-      micronots: 0n,
     });
 
     const currentTick = await client.query.ticks.currentTick();

--- a/src-vue/__test__/OperationalAccount.integration.test.ts
+++ b/src-vue/__test__/OperationalAccount.integration.test.ts
@@ -1,60 +1,169 @@
 import Path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { teardown } from '@argonprotocol/testing';
-import { startArgonTestNetwork } from '@argonprotocol/apps-core/__test__/startArgonTestNetwork.js';
-import { getClient, type ArgonClient } from '@argonprotocol/mainchain';
-import { sudoFundWallet } from '@argonprotocol/apps-core/__test__/helpers/sudoFundWallet.ts';
+import { sudo, teardown } from '@argonprotocol/testing';
+import {
+  startArgonTestNetwork,
+  type StartedArgonTestNetwork,
+} from '@argonprotocol/apps-core/__test__/startArgonTestNetwork.js';
+import {
+  createBitcoinAddress,
+  generateBlocks,
+  sendBitcoinToAddress,
+} from '@argonprotocol/apps-core/__test__/helpers/bitcoinCli.ts';
 import { submitAndFinalize } from '@argonprotocol/apps-core/__test__/helpers/mainchain.ts';
-import { createTestWallet } from './helpers/wallet.ts';
-import { buildOperatorAccountRegistrationTx, loadOperationalAccount } from '../lib/OperationalAccount.ts';
+import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
+import { loadCertificationProgress, MICROGONS_PER_ARGON, TreasuryBonds } from '@argonprotocol/apps-core';
+import { BitcoinLock, getClient, TxSubmitter, type ArgonClient } from '@argonprotocol/mainchain';
+import type { IConfig } from '../interfaces/IConfig.ts';
+import {
+  cleanupBitcoinLocksHarness,
+  createBitcoinLocksHarness,
+  defaultVaultRules,
+} from './helpers/bitcoinLocksHarness.ts';
+import BitcoinLocks from '../lib/BitcoinLocks.ts';
+import { Config } from '../lib/Config.ts';
+import {
+  buildOperatorAccountRegistrationTx,
+  getOperationalRewardConfig,
+  loadOperationalAccount,
+} from '../lib/OperationalAccount.ts';
 
 const skipE2E = Boolean(JSON.parse(process.env.SKIP_E2E ?? '0'));
 
-describe.skipIf(skipE2E).sequential('OperationalAccount integration tests', { timeout: 180_000 }, () => {
+describe.skipIf(skipE2E).sequential('OperationalAccount integration tests', { timeout: 300_000 }, () => {
   let client: ArgonClient | undefined;
+  let network: StartedArgonTestNetwork;
+  let previousComposeProjectName: string | undefined;
 
   beforeAll(async () => {
-    const network = await startArgonTestNetwork(Path.basename(import.meta.filename), {
-      profiles: ['miners'],
+    network = await startArgonTestNetwork(Path.basename(import.meta.filename), {
+      profiles: ['miners', 'price-oracle'],
       chainStartTimeoutMs: 120_000,
       chainStartPollMs: 250,
     });
 
     client = await getClient(network.archiveUrl);
+    previousComposeProjectName = process.env.COMPOSE_PROJECT_NAME;
+    process.env.COMPOSE_PROJECT_NAME = network.composeEnv.COMPOSE_PROJECT_NAME;
   });
 
   afterAll(async () => {
     await client?.disconnect();
+    if (previousComposeProjectName === undefined) {
+      delete process.env.COMPOSE_PROJECT_NAME;
+    } else {
+      process.env.COMPOSE_PROJECT_NAME = previousComposeProjectName;
+    }
     await teardown();
   });
 
   it('registers an operational account on the current runtime', async () => {
     const runtimeClient = client!;
-    const wallet = createTestWallet('//op-register');
-    const operationalAccount = await wallet.walletKeys.getOperationalKeypair();
+    await waitFor(90_000, 'price oracle update', async () => {
+      const current = await runtimeClient.query.priceIndex.current();
+      if (current.isNone) return;
 
-    await sudoFundWallet({
-      address: operationalAccount.address,
-      microgons: 1_000_000_000n,
-      micronots: 0n,
-      client: runtimeClient,
+      const priceIndex = current.unwrap();
+      if (priceIndex.btcUsdPrice.toBigInt() <= 0n) return;
+      if (priceIndex.argonUsdPrice.toBigInt() <= 0n) return;
+      return true;
     });
 
-    const tx = await buildOperatorAccountRegistrationTx({
-      walletKeys: wallet.walletKeys,
-      accessProof: null,
-      client: runtimeClient,
+    const rewardConfig = await getOperationalRewardConfig(runtimeClient);
+    const configuredVaultRules = Config.getDefault('vaultingRules') as IConfig['vaultingRules'];
+    const vaultRules = {
+      ...defaultVaultRules,
+      baseMicrogonCommitment: configuredVaultRules.baseMicrogonCommitment,
+    };
+    const harness = await createBitcoinLocksHarness({
+      archiveUrl: network.archiveUrl,
+      esploraHost: network.networkConfigOverride.esploraHost,
+      network: 'dev-docker',
+      vaultRules,
+      walletFundingMicrogons:
+        vaultRules.baseMicrogonCommitment + rewardConfig.treasuryMinimumBonds + 20n * BigInt(MICROGONS_PER_ARGON),
     });
 
-    expect(tx).toBeTruthy();
-    if (!tx) {
-      throw new Error('expected operational registration transaction');
+    try {
+      const { bitcoinLocks, myVault, walletKeys } = harness;
+      const vault = myVault.createdVault!;
+
+      const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(rewardConfig.treasuryMinimumBitcoin);
+      const { txInfo } = await bitcoinLocks.initializeLock({ vault, satoshis });
+      expect(txInfo).toBeTruthy();
+      if (!txInfo) throw new Error('expected treasury bitcoin lock transaction');
+
+      const blockHash = txInfo.tx.blockHash ?? (await txInfo.txResult.waitForInFirstBlock);
+      const apiAt = await runtimeClient.at(blockHash);
+      const { lock } = await BitcoinLock.getBitcoinLockFromTxResult(apiAt, txInfo.txResult);
+      const fundingAddress = BitcoinLocks.formatP2wshAddress(lock.p2wshScriptHashHex, bitcoinLocks.bitcoinNetwork);
+      const minerAddress = createBitcoinAddress();
+      sendBitcoinToAddress(fundingAddress, lock.satoshis);
+
+      const bondTx = await TreasuryBonds.buildBuyBondTx({
+        client: runtimeClient,
+        vaultId: vault.vaultId,
+        bondPurchaseMicrogons: rewardConfig.treasuryMinimumBonds,
+      });
+      const treasurySigner = await walletKeys.getTreasuryKeypair();
+
+      const transferTotalsKey = runtimeClient.query.crosschainTransfer.transferTotalsByAccount.key(
+        walletKeys.treasuryAddress,
+      );
+      const transferTotalsValue = runtimeClient
+        .createType('PalletCrosschainTransferAccountTransferTotals', {
+          microgonsIn: rewardConfig.treasuryMinimumUniswapTransfer,
+          microgonsOut: 0n,
+          argonTransfersInCount: 1,
+          argonTransfersOutCount: 0,
+          micronotsIn: 0n,
+          micronotsOut: 0n,
+          argonotTransfersInCount: 0,
+          argonotTransfersOutCount: 0,
+        })
+        .toHex();
+      const transferResultPromise = new TxSubmitter(
+        runtimeClient,
+        runtimeClient.tx.sudo.sudo(runtimeClient.tx.system.setStorage([[transferTotalsKey, transferTotalsValue]])),
+        sudo(),
+      ).submit({ useLatestNonce: true });
+
+      generateBlocks(8, minerAddress);
+
+      await Promise.all([
+        transferResultPromise.then(result => result.waitForInFirstBlock),
+        waitFor(45_000, 'treasury bitcoin funded', async () => {
+          const currentLock = await BitcoinLock.get(runtimeClient, lock.utxoId);
+          if (!currentLock?.isFunded) return;
+          return currentLock;
+        }),
+      ]);
+
+      const bondResult = await new TxSubmitter(runtimeClient, bondTx, treasurySigner).submit({ useLatestNonce: true });
+      await bondResult.waitForInFirstBlock;
+
+      const certification = await loadCertificationProgress({
+        client: runtimeClient,
+        defaultAccountId: walletKeys.treasuryAddress,
+      });
+      expect(certification.isTreasuryCertified).toBe(true);
+
+      const tx = await buildOperatorAccountRegistrationTx({
+        walletKeys,
+        accessProof: null,
+        client: runtimeClient,
+      });
+
+      expect(tx).toBeTruthy();
+      if (!tx) throw new Error('expected operational registration transaction');
+
+      const result = await submitAndFinalize(runtimeClient, tx, treasurySigner);
+      expect(result.extrinsicError).toBeUndefined();
+
+      const registered = await loadOperationalAccount(walletKeys, runtimeClient);
+      expect(registered.isSome).toBe(true);
+    } finally {
+      await cleanupBitcoinLocksHarness(harness);
     }
-
-    const result = await submitAndFinalize(runtimeClient, tx, operationalAccount);
-    expect(result.extrinsicError).toBeUndefined();
-
-    const registered = await loadOperationalAccount(wallet.walletKeys, runtimeClient);
-    expect(registered.isSome).toBe(true);
   });
 });

--- a/src-vue/__test__/helpers/bitcoinLocksHarness.ts
+++ b/src-vue/__test__/helpers/bitcoinLocksHarness.ts
@@ -102,6 +102,7 @@ export async function createBitcoinLocksHarness(args: {
   esploraHost: string;
   network: string;
   vaultRules?: IVaultingRules;
+  walletFundingMicrogons?: bigint;
 }): Promise<BitcoinLocksHarness> {
   const { archiveUrl, esploraHost, network, vaultRules = defaultVaultRules } = args;
   const clientHarness = await createBitcoinLocksClientHarness({
@@ -110,10 +111,11 @@ export async function createBitcoinLocksHarness(args: {
     network,
   });
   const { db, clients, walletKeys, currency, transactionTracker, bitcoinLocks, miningFrames } = clientHarness;
+  const fundingMicrogons = args.walletFundingMicrogons ?? walletFundingMicrogons;
 
   await sudoFundWallet({
     address: walletKeys.vaultingAddress,
-    microgons: walletFundingMicrogons,
+    microgons: fundingMicrogons,
     micronots: 0n,
     archiveUrl,
   });
@@ -125,7 +127,7 @@ export async function createBitcoinLocksHarness(args: {
     const balance = await finalizedClient.query.system
       .account(walletKeys.vaultingAddress)
       .then(x => x.data.free.toBigInt());
-    if (balance < walletFundingMicrogons) return;
+    if (balance < fundingMicrogons) return;
     return balance;
   });
 

--- a/src-vue/components/BgOverlay.vue
+++ b/src-vue/components/BgOverlay.vue
@@ -8,6 +8,7 @@
       @pointermove="handlePointerMove"
       class="absolute bg-black/40 pointer-events-auto"
       :class="[enableTopBar ? 'top-14 bottom-0 inset-x-0' : 'inset-0', enableTopBar ? roundedBottomClass : roundedClass]"
+      data-testid="BgOverlay.close()"
       data-tauri-drag-region
     >
       <div

--- a/src-vue/e2e/commands.ts
+++ b/src-vue/e2e/commands.ts
@@ -760,13 +760,8 @@ async function ensureAppReadyForUi(timeoutMs: number): Promise<void> {
   await waitForAppReady(timeoutMs);
 }
 
-function isVisible(element: HTMLElement): boolean {
+function isRendered(element: HTMLElement): boolean {
   if (!element.isConnected) {
-    return false;
-  }
-
-  const hiddenAncestor = element.closest('[aria-hidden="true"], [inert]');
-  if (hiddenAncestor) {
     return false;
   }
 
@@ -776,6 +771,14 @@ function isVisible(element: HTMLElement): boolean {
   }
   const rect = element.getBoundingClientRect();
   return rect.width > 0 && rect.height > 0;
+}
+
+function isVisible(element: HTMLElement): boolean {
+  if (element.closest('[aria-hidden="true"], [inert]')) {
+    return false;
+  }
+
+  return isRendered(element);
 }
 
 function isEnabled(element: HTMLElement): boolean {
@@ -846,7 +849,7 @@ function isHitWithinElement(element: HTMLElement, hit: Element): boolean {
 }
 
 function getPointerInteractableResult(element: HTMLElement): PointerInteractableResult {
-  if (!isVisible(element)) {
+  if (!isRendered(element) || element.closest('[inert]')) {
     return {
       clickable: false,
       point: null,
@@ -981,7 +984,7 @@ function isStateSatisfied(state: WaitState, element: HTMLElement | null): boolea
     case 'enabled':
       return !!element && isVisible(element) && isEnabled(element);
     case 'clickable':
-      return !!element && isVisible(element) && isEnabled(element) && isPointerInteractable(element);
+      return !!element && isEnabled(element) && getPointerInteractableResult(element).clickable;
     default:
       return false;
   }
@@ -1382,11 +1385,11 @@ async function runCommandInternal(command: string, argsInput: unknown, context: 
     const target = getTarget(args);
     const timeoutMs = getTimeoutMs(args.timeoutMs, 'timeoutMs', DEFAULT_TIMEOUT_MS);
     const startedAt = Date.now();
-    const visibleElement = await waitForState(target, 'visible', timeoutMs, buildProgressEmitter(target, 'visible'));
-    if (!visibleElement) {
+    const existingElement = await waitForState(target, 'exists', timeoutMs, buildProgressEmitter(target, 'exists'));
+    if (!existingElement) {
       throw new CommandError('not_found', `Target ${getTargetLabel(target)} not found`);
     }
-    visibleElement.scrollIntoView({ block: 'center', inline: 'center' });
+    existingElement.scrollIntoView({ block: 'center', inline: 'center' });
     const elapsedMs = Date.now() - startedAt;
     const clickableTimeoutMs = Math.max(150, timeoutMs - elapsedMs);
     const element = await waitForState(

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -643,7 +643,10 @@ export class Config implements IConfig {
         this.hasMiningSeats = true;
       }
       this.miningBotAccountPreviousHistory = miningHistory;
-      this.miningSetupStatus = MiningSetupStatus.Checklist;
+      // Account recovery continues after the initial config load resolves, so onboarding may already be installing.
+      if (this.miningSetupStatus === MiningSetupStatus.None) {
+        this.miningSetupStatus = MiningSetupStatus.Checklist;
+      }
       if (this.serverDetails.ipAddress) {
         this.miningSetupStatus = MiningSetupStatus.Finished;
         this.miningBotAccountPreviousHistory = null;

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -9,6 +9,7 @@ import {
   EthereumClient,
   type IEthereumFinalizeTransferOutOfArgonArgs,
   type IEthereumMoveToken,
+  getEthereumExecutionRpcUrl,
   getEthereumUserErrorMessage,
   loadEthereumChainConfig,
   toEvmRecoverableSignature,
@@ -114,8 +115,12 @@ export class EthereumOutboundTransferTracker {
     private readonly walletKeys: WalletKeys,
     private readonly ethereumClient: IEthereumOutboundTransferClient,
     private readonly mintingAuthorities?: Pick<MintingAuthorities, 'data' | 'refresh' | 'authorize'>,
-    private readonly executionRpcUrl?: string,
+    private readonly configuredExecutionRpcUrl?: string,
   ) {}
+
+  public get executionRpcUrl(): string | undefined {
+    return getEthereumExecutionRpcUrl(this.configuredExecutionRpcUrl);
+  }
 
   public async load(): Promise<void> {
     if (this.#loadPromise) {
@@ -198,7 +203,7 @@ export class EthereumOutboundTransferTracker {
       return;
     }
 
-    const chainConfig = await loadEthereumChainConfig(this.executionRpcUrl);
+    const chainConfig = await loadEthereumChainConfig(this.configuredExecutionRpcUrl);
     if (!chainConfig) {
       throw new Error('Ethereum gateway chain config is not available on this Argon network.');
     }

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -128,6 +128,11 @@ function closeWallet(side: 'left' | 'right') {
   if (!openWallet.value) return;
 
   const nextState = closeWalletOverlaySide(openWallet.value, side);
+  if (!nextState.leftWallet && !nextState.rightWallet) {
+    closeOverlay();
+    return;
+  }
+
   openWallet.value.leftWallet = nextState.leftWallet;
   openWallet.value.rightWallet = nextState.rightWallet;
   void syncActiveEthereumWallet();

--- a/src-vue/wallets/components/ExtraMenu.vue
+++ b/src-vue/wallets/components/ExtraMenu.vue
@@ -4,6 +4,7 @@
     <DropdownMenuRoot :openDelay="0" :closeDelay="0" v-model:open="isOpen">
       <DropdownMenuTrigger
         Trigger
+        :data-testid="walletAddressTestId ? `${walletAddressTestId}.openMenu()` : undefined"
         class="group relative flex  cursor-pointer flex-col items-center justify-center gap-y-[2px] rounded-md text-slate-400 hover:bg-slate-400/10 hover:text-slate-500 focus:outline-none data-[state=open]:bg-slate-400/10 data-[state=open]:text-slate-500"
         :class="[showBorders ? 'h-[34px] w-[34px] border border-slate-400/60' : 'h-[22px] w-[22px]']"
       >
@@ -33,8 +34,9 @@
               </DropdownMenuItem>
               <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
             </template>
-            <DropdownMenuItem MenuItem @click="() => copyEthereumAddress()" >
+            <DropdownMenuItem MenuItem>
               <CopyToClipboard
+                :data-testid="walletAddressTestId"
                 :content="wallet.address"
               >
                 <div ItemWrapper>
@@ -127,6 +129,9 @@ const props = withDefaults(
 const rootRef = Vue.ref<HTMLElement>();
 const isOpen = Vue.ref(false);
 const floatingZIndex = useFloatingZIndex();
+const walletAddressTestId = Vue.computed(() =>
+  props.walletIsOpen && props.walletType === WalletType.defaultArgon ? 'defaultArgonWalletAddress' : undefined,
+);
 
 const showQrCode = Vue.ref(false);
 const qrCode = Vue.ref('');
@@ -165,8 +170,6 @@ function openEthereumPrivateKeyExport() {
 function openWallet(walletType: WalletType) {
   basicEmitter.emit('openWalletOverlay', { walletType: walletType as any });
 }
-
-function copyEthereumAddress() {}
 
 function openProfileOverlay(): void {
   basicEmitter.emit('openProfileOverlay');


### PR DESCRIPTION
## Summary

Argon installation progress now follows the local node's fast-sync status instead of chasing a continuously advancing archive height. Header and block download account for roughly two-thirds of node sync, state download fills the final third, and state import remains below completion until best-block state is readable. An idle, healthy node can then reach 100% even when its best-seen height is stale, while older nodes retain the archive-height fallback.

## Related

Related: #404

## Validation

Validated against a live `v1.4.10` node and router endpoint; all 40 router tests and the router typecheck pass. The mining onboarding flow did not reach installation because the base branch's `Mining.op.completeChecklist` operation did not become runnable.
