### PR TITLE
fix(e2e): isolate vault and runtime state storage

### DIFF
--- a/e2e/__test__/devEthereumRuntimeState.e2e.test.ts
+++ b/e2e/__test__/devEthereumRuntimeState.e2e.test.ts
@@ -1,9 +1,8 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const fsState = vi.hoisted(() => ({
-  files: new Map<string, string>(),
-}));
 const runtimeState = {
   beaconPreset: 'minimal',
   enclaveName: 'argon-eth-test',
@@ -16,37 +15,6 @@ const runtimeState = {
   setupStatus: 'starting',
 } as const;
 
-vi.mock('node:fs/promises', () => ({
-  default: {
-    mkdir: vi.fn(async () => undefined),
-    readFile: vi.fn(async (filePath: string) => {
-      const contents = fsState.files.get(String(filePath));
-      if (contents !== undefined) {
-        return contents;
-      }
-
-      const error = new Error(`Missing file: ${String(filePath)}`) as NodeJS.ErrnoException;
-      error.code = 'ENOENT';
-      throw error;
-    }),
-    rename: vi.fn(async (sourcePath: string, destinationPath: string) => {
-      const contents = fsState.files.get(String(sourcePath));
-      if (contents === undefined) {
-        throw new Error(`Missing temporary file: ${String(sourcePath)}`);
-      }
-
-      fsState.files.set(String(destinationPath), contents);
-      fsState.files.delete(String(sourcePath));
-    }),
-    rm: vi.fn(async (filePath: string) => {
-      fsState.files.delete(String(filePath));
-    }),
-    writeFile: vi.fn(async (filePath: string, contents: string) => {
-      fsState.files.set(String(filePath), String(contents));
-    }),
-  },
-}));
-
 import {
   readDevEthereumRuntimeState,
   updateDevEthereumRuntimeState,
@@ -55,17 +23,20 @@ import {
 
 describe('dev Ethereum runtime state', () => {
   const previousRuntimeStateDir = process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR;
+  let runtimeStateDir: string;
 
-  beforeEach(() => {
-    fsState.files.clear();
+  beforeEach(async () => {
+    runtimeStateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'argon-dev-ethereum-runtime-state-'));
+    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = runtimeStateDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (previousRuntimeStateDir === undefined) {
       delete process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR;
     } else {
       process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = previousRuntimeStateDir;
     }
+    await fs.rm(runtimeStateDir, { recursive: true, force: true });
   });
 
   it('preserves concurrent setup and minting authority updates', async () => {
@@ -82,28 +53,24 @@ describe('dev Ethereum runtime state', () => {
       setupStatus: 'ready',
       mintingAuthorityStatus: 'ready',
     });
-    expect([...fsState.files.keys()].filter(filePath => filePath.endsWith('.tmp'))).toEqual([]);
+    expect((await fs.readdir(runtimeStateDir)).filter(filePath => filePath.endsWith('.tmp'))).toEqual([]);
   });
 
   it('stores state in the isolated test directory when configured', async () => {
-    const runtimeStateDir = path.resolve('/isolated/session/test-data/dev-ethereum');
-    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = runtimeStateDir;
-
     await writeDevEthereumRuntimeState(runtimeState);
 
-    expect([...fsState.files.keys()]).toHaveLength(2);
-    expect([...fsState.files.keys()].every(filePath => filePath.startsWith(`${runtimeStateDir}${path.sep}`))).toBe(
-      true,
-    );
+    const stateFiles = await fs.readdir(runtimeStateDir);
+    expect(stateFiles).toHaveLength(2);
+    expect(stateFiles).toContain('latest.json');
   });
 
   it('reads from the flow session directory instead of ambient process state', async () => {
-    const runtimeStateDir = path.resolve('/isolated/session/test-data/dev-ethereum');
-    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = path.resolve('/different/session/dev-ethereum');
-    const scopedStatePath = path.join(runtimeStateDir, 'http_127.0.0.1_32003.json');
-    fsState.files.set(scopedStatePath, JSON.stringify(runtimeState));
+    const flowRuntimeStateDir = path.join(runtimeStateDir, 'flow');
+    process.env.ARGON_DEV_ETHEREUM_RUNTIME_STATE_DIR = path.join(runtimeStateDir, 'ambient');
+    await fs.mkdir(flowRuntimeStateDir);
+    await fs.writeFile(path.join(flowRuntimeStateDir, 'http_127.0.0.1_32003.json'), JSON.stringify(runtimeState));
 
-    expect(await readDevEthereumRuntimeState(runtimeState.executionRpcUrl, runtimeStateDir)).toMatchObject(
+    expect(await readDevEthereumRuntimeState(runtimeState.executionRpcUrl, flowRuntimeStateDir)).toMatchObject(
       runtimeState,
     );
   });

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -125,7 +125,13 @@ export class AppVaultOperator {
         },
       }),
     );
-    const vaults = new Vaults('dev-docker', currency, miningFrames);
+    let vaultStats: string | null = null;
+    const vaults = new Vaults('dev-docker', currency, miningFrames, {
+      read: async () => vaultStats,
+      write: async data => {
+        vaultStats = data;
+      },
+    });
     const myVault = new MyVault(
       dbPromise,
       vaults,

--- a/src-vue/__test__/Vaults.test.ts
+++ b/src-vue/__test__/Vaults.test.ts
@@ -1,0 +1,45 @@
+import type { IAllVaultStats } from '@argonprotocol/apps-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Vaults } from '../lib/Vaults.ts';
+import { setMainchainClients } from '../stores/mainchain.ts';
+
+class TestVaults extends Vaults {
+  public async persist(stats: IAllVaultStats): Promise<void> {
+    this.stats = stats;
+    await this.saveStats();
+  }
+
+  public async restore(): Promise<IAllVaultStats | void> {
+    return await this.loadStatsFromFile();
+  }
+}
+
+describe('Vaults stats storage', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  it('uses supplied storage when a virtual window has no Tauri runtime', async () => {
+    globalThis.window = {} as Window & typeof globalThis;
+    setMainchainClients({} as any);
+
+    let savedStats: string | null = null;
+    const vaults = new TestVaults('dev-docker', {} as any, {} as any, {
+      read: async () => savedStats,
+      write: async data => {
+        savedStats = data;
+      },
+    });
+    const stats: IAllVaultStats = {
+      synchedToFrame: 1,
+      vaultsById: {},
+    };
+
+    await vaults.persist(stats);
+
+    expect(savedStats).not.toBeNull();
+    await expect(vaults.restore()).resolves.toEqual(stats);
+  });
+});

--- a/src-vue/lib/Vaults.ts
+++ b/src-vue/lib/Vaults.ts
@@ -9,8 +9,18 @@ import { BaseDirectory, mkdir, readTextFile, rename, writeTextFile } from '@taur
 import { getMainchainClients } from '../stores/mainchain.ts';
 import { INSTANCE_NAME, NETWORK_NAME } from './Env.ts';
 
+export interface IVaultStatsStorage {
+  read(): Promise<string | null>;
+  write(data: string): Promise<void>;
+}
+
 export class Vaults extends VaultsBase {
-  constructor(network = NETWORK_NAME, currency: CurrencyBase, miningFrames: MiningFrames) {
+  constructor(
+    network = NETWORK_NAME,
+    currency: CurrencyBase,
+    miningFrames: MiningFrames,
+    private readonly statsStorage?: IVaultStatsStorage,
+  ) {
     const clients = getMainchainClients();
     super(network, currency, miningFrames, clients);
   }
@@ -27,13 +37,17 @@ export class Vaults extends VaultsBase {
   }
 
   protected async saveStats(): Promise<void> {
-    // Vitest integration runs in Node, so keep vault stats in memory instead of calling Tauri fs.
-    if (typeof window === 'undefined') return;
     if (!this.stats) return;
     if (this.isSavingStats) return;
+    if (!this.statsStorage && typeof window === 'undefined') return;
     this.isSavingStats = true;
     try {
       const statsJson = JsonExt.stringify(this.stats, 2);
+      if (this.statsStorage) {
+        await this.statsStorage.write(statsJson);
+        return;
+      }
+
       await mkdir(this.statsDirectory(), { baseDir: BaseDirectory.AppConfig, recursive: true }).catch(() => null);
       await writeTextFile(this.statsFile() + '.tmp', statsJson, {
         baseDir: BaseDirectory.AppConfig,
@@ -52,7 +66,12 @@ export class Vaults extends VaultsBase {
   }
 
   protected async loadStatsFromFile(): Promise<IAllVaultStats | void> {
+    if (this.statsStorage) {
+      const state = await this.statsStorage.read();
+      return state ? JsonExt.parse(state) : undefined;
+    }
     if (typeof window === 'undefined') return;
+
     console.log('load stats from file', this.statsFile());
     const state = await readTextFile(this.statsFile(), {
       baseDir: BaseDirectory.AppConfig,


### PR DESCRIPTION
## Summary

The upstream minting-authority runner now keeps vault stats in memory instead of calling Tauri filesystem APIs from its virtual frontend environment. Runtime-state tests use unique real temporary directories, preventing their Node filesystem behavior from leaking into later e2e files while preserving per-test isolation.

Related: #417

## Validation

- `yarn vitest --run --project src-vue src-vue/__test__/Vaults.test.ts`
- `yarn vitest --run --project e2e e2e/__test__/devEthereumRuntimeState.e2e.test.ts`
- `yarn typecheck`
