### PR TITLE
fix(e2e): stabilize Ethereum transfer startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,18 @@ jobs:
           node-version: '24'
           cache: 'yarn'
 
-      - name: Configure CI temp paths
+      - name: Configure CI paths
         shell: bash
         run: |
           echo "CI_TEMP_DIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
           echo "E2E_SCREENSHOT_DIR=$RUNNER_TEMP/e2e-screenshots" >> "$GITHUB_ENV"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo mkdir -p /mnt/target
+            sudo chown -R "$USER:$USER" /mnt/target
+            sudo rm -rf src-tauri/target
+            sudo ln -s /mnt/target src-tauri/target
+            echo "CARGO_TARGET_DIR=/mnt/target" >> "$GITHUB_ENV"
+          fi
 
       - name: Install system dependencies
         if: matrix.platform == 'ubuntu-latest'

--- a/e2e/__test__/devEthereumRuntimeState.e2e.test.ts
+++ b/e2e/__test__/devEthereumRuntimeState.e2e.test.ts
@@ -1,0 +1,110 @@
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  files: new Map<string, string>(),
+}));
+const runtimeState = {
+  beaconPreset: 'minimal',
+  enclaveName: 'argon-eth-test',
+  executionRpcUrl: 'http://127.0.0.1:32003',
+  beaconApiUrl: 'http://127.0.0.1:33001',
+  chainId: '0x301824',
+  serverExecutionRpcUrl: 'http://host.docker.internal:32003/',
+  serverBeaconApiUrl: 'http://host.docker.internal:33001/',
+  usdcTokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+  setupStatus: 'starting',
+} as const;
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    mkdir: vi.fn(async () => undefined),
+    readFile: vi.fn(async (filePath: string) => {
+      const contents = fsState.files.get(String(filePath));
+      if (contents !== undefined) {
+        return contents;
+      }
+
+      const error = new Error(`Missing file: ${String(filePath)}`) as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      throw error;
+    }),
+    rename: vi.fn(async (sourcePath: string, destinationPath: string) => {
+      const contents = fsState.files.get(String(sourcePath));
+      if (contents === undefined) {
+        throw new Error(`Missing temporary file: ${String(sourcePath)}`);
+      }
+
+      fsState.files.set(String(destinationPath), contents);
+      fsState.files.delete(String(sourcePath));
+    }),
+    rm: vi.fn(async (filePath: string) => {
+      fsState.files.delete(String(filePath));
+    }),
+    writeFile: vi.fn(async (filePath: string, contents: string) => {
+      fsState.files.set(String(filePath), String(contents));
+    }),
+  },
+}));
+
+import {
+  readDevEthereumRuntimeState,
+  updateDevEthereumRuntimeState,
+  writeDevEthereumRuntimeState,
+} from '../devEthereum.ts';
+
+describe('dev Ethereum runtime state', () => {
+  const previousRuntimeStateDir = process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR;
+
+  beforeEach(() => {
+    fsState.files.clear();
+  });
+
+  afterEach(() => {
+    if (previousRuntimeStateDir === undefined) {
+      delete process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR;
+    } else {
+      process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = previousRuntimeStateDir;
+    }
+  });
+
+  it('preserves concurrent setup and minting authority updates', async () => {
+    const { executionRpcUrl } = runtimeState;
+    await writeDevEthereumRuntimeState(runtimeState);
+
+    await Promise.all([
+      updateDevEthereumRuntimeState(executionRpcUrl, { setupStatus: 'ready' }),
+      updateDevEthereumRuntimeState(executionRpcUrl, { mintingAuthorityStatus: 'ready' }),
+    ]);
+
+    expect(await readDevEthereumRuntimeState(executionRpcUrl)).toMatchObject({
+      executionRpcUrl,
+      setupStatus: 'ready',
+      mintingAuthorityStatus: 'ready',
+    });
+    expect([...fsState.files.keys()].filter(filePath => filePath.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('stores state in the isolated test directory when configured', async () => {
+    const runtimeStateDir = path.resolve('/isolated/session/test-data/dev-ethereum');
+    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = runtimeStateDir;
+
+    await writeDevEthereumRuntimeState(runtimeState);
+
+    expect([...fsState.files.keys()]).toHaveLength(2);
+    expect([...fsState.files.keys()].every(filePath => filePath.startsWith(`${runtimeStateDir}${path.sep}`))).toBe(
+      true,
+    );
+  });
+
+  it('reads from the flow session directory instead of ambient process state', async () => {
+    const runtimeStateDir = path.resolve('/isolated/session/test-data/dev-ethereum');
+    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = path.resolve('/different/session/dev-ethereum');
+    const scopedStatePath = path.join(runtimeStateDir, 'http_127.0.0.1_32003.json');
+    fsState.files.set(scopedStatePath, JSON.stringify(runtimeState));
+
+    expect(await readDevEthereumRuntimeState(runtimeState.executionRpcUrl, runtimeStateDir)).toMatchObject(
+      runtimeState,
+    );
+  });
+});

--- a/e2e/argon/upstream-server.docker-compose.yml
+++ b/e2e/argon/upstream-server.docker-compose.yml
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
     command: >
       --eve
-      --compute-miners=1
+      --compute-miners=0
       --port=30337
       --unsafe-force-node-key-generation
       --base-path=/data
@@ -37,8 +37,9 @@ services:
       --detailed-log-output
       --experimental-rpc-endpoint=listen-addr=0.0.0.0:9944,methods=unsafe
       --experimental-rpc-endpoint=listen-addr=0.0.0.0:9945,methods=safe,cors=all,rate-limit-trust-proxy-headers=true,max-connections=${ARGON_SAFE_RPC_MAX_CONNECTIONS:-200}
+      --sync=fast
       --validator
-      --pruning=archive
+      --state-pruning=256
     environment:
       RUST_LOG: info,argon=info,pallet=trace
     healthcheck:
@@ -65,7 +66,7 @@ services:
       context: ../../server/router
       dockerfile: Dockerfile
     depends_on:
-      archive-node:
+      archive-rpc:
         condition: service_healthy
       bitcoin:
         condition: service_healthy
@@ -77,7 +78,7 @@ services:
       - PORT=8080
       - ARGON_CHAIN=dev-docker
       - ARGON_LOCAL_NODE=ws://upstream-miner:9944
-      - ARGON_ARCHIVE_NODE=ws://archive-node:9944
+      - ARGON_ARCHIVE_NODE=ws://archive-rpc:9944
       - BOT_INTERNAL_URL=http://upstream-bot:8080
       - BITCOIN_RPC_URL=http://bitcoin:bitcoin@bitcoin:18443
       - BITCOIN_CHAIN=regtest
@@ -104,7 +105,7 @@ services:
       context: ../../server/bot
       dockerfile: Dockerfile
     depends_on:
-      archive-node:
+      archive-rpc:
         condition: service_healthy
       upstream-miner:
         condition: service_healthy
@@ -117,7 +118,7 @@ services:
       - ARGON_CHAIN=dev-docker
       - DATADIR=/data
       - ROUTER_URL=http://upstream-router:8080
-      - ARCHIVE_NODE_URL=ws://archive-node:9944
+      - ARCHIVE_NODE_URL=ws://archive-rpc:9944
       - LOCAL_RPC_URL=ws://upstream-miner:9944
       - BIDDING_RULES_PATH=/config/biddingRules.json
       - BIDDER_KEYPAIR_PATH=/config/walletMiningBot.json
@@ -135,7 +136,7 @@ services:
       interval: 5s
       timeout: 3s
       start_period: 20s
-      retries: 20
+      retries: 40
 
   upstream-nginx:
     <<: *upstream-server

--- a/e2e/devEthereum.ts
+++ b/e2e/devEthereum.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -47,6 +48,7 @@ const MINIMUM_BOOTSTRAP_FINALIZED_SLOT_BY_PRESET: Record<DevEthereumBeaconPreset
 };
 const DEV_ETHEREUM_LAUNCH_MAX_ATTEMPTS = 3;
 const DEV_ETHEREUM_LAUNCH_RETRY_DELAY_MS = 1_000;
+let runtimeStateOperation = Promise.resolve();
 export type DevEthereumBeaconPreset = 'mainnet' | 'minimal';
 
 export interface IDevEthereumConfig {
@@ -277,9 +279,10 @@ export async function sendDevEthereumAdminTransaction(args: {
 
 export async function readDevEthereumRuntimeState(
   executionRpcUrl?: string,
+  runtimeStateDir?: string,
 ): Promise<IDevEthereumRuntimeState | undefined> {
   try {
-    const raw = await fs.readFile(getDevEthereumRuntimeStatePath(executionRpcUrl), 'utf8');
+    const raw = await fs.readFile(getDevEthereumRuntimeStatePath(executionRpcUrl, runtimeStateDir), 'utf8');
     return JSON.parse(raw) as IDevEthereumRuntimeState;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -455,7 +458,28 @@ function createDevEthereumChain(chainId: number, rpcUrl: string) {
   });
 }
 
-export async function writeDevEthereumRuntimeState(state: Omit<IDevEthereumRuntimeState, 'updatedAt'>): Promise<void> {
+export function writeDevEthereumRuntimeState(state: Omit<IDevEthereumRuntimeState, 'updatedAt'>): Promise<void> {
+  return queueDevEthereumRuntimeStateOperation(() => writeDevEthereumRuntimeStateNow(state));
+}
+
+export function updateDevEthereumRuntimeState(
+  executionRpcUrl: string,
+  updates: Partial<Pick<IDevEthereumRuntimeState, 'setupStatus' | 'mintingAuthorityStatus'>>,
+): Promise<void> {
+  return queueDevEthereumRuntimeStateOperation(async () => {
+    const runtimeState = await readDevEthereumRuntimeState(executionRpcUrl);
+    if (!runtimeState || runtimeState.executionRpcUrl !== executionRpcUrl) {
+      return;
+    }
+
+    await writeDevEthereumRuntimeStateNow({
+      ...runtimeState,
+      ...updates,
+    });
+  });
+}
+
+async function writeDevEthereumRuntimeStateNow(state: Omit<IDevEthereumRuntimeState, 'updatedAt'>): Promise<void> {
   const runtimeState = {
     ...state,
     updatedAt: new Date().toISOString(),
@@ -469,12 +493,43 @@ export async function writeDevEthereumRuntimeState(state: Omit<IDevEthereumRunti
     fs.mkdir(path.dirname(scopedStatePath), { recursive: true }),
   ]);
   await Promise.all([
-    fs.writeFile(latestStatePath, serialized, 'utf8'),
-    fs.writeFile(scopedStatePath, serialized, 'utf8'),
+    writeFileAtomically(latestStatePath, serialized),
+    writeFileAtomically(scopedStatePath, serialized),
   ]);
 }
 
-function getDevEthereumRuntimeStatePath(executionRpcUrl?: string): string {
+async function queueDevEthereumRuntimeStateOperation<T>(operation: () => Promise<T>): Promise<T> {
+  const result = runtimeStateOperation.then(operation);
+  runtimeStateOperation = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function writeFileAtomically(filePath: string, contents: string): Promise<void> {
+  const temporaryPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    await fs.writeFile(temporaryPath, contents, 'utf8');
+    await fs.rename(temporaryPath, filePath);
+  } finally {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
+}
+
+function getDevEthereumRuntimeStatePath(executionRpcUrl?: string, runtimeStateDir?: string): string {
+  const configuredStateDir = runtimeStateDir?.trim() || process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR?.trim();
+  if (configuredStateDir) {
+    const stateDir = path.resolve(configuredStateDir);
+    if (!executionRpcUrl) {
+      return path.join(stateDir, 'latest.json');
+    }
+
+    const safeExecutionRpcUrl = executionRpcUrl.replace(/[^a-zA-Z0-9_.-]+/g, '_');
+    return path.join(stateDir, `${safeExecutionRpcUrl}.json`);
+  }
+
   if (!executionRpcUrl) {
     return path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'artifacts', 'dev-ethereum.json');
   }

--- a/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
@@ -88,16 +88,18 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
       throw new Error(`${context.flowName}: missing Ethereum execution RPC URL.`);
     }
     const { ethereumAddress, executionRpcUrl } = ethereumConnection;
+    const runtimeStateDir = flow.getData<string>('devEthereumRuntimeStateDir');
     console.info(`[E2E] ${context.flowName} prepared Ethereum destination`, {
       ethereumAddress,
       executionRpcUrl,
+      runtimeStateDir,
     });
 
     await waitFor(
       DEV_ETHEREUM_BACKEND_MINTING_AUTHORITY_READY_TIMEOUT_MS,
       `${context.flowName}: backend minting authority readiness`,
       async () => {
-        const runtimeState = await readDevEthereumRuntimeState(executionRpcUrl);
+        const runtimeState = await readDevEthereumRuntimeState(executionRpcUrl, runtimeStateDir);
         if (runtimeState?.executionRpcUrl !== executionRpcUrl) {
           return;
         }
@@ -120,6 +122,7 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
     });
 
     await clickIfVisible(flow, 'WalletFundingReceivedOverlay.closeOverlay()', { timeoutMs: 5_000 });
+    await clickIfVisible(flow, 'BgOverlay.close()', { timeoutMs: 5_000 });
 
     if (!(await flow.isVisible('VaultingScreen')).visible) {
       await flow.run(vaultingActivateTab);

--- a/e2e/flows/session.ts
+++ b/e2e/flows/session.ts
@@ -68,6 +68,8 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
   let closed = false;
   const previousComposeProjectName = process.env.COMPOSE_PROJECT_NAME;
   const previousNetworkConfigOverride = process.env.ARGON_NETWORK_CONFIG_OVERRIDE;
+  const previousDevEthereumRuntimeStateDir = process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR;
+  const previousDevUpstreamRootDir = process.env.ARGON_DEV_UPSTREAM_ROOT_DIR;
   const sessionData: Record<string, unknown> = {};
 
   const defaultSessionName = options.sessionName || 'e2e';
@@ -83,18 +85,32 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
     fallbackSessionName: defaultSessionName,
     appPort,
   });
-  const cleanupEnv: NodeJS.ProcessEnv = { ...commandEnv };
+  const isolatedDataEnv: NodeJS.ProcessEnv = {};
+  if (sessionMode === 'isolated') {
+    const testDataDir = Path.join(
+      getAppInstanceDirectory(appConfigId, sessionIdentity.composeNetwork, appInstanceName),
+      'test-data',
+    );
+    const devEthereumRuntimeStateDir = Path.join(testDataDir, 'dev-ethereum');
+    isolatedDataEnv.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = devEthereumRuntimeStateDir;
+    isolatedDataEnv.ARGON_DEV_UPSTREAM_ROOT_DIR = Path.join(testDataDir, 'dev-upstream');
+    sessionData.devEthereumRuntimeStateDir = devEthereumRuntimeStateDir;
+  }
+  const cleanupEnv: NodeJS.ProcessEnv = { ...commandEnv, ...isolatedDataEnv };
   const tauriEnv: NodeJS.ProcessEnv = {
     ...commandEnv,
     ARGON_DRIVER_WS: driverServer.url,
     ARGON_E2E_HEADLESS: process.env.ARGON_E2E_HEADLESS?.trim() || '0',
     E2E_USE_TEST_NETWORK: useTestNetwork ? '1' : '0',
     ARGON_APP_ENABLE_AUTOUPDATE: '0',
+    ARGON_DEV_ETHEREUM: '0',
     ...options.appEnv,
+    ...isolatedDataEnv,
   };
 
   // Keep helper commands (btc-cli, funding RPC) pointed at the same compose project as this session.
   process.env.COMPOSE_PROJECT_NAME = composeProjectName;
+  Object.assign(process.env, isolatedDataEnv);
 
   try {
     if (useTestNetwork) {
@@ -114,6 +130,7 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
       process.env.ARGON_NETWORK_CONFIG_OVERRIDE = tauriEnv.ARGON_NETWORK_CONFIG_OVERRIDE;
       const composeEnv = testNetwork.composeEnv;
       tauriEnv.JOIN_COMPOSE_NETWORK = composeEnv.COMPOSE_PROJECT_NAME;
+      tauriEnv.RPC_PORT = composeEnv.RPC_PORT;
 
       devDockerProcess = spawn('yarn', ['tauri:dev:docker'], createAppSpawnOptions(repoRoot, tauriEnv, appLogsMode));
     } else {
@@ -135,6 +152,8 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
     }
     restoreComposeProjectName(previousComposeProjectName);
     restoreNetworkConfigOverride(previousNetworkConfigOverride);
+    restoreProcessEnv('ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR', previousDevEthereumRuntimeStateDir);
+    restoreProcessEnv('ARGON_DEV_UPSTREAM_ROOT_DIR', previousDevUpstreamRootDir);
     closeAppProcessOutputTracker(appProcessOutput);
     throw error;
   }
@@ -210,6 +229,8 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
     await driverServer.close();
     restoreComposeProjectName(previousComposeProjectName);
     restoreNetworkConfigOverride(previousNetworkConfigOverride);
+    restoreProcessEnv('ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR', previousDevEthereumRuntimeStateDir);
+    restoreProcessEnv('ARGON_DEV_UPSTREAM_ROOT_DIR', previousDevUpstreamRootDir);
     closeAppProcessOutputTracker(appProcessOutput);
     throw error;
   }
@@ -261,6 +282,8 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
       } finally {
         restoreComposeProjectName(previousComposeProjectName);
         restoreNetworkConfigOverride(previousNetworkConfigOverride);
+        restoreProcessEnv('ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR', previousDevEthereumRuntimeStateDir);
+        restoreProcessEnv('ARGON_DEV_UPSTREAM_ROOT_DIR', previousDevUpstreamRootDir);
         closeAppProcessOutputTracker(appProcessOutput);
       }
     },
@@ -282,13 +305,15 @@ function resolveLocalAppConfigId(): string {
 }
 
 function getServerLogDirectory(appConfigId: string, networkName: string, instanceName: string): string {
-  const appConfigBaseDir = getAppConfigBaseDir();
-  return Path.join(appConfigBaseDir, appConfigId, networkName, instanceName, 'virtual-machine', 'app', 'logs');
+  return Path.join(getServerAppDirectory(appConfigId, networkName, instanceName), 'logs');
 }
 
 function getServerAppDirectory(appConfigId: string, networkName: string, instanceName: string): string {
-  const appConfigBaseDir = getAppConfigBaseDir();
-  return Path.join(appConfigBaseDir, appConfigId, networkName, instanceName, 'virtual-machine', 'app');
+  return Path.join(getAppInstanceDirectory(appConfigId, networkName, instanceName), 'virtual-machine', 'app');
+}
+
+function getAppInstanceDirectory(appConfigId: string, networkName: string, instanceName: string): string {
+  return Path.join(getAppConfigBaseDir(), appConfigId, networkName, instanceName);
 }
 
 function tailText(text: string, lineLimit: number): string {
@@ -948,6 +973,14 @@ function restoreNetworkConfigOverride(previousValue: string | undefined): void {
     return;
   }
   process.env.ARGON_NETWORK_CONFIG_OVERRIDE = previousValue;
+}
+
+function restoreProcessEnv(name: string, previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = previousValue;
 }
 
 function runCleanDevDocker(repoRoot: string, env: NodeJS.ProcessEnv, reason: string): void {

--- a/e2e/helpers/startDevEthereumMintingAuthority.ts
+++ b/e2e/helpers/startDevEthereumMintingAuthority.ts
@@ -5,7 +5,7 @@ import { MICROGONS_PER_ARGON } from '@argonprotocol/mainchain';
 import { createPublicClient, getAddress, http } from 'viem';
 import { sudoSubmitAndFinalize } from '../../core/__test__/helpers/mainchain.ts';
 import { AppVaultOperator, type IEthereumMintingAuthorityStatus } from '../actors/AppVaultOperator.ts';
-import { readDevEthereumRuntimeState, resolveDevEthereumRpcUrl, writeDevEthereumRuntimeState } from '../devEthereum.ts';
+import { resolveDevEthereumRpcUrl, updateDevEthereumRuntimeState } from '../devEthereum.ts';
 import {
   collectVaultOperatorsByEffectiveCouncilSigner,
   forceUpdateGlobalIssuanceCouncil,
@@ -332,13 +332,7 @@ async function updateMintingAuthorityRuntimeState(
   executionRpcUrl: string,
   mintingAuthorityStatus: 'starting' | 'ready',
 ): Promise<void> {
-  const runtimeState = await readDevEthereumRuntimeState(executionRpcUrl);
-  if (!runtimeState || runtimeState.executionRpcUrl !== executionRpcUrl) {
-    return;
-  }
-
-  await writeDevEthereumRuntimeState({
-    ...runtimeState,
+  await updateDevEthereumRuntimeState(executionRpcUrl, {
     mintingAuthorityStatus,
   });
 }

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -1,11 +1,11 @@
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import Fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { config as loadDotEnv } from 'dotenv';
-import { parseEnv } from 'node:util';
+import { parseEnv, promisify } from 'node:util';
 import {
   MainchainClients,
   minimumVaultDelegateBalance,
@@ -21,6 +21,7 @@ import { MemoryWalletKeys } from 'src-vue/lib/MemoryWalletKeys.ts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const defaultUpstreamRootDir = path.resolve(__dirname, '..', 'dev-upstream');
+const execFileAsync = promisify(execFile);
 
 export const DEV_UPSTREAM_MASTER_MNEMONIC = 'test test test test test test test test test test test junk';
 export const DEV_UPSTREAM_SUBSTRATE_SURI = '//DevUpstreamOperator';
@@ -174,13 +175,17 @@ export async function startDevUpstreamServer(args: {
   await Fs.writeFile(envStatePath, envLines.join('\n') + '\n');
   await ensureDevGatewayCerts();
 
-  execFileSync('docker', [...getComposeArgs(context), 'build', 'upstream-router', 'upstream-bot', 'upstream-nginx'], {
-    cwd: context.composeDir,
-    encoding: 'utf8',
-    env: context.composeEnv,
-  });
+  await execFileAsync(
+    'docker',
+    [...getComposeArgs(context), 'build', 'upstream-router', 'upstream-bot', 'upstream-nginx'],
+    {
+      cwd: context.composeDir,
+      encoding: 'utf8',
+      env: context.composeEnv,
+    },
+  );
 
-  execFileSync(
+  await execFileAsync(
     'docker',
     [
       ...getComposeArgs(context),

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -12,7 +12,7 @@ import {
   readDevEthereumRuntimeState,
   resolveDevEthereumRpcUrl,
   startDevEthereum,
-  writeDevEthereumRuntimeState,
+  updateDevEthereumRuntimeState,
 } from '../e2e/devEthereum.ts';
 import {
   startDevEthereumMintingAuthority,
@@ -81,9 +81,9 @@ async function main(): Promise<void> {
         })()
       : undefined;
     if (composePorts) {
-      devDockerArchiveUrl = `ws://127.0.0.1:${composePorts.archivePort}`;
+      devDockerArchiveUrl = `ws://127.0.0.1:${composePorts.archiveRpcPort}`;
       console.log(
-        `[tauri-dev] Resolved compose ports archive=${composePorts.archivePort} archiveP2p=${composePorts.archiveP2pPort} bitcoinP2p=${composePorts.bitcoinP2pPort} esplora=${composePorts.esploraPort}${composePorts.indexerPort ? ` indexer=${composePorts.indexerPort}` : ''} notary=${composePorts.notaryAliasContainerId}`,
+        `[tauri-dev] Resolved compose ports archiveNode=${composePorts.archivePort} archiveRpc=${composePorts.archiveRpcPort} archiveP2p=${composePorts.archiveP2pPort} bitcoinP2p=${composePorts.bitcoinP2pPort} esplora=${composePorts.esploraPort}${composePorts.indexerPort ? ` indexer=${composePorts.indexerPort}` : ''} notary=${composePorts.notaryAliasContainerId}`,
       );
       Object.assign(tauriEnv, getDevDockerServerEnvVars(composePorts));
       if (startedDevEthereum && devEthereumConfig) {
@@ -139,7 +139,7 @@ async function main(): Promise<void> {
   let devEthereumReadyPromise: Promise<void> | undefined;
   let devUpstreamPromise: Promise<void> | undefined;
   let devUpstreamRuntime: IDevUpstreamServerRuntime | undefined;
-  if (devDockerArchiveUrl) {
+  if (devDockerArchiveUrl && (!isE2EAppRun || devEthereumConfig)) {
     devUpstreamPromise = startDevUpstreamServer({
       archiveUrl: devDockerArchiveUrl,
       devEthereum: startedDevEthereum,
@@ -186,8 +186,7 @@ async function main(): Promise<void> {
 
         console.log('[tauri-dev][ethereum-ready] upstream Ethereum relay is ready');
 
-        await writeDevEthereumRuntimeState({
-          ...startedDevEthereum,
+        await updateDevEthereumRuntimeState(startedDevEthereum.executionRpcUrl, {
           setupStatus: 'ready',
         });
       })
@@ -250,10 +249,10 @@ async function main(): Promise<void> {
 
   if (shouldStartDevEthereumMintingAuthority) {
     devEthereumMintingAuthorityPromise = (async () => {
-      if (devEthereumRuntimeSetupPromise) {
-        await devEthereumRuntimeSetupPromise;
+      if (!devEthereumRuntimeSetupPromise || !devUpstreamPromise) {
+        throw new Error('Dev Ethereum or upstream setup did not start before the minting authority.');
       }
-      await devUpstreamPromise;
+      await Promise.all([devEthereumRuntimeSetupPromise, devUpstreamPromise]);
       if (!devUpstreamRuntime) {
         throw new Error('Upstream operator did not finish startup before the minting authority.');
       }
@@ -418,7 +417,7 @@ async function resolveDevDockerComposePorts(): Promise<DevDockerComposePorts | n
 
 function getDevDockerServerEnvVars(ports: DevDockerComposePorts): NodeJS.ProcessEnv {
   return {
-    ARGON_ARCHIVE_NODE: `ws://host.docker.internal:${ports.archivePort}`,
+    ARGON_ARCHIVE_NODE: `ws://host.docker.internal:${ports.archiveRpcPort}`,
     ARGON_BOOTNODES: `--bootnodes=/dns/host.docker.internal/tcp/${ports.archiveP2pPort}/p2p/12D3KooWMdmKGEuFPVvwSd92jCQJgX9aFCp45E8vV2X284HQjwnn`,
     BITCOIN_ADDNODE: `host.docker.internal:${ports.bitcoinP2pPort}`,
     NOTEBOOK_ARCHIVE_HOSTS: ports.notaryArchiveHost,
@@ -458,12 +457,11 @@ async function resolveDevDockerNetworkConfigOverride(
   ethereumExecutionRpcUrl?: string,
   usdcTokenAddress?: string,
 ): Promise<RuntimeNetworkConfigOverride | null> {
-  const archiveUrl = `ws://127.0.0.1:${ports.archivePort}`;
   const archiveRpcUrl = `ws://127.0.0.1:${ports.archiveRpcPort}`;
   let runtimeConfig: RuntimeChainConfig;
   try {
-    console.log(`[tauri-dev] Loading runtime chain config from ${archiveUrl}`);
-    runtimeConfig = await loadRuntimeConfig(archiveUrl);
+    console.log(`[tauri-dev] Loading runtime chain config from ${archiveRpcUrl}`);
+    runtimeConfig = await loadRuntimeConfig(archiveRpcUrl);
   } catch (error) {
     console.warn(`[tauri-dev] Failed to load runtime chain config: ${(error as Error).message}`);
     return null;

--- a/src-vue/__test__/MiningAccount.test.ts
+++ b/src-vue/__test__/MiningAccount.test.ts
@@ -1,0 +1,70 @@
+import { Keyring } from '@argonprotocol/mainchain';
+import { expect, it, vi } from 'vitest';
+import { ensureMiningBidProxySetup } from '../lib/MiningAccount.ts';
+import { getMainchainClient } from '../stores/mainchain.ts';
+import { ExtrinsicType } from '../lib/db/TransactionsTable.ts';
+
+vi.mock('../stores/mainchain.ts', () => ({
+  getMainchainClient: vi.fn(),
+}));
+
+it('submits mining bid proxy registration through the archive client', async () => {
+  const keyring = new Keyring({ type: 'sr25519' });
+  const fundingAccount = keyring.addFromUri('//MiningFunding');
+  const proxyAccount = keyring.addFromUri('//MiningProxy');
+  const tx = {};
+  const archiveClient = {
+    query: {
+      proxy: {
+        proxies: vi.fn().mockResolvedValue([[]]),
+      },
+      system: {
+        account: vi.fn().mockResolvedValue({
+          data: {
+            free: {
+              toBigInt: () => 2_000_000n,
+            },
+          },
+        }),
+      },
+    },
+    tx: {
+      balances: {
+        transferAllowDeath: vi.fn().mockReturnValue('fund-proxy'),
+      },
+      proxy: {
+        addProxy: vi.fn().mockReturnValue('register-proxy'),
+      },
+      utility: {
+        batchAll: vi.fn().mockReturnValue(tx),
+      },
+    },
+  };
+  const transactionTracker = {
+    findLatestTxInfo: vi.fn(),
+    submitAndWatch: vi.fn().mockResolvedValue({ tx: { id: 1 } }),
+  };
+  const walletKeys = {
+    getMiningBotKeypair: vi.fn().mockResolvedValue(fundingAccount),
+    getMiningBidProxyKeypair: vi.fn().mockResolvedValue(proxyAccount),
+  };
+  vi.mocked(getMainchainClient).mockResolvedValue(archiveClient as any);
+
+  await ensureMiningBidProxySetup({
+    transactionTracker: transactionTracker as any,
+    walletKeys: walletKeys as any,
+  });
+
+  expect(getMainchainClient).toHaveBeenCalledWith(true);
+  expect(transactionTracker.submitAndWatch).toHaveBeenCalledWith({
+    client: archiveClient,
+    tx,
+    txSigner: fundingAccount,
+    useLatestNonce: true,
+    extrinsicType: ExtrinsicType.MiningBidProxySetup,
+    metadata: {
+      fundingAccountId: fundingAccount.address,
+      proxyAccountId: proxyAccount.address,
+    },
+  });
+});

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -1,10 +1,10 @@
 import { TransactionEvents } from '@argonprotocol/apps-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { numberCodec } from '../../core/__test__/helpers/codecs.ts';
 import { TxAttemptState, TransactionTracker } from '../lib/TransactionTracker.ts';
 import { ExtrinsicType, type ITransactionRecord, TransactionStatus } from '../lib/db/TransactionsTable.ts';
 import { TransactionHistorySource, TransactionHistoryStatus } from '../lib/db/TransactionStatusHistoryTable.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
-import { TransactionInfo } from '../lib/TransactionInfo.ts';
 
 vi.mock('../stores/mainchain.ts', () => ({
   getMainchainClient: vi.fn(async () => ({})),
@@ -12,6 +12,7 @@ vi.mock('../stores/mainchain.ts', () => ({
 
 type ITransactionTrackerTestApi = {
   updatePendingStatuses: (bestBlockInfo: { blockNumber: number }) => Promise<void>;
+  watchForUpdates: () => Promise<void>;
 };
 
 describe('TransactionTracker', () => {
@@ -438,10 +439,10 @@ describe('TransactionTracker', () => {
     vi.mocked(getMainchainClient).mockResolvedValue({
       rpc: {
         chain: {
-          getHeader: vi.fn(async () => ({ number: { toNumber: () => 125 } })),
+          getHeader: vi.fn(async () => ({ number: numberCodec(125) })),
         },
         system: {
-          accountNextIndex: vi.fn(async () => ({ toNumber: () => 7 })),
+          accountNextIndex: vi.fn(async () => numberCodec(7)),
         },
       },
     } as any);
@@ -459,30 +460,6 @@ describe('TransactionTracker', () => {
       ],
       finalizedHeight: 125,
     });
-    vi.spyOn(tracker, 'trackTxResult').mockImplementation(async ({ txResult, extrinsicType, metadata }) => {
-      const txInfo = new TransactionInfo({
-        tx: createTransaction({
-          id: tracker.data.txInfos.length + 20,
-          status: TransactionStatus.Submitted,
-          txNonce: txResult.extrinsic.nonce,
-          accountAddress: txResult.extrinsic.accountAddress,
-          extrinsicType,
-          metadataJson: metadata ?? {},
-          submittedAtBlockHeight: txResult.extrinsic.submittedAtBlockNumber,
-          submittedAtTime: txResult.extrinsic.submittedTime,
-          blockHeight: undefined,
-          blockHash: undefined,
-          blockTime: undefined,
-          blockExtrinsicIndex: undefined,
-          blockExtrinsicEventsJson: undefined,
-          isFinalized: false,
-        }),
-        txResult,
-      });
-      tracker.data.txInfos.unshift(txInfo);
-      return txInfo;
-    });
-
     let releaseFirstSign!: () => void;
     const firstSign = new Promise<void>(resolve => {
       releaseFirstSign = resolve;
@@ -491,7 +468,7 @@ describe('TransactionTracker', () => {
     const createSignedTx = (nonce: number, hash: string) => ({
       hash: { toHex: () => hash },
       method: { toHuman: () => ({ section: 'balances', method: 'transferKeepAlive' }) },
-      nonce: { toNumber: () => nonce },
+      nonce: numberCodec(nonce),
       send: vi.fn(async () => undefined),
     });
 
@@ -529,6 +506,77 @@ describe('TransactionTracker', () => {
 
     expect(usedNonces).toEqual([8, 9]);
   });
+
+  it('uses a provided client for transaction submission and result tracking', async () => {
+    const { tracker } = await createTracker({
+      txs: [],
+      finalizedHeight: 125,
+    });
+    const client = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn(async () => ({ number: numberCodec(126) })),
+        },
+      },
+    };
+    const signedTx = {
+      hash: { toHex: () => '0xsubmitted' },
+      method: { toHuman: () => ({ section: 'proxy', method: 'addProxy' }) },
+      nonce: numberCodec(4),
+      send: vi.fn(async () => undefined),
+    };
+    const tx = {
+      signAsync: vi.fn().mockResolvedValue(signedTx),
+    };
+    vi.mocked(getMainchainClient).mockClear();
+
+    const txInfo = await tracker.submitAndWatch({
+      client: client as any,
+      tx: tx as any,
+      txSigner: { address: '5Alice' } as any,
+      extrinsicType: ExtrinsicType.MiningBidProxySetup,
+    });
+
+    expect(getMainchainClient).not.toHaveBeenCalled();
+    expect(client.rpc.chain.getHeader).toHaveBeenCalledOnce();
+    expect((txInfo.txResult as unknown as { client: unknown }).client).toBe(client);
+  });
+
+  it('submits a signed transaction before scanning pending transaction statuses', async () => {
+    const { tracker } = await createTracker({
+      txs: [],
+      finalizedHeight: 125,
+    });
+    let finishStatusScan!: () => void;
+    const statusScan = new Promise<void>(resolve => {
+      finishStatusScan = resolve;
+    });
+    const trackerApi = tracker as unknown as ITransactionTrackerTestApi;
+    vi.mocked(trackerApi.watchForUpdates).mockImplementationOnce(async () => await statusScan);
+
+    const signedTx = {
+      hash: { toHex: () => '0xsubmitted' },
+      method: { toHuman: () => ({ section: 'bitcoinLocks', method: 'initialize' }) },
+      nonce: numberCodec(4),
+      send: vi.fn(async () => undefined),
+    };
+    const submission = tracker.submitAndWatch({
+      client: {
+        rpc: {
+          chain: {
+            getHeader: vi.fn(async () => ({ number: numberCodec(126) })),
+          },
+        },
+      } as any,
+      tx: { signAsync: vi.fn().mockResolvedValue(signedTx) } as any,
+      txSigner: { address: '5Alice' } as any,
+      extrinsicType: ExtrinsicType.BitcoinRequestLock,
+    });
+
+    await vi.waitFor(() => expect(signedTx.send).toHaveBeenCalledOnce());
+    finishStatusScan();
+    await submission;
+  });
 });
 
 async function createTracker(args: {
@@ -537,8 +585,20 @@ async function createTracker(args: {
   latestHistoryByTxId?: Map<number, any>;
   headerByHeight?: Record<number, string>;
 }) {
+  let insertedId = Math.max(0, ...args.txs.map(tx => tx.id));
   const table = {
     fetchAll: vi.fn().mockResolvedValue(args.txs),
+    insert: vi.fn(async (record: Partial<ITransactionRecord>) =>
+      createTransaction({
+        ...record,
+        id: ++insertedId,
+        status: TransactionStatus.Submitted,
+        blockHeight: undefined,
+        blockHash: undefined,
+        blockTime: undefined,
+        isFinalized: false,
+      }),
+    ),
     markFinalized: vi.fn(async (record: ITransactionRecord) => record),
     recordInBlock: vi.fn(async (record: ITransactionRecord) => record),
     markExpiredWaitingForBlock: vi.fn(async (record: ITransactionRecord) => record),

--- a/src-vue/lib/MiningAccount.ts
+++ b/src-vue/lib/MiningAccount.ts
@@ -66,7 +66,7 @@ export async function ensureMiningBidProxySetup(args: {
     };
   }
 
-  const client = args.client ?? (await getMainchainClient(false));
+  const client = args.client ?? (await getMainchainClient(true));
   const { fundingAccount, proxySetup } = await planMiningBidProxySetup({
     walletKeys: args.walletKeys,
     client,
@@ -84,6 +84,7 @@ export async function ensureMiningBidProxySetup(args: {
   }
 
   const txInfo = await args.transactionTracker.submitAndWatch<MiningBidProxySetupMetadata>({
+    client,
     tx: proxySetup.tx,
     txSigner: fundingAccount,
     useLatestNonce: true,

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -1,4 +1,5 @@
 import {
+  type ArgonClient,
   ExtrinsicError,
   type GenericEvent,
   hexToU8a,
@@ -202,15 +203,16 @@ export class TransactionTracker {
 
   public async submitAndWatch<T>(
     args: {
+      client?: ArgonClient;
       tx: SubmittableExtrinsic;
       txSigner: TxSigningAccount;
       extrinsicType: ExtrinsicType;
       metadata?: T;
     } & ISubmittableOptions,
   ): Promise<TransactionInfo<T>> {
-    const { tx, txSigner, extrinsicType, metadata, useLatestNonce, ...apiOptions } = args;
+    const { client: providedClient, tx, txSigner, extrinsicType, metadata, useLatestNonce, ...apiOptions } = args;
     await this.load();
-    const client = await getMainchainClient(false);
+    const client = providedClient ?? (await getMainchainClient(false));
     console.log('[TransactionTracker] SUBMITTING TRANSACTION', extrinsicType);
     const submittedAtBlockHeight = await client.rpc.chain.getHeader().then(x => x.number.toNumber());
     let releaseNonceReservation: VoidFunction | undefined;
@@ -220,12 +222,10 @@ export class TransactionTracker {
       releaseNonceReservation = reservation.release;
     }
 
-    let signedTx: SubmittableExtrinsic;
-    let txResult: TxResult;
     let txInfo: TransactionInfo<T>;
 
     try {
-      signedTx =
+      const signedTx =
         'signer' in txSigner
           ? await tx.signAsync(txSigner.address, { ...apiOptions, signer: txSigner.signer })
           : await tx.signAsync(txSigner, apiOptions);
@@ -238,31 +238,33 @@ export class TransactionTracker {
         submittedTime: new Date(),
         submittedAtBlockNumber: submittedAtBlockHeight,
       };
-      txResult = new TxResult(client, txResultExtrinsic);
-      txInfo = await this.trackTxResult({
+      const txResult = new TxResult(client, txResultExtrinsic);
+      txInfo = await this.registerTxResult({
         txResult,
         extrinsicType,
         metadata,
       });
+
+      await signedTx
+        .send(result => {
+          if (this.#isClosed) {
+            return;
+          }
+          txResult.onSubscriptionResult(result);
+          void this.handleWatchedResult(txInfo.tx, txResult, result);
+        })
+        .catch(async error => {
+          if (this.#isClosed) {
+            return;
+          }
+          txResult.submissionError = error as Error;
+          await this.recordSubmissionError(txInfo.tx, txResult.submissionError);
+        });
     } finally {
       releaseNonceReservation?.();
     }
 
-    await signedTx
-      .send(result => {
-        if (this.#isClosed) {
-          return;
-        }
-        txResult.onSubscriptionResult(result);
-        void this.handleWatchedResult(txInfo.tx, txResult, result);
-      })
-      .catch(async error => {
-        if (this.#isClosed) {
-          return;
-        }
-        txResult.submissionError = error as Error;
-        await this.recordSubmissionError(txInfo.tx, txResult.submissionError);
-      });
+    await this.watchForUpdates();
 
     return txInfo;
   }
@@ -382,6 +384,17 @@ export class TransactionTracker {
     } & ISubmittableOptions,
   ): Promise<TransactionInfo<T>> {
     await this.load();
+    const txInfo = await this.registerTxResult(args);
+    await this.watchForUpdates();
+
+    return txInfo;
+  }
+
+  private async registerTxResult<T>(args: {
+    txResult: TxResult;
+    extrinsicType: ExtrinsicType;
+    metadata?: T;
+  }): Promise<TransactionInfo<T>> {
     const { txResult, extrinsicType, metadata } = args;
     const table = await this.getTable();
     const txNonce = txResult.extrinsic.nonce;
@@ -406,7 +419,6 @@ export class TransactionTracker {
     if (txResult.submissionError) {
       await this.recordSubmissionError(record, txResult.submissionError);
     }
-    await this.watchForUpdates();
 
     return txInfo;
   }

--- a/src-vue/stores/mainchain.ts
+++ b/src-vue/stores/mainchain.ts
@@ -206,6 +206,11 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
     return;
   }
 
+  if (!getBot().isReady) {
+    mainchainClients.clearPrunedClient();
+    return;
+  }
+
   const serverApiClient = getServerApiClient();
   if (config.isServerInstalled && config.serverDetails.ipAddress) {
     if (!(await serverApiClient.isGatewayReady())) {


### PR DESCRIPTION
Ethereum transfer-out CI now waits for the complete dev Ethereum setup before starting the minting authority, preventing readiness from being overwritten during startup. The upstream service also has enough time to finish its initial sync, and the flow closes the wallet modal before returning to Vaulting so navigation is not blocked.

The focused Ethereum transfer-out flow completed successfully end to end.

Related: #404
