### PR TITLE
fix(app): switch Ethereum relay to configured server

### DIFF
--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -60,6 +60,9 @@ type IEthereumInboundTransferClient = Pick<
   | 'waitForTransactionFinality'
 >;
 
+type ServerRelayClient = Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>;
+type ServerRelayClientSource = ServerRelayClient | (() => ServerRelayClient | undefined) | undefined;
+
 class InboundTransferInvariantError extends Error {}
 
 export class EthereumInboundTransferTracker {
@@ -83,9 +86,7 @@ export class EthereumInboundTransferTracker {
     private readonly blockWatch: BlockWatch,
     private readonly walletKeys: WalletKeys,
     private readonly ethereumClient: IEthereumInboundTransferClient,
-    private readonly serverApiClient:
-      | Pick<ServerApiClient, 'getEthereumRelayStatus' | 'requestEthereumGatewayCatchUp'>
-      | undefined,
+    private readonly serverApiClientSource: ServerRelayClientSource,
     private readonly upstreamOperatorClient: Pick<
       UpstreamOperatorClient,
       'operatorHost' | 'requestEthereumGatewayCatchUp'
@@ -683,11 +684,13 @@ export class EthereumInboundTransferTracker {
       }
     }
 
+    const serverApiClient =
+      typeof this.serverApiClientSource === 'function' ? this.serverApiClientSource() : this.serverApiClientSource;
     const upstreamOperatorHost = this.upstreamOperatorClient.operatorHost;
-    if (this.serverApiClient || upstreamOperatorHost) {
+    if (serverApiClient || upstreamOperatorHost) {
       const relayResult = await requestEthereumGatewayCatchup({
         throughGatewayActivityNonce,
-        serverApiClient: this.serverApiClient,
+        serverApiClient,
         upstreamOperatorClient: upstreamOperatorHost ? this.upstreamOperatorClient : undefined,
       });
 

--- a/src-vue/stores/moveFromEthereum.ts
+++ b/src-vue/stores/moveFromEthereum.ts
@@ -24,7 +24,6 @@ export function getEthereumMoveTracker(): EthereumInboundTransferTracker {
       throw new Error('Ethereum execution RPC is not configured for this app instance.');
     }
     const ethereumClient = new EthereumClient(walletKeys, executionRpcUrl);
-    const serverApiClient = config.serverDetails.ipAddress ? getServerApiClient() : undefined;
     const upstreamOperatorClient = getUpstreamOperatorClient();
     const myVault = getMyVault();
 
@@ -34,7 +33,7 @@ export function getEthereumMoveTracker(): EthereumInboundTransferTracker {
       getBlockWatch(),
       walletKeys,
       ethereumClient,
-      serverApiClient,
+      () => (config.serverDetails.ipAddress ? getServerApiClient() : undefined),
       upstreamOperatorClient,
       myVault,
     );


### PR DESCRIPTION
Ethereum inbound transfers created before server setup could keep asking the upstream operator to catch up even after the user's server finished installing. The tracker now resolves the local relay client at request time, so it automatically prefers the newly configured server while preserving upstream fallback. Existing callers that provide a fixed relay client remain compatible.

Validation was limited to `git diff --check`; this worktree does not have an installed Yarn dependency state.
