### PR TITLE
fix(core): recover stale bidding frame data

### DIFF
--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BlockWatch, type IBlockHeaderInfo } from '../src/BlockWatch.ts';
+import { MainchainClients } from '../src/MainchainClients.ts';
 
 type IBlockApi = Awaited<ReturnType<BlockWatch['getApi']>>;
 
@@ -108,6 +109,8 @@ describe('BlockWatch archive recovery', () => {
   });
 
   it('retries block api lookup on archive when pruned cannot decorate the supplied hash', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
     const blockApi = { query: { system: { events: vi.fn() } } };
     const prunedClient = {
       at: vi.fn().mockRejectedValue(new Error('Unable to retrieve header and parent from supplied hash')),
@@ -124,6 +127,114 @@ describe('BlockWatch archive recovery', () => {
     expect(prunedClient.at).toHaveBeenCalledWith('0xblock');
     expect(archiveClient.at).toHaveBeenCalledWith('0xblock');
     expect(result).toBe(blockApi);
+  });
+
+  it('does not query archive block state before archive has finalized the requested height', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    const archiveFinalizedHeader = createHeaderInfo(109, '0xarchive-finalized', '0x108');
+    const error = new Error('Unable to retrieve header and parent from supplied hash');
+    const prunedClient = {
+      at: vi.fn().mockRejectedValue(error),
+    };
+    const archiveClient = {
+      at: vi.fn().mockRejectedValue(error),
+      rpc: {
+        chain: {
+          getFinalizedHead: vi.fn().mockResolvedValue(archiveFinalizedHeader.blockHash),
+          getHeader: vi.fn().mockResolvedValue({ __info: archiveFinalizedHeader }),
+        },
+      },
+    };
+    const blockWatch = new BlockWatch(createClients(prunedClient, archiveClient) as any);
+    blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+    getInternalBlockWatch(blockWatch).activeSource = 'pruned';
+
+    await expect(blockWatch.getApi(createHeaderInfo(110, '0xblock', '0xparent'))).rejects.toBe(error);
+
+    expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce();
+    expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith(archiveFinalizedHeader.blockHash);
+    expect(archiveClient.at).not.toHaveBeenCalled();
+  });
+
+  it('shares one timeout across archive finality checks', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    try {
+      const error = new Error('Unable to retrieve header and parent from supplied hash');
+      const prunedClient = {
+        at: vi.fn().mockRejectedValue(error),
+      };
+      const archiveClient = {
+        at: vi.fn(),
+        rpc: {
+          chain: {
+            getFinalizedHead: vi.fn(
+              () => new Promise(resolve => setTimeout(() => resolve('0xarchive-finalized'), 80e3)),
+            ),
+            getHeader: vi.fn(() => new Promise(() => undefined)),
+          },
+        },
+      };
+      const blockWatch = new BlockWatch(createClients(prunedClient, archiveClient) as any);
+      blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+      getInternalBlockWatch(blockWatch).activeSource = 'pruned';
+
+      const resultPromise = blockWatch.getApi(createHeaderInfo(110, '0xblock', '0xparent'));
+      const resultAssertion = expect(resultPromise).rejects.toBe(error);
+      await vi.advanceTimersByTimeAsync(120e3);
+
+      await resultAssertion;
+      expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce();
+      expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith('0xarchive-finalized');
+      expect(archiveClient.at).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves repeated archive state failures after finality is covered', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const finalizedHeader = createHeaderInfo(110, '0xarchive-finalized', '0x109');
+    const archiveClient = {
+      at: vi.fn(() => Promise.reject(new Error('4003: State already discarded for 0xblock'))),
+      on: vi.fn(),
+      rpc: {
+        chain: {
+          getFinalizedHead: vi.fn().mockResolvedValue(finalizedHeader.blockHash),
+          getHeader: vi.fn().mockResolvedValue({ __info: finalizedHeader }),
+        },
+      },
+    };
+    const prunedClient = {
+      at: vi.fn().mockRejectedValue(new Error('Unable to retrieve header and parent from supplied hash')),
+    };
+    const clients = new MainchainClients('ws://archive', () => false, archiveClient as any);
+    clients.prunedClientPromise = Promise.resolve(prunedClient as any);
+    const degraded = vi.fn();
+    clients.events.on('degraded', degraded);
+
+    const blockWatch = new BlockWatch(clients);
+    blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+    getInternalBlockWatch(blockWatch).activeSource = 'pruned';
+
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      await expect(blockWatch.getApi(createHeaderInfo(110, '0xblock', '0xparent'))).rejects.toThrow(
+        'State already discarded',
+      );
+    }
+
+    expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce();
+    expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledOnce();
+    expect(archiveClient.at).toHaveBeenCalledTimes(6);
+    expect(degraded).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('4003') }),
+      'archive',
+    );
   });
 
   it('retries start after an initial startup failure without an explicit stop', async () => {
@@ -242,6 +353,8 @@ describe('BlockWatch archive recovery', () => {
   });
 
   it('retries signed block lookup on archive when the selected client disconnects', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
     const signedBlock = { block: { extrinsics: [] } };
     const prunedClient = {
       rpc: {
@@ -459,11 +572,12 @@ describe('BlockWatch archive recovery', () => {
 
       await blockWatch.start('pruned');
       await onNewHead({ __info: staleHead });
-      await vi.waitFor(() => expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith(staleHead.parentHash));
+      await vi.waitFor(() => expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce());
       await vi.runAllTimersAsync();
 
       expect(getInternalBlockWatch(blockWatch).activeSource).toBe('pruned');
       expect(archiveClient.rpc.chain.subscribeNewHeads).not.toHaveBeenCalled();
+      expect(archiveClient.rpc.chain.getHeader).not.toHaveBeenCalledWith(staleHead.parentHash);
       expect(blockWatch.latestHeaders).toEqual([finalizedHeader]);
 
       await onNewHead({ __info: nextHeader });
@@ -573,6 +687,21 @@ function createHeaderInfo(blockNumber: number, blockHash: string, parentHash: st
 }
 
 function createClients(prunedClient: unknown, archiveClient: unknown, clientEventUnsubscribes?: Array<() => void>) {
+  const archive = archiveClient as any;
+  archive.rpc ??= {};
+  archive.rpc.chain ??= {};
+  if (!archive.rpc.chain.getFinalizedHead) {
+    const finalizedHash = '0xtest-archive-finalized';
+    const getHeader = archive.rpc.chain.getHeader as ((hash?: string) => Promise<unknown>) | undefined;
+    archive.rpc.chain.getFinalizedHead = vi.fn().mockResolvedValue(finalizedHash);
+    archive.rpc.chain.getHeader = vi.fn(async (hash?: string) => {
+      if (hash === finalizedHash) {
+        return { __info: createHeaderInfo(Number.MAX_SAFE_INTEGER, finalizedHash, '0xparent') };
+      }
+      return getHeader ? await getHeader(hash) : undefined;
+    });
+  }
+
   let unsubscribeIndex = 0;
   return {
     prunedClientPromise: Promise.resolve(prunedClient),

--- a/core/__test__/MiningFrames.test.ts
+++ b/core/__test__/MiningFrames.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MiningFrames, NetworkConfig } from '../src/index.ts';
+import { createDeferred, MiningFrames, NetworkConfig } from '../src/index.ts';
 import type { IBlockHeaderInfo } from '../src/BlockWatch.ts';
 
 describe('MiningFrames frame refresh recovery', () => {
@@ -52,6 +52,91 @@ describe('MiningFrames frame refresh recovery', () => {
     expect(getApi).toHaveBeenNthCalledWith(2, frameHeader);
     expect(miningFrames.framesById[18]).toMatchObject({
       frameId: 18,
+      firstBlockNumber: 181,
+      firstBlockHash: '0xframe',
+      firstBlockTick: 1_810,
+      firstBlockSpecVersion: 153,
+    });
+  });
+
+  it('refreshes and retries a stale persisted frame behind a valid newer frame', async () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    const latestHeader = createHeaderInfo(192, '0xlatest', '0x191', 19, 1_920);
+    const newerFrameHeader = createHeaderInfo(191, '0xnewer-frame', '0x190', 19, 1_910);
+    const frameHeader = createHeaderInfo(181, '0xframe', '0x180', 18, 1_810);
+    const unreadableError = new Error('Unable to retrieve header and parent from supplied hash');
+    const currentApi = {
+      query: {
+        miningSlot: {
+          frameStartBlockNumbers: vi.fn().mockResolvedValue([createNumberLike(191), createNumberLike(181)]),
+        },
+      },
+    };
+    const frameApi = {
+      query: {
+        miningSlot: {
+          frameStartBlockNumbers: vi.fn().mockResolvedValue([createNumberLike(181)]),
+        },
+      },
+      runtimeVersion: {
+        specVersion: createNumberLike(153),
+      },
+    };
+    const pendingFrameApi = createDeferred<typeof frameApi>();
+    let frameApiCalls = 0;
+    const getApi = vi.fn(async ({ blockHash }: IBlockHeaderInfo) => {
+      if (blockHash === '0xstale') throw unreadableError;
+      if (blockHash === latestHeader.blockHash) return currentApi;
+      if (blockHash === newerFrameHeader.blockHash) return frameApi;
+      if (blockHash === frameHeader.blockHash) {
+        frameApiCalls += 1;
+        return frameApiCalls === 1 ? frameApi : await pendingFrameApi.promise;
+      }
+      throw new Error(`Unexpected block hash ${blockHash}`);
+    });
+    const blockWatch = {
+      latestHeaders: [latestHeader],
+      getApi,
+      getHeader: vi.fn(async (blockNumber: number) => {
+        if (blockNumber === newerFrameHeader.blockNumber) return newerFrameHeader;
+        if (blockNumber === frameHeader.blockNumber) return frameHeader;
+        throw new Error(`Unexpected block number ${blockNumber}`);
+      }),
+      events: { on: vi.fn() },
+    };
+    const miningFrames = new MiningFrames({} as any, blockWatch as any);
+    miningFrames.framesById[18] = {
+      frameId: 18,
+      frameStartTick: 1_800,
+      dateStart: new Date(1_800_000),
+      firstBlockNumber: 21_101,
+      firstBlockHash: '0xstale',
+      firstBlockTick: 1_800,
+      firstBlockSpecVersion: 152,
+    };
+    miningFrames.framesById[19] = {
+      frameId: 19,
+      frameStartTick: 1_910,
+      dateStart: new Date(1_910_000),
+      firstBlockNumber: 191,
+      firstBlockHash: '0xnewer-frame',
+      firstBlockTick: 1_910,
+      firstBlockSpecVersion: 153,
+    };
+
+    const frameStartPromise = miningFrames.getFrameStart(18);
+    await vi.waitFor(() => expect(frameApiCalls).toBe(2));
+
+    Object.assign(miningFrames.framesById[18], {
+      firstBlockNumber: 182,
+      firstBlockHash: '0xnext-frame',
+    });
+    pendingFrameApi.resolve(frameApi);
+    const frameStart = await frameStartPromise;
+
+    expect(frameStart.api).toBe(frameApi);
+    expect(frameStart.frame).toMatchObject({
       firstBlockNumber: 181,
       firstBlockHash: '0xframe',
       firstBlockTick: 1_810,

--- a/core/src/BiddingCalculatorData.ts
+++ b/core/src/BiddingCalculatorData.ts
@@ -84,20 +84,14 @@ export default class BiddingCalculatorData {
           await this.miningFrames.waitForFrameId(biddingFrameId);
 
           let api = await this.miningFrames.blockWatch.getCurrentApi();
+          let biddingFrame = this.miningFrames.framesById[biddingFrameId];
 
           const nextFrameId = await this.mining.fetchNextFrameId(api);
           if (biddingFrameId !== nextFrameId - 1) {
             // need to go back to the start of the bidding frame
-            const frame = this.miningFrames.framesById[biddingFrameId];
-            const frameStartBlockHash = frame.firstBlockHash;
-            const frameStartBlockNumber = frame.firstBlockNumber;
-            if (!frameStartBlockHash || frameStartBlockNumber == null) {
-              throw new Error(`No starting block for frame ${biddingFrameId}`);
-            }
-            api = await this.miningFrames.clientAt({
-              blockHash: frameStartBlockHash,
-              blockNumber: frameStartBlockNumber,
-            });
+            const frameStart = await this.miningFrames.getFrameStart(biddingFrameId);
+            biddingFrame = frameStart.frame;
+            api = frameStart.api;
           }
 
           const currency = new Currency(mining.clients);
@@ -120,8 +114,7 @@ export default class BiddingCalculatorData {
           this.microgonsInCirculation = await currency.fetchMicrogonsInCirculation(api);
 
           const biddingFrameSpecVersion =
-            this.miningFrames.framesById[biddingFrameId]?.firstBlockSpecVersion ??
-            api.runtimeVersion.specVersion.toNumber();
+            biddingFrame?.firstBlockSpecVersion ?? api.runtimeVersion.specVersion.toNumber();
           this.currentMicronotsForBid = await mining.fetchCurrentMicronotsForBid(api);
           if (biddingFrameSpecVersion >= MINING_BID_COLLATERAL_MULTIPLE_SPEC_VERSION) {
             this.maximumMicronotsForBid = percentOf(this.currentMicronotsForBid, 120, true);

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -66,6 +66,8 @@ export class BlockWatch {
   private pendingRestart: { reason: string; source: ISubscriptionSource; delayMs?: number } | undefined;
   private isRestarting: boolean = false;
   private readonly failedRestartDelayMs = 2_500;
+  private archiveFinalityClient?: ArgonClient;
+  private archiveFinalizedBlockNumber = -1;
 
   constructor(
     public clients: MainchainClients,
@@ -172,12 +174,7 @@ export class BlockWatch {
           try {
             gap = await this.fillNewHeadGap(this.finalizedBlockHeader, announcedHeader);
           } catch (error) {
-            const message = String(error).toLowerCase();
-            const isUnreadableHead =
-              message.includes('unable to retrieve header and parent from supplied hash') ||
-              (message.includes('4003') &&
-                (message.includes('state already discarded') || message.includes('unknown block')));
-            if (!isUnreadableHead) {
+            if (!isUnreadableBlockError(error)) {
               throw error;
             }
 
@@ -455,7 +452,7 @@ export class BlockWatch {
           client,
           `getBestHeader(${finalizedNumber})`,
           selectedClient => selectedClient.rpc.chain.getHeader(),
-          { finalizedNumber },
+          { blockNumber: finalizedNumber, finalizedNumber },
         );
         // presume our old finalized is still valid, fill in the gap to the new best
         const bestTail = await this.fillNewHeadGap(this.finalizedBlockHeader, bestHeader);
@@ -538,7 +535,7 @@ export class BlockWatch {
     client: ArgonClient,
     label: string,
     query: (client: ArgonClient) => Promise<T>,
-    details: Record<string, unknown>,
+    details: Record<string, unknown> & { blockNumber: number },
   ): Promise<T> {
     try {
       return await this.runQueryWithTimeout(label, query(client));
@@ -552,11 +549,54 @@ export class BlockWatch {
         throw error;
       }
 
+      if (this.archiveFinalityClient !== archiveClient) {
+        this.archiveFinalityClient = archiveClient;
+        this.archiveFinalizedBlockNumber = -1;
+      }
+
+      const archiveDeadline = Date.now() + BlockWatch.queryTimeoutMs;
+      const runArchiveQuery = async <R>(archiveLabel: string, archiveQuery: () => Promise<R>): Promise<R> => {
+        const timeoutMs = archiveDeadline - Date.now();
+        if (timeoutMs <= 0) {
+          throw new Error(`[BlockWatch] Query timed out after ${BlockWatch.queryTimeoutMs}ms (${archiveLabel})`);
+        }
+        return await this.runQueryWithTimeout(archiveLabel, archiveQuery(), timeoutMs);
+      };
+
+      if (this.archiveFinalizedBlockNumber < details.blockNumber) {
+        try {
+          const archiveFinalizedHash = await runArchiveQuery(`${label}.archiveFinalizedHash`, () =>
+            archiveClient.rpc.chain.getFinalizedHead(),
+          );
+          const archiveFinalizedHeader = await runArchiveQuery(`${label}.archiveFinalizedHeader`, () =>
+            archiveClient.rpc.chain.getHeader(archiveFinalizedHash),
+          );
+          const finalizedBlockNumber = BlockWatch.readHeader(archiveFinalizedHeader, true).blockNumber;
+          this.archiveFinalizedBlockNumber = Math.max(this.archiveFinalizedBlockNumber, finalizedBlockNumber);
+        } catch (archiveError) {
+          console.warn(`[BlockWatch]: ${label} could not verify archive finality`, {
+            ...details,
+            error: String(error),
+            archiveError: String(archiveError),
+          });
+          throw error;
+        }
+      }
+
+      if (this.archiveFinalizedBlockNumber < details.blockNumber) {
+        console.warn(`[BlockWatch]: ${label} archive fallback is behind requested block`, {
+          ...details,
+          archiveFinalizedBlockNumber: this.archiveFinalizedBlockNumber,
+          error: String(error),
+        });
+        throw error;
+      }
+
       console.warn(`[BlockWatch]: ${label} failed on selected client, retrying on archive`, {
         ...details,
         error: String(error),
       });
-      return await this.runQueryWithTimeout(label, query(archiveClient));
+      return await runArchiveQuery(label, () => query(archiveClient));
     }
   }
 
@@ -564,9 +604,7 @@ export class BlockWatch {
     const message = String(error).toLowerCase();
     return (
       (message.includes('blockwatch') && message.includes('query timed out')) ||
-      (message.includes('4003') &&
-        (message.includes('state already discarded') || message.includes('unknown block'))) ||
-      message.includes('unable to retrieve header and parent from supplied hash') ||
+      isUnreadableBlockError(error) ||
       message.includes('websocket is not connected') ||
       message.includes('no response received from rpc endpoint') ||
       message.includes('abnormal closure') ||
@@ -575,12 +613,16 @@ export class BlockWatch {
     );
   }
 
-  private async runQueryWithTimeout<T>(label: string, promise: Promise<T>): Promise<T> {
+  private async runQueryWithTimeout<T>(
+    label: string,
+    promise: Promise<T>,
+    timeoutMs = BlockWatch.queryTimeoutMs,
+  ): Promise<T> {
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutHandle = setTimeout(() => {
-        reject(new Error(`[BlockWatch] Query timed out after ${BlockWatch.queryTimeoutMs}ms (${label})`));
-      }, BlockWatch.queryTimeoutMs);
+        reject(new Error(`[BlockWatch] Query timed out after ${timeoutMs}ms (${label})`));
+      }, timeoutMs);
     });
 
     try {
@@ -711,4 +753,12 @@ export class BlockWatch {
       isNewFrame: frameInfo?.isNewFrame,
     };
   }
+}
+
+export function isUnreadableBlockError(error: unknown): boolean {
+  const message = String(error).toLowerCase();
+  return (
+    message.includes('unable to retrieve header and parent from supplied hash') ||
+    (message.includes('4003') && (message.includes('state already discarded') || message.includes('unknown block')))
+  );
 }

--- a/core/src/FrameIterator.ts
+++ b/core/src/FrameIterator.ts
@@ -31,17 +31,21 @@ export class FrameIterator {
 
     let frameId = this.miningFrames.currentFrameId;
     do {
-      const { firstBlockSpecVersion, firstBlockNumber, firstBlockHash, firstBlockTick } =
-        this.miningFrames.framesById[frameId];
-      if (firstBlockHash) {
+      const frame = this.miningFrames.framesById[frameId];
+      if (!frame) {
+        throw new Error(`Frame ID ${frameId} is not present in frame history`);
+      }
+
+      if (frame.firstBlockHash) {
+        const { frame: resolvedFrame, api } = await this.miningFrames.getFrameStart(frameId);
+        const { firstBlockSpecVersion, firstBlockNumber, firstBlockHash, firstBlockTick } = resolvedFrame;
         console.log(`[${this.name}] Exploring epoch frame ${frameId} (blockNumber = ${firstBlockNumber})`);
         const meta = {
           specVersion: firstBlockSpecVersion!,
           blockNumber: firstBlockNumber!,
-          blockHash: firstBlockHash,
+          blockHash: firstBlockHash!,
           blockTick: firstBlockTick!,
         };
-        const api = await this.miningFrames.clientAt({ blockHash: firstBlockHash, blockNumber: firstBlockNumber! });
         await callback(frameId, meta, api, abortController);
       }
 
@@ -63,21 +67,18 @@ export class FrameIterator {
     const frameIds = this.miningFrames.frameIds;
     frameIds.sort((a, b) => b - a); // Descending order
     for (const frameId of frameIds) {
-      const { firstBlockSpecVersion, firstBlockNumber, firstBlockHash, firstBlockTick } =
-        this.miningFrames.framesById[frameId];
-      if (firstBlockHash) {
+      const frame = this.miningFrames.framesById[frameId];
+      if (frame.firstBlockHash) {
+        const { frame: resolvedFrame, api } = await this.miningFrames.getFrameStart(frameId);
+        const { firstBlockSpecVersion, firstBlockNumber, firstBlockHash, firstBlockTick } = resolvedFrame;
         console.log(`[${this.name}] Exploring frame ${frameId} (blockNumber = ${firstBlockNumber})`);
 
         const firstBlockMeta = {
           specVersion: firstBlockSpecVersion!,
           blockNumber: firstBlockNumber!,
-          blockHash: firstBlockHash,
+          blockHash: firstBlockHash!,
           blockTick: firstBlockTick!,
         };
-        const api = await this.miningFrames.clientAt({
-          blockHash: firstBlockHash,
-          blockNumber: firstBlockNumber!,
-        });
         const result = await callback(frameId, firstBlockMeta, api, abortController);
         results.push(result);
       }

--- a/core/src/MiningFrames.ts
+++ b/core/src/MiningFrames.ts
@@ -7,9 +7,9 @@ import FramesHistoryTestnet from './data/frames.testnet.json' with { type: 'json
 import FramesHistoryMainnet from './data/frames.mainnet.json' with { type: 'json' };
 import type { MainchainClients } from './MainchainClients.js';
 import { createDeferred } from './Deferred.js';
-import { createTypedEventEmitter, getPercent } from './utils.js';
+import { createTypedEventEmitter, getPercent, raceWithTimeout } from './utils.js';
 import { SingleFileQueue } from './SingleFileQueue.js';
-import { BlockWatch, type IBlockHeaderInfo } from './BlockWatch.js';
+import { BlockWatch, isUnreadableBlockError, type IBlockHeaderInfo } from './BlockWatch.js';
 
 dayjs.extend(utc);
 
@@ -152,6 +152,49 @@ export class MiningFrames {
 
   public async clientAt(block: { blockHash: string; blockNumber: number }): Promise<ApiDecoration<'promise'>> {
     return await this.blockWatch.getApi(block);
+  }
+
+  public async getFrameStart(frameId: number): Promise<{ frame: IFrameHistory; api: ApiDecoration<'promise'> }> {
+    const frame = this.framesById[frameId];
+    if (!frame?.firstBlockHash || frame.firstBlockNumber == null) {
+      throw new Error(`No starting block for frame ${frameId}`);
+    }
+
+    const resolvedFrame = { ...frame };
+    const initialBlock = {
+      blockHash: frame.firstBlockHash,
+      blockNumber: frame.firstBlockNumber,
+    };
+    try {
+      const api = await this.clientAt(initialBlock);
+      return { frame: resolvedFrame, api };
+    } catch (error) {
+      if (!isUnreadableBlockError(error)) {
+        throw error;
+      }
+
+      const refresh = this.updateQueue.add(() => this.checkForFrameChange([...this.blockWatch.latestHeaders], frameId));
+      await raceWithTimeout(refresh.promise, 120e3, () => {
+        throw error;
+      });
+
+      const refreshedFrame = this.framesById[frameId];
+      if (
+        !refreshedFrame?.firstBlockHash ||
+        refreshedFrame.firstBlockNumber == null ||
+        (refreshedFrame.firstBlockHash === initialBlock.blockHash &&
+          refreshedFrame.firstBlockNumber === initialBlock.blockNumber)
+      ) {
+        throw error;
+      }
+
+      const resolvedFrame = { ...refreshedFrame };
+      const api = await this.clientAt({
+        blockHash: refreshedFrame.firstBlockHash,
+        blockNumber: refreshedFrame.firstBlockNumber,
+      });
+      return { frame: resolvedFrame, api };
+    }
   }
 
   private async onBestBlocks(headers: IBlockHeaderInfo[]): Promise<void> {
@@ -403,22 +446,22 @@ export class MiningFrames {
     }
   }
 
-  private async checkForFrameChange(headers: IBlockHeaderInfo[]): Promise<void> {
-    let hasNewFrame = false;
+  private async checkForFrameChange(headers: IBlockHeaderInfo[], throughFrameId?: number): Promise<void> {
+    let shouldCheckFrames = throughFrameId !== undefined;
 
     for (const header of headers) {
       if (header.frameId === undefined) {
-        hasNewFrame = true;
+        shouldCheckFrames = true;
       } else {
         if (header.frameId > this.currentFrameId) {
-          hasNewFrame = true;
+          shouldCheckFrames = true;
         } else if (this.framesById[header.frameId]?.firstBlockHash !== header.blockHash) {
-          hasNewFrame = true;
+          shouldCheckFrames = true;
         }
       }
     }
 
-    if (!hasNewFrame) {
+    if (!shouldCheckFrames) {
       return;
     }
 
@@ -446,24 +489,31 @@ export class MiningFrames {
           header.frameId ?? (await api.query.miningSlot.nextFrameId().then(x => x.toNumber() - 1));
 
         const existing = this.framesById[frameId];
-        if (existing && existing.firstBlockHash === blockHash) {
+        const matchesExisting = existing?.firstBlockHash === blockHash && existing.firstBlockNumber === blockNumber;
+        if (matchesExisting && (throughFrameId === undefined || frameId <= throughFrameId)) {
           break;
         }
 
-        const startingTick = header.tick;
-        const isChanged = this.setFrameHistory({
-          frameId,
-          frameStartTick: startingTick,
-          dateStart: MiningFrames.getTickDate(startingTick),
-          firstBlockNumber: blockNumber,
-          firstBlockHash: blockHash,
-          firstBlockTick: startingTick,
-          firstBlockSpecVersion: api.runtimeVersion.specVersion.toNumber(),
-        });
-        if (isChanged) {
-          this.events.emit('on-frame', { frameId, blockNumber, blockHash });
-          this.events.emit('on-tick', startingTick);
-          hasChanges = true;
+        if (!matchesExisting) {
+          const startingTick = header.tick;
+          const isChanged = this.setFrameHistory({
+            frameId,
+            frameStartTick: startingTick,
+            dateStart: MiningFrames.getTickDate(startingTick),
+            firstBlockNumber: blockNumber,
+            firstBlockHash: blockHash,
+            firstBlockTick: startingTick,
+            firstBlockSpecVersion: api.runtimeVersion.specVersion.toNumber(),
+          });
+          if (isChanged) {
+            this.events.emit('on-frame', { frameId, blockNumber, blockHash });
+            this.events.emit('on-tick', startingTick);
+            hasChanges = true;
+          }
+        }
+
+        if (throughFrameId !== undefined && frameId <= throughFrameId) {
+          break;
         }
 
         if (queue.length === 0) {


### PR DESCRIPTION
## Summary

Historical bidding data could fail permanently when persisted frame-start data pointed at an unreadable block and the archive node had not caught up. Frame reads now repair stale history from the current canonical chain and return one coherent frame/API pair, so the bidding rules panel and historical iterators can recover without a second block subscription or routine archive polling.

Archive fallback now verifies and caches finalized coverage only after the selected client fails. Repeated state-discarded errors remain visible as archive degradation, while the finality probes and fallback share one bounded timeout.

## Validation

- 29 focused bidding, frame, and block-watch tests pass.
- Full typecheck and lint checks pass.
