### PR TITLE
fix: harden troubleshooting package generation

### DIFF
--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -148,7 +148,7 @@ if ! (already_ran "UbuntuCheck"); then
 
     run_command "sudo apt update"
 
-    run_command "sudo apt install -y ufw curl jq bc"
+    run_command "sudo apt install -y ufw curl jq bc rsync"
 
     command_output=$(run_command "sudo ufw app list | sudo grep -q '^OpenSSH$' && echo 'OpenSSH found' || echo 'OpenSSH not found'")
     if echo "$command_output" | grep -q 'OpenSSH found'; then

--- a/src-vue/app-shared/overlays/troubleshooting/DataAndLogFiles.vue
+++ b/src-vue/app-shared/overlays/troubleshooting/DataAndLogFiles.vue
@@ -200,6 +200,9 @@ async function copyDirectorySnapshot(sourceDir: string, destinationDir: string, 
     if (!entry.name) {
       continue;
     }
+    if (entry.name === '.DS_Store') {
+      continue;
+    }
     if (!includeMnemonic && entry.name === 'mnemonic') {
       continue;
     }

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -94,8 +94,9 @@ export class ServerAdmin {
     totalProgress += 20;
     onProgress(totalProgress);
     const filename = file[1].trim();
+    const localFilename = filename.split('/').pop() || 'troubleshooting.tar.gz';
     const tmp = await tempDir();
-    const downloadPath = await join(tmp, filename);
+    const downloadPath = await join(tmp, localFilename);
     console.info(`Downloading troubleshooting package: ${filename} to ${tmp}`);
     await this.connection.downloadFileWithTimeout(
       file[1],


### PR DESCRIPTION
## Summary

- install `rsync` during server setup so troubleshooting bundle creation does not depend on the base image
- skip local macOS `.DS_Store` files when building the app-side support package snapshot
- download remote troubleshooting bundles into temp using the archive basename

## Why

The troubleshooting package flow assumed `rsync` was available on the server and could also trip over local macOS metadata files or absolute remote paths when assembling the final package.

## Validation

- `bash -n server/scripts/installer.sh`
