### PR TITLE
fix(router): track Argon fast sync progress

### DIFF
--- a/router/__test__/ArgonApis.test.ts
+++ b/router/__test__/ArgonApis.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  callArgonRpc: vi.fn(),
+  readTextFileOrDefault: vi.fn().mockResolvedValue('100'),
+}));
+
+vi.mock('../src/env.ts', () => ({
+  LOCAL_NODE_URL: 'http://argon-miner:9944',
+  LOGS_DIR: '/tmp',
+  MAIN_NODE_URL: 'https://archive.argon.network',
+}));
+
+vi.mock('../src/utils.ts', async importOriginal => ({
+  ...(await importOriginal()),
+  callArgonRpc: mocks.callArgonRpc,
+  readTextFileOrDefault: mocks.readTextFileOrDefault,
+}));
+
+import { ArgonApis } from '../src/ArgonApis.ts';
+
+describe('ArgonApis sync status', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.callArgonRpc.mockReset();
+    mocks.readTextFileOrDefault.mockResolvedValue('100');
+  });
+
+  it('uses state sync progress in the final third of fast sync', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 0,
+        currentBlock: 10,
+        state: 'downloading',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: {
+          percentage: 65,
+          phase: 'downloadingState',
+        },
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 89.6,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+    expect(mocks.callArgonRpc).toHaveBeenCalledWith('http://argon-miner:9944', 'system_syncStatus');
+  });
+
+  it('measures ordinary block sync from the node startup height', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 100,
+        currentBlock: 550,
+        state: 'downloading',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: null,
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 46.6,
+      localNodeBlockNumber: 550,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('hands header progress into state download without moving backward', async () => {
+    mocks.callArgonRpc
+      .mockResolvedValueOnce({
+        result: {
+          startingBlock: 100,
+          currentBlock: 1_000,
+          state: 'downloading',
+          targetBlock: 1_000,
+          bestSeenBlock: 1_000,
+          numPeers: 3,
+          stateSync: null,
+          warpSync: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        result: {
+          startingBlock: 100,
+          currentBlock: 1_000,
+          state: 'downloading',
+          targetBlock: 1_000,
+          bestSeenBlock: 1_000,
+          numPeers: 3,
+          stateSync: {
+            percentage: 0,
+            phase: 'downloadingState',
+          },
+          warpSync: null,
+        },
+      });
+
+    const headersComplete = await ArgonApis.syncStatus();
+    const stateStarted = await ArgonApis.syncStatus();
+
+    expect(headersComplete.syncPercent).toBe(73.3);
+    expect(stateStarted.syncPercent).toBe(headersComplete.syncPercent);
+  });
+
+  it('holds progress at the state import checkpoint until import completes', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 0,
+        currentBlock: 10,
+        state: 'idle',
+        targetBlock: 1_000,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: {
+          percentage: 100,
+          phase: 'importingState',
+        },
+        warpSync: null,
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 99.2,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('finishes idle sync when the best seen block remains ahead', async () => {
+    mocks.callArgonRpc.mockImplementation(async (_url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return {
+          result: {
+            startingBlock: 0,
+            currentBlock: 999,
+            state: 'idle',
+            targetBlock: null,
+            bestSeenBlock: 1_000,
+            numPeers: 3,
+            stateSync: null,
+            warpSync: null,
+          },
+        };
+      }
+
+      if (method === 'state_getRuntimeVersion') {
+        return { result: { specVersion: 1 } };
+      }
+
+      return { result: { isSyncing: false, peers: 3 } };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 100,
+      localNodeBlockNumber: 999,
+      mainNodeBlockNumber: 999,
+    });
+  });
+
+  it('finishes idle sync without peers when the local block has reached the archive', async () => {
+    mocks.callArgonRpc.mockImplementation(async (url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return {
+          result: {
+            startingBlock: 0,
+            currentBlock: 1_000,
+            state: 'idle',
+            targetBlock: null,
+            bestSeenBlock: null,
+            numPeers: 0,
+            stateSync: null,
+            warpSync: null,
+          },
+        };
+      }
+
+      if (method === 'chain_getHeader') {
+        expect(url).toBe('https://archive.argon.network');
+        return { result: { number: '0x3e8' } };
+      }
+
+      if (method === 'state_getRuntimeVersion') {
+        return { result: { specVersion: 1 } };
+      }
+
+      return { result: { isSyncing: false, peers: 0 } };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 100,
+      localNodeBlockNumber: 1_000,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('keeps syncing an idle node without peers when the archive is ahead', async () => {
+    mocks.callArgonRpc.mockImplementation(async (_url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return {
+          result: {
+            startingBlock: 0,
+            currentBlock: 500,
+            state: 'idle',
+            targetBlock: null,
+            bestSeenBlock: null,
+            numPeers: 0,
+            stateSync: null,
+            warpSync: null,
+          },
+        };
+      }
+
+      return { result: { number: '0x3e8' } };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 46.6,
+      localNodeBlockNumber: 500,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('does not report warp proof download as completed block sync', async () => {
+    mocks.callArgonRpc.mockResolvedValue({
+      result: {
+        startingBlock: 10,
+        currentBlock: 10,
+        state: 'idle',
+        targetBlock: null,
+        bestSeenBlock: 1_000,
+        numPeers: 3,
+        stateSync: null,
+        warpSync: {
+          phase: 'downloadingWarpProofs',
+        },
+      },
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 20,
+      localNodeBlockNumber: 10,
+      mainNodeBlockNumber: 1_000,
+    });
+  });
+
+  it('falls back to archive height progress for nodes without the sync status rpc', async () => {
+    mocks.callArgonRpc.mockImplementation(async (url: string, method: string) => {
+      if (method === 'system_syncStatus') {
+        return { error: { code: -32601, message: 'Method not found' } };
+      }
+
+      return {
+        result: {
+          number: url === 'http://argon-miner:9944' ? '0x32' : '0x64',
+        },
+      };
+    });
+
+    await expect(ArgonApis.syncStatus()).resolves.toEqual({
+      syncPercent: 60,
+      localNodeBlockNumber: 50,
+      mainNodeBlockNumber: 100,
+    });
+  });
+});

--- a/router/src/ArgonApis.ts
+++ b/router/src/ArgonApis.ts
@@ -2,6 +2,28 @@ import type { IBlockNumbers } from './interfaces/IBlockNumbers';
 import { LOCAL_NODE_URL, LOGS_DIR, MAIN_NODE_URL } from './env';
 import { callArgonRpc, getRoundedPercent, readTextFileOrDefault } from './utils';
 
+// Returned by the custom system_syncStatus RPC in mainchain/node/src/rpc.rs.
+interface IArgonNodeSyncStatus {
+  startingBlock: number;
+  currentBlock: number;
+  state: 'idle' | 'downloading' | 'importing';
+  targetBlock?: number | null;
+  bestSeenBlock?: number | null;
+  numPeers: number;
+  stateSync?: {
+    percentage: number;
+    phase: 'downloadingState' | 'importingState';
+  } | null;
+  warpSync?: {
+    phase: string;
+  } | null;
+}
+
+// Fast sync spends roughly two-thirds of its time downloading headers and one-third syncing state.
+const HEADER_SYNC_PERCENT = (2 / 3) * 100;
+const STATE_DOWNLOAD_COMPLETE_PERCENT = 98;
+const STATE_IMPORT_PERCENT = 99;
+
 let cache: null | {
   latestBlocks: IBlockNumbers;
   timestamp: number;
@@ -58,18 +80,65 @@ export class ArgonApis {
   }
 
   public static async syncStatus(): Promise<{ syncPercent: number } & IBlockNumbers> {
-    let dockerPercent = await this.dockerPercentComplete().catch(() => 0);
-    const { localNodeBlockNumber, mainNodeBlockNumber } = await this.latestBlocks().catch(() => ({
-      localNodeBlockNumber: 0,
-      mainNodeBlockNumber: 0,
-    }));
-    // if we have any blocks, docker is definitely done
-    if (localNodeBlockNumber > 0) {
-      dockerPercent = 100;
+    const response = LOCAL_NODE_URL
+      ? await callArgonRpc<IArgonNodeSyncStatus>(LOCAL_NODE_URL, 'system_syncStatus').catch(() => null)
+      : null;
+    const nodeSyncStatus = response?.result;
+
+    let localNodeBlockNumber = nodeSyncStatus?.currentBlock ?? 0;
+    let mainNodeBlockNumber = nodeSyncStatus?.currentBlock ?? 0;
+    const hasActiveStateSync = Boolean(nodeSyncStatus?.stateSync);
+    const hasActiveWarpSync = Boolean(nodeSyncStatus?.warpSync && nodeSyncStatus.warpSync.phase !== 'complete');
+    if (nodeSyncStatus && (nodeSyncStatus.state !== 'idle' || hasActiveStateSync || hasActiveWarpSync)) {
+      mainNodeBlockNumber = nodeSyncStatus.targetBlock ?? nodeSyncStatus.bestSeenBlock ?? localNodeBlockNumber;
+    }
+    let nodeSyncPercent = 0;
+
+    if (nodeSyncStatus) {
+      const stateSync = nodeSyncStatus.stateSync;
+      const warpPhase = nodeSyncStatus.warpSync?.phase;
+
+      if (stateSync?.phase === 'downloadingState') {
+        const stateDownloadPercent = Math.min(Math.max(stateSync.percentage, 0), 100);
+        const stateDownloadSpan = STATE_DOWNLOAD_COMPLETE_PERCENT - HEADER_SYNC_PERCENT;
+        nodeSyncPercent = HEADER_SYNC_PERCENT + (stateDownloadPercent / 100) * stateDownloadSpan;
+      } else if (stateSync?.phase === 'importingState' || warpPhase === 'importingState') {
+        nodeSyncPercent = STATE_IMPORT_PERCENT;
+      } else if (warpPhase === 'complete') {
+        nodeSyncPercent = 100;
+      } else if (warpPhase === 'downloadingState') {
+        nodeSyncPercent = HEADER_SYNC_PERCENT;
+      } else if (!warpPhase || warpPhase === 'downloadingBlocks') {
+        const isIdleWithBlocks = localNodeBlockNumber > 0 && nodeSyncStatus.state === 'idle';
+        let idleNodeCanComplete = isIdleWithBlocks && nodeSyncStatus.numPeers > 0;
+        if (isIdleWithBlocks && !idleNodeCanComplete && MAIN_NODE_URL) {
+          mainNodeBlockNumber = await this.getBlockNumber(MAIN_NODE_URL).catch(() => 0);
+          idleNodeCanComplete = mainNodeBlockNumber > 0 && localNodeBlockNumber >= mainNodeBlockNumber;
+        }
+
+        const blocksToSync = mainNodeBlockNumber - nodeSyncStatus.startingBlock;
+        const blocksSynced = Math.max(localNodeBlockNumber - nodeSyncStatus.startingBlock, 0);
+
+        if (idleNodeCanComplete) {
+          nodeSyncPercent = 100;
+        } else if (blocksToSync > 0) {
+          const headerDownloadRatio = Math.min(blocksSynced / blocksToSync, 1);
+          nodeSyncPercent = headerDownloadRatio * HEADER_SYNC_PERCENT;
+        }
+      }
+    } else {
+      const latestBlocks = await this.latestBlocks().catch(() => ({
+        localNodeBlockNumber: 0,
+        mainNodeBlockNumber: 0,
+      }));
+      localNodeBlockNumber = latestBlocks.localNodeBlockNumber;
+      mainNodeBlockNumber = latestBlocks.mainNodeBlockNumber;
+      nodeSyncPercent = mainNodeBlockNumber ? getRoundedPercent(localNodeBlockNumber / mainNodeBlockNumber) : 0;
     }
 
-    const blockSyncPercent = mainNodeBlockNumber ? getRoundedPercent(localNodeBlockNumber / mainNodeBlockNumber) : 0;
-    let syncPercent = getRoundedPercent((dockerPercent * 0.2 + blockSyncPercent * 0.8) / 100, 1);
+    const dockerPercent = localNodeBlockNumber > 0 ? 100 : await this.dockerPercentComplete().catch(() => 0);
+
+    let syncPercent = getRoundedPercent((dockerPercent * 0.2 + nodeSyncPercent * 0.8) / 100, 1);
     // if we're not all the way synced, don't report 100%
     if (syncPercent >= 100) {
       if (localNodeBlockNumber < mainNodeBlockNumber) {
@@ -83,7 +152,6 @@ export class ArgonApis {
   }
 
   public static async getBlockNumber(url: string): Promise<number> {
-    url = url.replace('ws://', 'http://').replace('wss://', 'https://');
     const header = await callArgonRpc<{ number: string }>(url, 'chain_getHeader');
     // header.number is hex string, convert to number
     if (header.result?.number) {

--- a/router/src/utils.ts
+++ b/router/src/utils.ts
@@ -105,6 +105,9 @@ export async function callArgonRpc<T = unknown>(
   params: any[] = [],
 ): Promise<IJsonRpcResponse<T>> {
   const rpcUrl = new URL(url);
+  if (rpcUrl.protocol === 'ws:') rpcUrl.protocol = 'http:';
+  if (rpcUrl.protocol === 'wss:') rpcUrl.protocol = 'https:';
+
   const body = JSON.stringify({
     jsonrpc: '2.0',
     id: requestId++,


### PR DESCRIPTION
## Summary

Argon installation progress now follows the local node's fast-sync status instead of chasing a continuously advancing archive height. Header and block download account for roughly two-thirds of node sync, state download fills the final third, and state import remains below completion until best-block state is readable. An idle, healthy node can then reach 100% even when its best-seen height is stale, while older nodes retain the archive-height fallback.

## Validation

Validated against a live `v1.4.10` node and router endpoint; all 40 router tests and the router typecheck pass on the `desktop-app` base.
