### PR TITLE
fix(core): unify network investment returns

### DIFF
--- a/core/__test__/FinancialReturns.test.ts
+++ b/core/__test__/FinancialReturns.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  calculateAggregateReturn,
   calculateAnnualPercentageRate,
   calculateAnnualPercentageYield,
   calculatePerformanceReturn,
@@ -7,6 +8,20 @@ import {
 import { calculateAPY, calculateProfitPct } from '../src/utils.ts';
 
 describe('FinancialReturns', () => {
+  it('aggregates undated positions by total capital instead of averaging participant returns', () => {
+    expect(
+      calculateAggregateReturn([
+        { startingCapital: 100n, endingCapital: 200n },
+        { startingCapital: 900n, endingCapital: 900n },
+      ]),
+    ).toEqual({
+      basisPoints: 1_000n,
+      percent: 10,
+      eligibleCapitalInvested: 1_000n,
+      totalProfits: 100n,
+    });
+  });
+
   it('aggregates realized income and current position value against invested capital', () => {
     const result = calculatePerformanceReturn([
       {
@@ -63,5 +78,30 @@ describe('FinancialReturns', () => {
       eligibleCapitalInvested: 0n,
       totalProfits: 0n,
     });
+  });
+
+  it('preserves minimum-age filtering before reducing dated positions', () => {
+    const result = calculatePerformanceReturn(
+      [
+        {
+          startingDate: new Date('2026-01-01T00:00:00Z'),
+          startingCapital: 1_000n,
+          endingCapital: 1_100n,
+        },
+        {
+          startingDate: new Date('2026-01-09T00:00:00Z'),
+          startingCapital: 9_000n,
+          endingCapital: 18_000n,
+        },
+      ],
+      {
+        minimumAgeMs: 5 * 24 * 60 * 60 * 1_000,
+        now: new Date('2026-01-10T00:00:00Z'),
+      },
+    );
+
+    expect(result.eligibleCapitalInvested).toBe(1_000n);
+    expect(result.totalProfits).toBe(100n);
+    expect(result.percent).toBe(10);
   });
 });

--- a/core/__test__/Mining.test.ts
+++ b/core/__test__/Mining.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GlobalMiningStats } from '../src/GlobalMiningStats.ts';
 import { Mining, normalizeMiningSeatSlots } from '../src/Mining.ts';
-import { bigintCodec } from './helpers/codecs.ts';
+import { NetworkConfig } from '../src/NetworkConfig.ts';
+import { bigintCodec, numberCodec } from './helpers/codecs.ts';
+
+beforeEach(() => {
+  NetworkConfig.setNetwork('mainnet');
+  NetworkConfig.clearRuntimeOverride('mainnet');
+});
 
 describe('Mining seat slot construction', () => {
   it('uses the next cohort size only for the upcoming auction slot', async () => {
@@ -14,8 +21,8 @@ describe('Mining seat slot construction', () => {
             ]),
           },
           bidsForNextSlotCohort: vi.fn().mockResolvedValue([createBid(13, 'bidder-1')]),
-          nextCohortSize: vi.fn().mockResolvedValue(createNumberLike(17)),
-          nextFrameId: vi.fn().mockResolvedValue(createNumberLike(13)),
+          nextCohortSize: vi.fn().mockResolvedValue(numberCodec(17)),
+          nextFrameId: vi.fn().mockResolvedValue(numberCodec(13)),
         },
       },
     };
@@ -43,12 +50,148 @@ describe('Mining seat slot construction', () => {
   });
 });
 
-function createNumberLike(value: number) {
-  return { toNumber: () => value };
-}
+describe('Mining network returns', () => {
+  it('uses every active cohort, the actual active count, and the runtime payout for both currencies', async () => {
+    NetworkConfig.setRuntimeOverride('mainnet', {
+      genesisTick: 0,
+      ticksBetweenFrames: 1,
+    });
+
+    const cohorts = [
+      [createCohortKey(1), [createMember('miner-1')]],
+      [createCohortKey(2), [createMember('miner-2'), createMember('miner-3'), createMember('miner-4')]],
+    ];
+    const api = {
+      consts: {
+        blockRewards: {
+          minerPayoutPercent: bigintCodec(500_000_000_000_000_000n),
+          halvingBeginTicks: numberCodec(1_000_000),
+          halvingTicks: numberCodec(1_000_000),
+          incrementalGrowth: [bigintCodec(0n), numberCodec(1_000), bigintCodec(100n)],
+        },
+      },
+      query: {
+        blockRewards: {
+          blockRewardsByCohort: vi.fn().mockResolvedValue([
+            [numberCodec(1), bigintCodec(100n)],
+            [numberCodec(2), bigintCodec(200n)],
+            [numberCodec(3), bigintCodec(300n)],
+          ]),
+        },
+        miningSlot: {
+          activeMinersCount: vi.fn().mockResolvedValue(numberCodec(4)),
+          frameRewardTicksRemaining: vi.fn().mockResolvedValue(numberCodec(1)),
+          minersByCohort: {
+            entries: vi.fn().mockResolvedValue(cohorts),
+          },
+        },
+        ticks: {
+          currentTick: vi.fn().mockResolvedValue(numberCodec(2)),
+        },
+      },
+    };
+    const mining = new Mining({
+      prunedClientPromise: Promise.resolve(api),
+      prunedClientOrArchivePromise: Promise.resolve(api),
+    } as any);
+
+    await expect(mining.fetchActiveMinersCount(api as any)).resolves.toBe(4);
+    await expect(mining.fetchAggregateBlockRewards(api as any)).resolves.toEqual({
+      microgons: 875n,
+      micronots: 500n,
+    });
+    await expect(mining.fetchAggregateBidCosts(api as any)).resolves.toBe(400n);
+    await expect(mining.fetchAggregateMicronotsStaked(api as any)).resolves.toBe(200n);
+  });
+
+  it('returns no aggregate block rewards when there are no active miners', async () => {
+    const api = {
+      query: {
+        blockRewards: {
+          blockRewardsByCohort: vi.fn().mockResolvedValue([]),
+        },
+        miningSlot: {
+          activeMinersCount: vi.fn().mockResolvedValue(numberCodec(0)),
+          minersByCohort: {
+            entries: vi.fn().mockResolvedValue([]),
+          },
+        },
+      },
+    };
+    const mining = new Mining({
+      prunedClientPromise: Promise.resolve(api),
+      prunedClientOrArchivePromise: Promise.resolve(api),
+    } as any);
+
+    await expect(mining.fetchAggregateBlockRewards(api as any)).resolves.toEqual({
+      microgons: 0n,
+      micronots: 0n,
+    });
+  });
+
+  it('values retained ARGNOT as capital while preserving bid and reward display totals', async () => {
+    const api = {};
+    const mining = {
+      prunedClientOrArchivePromise: Promise.resolve({
+        rpc: { chain: { getFinalizedHead: vi.fn().mockResolvedValue('0xfinalized') } },
+        at: vi.fn().mockResolvedValue(api),
+      }),
+      fetchActiveMinersCount: vi.fn().mockResolvedValue(4),
+      fetchAggregateBlockRewards: vi.fn().mockResolvedValue({ microgons: 875n, micronots: 500n }),
+      fetchAggregateBidCosts: vi.fn().mockResolvedValue(1_000n),
+      fetchAggregateMicronotsStaked: vi.fn().mockResolvedValue(200n),
+    };
+    const currency = {
+      load: vi.fn().mockResolvedValue(undefined),
+      convertMicronotTo: vi.fn((value: bigint) => value * 2n),
+    };
+    const stats = new GlobalMiningStats(mining as any, currency as any);
+
+    await stats.load();
+
+    expect(stats.activeSeatCount).toBe(4);
+    expect(stats.aggregatedBidCosts).toBe(1_000n);
+    expect(stats.aggregatedBlockRewards).toBe(1_875n);
+    expect(stats.activeBidCosts).toBe(stats.aggregatedBidCosts);
+    expect(stats.activeBlockRewards).toBe(stats.aggregatedBlockRewards);
+    expect(stats.averageAPR).toBeCloseTo(2_281.25);
+    expect(stats.activeAPR).toBe(stats.averageAPR);
+    expect(stats.activeAPY).toBe(stats.averageAPY);
+    expect(mining.fetchActiveMinersCount).toHaveBeenCalledWith(api);
+    expect(mining.fetchAggregateBlockRewards).toHaveBeenCalledWith(api);
+    expect(mining.fetchAggregateBidCosts).toHaveBeenCalledWith(api);
+    expect(mining.fetchAggregateMicronotsStaked).toHaveBeenCalledWith(api);
+  });
+
+  it('returns zero rates when no active mining capital exists', async () => {
+    const api = {};
+    const mining = {
+      prunedClientOrArchivePromise: Promise.resolve({
+        rpc: { chain: { getFinalizedHead: vi.fn().mockResolvedValue('0xfinalized') } },
+        at: vi.fn().mockResolvedValue(api),
+      }),
+      fetchActiveMinersCount: vi.fn().mockResolvedValue(0),
+      fetchAggregateBlockRewards: vi.fn().mockResolvedValue({ microgons: 0n, micronots: 0n }),
+      fetchAggregateBidCosts: vi.fn().mockResolvedValue(0n),
+      fetchAggregateMicronotsStaked: vi.fn().mockResolvedValue(0n),
+    };
+    const currency = {
+      load: vi.fn().mockResolvedValue(undefined),
+      convertMicronotTo: vi.fn(() => 0n),
+    };
+    const stats = new GlobalMiningStats(mining as any, currency as any);
+
+    await stats.load();
+
+    expect(stats.averageAPR).toBe(0);
+    expect(stats.averageAPY).toBe(0);
+    expect(stats.activeAPR).toBe(0);
+    expect(stats.activeAPY).toBe(0);
+  });
+});
 
 function createCohortKey(startingFrameId: number) {
-  return { args: [createNumberLike(startingFrameId)] };
+  return { args: [numberCodec(startingFrameId)] };
 }
 
 function createMember(address: string) {
@@ -62,7 +205,7 @@ function createMember(address: string) {
 
 function createBid(startingFrameId: number, address: string) {
   return {
-    startingFrameId: createNumberLike(startingFrameId),
+    startingFrameId: numberCodec(startingFrameId),
     accountId: { toHuman: () => address },
     bid: { toBigInt: () => 200n },
     argonots: bigintCodec(75n),

--- a/core/__test__/Vaults.test.ts
+++ b/core/__test__/Vaults.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GlobalVaultingStats } from '../src/GlobalVaultingStats.ts';
+import type { IAllVaultStats, IVaultFrameStats, IVaultStats } from '../src/interfaces/IVaultStats.ts';
+import { NetworkConfig } from '../src/NetworkConfig.ts';
 import { Vaults } from '../src/Vaults.ts';
+import { bigintCodec, numberCodec } from './helpers/codecs.ts';
+
+beforeEach(() => {
+  NetworkConfig.setNetwork('mainnet');
+  NetworkConfig.clearRuntimeOverride('mainnet');
+});
 
 describe('Vaults load retry', () => {
   it('retries after an initial bootstrap failure', async () => {
@@ -28,3 +37,232 @@ describe('Vaults load retry', () => {
     expect(client.query.vaults.vaultsById.entries).toHaveBeenCalledOnce();
   });
 });
+
+describe('Vault and bond network returns', () => {
+  it('uses the inclusive return window for coupon-net vault income and recorded external bond earnings', () => {
+    const vaults = createVaults();
+    vaults.vaultsById[1] = {
+      securitization: 1_000n,
+      terms: { treasuryProfitSharing: 0.99 },
+    } as any;
+    const includedFrame = {
+      bitcoinFeeRevenue: 100n,
+      bitcoinFeeCouponValueUsed: 40n,
+      securitization: 1_000n,
+      externalCapital: 1_000n,
+      totalEarnings: 100n,
+      vaultEarnings: 40n,
+    };
+    const excludedFrame = {
+      bitcoinFeeRevenue: 10_000n,
+      bitcoinFeeCouponValueUsed: 0n,
+      securitization: 1n,
+      externalCapital: 1n,
+      totalEarnings: 10_000n,
+    };
+    vaults.stats = createStats([
+      createFrame({ frameId: 10, ...excludedFrame }),
+      createFrame({ frameId: 11, ...includedFrame }),
+      createFrame({ frameId: 20, ...includedFrame }),
+      createFrame({ frameId: 21, ...excludedFrame }),
+    ]);
+
+    expect(vaults.calculateApr()).toBeCloseTo(3_650);
+    expect(vaults.calculateApy()).toBeCloseTo((1.1 ** 365 - 1) * 100);
+    expect(vaults.calculateVaultApr(1)).toBeCloseTo(3_650);
+    expect(vaults.calculateVaultApy(1)).toBeCloseTo((1.1 ** 365 - 1) * 100);
+    expect(vaults.calculateBondsApr()).toBeCloseTo(2_190);
+  });
+
+  it('weights global and single-vault returns by recorded frame capital', () => {
+    const vaults = createVaults();
+    vaults.stats = {
+      synchedToFrame: 20,
+      vaultsById: {
+        1: createVaultStats([
+          createFrame({
+            frameId: 20,
+            bitcoinFeeRevenue: 100n,
+            bitcoinFeeCouponValueUsed: 0n,
+            securitization: 1_000n,
+          }),
+        ]),
+        2: createVaultStats([
+          createFrame({
+            frameId: 20,
+            bitcoinFeeCouponValueUsed: 0n,
+            securitization: 9_000n,
+          }),
+        ]),
+      },
+    };
+
+    expect(vaults.calculateVaultApr(1)).toBeCloseTo(3_650);
+    expect(vaults.calculateVaultApr(2)).toBe(0);
+    expect(vaults.calculateApr()).toBeCloseTo(365);
+  });
+
+  it('records current coupon usage and preserves missing historical coupon data', async () => {
+    const vaults = createVaults();
+    const frameRevenue = {
+      frameId: numberCodec(20),
+      bitcoinLocksNewLiquidityPromised: bigintCodec(0n),
+      bitcoinLocksReleasedLiquidity: bigintCodec(0n),
+      bitcoinLocksAddedSatoshis: bigintCodec(0n),
+      bitcoinLocksReleasedSatoshis: bigintCodec(0n),
+      bitcoinLockFeeRevenue: bigintCodec(100n),
+      bitcoinLockFeeCouponValueUsed: bigintCodec(40n),
+      bitcoinLocksCreated: numberCodec(0),
+      treasuryTotalEarnings: bigintCodec(0n),
+      treasuryVaultEarnings: bigintCodec(0n),
+      treasuryExternalCapital: bigintCodec(0n),
+      treasuryVaultCapital: bigintCodec(0n),
+      securitization: bigintCodec(1_000n),
+      securitizationActivated: bigintCodec(1_000n),
+      securitizationRelockable: bigintCodec(0n),
+      uncollectedRevenue: bigintCodec(0n),
+    };
+    const { bitcoinLockFeeCouponValueUsed: _coupon, ...historicalFrameRevenue } = {
+      ...frameRevenue,
+      frameId: numberCodec(19),
+    };
+
+    await vaults.updateVaultRevenue(1, [frameRevenue, historicalFrameRevenue] as any);
+
+    expect(vaults.stats?.vaultsById[1].changesByFrame[0].bitcoinFeeCouponValueUsed).toBe(40n);
+    expect(vaults.stats?.vaultsById[1].changesByFrame[1].bitcoinFeeCouponValueUsed).toBeUndefined();
+  });
+
+  it('falls back when an old cache has no selected frames and decodes bundled coupon data', async () => {
+    const cachedStats = createStats([createFrame({ frameId: 10, bitcoinFeeRevenue: 100n })]);
+    const miningFrames = {
+      load: vi.fn().mockResolvedValue(undefined),
+    };
+    const client = {
+      query: {
+        vaults: {
+          vaultsById: {
+            entries: vi.fn().mockResolvedValue([]),
+          },
+        },
+      },
+    };
+    const mainchainClients = {
+      get: vi.fn().mockResolvedValue(client),
+    };
+    const vaults = new CachedVaults(cachedStats, miningFrames as any, mainchainClients as any);
+
+    await vaults.load();
+
+    expect(vaults.stats).not.toBe(cachedStats);
+    const oldestFrameId = vaults.stats!.synchedToFrame - NetworkConfig.framesPerCohort + 1;
+    const selectedFrames = Object.values(vaults.stats!.vaultsById).flatMap(vault => {
+      return vault.changesByFrame.filter(
+        frame => frame.frameId >= oldestFrameId && frame.frameId <= vaults.stats!.synchedToFrame,
+      );
+    });
+    expect(selectedFrames.length).toBeGreaterThan(0);
+    expect(selectedFrames.every(frame => typeof frame.bitcoinFeeCouponValueUsed === 'bigint')).toBe(true);
+    expect(Number.isFinite(vaults.calculateApr())).toBe(true);
+    expect(Number.isFinite(vaults.calculateBondsApr())).toBe(true);
+
+    const incompleteVaults = createVaults();
+    incompleteVaults.stats = createStats([createFrame({ bitcoinFeeRevenue: 100n })]);
+    expect(() => incompleteVaults.calculateApr()).toThrow('coupon');
+    expect(() => incompleteVaults.calculateBondsApr()).toThrow('coupon');
+  });
+
+  it('does not manufacture returns from zero-capital frames', () => {
+    const vaults = createVaults();
+    vaults.stats = createStats([
+      createFrame({
+        bitcoinFeeRevenue: 100n,
+        bitcoinFeeCouponValueUsed: 0n,
+        totalEarnings: 100n,
+        vaultEarnings: 40n,
+      }),
+    ]);
+
+    expect(vaults.calculateApr()).toBe(0);
+    expect(vaults.calculateApy()).toBe(0);
+    expect(vaults.calculateBondsApr()).toBe(0);
+  });
+
+  it('calculates restabilization leverage from caller-supplied circulation', () => {
+    const stats = new GlobalVaultingStats({} as any, {} as any);
+    stats.argonBurnCapacity = 25;
+
+    expect(stats.calculateRestabilizationLeverage(10_000_000n)).toBe(2.5);
+    expect(stats.calculateRestabilizationLeverage(0n)).toBe(0);
+  });
+});
+
+class CachedVaults extends Vaults {
+  constructor(
+    private readonly cachedStats: IAllVaultStats,
+    miningFrames: any,
+    mainchainClients: any,
+  ) {
+    super('mainnet', {} as any, miningFrames, mainchainClients);
+  }
+
+  protected async loadStatsFromFile(): Promise<IAllVaultStats> {
+    return this.cachedStats;
+  }
+}
+
+function createVaults(): Vaults {
+  return new Vaults('mainnet', {} as any, {} as any, {} as any);
+}
+
+function createStats(frames: IVaultFrameStats[]): IAllVaultStats {
+  return {
+    synchedToFrame: 20,
+    vaultsById: {
+      1: createVaultStats(frames),
+    },
+  };
+}
+
+function createVaultStats(frames: IVaultFrameStats[]): IVaultStats {
+  return {
+    openedTick: 0,
+    baseline: {
+      feeRevenue: 0n,
+      satoshis: 0n,
+      bitcoinLocks: 0,
+      microgonLiquidityRealized: 0n,
+    },
+    changesByFrame: frames,
+  };
+}
+
+function createFrame(
+  overrides: Partial<Omit<IVaultFrameStats, 'treasuryPool'>> & Partial<IVaultFrameStats['treasuryPool']> = {},
+): IVaultFrameStats {
+  const {
+    externalCapital = 0n,
+    vaultCapital = 0n,
+    totalEarnings = 0n,
+    vaultEarnings = 0n,
+    ...frameOverrides
+  } = overrides;
+
+  return {
+    frameId: 20,
+    bitcoinFeeRevenue: 0n,
+    satoshisAdded: 0n,
+    bitcoinLocksCreated: 0,
+    microgonLiquidityAdded: 0n,
+    securitization: 0n,
+    securitizationActivated: 0n,
+    treasuryPool: {
+      externalCapital,
+      vaultCapital,
+      totalEarnings,
+      vaultEarnings,
+    },
+    uncollectedEarnings: 0n,
+    ...frameOverrides,
+  };
+}

--- a/core/__test__/Vaults.test.ts
+++ b/core/__test__/Vaults.test.ts
@@ -167,9 +167,16 @@ describe('Vault and bond network returns', () => {
     expect(Number.isFinite(vaults.calculateBondsApr())).toBe(true);
 
     const incompleteVaults = createVaults();
-    incompleteVaults.stats = createStats([createFrame({ bitcoinFeeRevenue: 100n })]);
+    incompleteVaults.stats = createStats([
+      createFrame({
+        bitcoinFeeRevenue: 100n,
+        externalCapital: 1_000n,
+        totalEarnings: 100n,
+        vaultEarnings: 40n,
+      }),
+    ]);
     expect(() => incompleteVaults.calculateApr()).toThrow('coupon');
-    expect(() => incompleteVaults.calculateBondsApr()).toThrow('coupon');
+    expect(incompleteVaults.calculateBondsApr()).toBeCloseTo(2_190);
   });
 
   it('does not manufacture returns from zero-capital frames', () => {

--- a/core/src/FinancialReturns.ts
+++ b/core/src/FinancialReturns.ts
@@ -7,6 +7,8 @@ export type IPerformanceReturnInput = {
   endingCapital: bigint;
 };
 
+export type IAggregateReturnInput = Pick<IPerformanceReturnInput, 'startingCapital' | 'endingCapital'>;
+
 export type IPerformanceReturnOptions = {
   /**
    * Exclude investments younger than this amount of time.
@@ -62,15 +64,23 @@ export function calculatePerformanceReturn(
   const nowMs = BigInt((options.now ?? new Date()).getTime());
   const minimumAgeMs = BigInt(options.minimumAgeMs ?? 0);
 
+  const eligibleInvestments = investments.filter(investment => {
+    if (investment.startingCapital <= 0n) return false;
+
+    const startMs = toDateMs(investment.startingDate);
+    const endMs = investment.endingDate ? toDateMs(investment.endingDate) : nowMs;
+    return endMs - startMs >= minimumAgeMs;
+  });
+
+  return calculateAggregateReturn(eligibleInvestments);
+}
+
+export function calculateAggregateReturn(investments: readonly IAggregateReturnInput[]): IPerformanceReturnResult {
   let eligibleCapitalInvested = 0n;
   let totalProfits = 0n;
 
   for (const investment of investments) {
     if (investment.startingCapital <= 0n) continue;
-
-    const startMs = toDateMs(investment.startingDate);
-    const endMs = investment.endingDate ? toDateMs(investment.endingDate) : nowMs;
-    if (endMs - startMs < minimumAgeMs) continue;
 
     eligibleCapitalInvested += investment.startingCapital;
     totalProfits += investment.endingCapital - investment.startingCapital;

--- a/core/src/GlobalMiningStats.ts
+++ b/core/src/GlobalMiningStats.ts
@@ -1,4 +1,8 @@
-import { calculateAnnualPercentageRate, calculateAnnualPercentageYield } from './FinancialReturns.js';
+import {
+  calculateAggregateReturn,
+  calculateAnnualPercentageRate,
+  calculateAnnualPercentageYield,
+} from './FinancialReturns.js';
 import { Currency, UnitOfMeasurement } from './Currency.js';
 import type { Mining } from './Mining.js';
 import { NetworkConfig } from './NetworkConfig.js';
@@ -31,47 +35,42 @@ export class GlobalMiningStats {
   }
 
   public async update() {
-    this.activeSeatCount = await this.mining.fetchActiveMinersCount();
     const miningTermDays = (NetworkConfig.ticksPerCohort * NetworkConfig.tickMillis) / MILLISECONDS_PER_DAY;
-    const framesPerMiningTerm = BigInt(NetworkConfig.framesPerCohort);
-
-    const aggregateBlockRewards = await this.mining.fetchAggregateBlockRewards();
-    this.aggregatedBidCosts = await this.mining.fetchAggregateBidCosts();
-    this.aggregatedBlockRewards = this.calculateBlockRewards(aggregateBlockRewards);
-    this.averageAPR = calculateAnnualPercentageRate({
-      startingValue: this.aggregatedBidCosts,
-      endingValue: this.aggregatedBlockRewards,
+    const client = await this.mining.prunedClientOrArchivePromise;
+    const api = await client.at(await client.rpc.chain.getFinalizedHead());
+    const [activeSeatCount, aggregateBlockRewards, aggregateBidCosts, aggregateMicronotsStaked] = await Promise.all([
+      this.mining.fetchActiveMinersCount(api),
+      this.mining.fetchAggregateBlockRewards(api),
+      this.mining.fetchAggregateBidCosts(api),
+      this.mining.fetchAggregateMicronotsStaked(api),
+    ]);
+    const markedStake = this.currency.convertMicronotTo(aggregateMicronotsStaked, UnitOfMeasurement.Microgon);
+    const valueOfMicronots = this.currency.convertMicronotTo(
+      aggregateBlockRewards.micronots,
+      UnitOfMeasurement.Microgon,
+    );
+    const aggregateRewards = aggregateBlockRewards.microgons + valueOfMicronots;
+    const aggregateReturn = calculateAggregateReturn([
+      {
+        startingCapital: aggregateBidCosts + markedStake,
+        endingCapital: markedStake + aggregateRewards,
+      },
+    ]);
+    const annualizedInput = {
+      startingValue: aggregateReturn.eligibleCapitalInvested,
+      endingValue: aggregateReturn.eligibleCapitalInvested + aggregateReturn.totalProfits,
       periodDays: miningTermDays,
-    });
-    this.averageAPY =
-      this.aggregatedBlockRewards === 0n
-        ? 0
-        : calculateAnnualPercentageYield({
-            startingValue: this.aggregatedBidCosts,
-            endingValue: this.aggregatedBlockRewards,
-            periodDays: miningTermDays,
-          });
+    };
 
-    const lastFrameBlockRewards = await this.mining.fetchLastFrameBlockRewards();
-    this.activeBidCosts = (await this.mining.fetchLastFramesBidCosts()) * framesPerMiningTerm;
-    this.activeBlockRewards = this.calculateBlockRewards(lastFrameBlockRewards) * framesPerMiningTerm;
-    this.activeAPR = calculateAnnualPercentageRate({
-      startingValue: this.activeBidCosts,
-      endingValue: this.activeBlockRewards,
-      periodDays: miningTermDays,
-    });
-    this.activeAPY =
-      this.activeBlockRewards === 0n
-        ? 0
-        : calculateAnnualPercentageYield({
-            startingValue: this.activeBidCosts,
-            endingValue: this.activeBlockRewards,
-            periodDays: miningTermDays,
-          });
-  }
+    this.activeSeatCount = activeSeatCount;
+    this.aggregatedBidCosts = aggregateBidCosts;
+    this.aggregatedBlockRewards = aggregateRewards;
+    this.averageAPR = calculateAnnualPercentageRate(annualizedInput);
+    this.averageAPY = calculateAnnualPercentageYield(annualizedInput);
 
-  private calculateBlockRewards(blockRewards: { micronots: bigint; microgons: bigint }): bigint {
-    const valueOfMicronots = this.currency.convertMicronotTo(blockRewards.micronots, UnitOfMeasurement.Microgon);
-    return blockRewards.microgons + valueOfMicronots;
+    this.activeBidCosts = this.aggregatedBidCosts;
+    this.activeBlockRewards = this.aggregatedBlockRewards;
+    this.activeAPR = this.averageAPR;
+    this.activeAPY = this.averageAPY;
   }
 }

--- a/core/src/GlobalVaultingStats.ts
+++ b/core/src/GlobalVaultingStats.ts
@@ -1,5 +1,6 @@
 import type { Vaults } from './Vaults.js';
 import { SATOSHIS_PER_BITCOIN, UnitOfMeasurement, type Currency } from './Currency.js';
+import BigNumber from 'bignumber.js';
 
 export class GlobalVaultingStats {
   private vaults: Vaults;
@@ -75,5 +76,14 @@ export class GlobalVaultingStats {
     } else {
       return (1 / r) * (0.576 * r + 0.4);
     }
+  }
+
+  public calculateRestabilizationLeverage(microgonsInCirculation: bigint): number {
+    if (microgonsInCirculation <= 0n) return 0;
+
+    return BigNumber(this.argonBurnCapacity)
+      .dividedBy(BigNumber(microgonsInCirculation.toString()).dividedBy(1_000_000))
+      .decimalPlaces(1)
+      .toNumber();
   }
 }

--- a/core/src/Mining.ts
+++ b/core/src/Mining.ts
@@ -490,7 +490,7 @@ export class Mining {
     const microgonsPerBlockByCohort = await api.query.blockRewards.blockRewardsByCohort();
     for (const [cohortFrameActivationId, blockReward] of microgonsPerBlockByCohort) {
       if (cohortFrameActivationId.toNumber() === frameId) {
-        return this.getMiningRewardCut(blockReward.toBigInt());
+        return this.getMiningRewardCut(blockReward.toBigInt(), api);
       }
     }
     throw new Error(`No block reward found for cohort starting at frame ID ${frameId}`);

--- a/core/src/Mining.ts
+++ b/core/src/Mining.ts
@@ -79,26 +79,40 @@ export class Mining {
     micronots: bigint;
   }> {
     const client = api ?? (await this.prunedClientOrArchivePromise);
-    const blockRewards = await client.query.blockRewards.blockRewardsByCohort();
-    const nextCohortId = blockRewards.pop()?.[0].toNumber() ?? 1;
+    const [blockRewards, minersByCohort, activeMiners] = await Promise.all([
+      client.query.blockRewards.blockRewardsByCohort(),
+      client.query.miningSlot.minersByCohort.entries(),
+      this.fetchActiveMinersCount(client),
+    ]);
+    const nextCohortId = blockRewards.at(-1)?.[0].toNumber() ?? 1;
     const currentCohortId = nextCohortId - 1;
 
-    const currentTick = await this.fetchCurrentTick(api);
-    const ticksBetweenFrames = NetworkConfig.rewardTicksPerFrame;
-    const ticksElapsedThisFrame = ticksBetweenFrames - (await this.fetchFrameRewardTicksRemaining(api));
-
     const rewards = { microgons: 0n, micronots: 0n };
+    if (activeMiners === 0) return rewards;
 
-    for (const [cohortId, blockReward] of blockRewards) {
-      const fullRotationsSinceCohortStart = currentCohortId - cohortId.toNumber();
+    const currentTick = await this.fetchCurrentTick(client);
+    const ticksBetweenFrames = NetworkConfig.rewardTicksPerFrame;
+    const ticksElapsedThisFrame = ticksBetweenFrames - (await this.fetchFrameRewardTicksRemaining(client));
+    const blockRewardsByCohort = new Map(blockRewards.map(([cohortId, reward]) => [cohortId.toNumber(), reward]));
+
+    for (const [cohortIdRaw, cohort] of minersByCohort) {
+      const cohortId = cohortIdRaw.args[0].toNumber();
+      const blockReward = blockRewardsByCohort.get(cohortId);
+      if (!blockReward || cohort.length === 0) continue;
+
+      const fullRotationsSinceCohortStart = currentCohortId - cohortId;
       const ticksSinceCohortStart = fullRotationsSinceCohortStart * ticksBetweenFrames + ticksElapsedThisFrame;
       const startingTick = currentTick - ticksSinceCohortStart;
       const endingTick = startingTick + NetworkConfig.ticksPerCohort;
-      const microgonsMinedInCohort = (blockReward.toBigInt() * BigInt(NetworkConfig.ticksPerCohort)) / 10n;
-      const micronotsMinedInCohort =
-        (await this.minimumMicronotsMinedDuringTickRange(startingTick, endingTick, api)) / 10n;
-      rewards.microgons += microgonsMinedInCohort;
-      rewards.micronots += micronotsMinedInCohort;
+      const seatCount = BigInt(cohort.length);
+      const scheduledMicrogons = await this.getMiningRewardCut(
+        blockReward.toBigInt() * BigInt(NetworkConfig.ticksPerCohort),
+        client,
+      );
+      const scheduledMicronots = await this.minimumMicronotsMinedDuringTickRange(startingTick, endingTick, client);
+
+      rewards.microgons += (scheduledMicrogons * seatCount) / BigInt(activeMiners);
+      rewards.micronots += (scheduledMicronots * seatCount) / BigInt(activeMiners);
     }
 
     return rewards;
@@ -393,8 +407,7 @@ export class Mining {
 
   public async fetchActiveMinersCount(api?: ApiDecoration<'promise'>): Promise<number> {
     const client = api ?? (await this.prunedClientOrArchivePromise);
-    const activeMiners = (await client.query.miningSlot.activeMinersCount()).toNumber();
-    return Math.max(activeMiners, 100);
+    return (await client.query.miningSlot.activeMinersCount()).toNumber();
   }
 
   public async fetchAggregateBidCosts(api?: ApiDecoration<'promise'>): Promise<bigint> {
@@ -407,6 +420,15 @@ export class Mining {
     }
 
     return aggregateBidCosts;
+  }
+
+  public async fetchAggregateMicronotsStaked(api?: ApiDecoration<'promise'>): Promise<bigint> {
+    const client = api ?? (await this.prunedClientOrArchivePromise);
+    const minersByCohort = await client.query.miningSlot.minersByCohort.entries();
+
+    return minersByCohort.reduce((total, [_, cohort]) => {
+      return total + cohort.reduce((cohortTotal, miner) => cohortTotal + miner.argonots.toBigInt(), 0n);
+    }, 0n);
   }
 
   public async fetchLastFramesBidCosts(api?: ApiDecoration<'promise'>): Promise<bigint> {
@@ -474,8 +496,8 @@ export class Mining {
     throw new Error(`No block reward found for cohort starting at frame ID ${frameId}`);
   }
 
-  public async getMiningRewardCut(microgons: bigint): Promise<bigint> {
-    const client = await this.prunedClientOrArchivePromise;
+  public async getMiningRewardCut(microgons: bigint, api?: ApiDecoration<'promise'>): Promise<bigint> {
+    const client = api ?? (await this.prunedClientOrArchivePromise);
     const minerPercent = fromFixedNumber(client.consts.blockRewards.minerPayoutPercent.toBigInt(), FIXED_U128_DECIMALS);
     return bigNumberToBigInt(minerPercent.times(microgons));
   }
@@ -521,7 +543,7 @@ export class Mining {
       }
       totalRewards += rewardsPerBlock;
     }
-    return this.getMiningRewardCut(totalRewards);
+    return this.getMiningRewardCut(totalRewards, client);
   }
 
   private getTicksSinceGenesis(currentTick: number): number {

--- a/core/src/Vaults.ts
+++ b/core/src/Vaults.ts
@@ -8,6 +8,7 @@ import {
   type IAllVaultStats,
   type IDeferred,
   type IVaultFrameStats,
+  type IVaultStats,
   MainchainClients,
   Mining,
   MiningFrames,
@@ -17,7 +18,13 @@ import BigNumber from 'bignumber.js';
 import mainnetVaultRevenueHistory from './data/vaultRevenue.mainnet.json' with { type: 'json' };
 import testnetVaultRevenueHistory from './data/vaultRevenue.testnet.json' with { type: 'json' };
 import { TreasuryBonds } from './TreasuryBonds.js';
-import { annualizeCompoundedReturn, annualizeSimpleReturn } from './FinancialReturns.js';
+import {
+  calculateAggregateReturn,
+  calculateAnnualPercentageRate,
+  calculateAnnualPercentageYield,
+} from './FinancialReturns.js';
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000;
 
 export class Vaults {
   public readonly vaultsById: { [id: number]: Vault } = {};
@@ -125,6 +132,7 @@ export class Vaults {
         frameId,
         microgonLiquidityAdded: microgonsAdded - microgonsRemoved,
         bitcoinFeeRevenue: revenue.bitcoinLockFeeRevenue.toBigInt(),
+        bitcoinFeeCouponValueUsed: revenue.bitcoinLockFeeCouponValueUsed?.toBigInt(),
         bitcoinLocksCreated: revenue.bitcoinLocksCreated.toNumber(),
         treasuryPool: {
           totalEarnings: (revenue.liquidityPoolTotalEarnings ?? revenue.treasuryTotalEarnings).toBigInt(),
@@ -175,7 +183,7 @@ export class Vaults {
       const oldestFrameToGet = this.stats.synchedToFrame - 10;
       const finalizedHead = this.miningFrames.blockWatch.finalizedBlockHeader;
       const frameIdsSeen = new Set<number>();
-      const vaultIdsSeen = new Set<number>();
+      const vaultFramesSeen = new Set<string>();
 
       await new FrameIterator(clients, this.miningFrames, 'VaultHistory').iterateFramesLimited(
         async (frameId, firstBlockMeta, api, abortController) => {
@@ -195,12 +203,13 @@ export class Vaults {
             const vaultId = vaultIdRaw.args[0].toNumber();
             for (const frameRevenue of frameRevenues) {
               const frameId = frameRevenue.frameId.toNumber();
-              if (!frameIdsSeen.has(frameId) || !vaultIdsSeen.has(vaultId)) {
+              const vaultFrame = `${vaultId}:${frameId}`;
+              if (!vaultFramesSeen.has(vaultFrame)) {
                 await this.updateVaultRevenue(vaultId, [frameRevenue], true);
                 frameIdsSeen.add(frameId);
+                vaultFramesSeen.add(vaultFrame);
               }
             }
-            vaultIdsSeen.add(vaultId);
           }
 
           if (frameId <= oldestFrameToGet) {
@@ -353,104 +362,113 @@ export class Vaults {
   }
 
   public calculateBondsApr(): number {
-    let epochExternalPoolCapital = 0n;
-    let epochExternalPoolEarnings = 0;
+    const frames = this.selectReturnFrames(this.stats);
+    const positions = frames.map(frame => {
+      if (frame.bitcoinFeeCouponValueUsed === undefined) {
+        throw new Error(`Vault frame ${frame.frameId} is missing bitcoin fee coupon usage`);
+      }
 
-    // TODO: We might want to update this once we have enough active Treasury app users
-    for (const vaultIdRaw of Object.keys(this.vaultsById)) {
-      const vaultId = Number(vaultIdRaw);
-      const vault = this.vaultsById[vaultId];
-      const totalPoolEarnings = this.treasuryPoolTotalEarnings(vaultId, 10);
-      const totalPoolCapital = this.contributedTotalTreasuryCapital(vaultId, 10);
-      if (!vault.terms.treasuryProfitSharing) continue;
-      if (!totalPoolEarnings) continue;
-      if (!totalPoolCapital) continue;
+      const externalEarnings = frame.treasuryPool.totalEarnings - frame.treasuryPool.vaultEarnings;
+      return {
+        startingCapital: frame.treasuryPool.externalCapital,
+        endingCapital: frame.treasuryPool.externalCapital + externalEarnings,
+      };
+    });
+    const result = calculateAggregateReturn(positions);
 
-      epochExternalPoolCapital += totalPoolCapital;
-      epochExternalPoolEarnings += BigNumber(totalPoolEarnings)
-        .multipliedBy(vault.terms.treasuryProfitSharing)
-        .toNumber();
-    }
-
-    let epochPoolEarningsRatio = 0;
-    if (epochExternalPoolCapital) {
-      epochPoolEarningsRatio = BigNumber(epochExternalPoolEarnings).div(epochExternalPoolCapital).toNumber();
-    }
-
-    return annualizeSimpleReturn(epochPoolEarningsRatio, 10);
-  }
-
-  private calculateEpochReturns(): [number, number] {
-    let yearFeeRevenue = 0n;
-    let securitization = 0n;
-    let epochPoolCapital = 0n;
-    let epochPoolEarnings = 0n;
-
-    for (const vaultIdRaw of Object.keys(this.vaultsById)) {
-      const vaultId = Number(vaultIdRaw);
-      yearFeeRevenue += this.getTrailingYearFeeRevenue(vaultId);
-      securitization += this.vaultsById[vaultId].securitization;
-      epochPoolCapital += this.contributedInternalTreasuryCapital(vaultId, 10);
-      epochPoolEarnings += this.treasuryPoolInternalEarnings(vaultId, 10);
-    }
-
-    let epochPoolEarningsRatio = 0;
-    if (epochPoolCapital) {
-      epochPoolEarningsRatio = BigNumber(epochPoolEarnings).div(epochPoolCapital).toNumber();
-    }
-
-    let feeApr = 0;
-    if (securitization > 0n) {
-      feeApr = BigNumber(yearFeeRevenue).div(securitization).toNumber();
-    }
-
-    return [epochPoolEarningsRatio, feeApr];
+    return calculateAnnualPercentageRate({
+      startingValue: result.eligibleCapitalInvested,
+      endingValue: result.eligibleCapitalInvested + result.totalProfits,
+      periodDays: this.returnFrameDays,
+    });
   }
 
   public calculateApr(): number {
-    const [epochPoolEarningsRatio, feeApr] = this.calculateEpochReturns();
-    const poolApr = annualizeSimpleReturn(epochPoolEarningsRatio, 10);
+    const result = this.calculateVaultReturn();
 
-    return poolApr + feeApr * 100;
+    return calculateAnnualPercentageRate({
+      startingValue: result.eligibleCapitalInvested,
+      endingValue: result.eligibleCapitalInvested + result.totalProfits,
+      periodDays: this.returnFrameDays,
+    });
   }
 
   public calculateApy(): number {
-    const [epochPoolEarningsRatio, feeApr] = this.calculateEpochReturns();
-    const poolApy = annualizeCompoundedReturn(epochPoolEarningsRatio, 10);
+    const result = this.calculateVaultReturn();
 
-    return poolApy + feeApr * 100;
-  }
-
-  private calculateEpochReturnsForVault(vaultId: number): [number, number] {
-    const vault = this.vaultsById[vaultId];
-
-    const yearFeeRevenue = Number(this.getTrailingYearFeeRevenue(vaultId));
-    const epochPoolCapital = Number(this.contributedInternalTreasuryCapital(vaultId, 10));
-    const epochPoolEarnings = Number(this.treasuryPoolInternalEarnings(vaultId, 10));
-    const epochPoolEarningsRatio = epochPoolCapital ? epochPoolEarnings / epochPoolCapital : 0;
-
-    const feeApr = vault.securitization > 0n ? yearFeeRevenue / Number(vault.securitization) : 0;
-
-    return [epochPoolEarningsRatio, feeApr];
+    return calculateAnnualPercentageYield({
+      startingValue: result.eligibleCapitalInvested,
+      endingValue: result.eligibleCapitalInvested + result.totalProfits,
+      periodDays: this.returnFrameDays,
+    });
   }
 
   public calculateVaultApr(vaultId: number): number {
-    const [epochPoolEarningsRatio, feeApr] = this.calculateEpochReturnsForVault(vaultId);
-    const poolApr = annualizeSimpleReturn(epochPoolEarningsRatio, 10);
+    const result = this.calculateVaultReturn(vaultId);
 
-    return poolApr + feeApr * 100;
+    return calculateAnnualPercentageRate({
+      startingValue: result.eligibleCapitalInvested,
+      endingValue: result.eligibleCapitalInvested + result.totalProfits,
+      periodDays: this.returnFrameDays,
+    });
   }
 
   public calculateVaultApy(vaultId: number): number {
-    const [epochPoolEarningsRatio, feeApr] = this.calculateEpochReturnsForVault(vaultId);
-    const poolApy = annualizeCompoundedReturn(epochPoolEarningsRatio, 10);
+    const result = this.calculateVaultReturn(vaultId);
 
-    return poolApy + feeApr * 100;
+    return calculateAnnualPercentageYield({
+      startingValue: result.eligibleCapitalInvested,
+      endingValue: result.eligibleCapitalInvested + result.totalProfits,
+      periodDays: this.returnFrameDays,
+    });
+  }
+
+  private calculateVaultReturn(vaultId?: number) {
+    const frames = this.selectReturnFrames(this.stats, vaultId);
+    const positions = frames.map(frame => {
+      if (frame.bitcoinFeeCouponValueUsed === undefined) {
+        throw new Error(`Vault frame ${frame.frameId} is missing bitcoin fee coupon usage`);
+      }
+
+      const profits = frame.treasuryPool.vaultEarnings + frame.bitcoinFeeRevenue - frame.bitcoinFeeCouponValueUsed;
+      return {
+        startingCapital: frame.securitization,
+        endingCapital: frame.securitization + profits,
+      };
+    });
+
+    return calculateAggregateReturn(positions);
+  }
+
+  private selectReturnFrames(stats?: IAllVaultStats, vaultId?: number): IVaultFrameStats[] {
+    if (!stats) return [];
+
+    let vaultStats: IVaultStats[] = Object.values(stats.vaultsById);
+    if (vaultId !== undefined) {
+      const selectedVault = stats.vaultsById[vaultId];
+      vaultStats = selectedVault ? [selectedVault] : [];
+    }
+
+    const oldestFrameId = stats.synchedToFrame - NetworkConfig.framesPerCohort + 1;
+    return vaultStats.flatMap(vault => {
+      return vault.changesByFrame.filter(
+        frame => frame.frameId >= oldestFrameId && frame.frameId <= stats.synchedToFrame,
+      );
+    });
+  }
+
+  private get returnFrameDays(): number {
+    return (NetworkConfig.rewardTicksPerFrame * NetworkConfig.tickMillis) / MILLISECONDS_PER_DAY;
   }
 
   private async loadStats(): Promise<IAllVaultStats> {
     const statsFromFile = await this.loadStatsFromFile();
-    if (statsFromFile) return statsFromFile;
+    if (statsFromFile) {
+      const recentFrames = this.selectReturnFrames(statsFromFile);
+      if (recentFrames.length > 0 && recentFrames.every(frame => frame.bitcoinFeeCouponValueUsed !== undefined)) {
+        return statsFromFile;
+      }
+    }
 
     const { synchedToFrame, vaultsById } =
       {
@@ -470,26 +488,30 @@ export class Vaults {
           microgonLiquidityRealized: convertBigIntStringToNumber(baseline.microgonLiquidityRealized as any) ?? 0n,
           satoshis: convertBigIntStringToNumber(baseline.satoshis as any) ?? 0n,
         },
-        changesByFrame: changesByFrame.map(
-          change =>
-            ({
-              frameId: change.frameId,
-              satoshisAdded: convertBigIntStringToNumber(change.satoshisAdded as any) ?? 0n,
-              bitcoinLocksCreated: change.bitcoinLocksCreated,
-              microgonLiquidityAdded: convertBigIntStringToNumber(change.microgonLiquidityAdded as any) ?? 0n,
-              bitcoinFeeRevenue: convertBigIntStringToNumber(change.bitcoinFeeRevenue as any) ?? 0n,
-              securitization: convertBigIntStringToNumber(change.securitization as any) ?? 0n,
-              securitizationRelockable: convertBigIntStringToNumber((change as any).securitizationRelockable) ?? 0n,
-              securitizationActivated: convertBigIntStringToNumber(change.securitizationActivated as any) ?? 0n,
-              treasuryPool: {
-                externalCapital: convertBigIntStringToNumber(change.treasuryPool.externalCapital as any) ?? 0n,
-                vaultCapital: convertBigIntStringToNumber(change.treasuryPool.vaultCapital as any) ?? 0n,
-                totalEarnings: convertBigIntStringToNumber(change.treasuryPool.totalEarnings as any) ?? 0n,
-                vaultEarnings: convertBigIntStringToNumber(change.treasuryPool.vaultEarnings as any) ?? 0n,
-              },
-              uncollectedEarnings: 0n,
-            }) as IVaultFrameStats,
-        ),
+        changesByFrame: changesByFrame.map(change => {
+          const bitcoinFeeCouponValueUsed =
+            'bitcoinFeeCouponValueUsed' in change
+              ? convertBigIntStringToNumber(change.bitcoinFeeCouponValueUsed)
+              : undefined;
+          return {
+            frameId: change.frameId,
+            satoshisAdded: convertBigIntStringToNumber(change.satoshisAdded as any) ?? 0n,
+            bitcoinLocksCreated: change.bitcoinLocksCreated,
+            microgonLiquidityAdded: convertBigIntStringToNumber(change.microgonLiquidityAdded as any) ?? 0n,
+            bitcoinFeeRevenue: convertBigIntStringToNumber(change.bitcoinFeeRevenue as any) ?? 0n,
+            bitcoinFeeCouponValueUsed,
+            securitization: convertBigIntStringToNumber(change.securitization as any) ?? 0n,
+            securitizationRelockable: convertBigIntStringToNumber((change as any).securitizationRelockable) ?? 0n,
+            securitizationActivated: convertBigIntStringToNumber(change.securitizationActivated as any) ?? 0n,
+            treasuryPool: {
+              externalCapital: convertBigIntStringToNumber(change.treasuryPool.externalCapital as any) ?? 0n,
+              vaultCapital: convertBigIntStringToNumber(change.treasuryPool.vaultCapital as any) ?? 0n,
+              totalEarnings: convertBigIntStringToNumber(change.treasuryPool.totalEarnings as any) ?? 0n,
+              vaultEarnings: convertBigIntStringToNumber(change.treasuryPool.vaultEarnings as any) ?? 0n,
+            },
+            uncollectedEarnings: 0n,
+          } as IVaultFrameStats;
+        }),
       };
     }
     for (const vault of Object.values(this.vaultsById)) {

--- a/core/src/Vaults.ts
+++ b/core/src/Vaults.ts
@@ -364,10 +364,6 @@ export class Vaults {
   public calculateBondsApr(): number {
     const frames = this.selectReturnFrames(this.stats);
     const positions = frames.map(frame => {
-      if (frame.bitcoinFeeCouponValueUsed === undefined) {
-        throw new Error(`Vault frame ${frame.frameId} is missing bitcoin fee coupon usage`);
-      }
-
       const externalEarnings = frame.treasuryPool.totalEarnings - frame.treasuryPool.vaultEarnings;
       return {
         startingCapital: frame.treasuryPool.externalCapital,

--- a/core/src/data/vaultRevenue.mainnet.json
+++ b/core/src/data/vaultRevenue.mainnet.json
@@ -1,5 +1,5 @@
 {
-  "synchedToFrame": 496,
+  "synchedToFrame": 502,
   "vaultsById": {
     "1": {
       "openedTick": 28997414,
@@ -1449,139 +1449,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "1690389415n",
+            "vaultEarnings": "1625239719n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "1625239719n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "1178049316n",
+            "vaultEarnings": "1158082378n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "1158082378n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "589923792n",
+            "vaultEarnings": "589923792n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "510938462n",
+            "vaultEarnings": "500581601n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "367308370n",
+            "vaultEarnings": "359104685n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
+          "treasuryPool": {
+            "totalEarnings": "581209888n",
+            "vaultEarnings": "567272587n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "310821376n",
             "vaultEarnings": "310553657n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "310553657n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "360615211n",
             "vaultEarnings": "360615211n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "371340081n",
             "vaultEarnings": "368166234n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "443556844n",
             "vaultEarnings": "443556844n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "169730873n",
             "vaultEarnings": "169730873n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "420292555n",
             "vaultEarnings": "420292555n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "543232175n",
             "vaultEarnings": "543232175n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8335673303n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3349997241n",
           "treasuryPool": {
             "totalEarnings": "544716156n",
             "vaultEarnings": "544716156n",
             "externalCapital": "0n",
             "vaultCapital": "2320000000n"
           },
-          "securitization": "8335673303n",
-          "securitizationActivated": "3349997241n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -1590,6 +1706,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
@@ -1607,14 +1724,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2320000000n",
             "totalEarnings": "96458240n",
-            "vaultEarnings": "96458240n"
+            "vaultEarnings": "96458240n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -1624,14 +1742,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2320000000n",
             "totalEarnings": "165831461n",
-            "vaultEarnings": "165831461n"
+            "vaultEarnings": "165831461n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -1641,14 +1760,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2320000000n",
             "totalEarnings": "374807972n",
-            "vaultEarnings": "374807972n"
+            "vaultEarnings": "374807972n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -1658,14 +1778,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2320000000n",
             "totalEarnings": "448204443n",
-            "vaultEarnings": "448204443n"
+            "vaultEarnings": "448204443n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -1675,14 +1796,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8335673303n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3349997241n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2320000000n",
             "totalEarnings": "193837692n",
-            "vaultEarnings": "193837692n"
+            "vaultEarnings": "193837692n",
+            "externalCapital": "0n",
+            "vaultCapital": "2320000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -3398,139 +3520,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "5292667552n",
+            "vaultEarnings": "5086787125n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "5086787125n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "3688513083n",
+            "vaultEarnings": "3625623685n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "3625623685n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "1847493522n",
+            "vaultEarnings": "1847493522n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "1599765979n",
+            "vaultEarnings": "1566765548n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "1150055190n",
+            "vaultEarnings": "1124058248n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
+          "treasuryPool": {
+            "totalEarnings": "1819788228n",
+            "vaultEarnings": "1775784751n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "973192461n",
             "vaultEarnings": "972255540n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "972255540n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1129581071n",
             "vaultEarnings": "1129581071n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1129581071n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1162678618n",
             "vaultEarnings": "1152366964n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1389110201n",
             "vaultEarnings": "1389110201n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "531515999n",
             "vaultEarnings": "531515999n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1316069447n",
             "vaultEarnings": "1316069447n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1701274238n",
             "vaultEarnings": "1701274238n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "7608214631n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "7608135690n",
           "treasuryPool": {
             "totalEarnings": "1705676855n",
             "vaultEarnings": "1705676855n",
             "externalCapital": "0n",
             "vaultCapital": "7264000000n"
           },
-          "securitization": "7608214631n",
-          "securitizationActivated": "7608135690n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -3539,6 +3777,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
@@ -3556,14 +3795,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7264000000n",
             "totalEarnings": "302057199n",
-            "vaultEarnings": "302057199n"
+            "vaultEarnings": "302057199n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -3573,14 +3813,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7264000000n",
             "totalEarnings": "519371294n",
-            "vaultEarnings": "519371294n"
+            "vaultEarnings": "519371294n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -3590,14 +3831,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7264000000n",
             "totalEarnings": "1173767448n",
-            "vaultEarnings": "1173767448n"
+            "vaultEarnings": "1173767448n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -3607,14 +3849,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7264000000n",
             "totalEarnings": "1403423857n",
-            "vaultEarnings": "1403423857n"
+            "vaultEarnings": "1403423857n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -3624,14 +3867,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "7608214631n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "7608135690n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7264000000n",
             "totalEarnings": "607050705n",
-            "vaultEarnings": "607050705n"
+            "vaultEarnings": "607050705n",
+            "externalCapital": "0n",
+            "vaultCapital": "7264000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -4871,139 +5115,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "1726091575n",
+            "vaultEarnings": "1658868535n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "1658868535n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "1202930554n",
+            "vaultEarnings": "1182465760n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "1182465760n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "602410295n",
+            "vaultEarnings": "602410295n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "521729844n",
+            "vaultEarnings": "510945845n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "375066179n",
+            "vaultEarnings": "366556014n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
+          "treasuryPool": {
+            "totalEarnings": "593485446n",
+            "vaultEarnings": "579302439n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "317386140n",
             "vaultEarnings": "317118416n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "317118416n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "368334798n",
             "vaultEarnings": "368334798n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "368334798n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "379183043n",
             "vaultEarnings": "375851309n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "452907186n",
             "vaultEarnings": "452907186n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "173317249n",
             "vaultEarnings": "173317249n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "429188591n",
             "vaultEarnings": "429188591n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "554845769n",
             "vaultEarnings": "554845769n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3399433892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "3399433178n",
           "treasuryPool": {
             "totalEarnings": "556198965n",
             "vaultEarnings": "556198965n",
             "externalCapital": "0n",
             "vaultCapital": "2369000000n"
           },
-          "securitization": "3399433892n",
-          "securitizationActivated": "3399433178n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -5012,6 +5372,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
@@ -5029,14 +5390,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2369000000n",
             "totalEarnings": "98512444n",
-            "vaultEarnings": "98512444n"
+            "vaultEarnings": "98512444n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -5046,14 +5408,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2369000000n",
             "totalEarnings": "169340727n",
-            "vaultEarnings": "169340727n"
+            "vaultEarnings": "169340727n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -5063,14 +5426,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2369000000n",
             "totalEarnings": "382750254n",
-            "vaultEarnings": "382750254n"
+            "vaultEarnings": "382750254n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -5080,14 +5444,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2369000000n",
             "totalEarnings": "457638214n",
-            "vaultEarnings": "457638214n"
+            "vaultEarnings": "457638214n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -5097,14 +5462,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3399433892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "3399433178n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2369000000n",
             "totalEarnings": "197916619n",
-            "vaultEarnings": "197916619n"
+            "vaultEarnings": "197916619n",
+            "externalCapital": "0n",
+            "vaultCapital": "2369000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6344,139 +6710,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "9198049977n",
+            "vaultEarnings": "8737766791n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "8737766791n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "6410213288n",
+            "vaultEarnings": "6227684511n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "6227684511n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "3216932174n",
+            "vaultEarnings": "3185641023n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "2780210039n",
+            "vaultEarnings": "2691309832n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "1998664201n",
+            "vaultEarnings": "1930609599n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
+          "treasuryPool": {
+            "totalEarnings": "3162583513n",
+            "vaultEarnings": "3050229526n",
+            "externalCapital": "0n",
+            "vaultCapital": "12624000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "1691297035n",
             "vaultEarnings": "1669998730n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1669998730n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "1986140671n",
             "vaultEarnings": "1986140670n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1986140670n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "2020602272n",
             "vaultEarnings": "1979519096n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "2442582082n",
             "vaultEarnings": "2442582081n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "923968329n",
             "vaultEarnings": "913547632n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "2291910699n",
             "vaultEarnings": "2269973377n",
             "externalCapital": "0n",
             "vaultCapital": "12624000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "12460239385n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "5572000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "12460239385n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "8352180n",
           "frameId": 489,
+          "satoshisAdded": "8352180n",
+          "bitcoinLocksCreated": 1,
           "microgonLiquidityAdded": "3787604066n",
           "bitcoinFeeRevenue": "625023097n",
-          "bitcoinLocksCreated": 1,
+          "bitcoinFeeCouponValueUsed": "625023097n",
+          "securitization": "12798374177n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "0n",
           "treasuryPool": {
             "totalEarnings": "1332963727n",
             "vaultEarnings": "968859103n",
             "externalCapital": "0n",
             "vaultCapital": "5572000000n"
           },
-          "securitization": "12798374177n",
-          "securitizationActivated": "0n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -6485,6 +6967,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
@@ -6502,14 +6985,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "5572000000n",
             "totalEarnings": "248826541n",
-            "vaultEarnings": "190631305n"
+            "vaultEarnings": "190631305n",
+            "externalCapital": "0n",
+            "vaultCapital": "5572000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6519,14 +7003,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "5572000000n",
             "totalEarnings": "416034627n",
-            "vaultEarnings": "309953863n"
+            "vaultEarnings": "309953863n",
+            "externalCapital": "0n",
+            "vaultCapital": "5572000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6536,14 +7021,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "5572000000n",
             "totalEarnings": "941582521n",
-            "vaultEarnings": "702530504n"
+            "vaultEarnings": "702530504n",
+            "externalCapital": "0n",
+            "vaultCapital": "5572000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6553,14 +7039,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "5572000000n",
             "totalEarnings": "1118403572n",
-            "vaultEarnings": "829020181n"
+            "vaultEarnings": "829020181n",
+            "externalCapital": "0n",
+            "vaultCapital": "5572000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6570,14 +7057,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "12798374177n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8672857884n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "5572000000n",
             "totalEarnings": "494082168n",
-            "vaultEarnings": "374001608n"
+            "vaultEarnings": "374001608n",
+            "externalCapital": "0n",
+            "vaultCapital": "5572000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -7800,139 +8288,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "7289804359n",
+            "vaultEarnings": "6898835849n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "6898835849n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "5080337771n",
+            "vaultEarnings": "4917169332n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "4917169332n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "2549541062n",
+            "vaultEarnings": "2515101391n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "2203422175n",
+            "vaultEarnings": "2124842299n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "1584017369n",
+            "vaultEarnings": "1524441494n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
+          "treasuryPool": {
+            "totalEarnings": "2506467677n",
+            "vaultEarnings": "2408491077n",
+            "externalCapital": "0n",
+            "vaultCapital": "10005000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1340417204n",
             "vaultEarnings": "1318540371n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
-          "uncollectedEarnings": "1318540371n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1576214593n",
             "vaultEarnings": "1572442616n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
-          "uncollectedEarnings": "1572442616n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1601404125n",
             "vaultEarnings": "1562974174n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1943117973n",
             "vaultEarnings": "1943117972n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "732280033n",
             "vaultEarnings": "721250415n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1816426373n",
             "vaultEarnings": "1792419948n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "2371307995n",
             "vaultEarnings": "2363041482n",
             "externalCapital": "0n",
             "vaultCapital": "10005000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "1586550n",
           "frameId": 489,
+          "satoshisAdded": "1586550n",
+          "bitcoinLocksCreated": 1,
           "microgonLiquidityAdded": "-242961008n",
           "bitcoinFeeRevenue": "497415666n",
-          "bitcoinLocksCreated": 1,
+          "bitcoinFeeCouponValueUsed": "497415666n",
+          "securitization": "17898399192n",
+          "securitizationRelockable": "242961008n",
+          "securitizationActivated": "9908090856n",
           "treasuryPool": {
             "totalEarnings": "1889401928n",
             "vaultEarnings": "1649076851n",
             "externalCapital": "0n",
             "vaultCapital": "7898000000n"
           },
-          "securitization": "17898399192n",
-          "securitizationActivated": "9908090856n",
-          "securitizationRelockable": "242961008n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -7941,6 +8545,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
@@ -7958,14 +8563,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7898000000n",
             "totalEarnings": "352697778n",
-            "vaultEarnings": "324511538n"
+            "vaultEarnings": "324511538n",
+            "externalCapital": "0n",
+            "vaultCapital": "7898000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -7975,14 +8581,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7898000000n",
             "totalEarnings": "589705936n",
-            "vaultEarnings": "527582406n"
+            "vaultEarnings": "527582406n",
+            "externalCapital": "0n",
+            "vaultCapital": "7898000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -7992,14 +8599,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7898000000n",
             "totalEarnings": "1334640844n",
-            "vaultEarnings": "1195801858n"
+            "vaultEarnings": "1195801858n",
+            "externalCapital": "0n",
+            "vaultCapital": "7898000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -8009,14 +8617,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7898000000n",
             "totalEarnings": "1585274831n",
-            "vaultEarnings": "1411078622n"
+            "vaultEarnings": "1411078622n",
+            "externalCapital": "0n",
+            "vaultCapital": "7898000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -8026,14 +8635,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "17898399192n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "10151274328n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "7898000000n",
             "totalEarnings": "700333984n",
-            "vaultEarnings": "636652601n"
+            "vaultEarnings": "636652601n",
+            "externalCapital": "0n",
+            "vaultCapital": "7898000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9205,139 +9815,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "1354497376n",
+            "vaultEarnings": "1327364586n",
+            "externalCapital": "0n",
+            "vaultCapital": "1859000000n"
+          },
+          "uncollectedEarnings": "1327364586n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "941931673n",
+            "vaultEarnings": "941931672n",
+            "externalCapital": "0n",
+            "vaultCapital": "1859000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "463784572n",
+            "vaultEarnings": "463784570n",
+            "externalCapital": "0n",
+            "vaultCapital": "1859000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "409411467n",
+            "vaultEarnings": "408751833n",
+            "externalCapital": "0n",
+            "vaultCapital": "1859000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "276747857n",
+            "vaultEarnings": "259247188n",
+            "externalCapital": "0n",
+            "vaultCapital": "1748000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
+          "treasuryPool": {
+            "totalEarnings": "437911585n",
+            "vaultEarnings": "409560968n",
+            "externalCapital": "0n",
+            "vaultCapital": "1748000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "234187828n",
             "vaultEarnings": "224307025n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "224307025n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "275384618n",
             "vaultEarnings": "267429061n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "279785542n",
             "vaultEarnings": "265796264n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "340508286n",
             "vaultEarnings": "332518705n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "127938576n",
             "vaultEarnings": "122675057n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "317352648n",
             "vaultEarnings": "304798037n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "414297481n",
             "vaultEarnings": "401882350n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2415645233n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2408834864n",
           "treasuryPool": {
             "totalEarnings": "418165927n",
             "vaultEarnings": "408354211n",
             "externalCapital": "0n",
             "vaultCapital": "1748000000n"
           },
-          "securitization": "2415645233n",
-          "securitizationActivated": "2408834864n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -9346,6 +10072,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2408834864n",
@@ -9363,14 +10090,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2408834864n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1748000000n",
             "totalEarnings": "75826895n",
-            "vaultEarnings": "75826894n"
+            "vaultEarnings": "75826894n",
+            "externalCapital": "0n",
+            "vaultCapital": "1748000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9380,14 +10108,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2408834864n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1748000000n",
             "totalEarnings": "130365478n",
-            "vaultEarnings": "130365477n"
+            "vaultEarnings": "130365477n",
+            "externalCapital": "0n",
+            "vaultCapital": "1748000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9397,14 +10126,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2408834864n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1748000000n",
             "totalEarnings": "294540259n",
-            "vaultEarnings": "294540258n"
+            "vaultEarnings": "294540258n",
+            "externalCapital": "0n",
+            "vaultCapital": "1748000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9414,14 +10144,15 @@
           "bitcoinLocksCreated": 1,
           "microgonLiquidityAdded": "452633603n",
           "bitcoinFeeRevenue": "24631680n",
+          "bitcoinFeeCouponValueUsed": "24631680n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2408834864n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1352000000n",
             "totalEarnings": "261134781n",
-            "vaultEarnings": "261134781n"
+            "vaultEarnings": "261134781n",
+            "externalCapital": "0n",
+            "vaultCapital": "1352000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9431,14 +10162,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2415645233n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1956201261n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1352000000n",
             "totalEarnings": "112968532n",
-            "vaultEarnings": "112968532n"
+            "vaultEarnings": "112968532n",
+            "externalCapital": "0n",
+            "vaultCapital": "1352000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -10559,139 +11291,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "1817897221n",
+            "vaultEarnings": "1747170094n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "1747170094n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "1266910815n",
+            "vaultEarnings": "1245446210n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "1245446210n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "634518465n",
+            "vaultEarnings": "634518465n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "634518465n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "549479079n",
+            "vaultEarnings": "538260817n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "395014825n",
+            "vaultEarnings": "386040731n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
+          "treasuryPool": {
+            "totalEarnings": "625051158n",
+            "vaultEarnings": "609895439n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "334266957n",
             "vaultEarnings": "333999222n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "333999222n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "387870098n",
             "vaultEarnings": "387870098n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "399350652n",
             "vaultEarnings": "395860102n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "477062245n",
             "vaultEarnings": "477062245n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "182539367n",
             "vaultEarnings": "182539367n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "452064127n",
             "vaultEarnings": "452064127n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "584235303n",
             "vaultEarnings": "584235303n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "3012083892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2925920256n",
           "treasuryPool": {
             "totalEarnings": "585862918n",
             "vaultEarnings": "585862918n",
             "externalCapital": "0n",
             "vaultCapital": "2495000000n"
           },
-          "securitization": "3012083892n",
-          "securitizationActivated": "2925920256n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -10700,6 +11548,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
@@ -10717,14 +11566,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2495000000n",
             "totalEarnings": "103737265n",
-            "vaultEarnings": "103737265n"
+            "vaultEarnings": "103737265n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -10734,14 +11584,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2495000000n",
             "totalEarnings": "178375219n",
-            "vaultEarnings": "178375219n"
+            "vaultEarnings": "178375219n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -10751,14 +11602,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2495000000n",
             "totalEarnings": "403197395n",
-            "vaultEarnings": "403197395n"
+            "vaultEarnings": "403197395n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -10768,14 +11620,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2495000000n",
             "totalEarnings": "481925157n",
-            "vaultEarnings": "481925157n"
+            "vaultEarnings": "481925157n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -10785,14 +11638,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "3012083892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2925920256n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "2495000000n",
             "totalEarnings": "208468623n",
-            "vaultEarnings": "208468623n"
+            "vaultEarnings": "208468623n",
+            "externalCapital": "0n",
+            "vaultCapital": "2495000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -11913,139 +12767,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19241448612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "4571337592n",
+            "vaultEarnings": "4508814974n",
+            "externalCapital": "0n",
+            "vaultCapital": "6274000000n"
+          },
+          "uncollectedEarnings": "4508814974n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "3104566212n",
+            "vaultEarnings": "3052149512n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "1554952478n",
+            "vaultEarnings": "1554952478n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "1346499060n",
+            "vaultEarnings": "1318887416n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "967984226n",
+            "vaultEarnings": "946163958n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
+          "treasuryPool": {
+            "totalEarnings": "1531688491n",
+            "vaultEarnings": "1494771497n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "819121516n",
             "vaultEarnings": "818318455n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "818318455n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "950612581n",
             "vaultEarnings": "950612581n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "978609175n",
             "vaultEarnings": "970041584n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "1169182356n",
             "vaultEarnings": "1169182356n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "447272691n",
             "vaultEarnings": "447272691n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "1107647907n",
             "vaultEarnings": "1107647907n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "1431791255n",
             "vaultEarnings": "1431791255n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "8812688612n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "8812688005n",
           "treasuryPool": {
             "totalEarnings": "1435591407n",
             "vaultEarnings": "1435591407n",
             "externalCapital": "0n",
             "vaultCapital": "6114000000n"
           },
-          "securitization": "8812688612n",
-          "securitizationActivated": "8812688005n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -12054,6 +13024,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
@@ -12071,14 +13042,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "6114000000n",
             "totalEarnings": "254229989n",
-            "vaultEarnings": "254229989n"
+            "vaultEarnings": "254229989n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -12088,14 +13060,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "6114000000n",
             "totalEarnings": "437090220n",
-            "vaultEarnings": "437090220n"
+            "vaultEarnings": "437090220n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -12105,14 +13078,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "6114000000n",
             "totalEarnings": "987884325n",
-            "vaultEarnings": "987884325n"
+            "vaultEarnings": "987884325n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -12122,14 +13096,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "6114000000n",
             "totalEarnings": "1181027742n",
-            "vaultEarnings": "1181027742n"
+            "vaultEarnings": "1181027742n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -12139,14 +13114,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "8812688612n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "8812688005n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "6114000000n",
             "totalEarnings": "510841238n",
-            "vaultEarnings": "510841238n"
+            "vaultEarnings": "510841238n",
+            "externalCapital": "0n",
+            "vaultCapital": "6114000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -13182,139 +14158,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "1200759378n",
+            "vaultEarnings": "1153849244n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "1153849244n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "836821234n",
+            "vaultEarnings": "822350264n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "822350264n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "419189899n",
+            "vaultEarnings": "419189899n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "362942491n",
+            "vaultEarnings": "355394667n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "260915600n",
+            "vaultEarnings": "255034939n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
+          "treasuryPool": {
+            "totalEarnings": "412859436n",
+            "vaultEarnings": "402837389n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "220790356n",
             "vaultEarnings": "220522731n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "220522731n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "256321953n",
             "vaultEarnings": "256321953n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "256321953n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "263779505n",
             "vaultEarnings": "261400255n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "315184440n",
             "vaultEarnings": "315184440n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "120619438n",
             "vaultEarnings": "120619438n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "298652804n",
             "vaultEarnings": "298652804n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "386093021n",
             "vaultEarnings": "386093021n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2434863581n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "2434784650n",
           "treasuryPool": {
             "totalEarnings": "387066632n",
             "vaultEarnings": "387066632n",
             "externalCapital": "0n",
             "vaultCapital": "1648000000n"
           },
-          "securitization": "2434863581n",
-          "securitizationActivated": "2434784650n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -13323,6 +14415,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
@@ -13340,14 +14433,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1648000000n",
             "totalEarnings": "68547870n",
-            "vaultEarnings": "68547870n"
+            "vaultEarnings": "68547870n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -13357,14 +14451,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1648000000n",
             "totalEarnings": "117821721n",
-            "vaultEarnings": "117821721n"
+            "vaultEarnings": "117821721n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -13374,14 +14469,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1648000000n",
             "totalEarnings": "266319816n",
-            "vaultEarnings": "266319816n"
+            "vaultEarnings": "266319816n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -13391,14 +14487,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1648000000n",
             "totalEarnings": "318339559n",
-            "vaultEarnings": "318339559n"
+            "vaultEarnings": "318339559n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -13408,14 +14505,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2434863581n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "2434784650n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1648000000n",
             "totalEarnings": "137708112n",
-            "vaultEarnings": "137708112n"
+            "vaultEarnings": "137708112n",
+            "externalCapital": "0n",
+            "vaultCapital": "1648000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -14451,139 +15549,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "1172343334n",
+            "vaultEarnings": "1127495770n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "1127495770n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "817017832n",
+            "vaultEarnings": "803534041n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "803534041n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "408996843n",
+            "vaultEarnings": "408996843n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "408996843n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "354353449n",
+            "vaultEarnings": "347231851n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "347231851n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "254741016n",
+            "vaultEarnings": "249014759n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
+          "treasuryPool": {
+            "totalEarnings": "403089093n",
+            "vaultEarnings": "393549970n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "215565339n",
             "vaultEarnings": "215431447n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
-          "uncollectedEarnings": "215431447n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "250177784n",
             "vaultEarnings": "250177784n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "257537147n",
             "vaultEarnings": "255315631n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "307587292n",
             "vaultEarnings": "307587292n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "117691782n",
             "vaultEarnings": "117691782n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "291390734n",
             "vaultEarnings": "291390734n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "376612526n",
             "vaultEarnings": "376612526n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "2327433892n",
+          "securitizationRelockable": "253610610n",
+          "securitizationActivated": "2063822520n",
           "treasuryPool": {
             "totalEarnings": "377736849n",
             "vaultEarnings": "377736849n",
             "externalCapital": "0n",
             "vaultCapital": "1609000000n"
           },
-          "securitization": "2327433892n",
-          "securitizationActivated": "2063822520n",
-          "securitizationRelockable": "253610610n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -14592,6 +15806,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
@@ -14609,14 +15824,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1609000000n",
             "totalEarnings": "66895576n",
-            "vaultEarnings": "66895576n"
+            "vaultEarnings": "66895576n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -14626,14 +15842,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1609000000n",
             "totalEarnings": "114984444n",
-            "vaultEarnings": "114984444n"
+            "vaultEarnings": "114984444n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -14643,14 +15860,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1609000000n",
             "totalEarnings": "259898402n",
-            "vaultEarnings": "259898402n"
+            "vaultEarnings": "259898402n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -14660,14 +15878,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1609000000n",
             "totalEarnings": "310712253n",
-            "vaultEarnings": "310712253n"
+            "vaultEarnings": "310712253n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -14677,14 +15896,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "2327433892n",
           "securitizationRelockable": "253610610n",
           "securitizationActivated": "2063822520n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1609000000n",
             "totalEarnings": "134427237n",
-            "vaultEarnings": "134427237n"
+            "vaultEarnings": "134427237n",
+            "externalCapital": "0n",
+            "vaultCapital": "1609000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -15703,139 +16923,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "824793427n",
+            "vaultEarnings": "792585873n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "792585873n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "574806824n",
+            "vaultEarnings": "564827538n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "287954151n",
+            "vaultEarnings": "287954151n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "249302733n",
+            "vaultEarnings": "244126897n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "179221152n",
+            "vaultEarnings": "175197188n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
+          "treasuryPool": {
+            "totalEarnings": "283590340n",
+            "vaultEarnings": "276745055n",
+            "externalCapital": "0n",
+            "vaultCapital": "1132000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "151659395n",
             "vaultEarnings": "151525538n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "151525538n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "175975176n",
             "vaultEarnings": "175975176n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "175975176n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "181188349n",
             "vaultEarnings": "179601761n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "216421455n",
             "vaultEarnings": "216421455n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "82852671n",
             "vaultEarnings": "82852671n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "205153596n",
             "vaultEarnings": "205153596n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "265216747n",
             "vaultEarnings": "265216747n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1619933892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1619933062n",
           "treasuryPool": {
             "totalEarnings": "265779372n",
             "vaultEarnings": "265779372n",
             "externalCapital": "0n",
             "vaultCapital": "1132000000n"
           },
-          "securitization": "1619933892n",
-          "securitizationActivated": "1619933062n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -15844,6 +17180,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15861,6 +17198,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15878,6 +17216,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15895,6 +17234,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15912,6 +17252,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15929,6 +17270,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
@@ -15946,14 +17288,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "432956973n",
-            "vaultEarnings": "432956973n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "432956973n",
+            "vaultEarnings": "432956973n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -15963,14 +17306,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "643405040n",
-            "vaultEarnings": "643405040n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "643405040n",
+            "vaultEarnings": "643405040n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -15980,14 +17324,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "98757486n",
-            "vaultEarnings": "98757486n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "98757486n",
+            "vaultEarnings": "98757486n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -15997,14 +17342,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "97783395n",
-            "vaultEarnings": "94490688n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "97783395n",
+            "vaultEarnings": "94490688n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16014,14 +17360,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "97253836n",
-            "vaultEarnings": "95288603n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "97253836n",
+            "vaultEarnings": "95288603n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16031,14 +17378,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1619933892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "98105096n",
-            "vaultEarnings": "96798735n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "98105096n",
+            "vaultEarnings": "96798735n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16052,10 +17400,10 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "97127344n",
-            "vaultEarnings": "96896292n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "97127344n",
+            "vaultEarnings": "96896292n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16069,10 +17417,10 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "98461326n",
-            "vaultEarnings": "96173498n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "98461326n",
+            "vaultEarnings": "96173498n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16086,10 +17434,10 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "97920827n",
-            "vaultEarnings": "94768009n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "97920827n",
+            "vaultEarnings": "94768009n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16103,10 +17451,10 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "98468847n",
-            "vaultEarnings": "93377327n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "98468847n",
+            "vaultEarnings": "93377327n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16120,10 +17468,10 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "96676416n",
-            "vaultEarnings": "91473233n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "96676416n",
+            "vaultEarnings": "91473233n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -16137,12 +17485,12 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "96517104n",
-            "vaultEarnings": "94129051n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "96517104n",
+            "vaultEarnings": "94129051n"
           },
-          "uncollectedEarnings": "94129051n"
+          "uncollectedEarnings": "0n"
         },
         {
           "frameId": 470,
@@ -16154,12 +17502,12 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "96506848n",
-            "vaultEarnings": "94410319n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "96506848n",
+            "vaultEarnings": "94410319n"
           },
-          "uncollectedEarnings": "94410319n"
+          "uncollectedEarnings": "0n"
         },
         {
           "frameId": 469,
@@ -16171,12 +17519,12 @@
           "securitizationRelockable": "0n",
           "securitizationActivated": "1619933062n",
           "treasuryPool": {
-            "totalEarnings": "97458959n",
-            "vaultEarnings": "96311883n",
             "externalCapital": "0n",
-            "vaultCapital": "1132000000n"
+            "vaultCapital": "1132000000n",
+            "totalEarnings": "97458959n",
+            "vaultEarnings": "96311883n"
           },
-          "uncollectedEarnings": "96311883n"
+          "uncollectedEarnings": "0n"
         },
         {
           "frameId": 468,
@@ -18349,139 +19697,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "8075981171n",
+            "vaultEarnings": "7762242048n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "7762242048n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "5628232268n",
+            "vaultEarnings": "5532889264n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "2818892880n",
+            "vaultEarnings": "2818892880n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "2441052609n",
+            "vaultEarnings": "2390795009n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "1754847434n",
+            "vaultEarnings": "1715080588n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
+          "treasuryPool": {
+            "totalEarnings": "2776780393n",
+            "vaultEarnings": "2709793438n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "1484975946n",
             "vaultEarnings": "1483503685n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1483503685n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "1723517006n",
             "vaultEarnings": "1723517006n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1723517006n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "1774109283n",
             "vaultEarnings": "1758560838n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "1758560838n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "2119605680n",
             "vaultEarnings": "2119605680n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "2119605680n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "810960792n",
             "vaultEarnings": "810960792n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "810960792n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "2007963590n",
             "vaultEarnings": "2007963590n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "2007963590n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "2595758639n",
             "vaultEarnings": "2595758639n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "2595758639n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "16628203892n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "15271979984n",
           "treasuryPool": {
             "totalEarnings": "2602532746n",
             "vaultEarnings": "2602532746n",
             "externalCapital": "0n",
             "vaultCapital": "11084000000n"
           },
-          "securitization": "16628203892n",
-          "securitizationActivated": "15271979984n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -18490,6 +19954,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
@@ -18507,14 +19972,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "11084000000n",
             "totalEarnings": "460900705n",
-            "vaultEarnings": "460900705n"
+            "vaultEarnings": "460900705n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -18524,14 +19990,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "11084000000n",
             "totalEarnings": "792422017n",
-            "vaultEarnings": "792422017n"
+            "vaultEarnings": "792422017n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -18541,14 +20008,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "11084000000n",
             "totalEarnings": "1790899428n",
-            "vaultEarnings": "1790899428n"
+            "vaultEarnings": "1790899428n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -18558,14 +20026,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "11084000000n",
             "totalEarnings": "2141265129n",
-            "vaultEarnings": "2141265129n"
+            "vaultEarnings": "2141265129n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -18575,14 +20044,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "16628203892n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "15271979984n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "11084000000n",
             "totalEarnings": "926182386n",
-            "vaultEarnings": "926182386n"
+            "vaultEarnings": "926182386n",
+            "externalCapital": "0n",
+            "vaultCapital": "11084000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -19312,139 +20782,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "806379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "457570888n",
+            "vaultEarnings": "440052860n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "440052860n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "806379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "318885746n",
+            "vaultEarnings": "313396320n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "159776327n",
+            "vaultEarnings": "159776327n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "138305751n",
+            "vaultEarnings": "135500798n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "99426569n",
+            "vaultEarnings": "97258388n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
+          "treasuryPool": {
+            "totalEarnings": "157327493n",
+            "vaultEarnings": "153657333n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "84136125n",
             "vaultEarnings": "84136125n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "84136125n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "97676462n",
             "vaultEarnings": "97676462n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "97676462n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "100517912n",
             "vaultEarnings": "99723931n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "119996048n",
             "vaultEarnings": "119996048n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "45964204n",
             "vaultEarnings": "45964204n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "113833006n",
             "vaultEarnings": "113833006n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "146947610n",
             "vaultEarnings": "146947610n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "771379615n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "771378259n",
           "treasuryPool": {
             "totalEarnings": "147362821n",
             "vaultEarnings": "147362821n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "771379615n",
-          "securitizationActivated": "771378259n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -19453,6 +21039,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
@@ -19470,14 +21057,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "628000000n",
             "totalEarnings": "26124105n",
-            "vaultEarnings": "26124105n"
+            "vaultEarnings": "26124105n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -19487,14 +21075,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "628000000n",
             "totalEarnings": "44873798n",
-            "vaultEarnings": "44873798n"
+            "vaultEarnings": "44873798n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -19504,14 +21093,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "628000000n",
             "totalEarnings": "101390793n",
-            "vaultEarnings": "101390793n"
+            "vaultEarnings": "101390793n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -19521,14 +21111,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "628000000n",
             "totalEarnings": "121233982n",
-            "vaultEarnings": "121233982n"
+            "vaultEarnings": "121233982n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -19538,14 +21129,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "771379615n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "771378259n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "628000000n",
             "totalEarnings": "52494013n",
-            "vaultEarnings": "52494013n"
+            "vaultEarnings": "52494013n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -20224,139 +21816,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "864867339n",
+            "vaultEarnings": "831253061n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "831253061n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "602734712n",
+            "vaultEarnings": "592747392n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "592747392n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "301969624n",
+            "vaultEarnings": "301969624n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "301969624n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "261415496n",
+            "vaultEarnings": "256023262n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "256023262n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "187928888n",
+            "vaultEarnings": "183749250n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "183749250n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
+          "treasuryPool": {
+            "totalEarnings": "297369015n",
+            "vaultEarnings": "290277155n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
+          },
+          "uncollectedEarnings": "290277155n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "159028000n",
             "vaultEarnings": "158894138n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "158894138n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "184482482n",
             "vaultEarnings": "184482482n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "184482482n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "189991665n",
             "vaultEarnings": "188404433n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "188404433n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "226940586n",
             "vaultEarnings": "226940586n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "226940586n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "86878197n",
             "vaultEarnings": "86878197n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "86878197n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "214957404n",
             "vaultEarnings": "214957404n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "214957404n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "278015415n",
             "vaultEarnings": "278015415n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "278015415n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "1595565043n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "1595564646n",
           "treasuryPool": {
             "totalEarnings": "278697547n",
             "vaultEarnings": "278697547n",
             "externalCapital": "0n",
             "vaultCapital": "1187000000n"
           },
-          "securitization": "1595565043n",
-          "securitizationActivated": "1595564646n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "278697547n"
         },
         {
@@ -20365,6 +22073,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
@@ -20382,16 +22091,17 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1187000000n",
             "totalEarnings": "49345534n",
-            "vaultEarnings": "49345534n"
+            "vaultEarnings": "49345534n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
           },
-          "uncollectedEarnings": "0n"
+          "uncollectedEarnings": "49345534n"
         },
         {
           "frameId": 486,
@@ -20399,16 +22109,17 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1187000000n",
             "totalEarnings": "84894355n",
-            "vaultEarnings": "84894355n"
+            "vaultEarnings": "84894355n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
           },
-          "uncollectedEarnings": "0n"
+          "uncollectedEarnings": "84894355n"
         },
         {
           "frameId": 485,
@@ -20416,16 +22127,17 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1187000000n",
             "totalEarnings": "191797587n",
-            "vaultEarnings": "191797587n"
+            "vaultEarnings": "191797587n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
           },
-          "uncollectedEarnings": "0n"
+          "uncollectedEarnings": "191797587n"
         },
         {
           "frameId": 484,
@@ -20433,16 +22145,17 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1187000000n",
             "totalEarnings": "229220541n",
-            "vaultEarnings": "229220541n"
+            "vaultEarnings": "229220541n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
           },
-          "uncollectedEarnings": "0n"
+          "uncollectedEarnings": "229220541n"
         },
         {
           "frameId": 483,
@@ -20450,16 +22163,17 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "1595565043n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "1595564646n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "1187000000n",
             "totalEarnings": "99224325n",
-            "vaultEarnings": "99224325n"
+            "vaultEarnings": "99224325n",
+            "externalCapital": "0n",
+            "vaultCapital": "1187000000n"
           },
-          "uncollectedEarnings": "0n"
+          "uncollectedEarnings": "99224325n"
         },
         {
           "frameId": 482,
@@ -21136,139 +22850,255 @@
       },
       "changesByFrame": [
         {
+          "frameId": 502,
           "satoshisAdded": "0n",
-          "frameId": 496,
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "223685112n",
+            "vaultEarnings": "214597904n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "214597904n"
+        },
+        {
+          "frameId": 501,
+          "satoshisAdded": "0n",
           "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "155888410n",
+            "vaultEarnings": "152900133n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 500,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "78231781n",
+            "vaultEarnings": "78231781n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 499,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "67611247n",
+            "vaultEarnings": "66103989n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 498,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "48605027n",
+            "vaultEarnings": "47370613n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 497,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
+          "treasuryPool": {
+            "totalEarnings": "76910097n",
+            "vaultEarnings": "74956824n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 496,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "41130240n",
             "vaultEarnings": "40996700n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
-          "uncollectedEarnings": "40996700n"
+          "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 495,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "47735429n",
             "vaultEarnings": "47735429n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 494,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "49138534n",
             "vaultEarnings": "48662999n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 493,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "58829235n",
             "vaultEarnings": "58829235n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 492,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "22469761n",
             "vaultEarnings": "22469761n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 491,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "55736411n",
             "vaultEarnings": "55736411n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 490,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "72051736n",
             "vaultEarnings": "72051736n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 489,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "499461614n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "350816674n",
           "treasuryPool": {
             "totalEarnings": "72246056n",
             "vaultEarnings": "72246056n",
             "externalCapital": "0n",
             "vaultCapital": "307000000n"
           },
-          "securitization": "499461614n",
-          "securitizationActivated": "350816674n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -21277,6 +23107,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
@@ -21294,14 +23125,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "307000000n",
             "totalEarnings": "12771785n",
-            "vaultEarnings": "12771785n"
+            "vaultEarnings": "12771785n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -21311,14 +23143,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "307000000n",
             "totalEarnings": "21951573n",
-            "vaultEarnings": "21951573n"
+            "vaultEarnings": "21951573n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -21328,14 +23161,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "307000000n",
             "totalEarnings": "49681483n",
-            "vaultEarnings": "49681483n"
+            "vaultEarnings": "49681483n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -21345,14 +23179,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "307000000n",
             "totalEarnings": "59412671n",
-            "vaultEarnings": "59412671n"
+            "vaultEarnings": "59412671n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -21362,14 +23197,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "499461614n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "350816674n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "307000000n",
             "totalEarnings": "25714970n",
-            "vaultEarnings": "25714970n"
+            "vaultEarnings": "25714970n",
+            "externalCapital": "0n",
+            "vaultCapital": "307000000n"
           },
           "uncollectedEarnings": "0n"
         },

--- a/core/src/data/vaultRevenue.testnet.json
+++ b/core/src/data/vaultRevenue.testnet.json
@@ -1,5 +1,5 @@
 {
-  "synchedToFrame": 524,
+  "synchedToFrame": 530,
   "vaultsById": {
     "5": {
       "openedTick": 28996910,
@@ -3959,122 +3959,237 @@
       },
       "changesByFrame": [
         {
+          "frameId": 530,
           "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 529,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 528,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 527,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 526,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 525,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
           "frameId": 524,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 523,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 522,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 521,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 520,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 519,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 518,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999902074n",
+          "securitizationRelockable": "1447123n",
+          "securitizationActivated": "998454945n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "654000000n"
           },
-          "securitization": "999902074n",
-          "securitizationActivated": "998454945n",
-          "securitizationRelockable": "1447123n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -4083,6 +4198,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
@@ -4100,6 +4216,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
@@ -4117,14 +4234,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "654000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -4134,14 +4252,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "654000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -4151,14 +4270,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "654000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -4168,14 +4288,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "654000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -4185,14 +4306,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999902074n",
           "securitizationRelockable": "1447123n",
           "securitizationActivated": "998454945n",
           "treasuryPool": {
-            "externalCapital": "0n",
-            "vaultCapital": "654000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "654000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6248,122 +6370,237 @@
       },
       "changesByFrame": [
         {
+          "frameId": 530,
           "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 529,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 528,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 527,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 526,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 525,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "0n",
+            "vaultCapital": "628000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
           "frameId": 524,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 523,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 522,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 521,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 520,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 519,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 518,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "999933892n",
+          "securitizationRelockable": "202357n",
+          "securitizationActivated": "999731100n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "0n",
             "vaultCapital": "628000000n"
           },
-          "securitization": "999933892n",
-          "securitizationActivated": "999731100n",
-          "securitizationRelockable": "202357n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -6372,6 +6609,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6389,6 +6627,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6406,6 +6645,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6423,6 +6663,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6440,6 +6681,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6457,6 +6699,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6474,6 +6717,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
@@ -6491,14 +6735,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6508,14 +6753,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6525,14 +6771,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6542,14 +6789,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6559,14 +6807,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6576,14 +6825,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "999933892n",
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6597,10 +6847,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6614,10 +6864,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6631,10 +6881,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6648,10 +6898,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6665,10 +6915,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6682,10 +6932,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -6699,10 +6949,10 @@
           "securitizationRelockable": "202357n",
           "securitizationActivated": "999731100n",
           "treasuryPool": {
-            "totalEarnings": "0n",
-            "vaultEarnings": "0n",
             "externalCapital": "0n",
-            "vaultCapital": "628000000n"
+            "vaultCapital": "628000000n",
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9521,122 +9771,237 @@
       },
       "changesByFrame": [
         {
+          "frameId": 530,
           "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 529,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 528,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 527,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 526,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
+          "frameId": 525,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
+          "microgonLiquidityAdded": "0n",
+          "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
+          "treasuryPool": {
+            "totalEarnings": "0n",
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
+          },
+          "uncollectedEarnings": "0n"
+        },
+        {
           "frameId": 524,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 523,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 522,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 521,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 520,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 519,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
-          "satoshisAdded": "0n",
           "frameId": 518,
+          "satoshisAdded": "0n",
+          "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
-          "bitcoinLocksCreated": 0,
+          "bitcoinFeeCouponValueUsed": "0n",
+          "securitization": "19664836712n",
+          "securitizationRelockable": "0n",
+          "securitizationActivated": "19664506980n",
           "treasuryPool": {
             "totalEarnings": "0n",
             "vaultEarnings": "0n",
             "externalCapital": "1000000000n",
             "vaultCapital": "6537000000n"
           },
-          "securitization": "19664836712n",
-          "securitizationActivated": "19664506980n",
-          "securitizationRelockable": "0n",
           "uncollectedEarnings": "0n"
         },
         {
@@ -9645,6 +10010,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
@@ -9662,6 +10028,7 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
@@ -9679,14 +10046,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
           "treasuryPool": {
-            "externalCapital": "1000000000n",
-            "vaultCapital": "6537000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9696,14 +10064,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
           "treasuryPool": {
-            "externalCapital": "1000000000n",
-            "vaultCapital": "6537000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9713,14 +10082,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
           "treasuryPool": {
-            "externalCapital": "1000000000n",
-            "vaultCapital": "6537000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9730,14 +10100,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
           "treasuryPool": {
-            "externalCapital": "1000000000n",
-            "vaultCapital": "6537000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
           },
           "uncollectedEarnings": "0n"
         },
@@ -9747,14 +10118,15 @@
           "bitcoinLocksCreated": 0,
           "microgonLiquidityAdded": "0n",
           "bitcoinFeeRevenue": "0n",
+          "bitcoinFeeCouponValueUsed": "0n",
           "securitization": "19664836712n",
           "securitizationRelockable": "0n",
           "securitizationActivated": "19664506980n",
           "treasuryPool": {
-            "externalCapital": "1000000000n",
-            "vaultCapital": "6537000000n",
             "totalEarnings": "0n",
-            "vaultEarnings": "0n"
+            "vaultEarnings": "0n",
+            "externalCapital": "1000000000n",
+            "vaultCapital": "6537000000n"
           },
           "uncollectedEarnings": "0n"
         },

--- a/core/src/interfaces/IVaultStats.ts
+++ b/core/src/interfaces/IVaultStats.ts
@@ -19,6 +19,7 @@ export interface IVaultStats {
 export interface IVaultFrameStats {
   frameId: number;
   bitcoinFeeRevenue: bigint;
+  bitcoinFeeCouponValueUsed?: bigint;
   satoshisAdded: bigint;
   bitcoinLocksCreated: number;
   microgonLiquidityAdded: bigint;


### PR DESCRIPTION
## Summary

Network mining, vaulting, and bond estimates now use the same capital-weighted return methodology as financial investment positions.

- Mining uses actual active cohorts, seat counts, bid costs, marked ARGNOT stake, and runtime reward settings.
- Vault returns use completed frame records and deduct vault-paid Bitcoin fee coupons.
- Bond returns use recorded external capital and earnings instead of reconstructing profit sharing.
- The shared aggregate reducer and restabilization leverage calculation are available to static publication consumers.

## Boundaries

Core owns network facts and return formulas. Publication scenarios and serialized website output remain consumer-owned, with no website runtime lookup added.

Design decisions carried from planning: publication scenarios stay website-owned; mining uses scheduled rewards across all active cohorts with no guaranteed mint; vault and bond returns remain separate views of completed frame records.
