### PR TITLE
fix(e2e): isolate session data in temporary storage

### DIFF
--- a/core/__test__/startArgonTestNetwork.test.ts
+++ b/core/__test__/startArgonTestNetwork.test.ts
@@ -1,0 +1,22 @@
+import Path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveTestSessionDataDir } from './startArgonTestNetwork.ts';
+
+describe('resolveTestSessionDataDir', () => {
+  it('isolates each driver session beneath the temporary root', () => {
+    const rootDir = Path.resolve('/ci-temp');
+
+    const firstSessionDir = resolveTestSessionDataDir({
+      rootDir,
+      sessionId: 'driver-session-one',
+    });
+    const secondSessionDir = resolveTestSessionDataDir({
+      rootDir,
+      sessionId: 'driver-session-two',
+    });
+
+    expect(firstSessionDir).toBe(Path.join(rootDir, 'argon-e2e', 'driver-session-one'));
+    expect(secondSessionDir).toBe(Path.join(rootDir, 'argon-e2e', 'driver-session-two'));
+    expect(firstSessionDir).not.toBe(secondSessionDir);
+  });
+});

--- a/core/__test__/startArgonTestNetwork.ts
+++ b/core/__test__/startArgonTestNetwork.ts
@@ -65,6 +65,10 @@ export interface ResolvedTestSessionCommandEnv {
   appEnv: NodeJS.ProcessEnv;
 }
 
+export function resolveTestSessionDataDir(args: { rootDir: string; sessionId: string }): string {
+  return Path.join(args.rootDir, 'argon-e2e', args.sessionId);
+}
+
 export interface TestSessionCommandEnvOptions extends TestSessionIdentityOptions {
   appPort: number;
   baseEnv?: NodeJS.ProcessEnv;

--- a/e2e/flows/session.ts
+++ b/e2e/flows/session.ts
@@ -12,6 +12,7 @@ import { getFlow, runFlow } from './index.ts';
 import {
   resolveTestSessionIdentity,
   resolveTestSessionCommandEnv,
+  resolveTestSessionDataDir,
   startArgonTestNetwork,
   type StartedArgonTestNetwork,
 } from '@argonprotocol/apps-core/__test__/startArgonTestNetwork.ts';
@@ -87,10 +88,10 @@ export async function createFlowSession(options: IFlowSessionOptions = {}): Prom
   });
   const isolatedDataEnv: NodeJS.ProcessEnv = {};
   if (sessionMode === 'isolated') {
-    const testDataDir = Path.join(
-      getAppInstanceDirectory(appConfigId, sessionIdentity.composeNetwork, appInstanceName),
-      'test-data',
-    );
+    const testDataDir = resolveTestSessionDataDir({
+      rootDir: process.env.CI_TEMP_DIR?.trim() || os.tmpdir(),
+      sessionId: driverServer.session,
+    });
     const devEthereumRuntimeStateDir = Path.join(testDataDir, 'dev-ethereum');
     isolatedDataEnv.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = devEthereumRuntimeStateDir;
     isolatedDataEnv.ARGON_DEV_UPSTREAM_ROOT_DIR = Path.join(testDataDir, 'dev-upstream');


### PR DESCRIPTION
Isolated e2e sessions now keep runtime state and upstream fixture data in a user-writable temporary directory instead of the app instance tree. Each driver session gets a UUID-scoped root, preserving per-test isolation while avoiding the filesystem permission boundary that hid a successfully activated minting authority from the transfer-out test.

Related: https://github.com/argonprotocol/apps/actions/runs/29528328263/job/87722224322

Verified that distinct driver sessions resolve to distinct roots and that existing dev Ethereum runtime-state updates remain readable.
