### PR TITLE
feat(wallets): add wallet account selector

### DIFF
--- a/src-vue/__test__/WalletOverlayState.test.ts
+++ b/src-vue/__test__/WalletOverlayState.test.ts
@@ -8,6 +8,7 @@ import {
   getInitialWalletOverlayState,
   getWalletSelectionKey,
   getWalletSelectionName,
+  selectWalletOverlaySide,
   type IWalletOverlayState,
   WALLET_JUMP_LABEL,
 } from '../wallets/walletOverlayState.ts';
@@ -85,6 +86,15 @@ describe('wallet overlay state', () => {
   it('swaps source and recipient', () => {
     expect(flipWalletOverlay(openPair)).toEqual({
       leftWallet: openPair.rightWallet,
+      rightWallet: openPair.leftWallet,
+    });
+  });
+
+  it('closes the opposite panel when selecting its wallet', () => {
+    expect(selectWalletOverlaySide(openPair, 'left', openPair.rightWallet)).toEqual({
+      leftWallet: openPair.rightWallet,
+    });
+    expect(selectWalletOverlaySide(openPair, 'right', openPair.leftWallet)).toEqual({
       rightWallet: openPair.leftWallet,
     });
   });

--- a/src-vue/emitters/basicEmitter.ts
+++ b/src-vue/emitters/basicEmitter.ts
@@ -9,6 +9,7 @@ export type IWalletGuidanceContext = 'mining' | 'vaulting';
 
 export type IWalletOverlayRequest = {
   walletType: WalletType.defaultArgon | WalletType.miningBot | WalletType.ethereum;
+  ethereumWalletRecordId?: number;
   showGuidance?: boolean;
   guidanceContext?: IWalletGuidanceContext;
 };

--- a/src-vue/emitters/basicEmitter.ts
+++ b/src-vue/emitters/basicEmitter.ts
@@ -8,7 +8,7 @@ import type { IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 export type IWalletGuidanceContext = 'mining' | 'vaulting';
 
 export type IWalletOverlayRequest = {
-  walletType: WalletType.defaultArgon | WalletType.ethereum;
+  walletType: WalletType.defaultArgon | WalletType.miningBot | WalletType.ethereum;
   showGuidance?: boolean;
   guidanceContext?: IWalletGuidanceContext;
 };

--- a/src-vue/lib/Wallet.ts
+++ b/src-vue/lib/Wallet.ts
@@ -1,5 +1,6 @@
 import { UnitOfMeasurement } from '@argonprotocol/apps-core';
 import type { Address } from 'viem';
+import type { Currency } from './Currency.ts';
 
 type IOtherChain = 'ethereum' | 'base';
 
@@ -47,3 +48,11 @@ export const defaultWalletData: IWallet = {
   otherTokens: [],
   fetchErrorMsg: '',
 };
+
+export function getWalletTotalValue(wallet: IWallet, currency: Currency): bigint {
+  const micronotValue = currency.convertMicronotTo(wallet.totalMicronots, UnitOfMeasurement.Microgon);
+  const otherTokenValue = wallet.otherTokens.reduce((total, token) => {
+    return total + currency.convertOtherToMicrogon(token);
+  }, 0n);
+  return wallet.totalMicrogons + micronotValue + otherTokenValue;
+}

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -334,60 +334,22 @@
           <div class="absolute top-0 left-0 h-full w-5 rounded-bl-lg bg-linear-to-r from-slate-600/10 to-transparent" />
           <div class="flex flex-col justify-center pt-3 pr-3 pl-3">
             <header class="flex w-full flex-row items-center border-b border-slate-500/20">
-              <DropdownMenuRoot v-model:open="walletMenuIsOpen">
-                <DropdownMenuTrigger
-                  data-testid="LeftBar.walletMenu.open()"
-                  class="hover:text-argon-700 flex cursor-pointer items-center focus:outline-none"
-                >
-                  <span>{{ selectedWalletName }}</span>
-                  <ChevronDownIcon class="ml-1.5 w-4" />
-                </DropdownMenuTrigger>
-
-                <DropdownMenuPortal>
-                  <DropdownMenuContent
-                    align="start"
-                    side="top"
-                    :sideOffset="8"
-                    :style="walletMenuZIndex"
-                    class="bg-argon-menu-bg min-w-64 rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20"
-                  >
-                    <DropdownMenuItem
-                      v-for="wallet in walletSelections"
-                      :key="getWalletSelectionKey(wallet)"
-                      :data-testid="`LeftBar.walletMenu.select(${getWalletSelectionKey(wallet)})`"
-                      class="focus:bg-argon-menu-hover flex cursor-pointer items-center rounded px-3 py-2 focus:outline-none"
-                      @select="selectWallet(wallet)"
-                    >
-                      <CheckIcon
-                        class="mr-2 h-4 w-4 shrink-0"
-                        :class="getWalletSelectionKey(wallet) === selectedWalletKey ? 'visible' : 'invisible'"
-                      />
-                      <span class="min-w-0 grow">
-                        <strong class="block truncate text-slate-800">{{ getWalletName(wallet) }}</strong>
-                        <span class="block font-mono text-xs font-normal text-slate-500">
-                          {{ abbreviateAddress(getWalletAddress(wallet), 8) }}
-                        </span>
-                      </span>
-                    </DropdownMenuItem>
-                    <DropdownMenuArrow :width="18" :height="10" class="fill-white stroke-gray-300" />
-                  </DropdownMenuContent>
-                </DropdownMenuPortal>
-              </DropdownMenuRoot>
-              <div class="flex grow flex-row justify-end gap-x-3.5 pr-1">
-                <CopyToClipboard
-                  :content="selectedWalletData.address"
-                  :data-testid="selectedWalletAddressTestId"
-                  class="cursor-pointer"
-                >
-                  <CopyIcon class="h-4 opacity-80" />
-                  <template #copying>
-                    <CopyIcon class="h-4 opacity-100" />
-                  </template>
-                </CopyToClipboard>
-                <button type="button" class="cursor-pointer" @click="openSelectedWallet">
-                  <MoreIcon class="h-4 opacity-80" />
-                </button>
-              </div>
+              <WalletSelector
+                :selectedWallet="selectedWallet"
+                :walletSelections="walletSelections"
+                :getName="getWalletName"
+                testIdPrefix="LeftBar.walletMenu"
+                side="top"
+                class="hover:text-argon-700"
+                @select="selectWallet"
+              />
+              <WalletActions
+                :selection="selectedWallet"
+                :wallet="selectedWalletData"
+                :walletAddressTestId="selectedWalletAddressTestId"
+                :canExportPrivateKey="selectedWalletCanExportPrivateKey"
+                class="grow justify-end pr-1"
+              />
             </header>
             <div class="flex cursor-pointer flex-col justify-center py-7" @click="openSelectedWallet">
               <div class="text-argon-600/70 flex flex-row justify-center text-5xl font-bold">
@@ -437,19 +399,8 @@ import { useMiningAssetBreakdown } from '../stores/miningAssetBreakdown.ts';
 import { useVaultingAssetBreakdown } from '../stores/vaultingAssetBreakdown.ts';
 import type { FinancialGroup } from '../interfaces/IFinancialPosition.ts';
 import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';
-import {
-  DropdownMenuArrow,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuPortal,
-  DropdownMenuRoot,
-  DropdownMenuTrigger,
-} from 'reka-ui';
-import { CheckIcon } from '@heroicons/vue/20/solid';
 import DiamondsIcon from '../assets/diamonds.svg?component';
-import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 import MoreIcon from '../assets/more.svg';
-import CopyIcon from '../assets/copy.svg';
 import GiftIcon from '../assets/gift.svg';
 import EditIcon from '../assets/edit.svg';
 import BitcoinIcon from '../assets/wallets/bitcoin.svg';
@@ -463,15 +414,14 @@ import VaultIcon from '../assets/vault-small.svg';
 import WorldNetworkIcon from '../assets/world-network.svg';
 import OnboardingIcon from '../assets/onboarding.svg';
 import ExternalIcon from '../assets/external.svg';
-import CopyToClipboard from '../components/CopyToClipboard.vue';
-import { abbreviateAddress } from '../lib/Utils.ts';
 import {
   getAvailableWalletSelections,
   getWalletSelectionKey,
   isEthereumWalletSelection,
   type IWalletSelection,
 } from '../wallets/walletOverlayState.ts';
-import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
+import WalletSelector from '../wallets/components/WalletSelector.vue';
+import WalletActions from '../wallets/components/WalletActions.vue';
 
 const controller = useCertificationController();
 const bitcoinLockCoupons = getBitcoinLockCoupons();
@@ -481,13 +431,10 @@ const currency = getCurrency();
 const financials = useFinancials();
 const miningAssets = useMiningAssetBreakdown();
 const vaultingAssets = useVaultingAssetBreakdown();
-const walletMenuZIndex = useFloatingZIndex();
-
 const { microgonToArgonNm, microgonToMoneyNm, micronotToArgonotNm, micronotToMoneyNm, satToMoneyNm } =
   createNumeralHelpers(currency);
 
 const showOperationsNavigationCallouts = Vue.ref(false);
-const walletMenuIsOpen = Vue.ref(false);
 const selectedWallet = Vue.ref<IWalletSelection>({ walletType: WalletType.defaultArgon });
 const selectedWalletIsRefreshing = Vue.ref(false);
 
@@ -504,8 +451,12 @@ const selectedWalletData = Vue.computed<IWallet>(() => {
     : wallets.defaultArgonWallet;
 });
 
-const selectedWalletName = Vue.computed(() => getWalletName(selectedWallet.value));
 const selectedWalletKey = Vue.computed(() => getWalletSelectionKey(selectedWallet.value));
+const selectedWalletCanExportPrivateKey = Vue.computed(() => {
+  return (
+    isEthereumWalletSelection(selectedWallet.value) && selectedWallet.value.walletRecord.role === 'defaultEthereum'
+  );
+});
 const selectedWalletAddressTestId = Vue.computed(() => {
   return `LeftBar.${selectedWalletKey.value}Address`;
 });
@@ -530,7 +481,6 @@ const selectedWalletBalance = Vue.computed(() => {
 
 async function selectWallet(wallet: IWalletSelection) {
   selectedWallet.value = wallet;
-  walletMenuIsOpen.value = false;
   if (!isEthereumWalletSelection(wallet)) return;
 
   selectedWalletIsRefreshing.value = true;
@@ -542,19 +492,20 @@ async function selectWallet(wallet: IWalletSelection) {
 }
 
 function openSelectedWallet() {
+  if (isEthereumWalletSelection(selectedWallet.value)) {
+    basicEmitter.emit('openWalletOverlay', {
+      walletType: WalletType.ethereum,
+      ethereumWalletRecordId: selectedWallet.value.walletRecord.id,
+    });
+    return;
+  }
+
   basicEmitter.emit('openWalletOverlay', { walletType: selectedWallet.value.walletType });
 }
 
 function getWalletName(wallet: IWalletSelection): string {
   if (isEthereumWalletSelection(wallet)) return wallet.walletRecord.name;
   return wallet.walletType === WalletType.miningBot ? 'Mining Bot Wallet' : 'Argon Wallet';
-}
-
-function getWalletAddress(wallet: IWalletSelection): string {
-  if (isEthereumWalletSelection(wallet)) return wallet.walletRecord.address;
-  return wallet.walletType === WalletType.miningBot
-    ? wallets.miningBotWallet.address
-    : wallets.defaultArgonWallet.address;
 }
 
 function formatFinancialGroupValue(group: FinancialGroup): string {

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -330,36 +330,82 @@
         <div
           class="border-argon-400 absolute -top-5 -left-px h-5 w-2.5 rounded-l-full border border-t-transparent border-r-transparent"
         />
-        <div
-          @click="openDefaultArgonWallet"
-          class="bg-argon-100/20 hover:bg-argon-100/30 h-full w-full cursor-pointer"
-          style="text-shadow: 1px 1px 0 white"
-        >
+        <div class="bg-argon-100/20 h-full w-full" style="text-shadow: 1px 1px 0 white">
           <div class="absolute top-0 left-0 h-full w-5 rounded-bl-lg bg-linear-to-r from-slate-600/10 to-transparent" />
           <div class="flex flex-col justify-center pt-3 pr-3 pl-3">
             <header class="flex w-full flex-row items-center border-b border-slate-500/20">
-              <div>Argon Wallet</div>
-              <ChevronDownIcon class="ml-1.5 w-4" />
+              <DropdownMenuRoot v-model:open="walletMenuIsOpen">
+                <DropdownMenuTrigger
+                  data-testid="LeftBar.walletMenu.open()"
+                  class="hover:text-argon-700 flex cursor-pointer items-center focus:outline-none"
+                >
+                  <span>{{ selectedWalletName }}</span>
+                  <ChevronDownIcon class="ml-1.5 w-4" />
+                </DropdownMenuTrigger>
+
+                <DropdownMenuPortal>
+                  <DropdownMenuContent
+                    align="start"
+                    side="top"
+                    :sideOffset="8"
+                    :style="walletMenuZIndex"
+                    class="bg-argon-menu-bg min-w-64 rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20"
+                  >
+                    <DropdownMenuItem
+                      v-for="wallet in walletSelections"
+                      :key="getWalletSelectionKey(wallet)"
+                      :data-testid="`LeftBar.walletMenu.select(${getWalletSelectionKey(wallet)})`"
+                      class="focus:bg-argon-menu-hover flex cursor-pointer items-center rounded px-3 py-2 focus:outline-none"
+                      @select="selectWallet(wallet)"
+                    >
+                      <CheckIcon
+                        class="mr-2 h-4 w-4 shrink-0"
+                        :class="getWalletSelectionKey(wallet) === selectedWalletKey ? 'visible' : 'invisible'"
+                      />
+                      <span class="min-w-0 grow">
+                        <strong class="block truncate text-slate-800">{{ getWalletName(wallet) }}</strong>
+                        <span class="block font-mono text-xs font-normal text-slate-500">
+                          {{ abbreviateAddress(getWalletAddress(wallet), 8) }}
+                        </span>
+                      </span>
+                    </DropdownMenuItem>
+                    <DropdownMenuArrow :width="18" :height="10" class="fill-white stroke-gray-300" />
+                  </DropdownMenuContent>
+                </DropdownMenuPortal>
+              </DropdownMenuRoot>
               <div class="flex grow flex-row justify-end gap-x-3.5 pr-1">
-                <button type="button" class="cursor-pointer" @click="openDefaultArgonWallet">
+                <CopyToClipboard
+                  :content="selectedWalletData.address"
+                  :data-testid="selectedWalletAddressTestId"
+                  class="cursor-pointer"
+                >
                   <CopyIcon class="h-4 opacity-80" />
-                </button>
-                <button type="button" class="cursor-pointer" @click="openDefaultArgonWallet">
+                  <template #copying>
+                    <CopyIcon class="h-4 opacity-100" />
+                  </template>
+                </CopyToClipboard>
+                <button type="button" class="cursor-pointer" @click="openSelectedWallet">
                   <MoreIcon class="h-4 opacity-80" />
                 </button>
               </div>
             </header>
-            <div class="flex flex-col justify-center py-7">
+            <div class="flex cursor-pointer flex-col justify-center py-7" @click="openSelectedWallet">
               <div class="text-argon-600/70 flex flex-row justify-center text-5xl font-bold">
                 <span>{{ currency.symbol }}</span>
-                <FormattedMoney :isLoaded="financials.savingsIsLoaded" :value="financials.savingsTotalValue" />
+                <FormattedMoney :isLoaded="selectedWalletBalanceIsLoaded" :value="selectedWalletBalance" />
               </div>
               <div
-                v-if="financials.savingsTotalPending"
+                v-if="selectedWallet.walletType === WalletType.defaultArgon"
                 class="mx-auto mt-2 w-fit border-t border-slate-500/30 pt-2 text-center opacity-50"
               >
-                {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }} Is Waiting
-                to Mint
+                Includes {{ currency.symbol
+                }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }} waiting to mint
+              </div>
+              <div
+                v-else-if="isEthereumWalletSelection(selectedWallet)"
+                class="mx-auto mt-2 flex w-fit gap-x-2 border-t border-slate-500/30 pt-2 text-center opacity-50"
+              >
+                {{ currency.symbol }}{{ microgonToMoneyNm(selectedOtherTokenValue).format('0,0.00') }} non-native tokens
               </div>
             </div>
           </div>
@@ -380,9 +426,8 @@ import {
 import { getConfig } from '../stores/config.ts';
 import FormattedMoney from '../components/FormattedMoney.vue';
 import { getBitcoinLockCoupons } from '../stores/bitcoin.ts';
-import WalletsMenu from './WalletsMenu.vue';
 import basicEmitter from '../emitters/basicEmitter.ts';
-import { WalletType } from '../lib/Wallet.ts';
+import { getWalletTotalValue, type IWallet, WalletType } from '../lib/Wallet.ts';
 import ArrowCalloutButton from '../components/ArrowCalloutButton.vue';
 import { useWallets } from '../stores/wallets.ts';
 import { getCurrency } from '../stores/currency.ts';
@@ -392,6 +437,15 @@ import { useMiningAssetBreakdown } from '../stores/miningAssetBreakdown.ts';
 import { useVaultingAssetBreakdown } from '../stores/vaultingAssetBreakdown.ts';
 import type { FinancialGroup } from '../interfaces/IFinancialPosition.ts';
 import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';
+import {
+  DropdownMenuArrow,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+} from 'reka-ui';
+import { CheckIcon } from '@heroicons/vue/20/solid';
 import DiamondsIcon from '../assets/diamonds.svg?component';
 import { ChevronDownIcon } from '@heroicons/vue/24/outline';
 import MoreIcon from '../assets/more.svg';
@@ -409,6 +463,15 @@ import VaultIcon from '../assets/vault-small.svg';
 import WorldNetworkIcon from '../assets/world-network.svg';
 import OnboardingIcon from '../assets/onboarding.svg';
 import ExternalIcon from '../assets/external.svg';
+import CopyToClipboard from '../components/CopyToClipboard.vue';
+import { abbreviateAddress } from '../lib/Utils.ts';
+import {
+  getAvailableWalletSelections,
+  getWalletSelectionKey,
+  isEthereumWalletSelection,
+  type IWalletSelection,
+} from '../wallets/walletOverlayState.ts';
+import { useFloatingZIndex } from '../overlays/helpers/OverlayZIndex.ts';
 
 const controller = useCertificationController();
 const bitcoinLockCoupons = getBitcoinLockCoupons();
@@ -418,11 +481,81 @@ const currency = getCurrency();
 const financials = useFinancials();
 const miningAssets = useMiningAssetBreakdown();
 const vaultingAssets = useVaultingAssetBreakdown();
+const walletMenuZIndex = useFloatingZIndex();
 
 const { microgonToArgonNm, microgonToMoneyNm, micronotToArgonotNm, micronotToMoneyNm, satToMoneyNm } =
   createNumeralHelpers(currency);
 
 const showOperationsNavigationCallouts = Vue.ref(false);
+const walletMenuIsOpen = Vue.ref(false);
+const selectedWallet = Vue.ref<IWalletSelection>({ walletType: WalletType.defaultArgon });
+const selectedWalletIsRefreshing = Vue.ref(false);
+
+const walletSelections = Vue.computed(() => {
+  return getAvailableWalletSelections(wallets.walletRecords, [], config.hasExtensionOperations);
+});
+
+const selectedWalletData = Vue.computed<IWallet>(() => {
+  if (isEthereumWalletSelection(selectedWallet.value)) {
+    return wallets.getEthereumWalletRecord(selectedWallet.value.walletRecord.id);
+  }
+  return selectedWallet.value.walletType === WalletType.miningBot
+    ? wallets.miningBotWallet
+    : wallets.defaultArgonWallet;
+});
+
+const selectedWalletName = Vue.computed(() => getWalletName(selectedWallet.value));
+const selectedWalletKey = Vue.computed(() => getWalletSelectionKey(selectedWallet.value));
+const selectedWalletAddressTestId = Vue.computed(() => {
+  return `LeftBar.${selectedWalletKey.value}Address`;
+});
+const selectedWalletBalanceIsLoaded = Vue.computed(() => {
+  if (selectedWalletIsRefreshing.value) return false;
+  if (selectedWallet.value.walletType === WalletType.defaultArgon) return financials.savingsIsLoaded;
+  return wallets.isLoaded;
+});
+const selectedOtherTokenValue = Vue.computed(() => {
+  return selectedWalletData.value.otherTokens.reduce((total, token) => {
+    return total + currency.convertOtherToMicrogon(token);
+  }, 0n);
+});
+const selectedWalletBalance = Vue.computed(() => {
+  if (selectedWallet.value.walletType === WalletType.defaultArgon) {
+    return financials.savingsTotalValue;
+  }
+
+  const wallet = selectedWalletData.value;
+  return getWalletTotalValue(wallet, currency);
+});
+
+async function selectWallet(wallet: IWalletSelection) {
+  selectedWallet.value = wallet;
+  walletMenuIsOpen.value = false;
+  if (!isEthereumWalletSelection(wallet)) return;
+
+  selectedWalletIsRefreshing.value = true;
+  try {
+    await wallets.selectEthereumWalletRecord(wallet.walletRecord.id);
+  } finally {
+    selectedWalletIsRefreshing.value = false;
+  }
+}
+
+function openSelectedWallet() {
+  basicEmitter.emit('openWalletOverlay', { walletType: selectedWallet.value.walletType });
+}
+
+function getWalletName(wallet: IWalletSelection): string {
+  if (isEthereumWalletSelection(wallet)) return wallet.walletRecord.name;
+  return wallet.walletType === WalletType.miningBot ? 'Mining Bot Wallet' : 'Argon Wallet';
+}
+
+function getWalletAddress(wallet: IWalletSelection): string {
+  if (isEthereumWalletSelection(wallet)) return wallet.walletRecord.address;
+  return wallet.walletType === WalletType.miningBot
+    ? wallets.miningBotWallet.address
+    : wallets.defaultArgonWallet.address;
+}
 
 function formatFinancialGroupValue(group: FinancialGroup): string {
   const summary = financials.financialPositionAggregate.groupSummaries[group];

--- a/src-vue/screens/OldWalletsScreen.vue
+++ b/src-vue/screens/OldWalletsScreen.vue
@@ -81,7 +81,7 @@
               <div class="grow">{{ wallet.name }}</div>
               <ExtraMenu
                 v-if="!wallet.isPlaceholder && !hasOpenedWallet"
-                :walletType="wallet.type"
+                :selection="getWalletSelection(wallet)"
                 :wallet="wallet.wallet"
                 :showBorders="false"
                 @click.stop
@@ -118,6 +118,7 @@ import numeral from '../lib/numeral.ts';
 import ExtraMenu from '../wallets/components/ExtraMenu.vue';
 import { useWallets } from '../stores/wallets.ts';
 import type { IWalletRecord as IDbWalletRecord } from '../lib/db/WalletsTable.ts';
+import type { IWalletSelection } from '../wallets/walletOverlayState.ts';
 
 const financials = useFinancials();
 const wallets = useWallets();
@@ -350,6 +351,13 @@ function reorderDraggedWallet() {
 
 function openEthereumChoice() {
   basicEmitter.emit('openEthereumWalletImportOverlay', 'choice');
+}
+
+function getWalletSelection(wallet: IWalletRecord): IWalletSelection {
+  if (wallet.record?.walletType === 'ethereum') {
+    return { walletType: WalletType.ethereum, walletRecord: wallet.record };
+  }
+  return { walletType: WalletType.defaultArgon };
 }
 
 Vue.onUnmounted(() => {

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -42,12 +42,13 @@
             >
               <NavHeader
                 v-if="props.leftWallet"
-                :walletType="props.leftWallet.walletType"
+                :selection="props.leftWallet"
+                :walletSelections="props.walletSelections"
                 :wallet="getWallet(props.leftWallet)"
-                :name="getWalletSelectionName(props.leftWallet)"
                 :canExportPrivateKey="canExportEthereumPrivateKey(props.leftWallet)"
                 :showClose="true"
                 closeSide="left"
+                @select="emit('selectLeftWallet', $event)"
                 @close="emit('closeLeft')"
               />
               <header v-else class="grow px-2 text-left text-xl font-bold text-slate-600">Choose a Wallet</header>
@@ -96,12 +97,13 @@
             >
               <NavHeader
                 v-if="props.rightWallet"
-                :walletType="props.rightWallet.walletType"
+                :selection="props.rightWallet"
+                :walletSelections="props.walletSelections"
                 :wallet="getWallet(props.rightWallet)"
-                :name="getWalletSelectionName(props.rightWallet)"
                 :canExportPrivateKey="canExportEthereumPrivateKey(props.rightWallet)"
                 :showClose="true"
                 closeSide="right"
+                @select="emit('selectRightWallet', $event)"
                 @close="emit('closeRight')"
               />
               <header v-else class="grow px-2 text-left text-xl font-bold text-slate-600">Choose a Wallet</header>
@@ -194,6 +196,7 @@ const props = withDefaults(
   defineProps<{
     leftWallet?: IWalletSelection;
     rightWallet?: IWalletSelection;
+    walletSelections: IWalletSelection[];
     availableWallets: IWalletSelection[];
     canAddDefaultEthereum: boolean;
     showGuidance?: boolean;

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -3,6 +3,7 @@
     v-if="openWallet"
     :rightWallet="openWallet.rightWallet"
     :leftWallet="openWallet.leftWallet"
+    :walletSelections="walletSelections"
     :availableWallets="availableWallets"
     :canAddDefaultEthereum="canAddDefaultEthereum"
     :showGuidance="openWallet.showGuidance"
@@ -48,6 +49,7 @@ import {
   getInitialWalletOverlayState,
   getWalletSelectionKey,
   isEthereumWalletSelection,
+  selectWalletOverlaySide,
   type IWalletOverlayState,
   type IWalletSelection,
 } from './walletOverlayState.ts';
@@ -65,6 +67,10 @@ const openWallet = Vue.ref<IOpenWallet>();
 const pendingEthereumWalletAction = Vue.ref<
   { type: 'open'; request: IWalletOverlayRequest } | { type: 'select'; side: 'left' | 'right' }
 >();
+
+const walletSelections = Vue.computed(() => {
+  return getAvailableWalletSelections(walletStore.walletRecords, [], config.hasExtensionOperations);
+});
 
 const availableWallets = Vue.computed(() => {
   if (!openWallet.value) return [];
@@ -96,11 +102,9 @@ async function selectWallet(side: 'left' | 'right', wallet: IWalletSelection) {
     await walletStore.selectEthereumWalletRecord(wallet.walletRecord.id);
   }
 
-  if (side === 'left') {
-    openWallet.value.leftWallet = wallet;
-  } else {
-    openWallet.value.rightWallet = wallet;
-  }
+  const nextState = selectWalletOverlaySide(openWallet.value, side, wallet);
+  openWallet.value.leftWallet = nextState.leftWallet;
+  openWallet.value.rightWallet = nextState.rightWallet;
 
   await syncActiveEthereumWallet();
 }
@@ -211,8 +215,12 @@ function getRequestedWallet(
   const activeWalletRecord = walletStore.walletRecords.find(
     record => record.id === walletStore.activeEthereumWalletRecordId,
   );
+  const requestedWalletRecord = walletStore.walletRecords.find(
+    record => record.walletType === 'ethereum' && record.id === request.ethereumWalletRecordId,
+  );
   const walletRecord =
     ethereumWalletRecord ??
+    requestedWalletRecord ??
     activeWalletRecord ??
     walletStore.walletRecords.find(record => record.walletType === 'ethereum');
   return walletRecord ? { walletType: WalletType.ethereum, walletRecord } : undefined;

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -204,6 +204,9 @@ function getRequestedWallet(
   if (request.walletType === WalletType.defaultArgon) {
     return { walletType: WalletType.defaultArgon };
   }
+  if (request.walletType === WalletType.miningBot) {
+    return { walletType: WalletType.miningBot };
+  }
 
   const activeWalletRecord = walletStore.walletRecords.find(
     record => record.id === walletStore.activeEthereumWalletRecordId,

--- a/src-vue/wallets/components/ExtraMenu.vue
+++ b/src-vue/wallets/components/ExtraMenu.vue
@@ -4,13 +4,23 @@
     <DropdownMenuRoot :openDelay="0" :closeDelay="0" v-model:open="isOpen">
       <DropdownMenuTrigger
         Trigger
-        :data-testid="walletAddressTestId ? `${walletAddressTestId}.openMenu()` : undefined"
-        class="group relative flex  cursor-pointer flex-col items-center justify-center gap-y-[2px] rounded-md text-slate-400 hover:bg-slate-400/10 hover:text-slate-500 focus:outline-none data-[state=open]:bg-slate-400/10 data-[state=open]:text-slate-500"
-        :class="[showBorders ? 'h-[34px] w-[34px] border border-slate-400/60' : 'h-[22px] w-[22px]']"
+        :data-testid="props.testIdPrefix ? `${props.testIdPrefix}.openMenu()` : undefined"
+        class="focus:outline-none"
+        :class="
+          $slots.trigger
+            ? 'cursor-pointer'
+            : [
+                'group relative flex cursor-pointer flex-col items-center justify-center gap-y-[2px] rounded-md text-slate-400 hover:bg-slate-400/10 hover:text-slate-500 data-[state=open]:bg-slate-400/10 data-[state=open]:text-slate-500',
+                props.showBorders ? 'h-[34px] w-[34px] border border-slate-400/60' : 'h-[22px] w-[22px]',
+              ]
+        "
       >
-        <span class="h-1 w-1 rounded-full bg-current" />
-        <span class="h-1 w-1 rounded-full bg-current" />
-        <span class="h-1 w-1 rounded-full bg-current" />
+        <slot v-if="$slots.trigger" name="trigger" />
+        <template v-else>
+          <span class="h-1 w-1 rounded-full bg-current" />
+          <span class="h-1 w-1 rounded-full bg-current" />
+          <span class="h-1 w-1 rounded-full bg-current" />
+        </template>
       </DropdownMenuTrigger>
 
       <DropdownMenuPortal>
@@ -26,7 +36,7 @@
         >
           <div class="bg-argon-menu-bg flex min-w-66 shrink flex-col rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20">
             <template v-if="!props.walletIsOpen">
-              <DropdownMenuItem MenuItem @click="() => openWallet(walletType)">
+              <DropdownMenuItem MenuItem @click="openWallet">
                 <div ItemWrapper>
                   <header>Open Wallet Overlay</header>
                   <WindowIcon class="w-4 h-4" />
@@ -34,24 +44,6 @@
               </DropdownMenuItem>
               <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
             </template>
-            <DropdownMenuItem MenuItem>
-              <CopyToClipboard
-                :data-testid="walletAddressTestId"
-                :content="wallet.address"
-              >
-                <div ItemWrapper>
-                  <header>Copy Wallet Address</header>
-                  <CopyIcon class="w-4 h-4" />
-                </div>
-                <template #copying>
-                  <div ItemWrapper class="absolute top-0 left-0 w-full h-full">
-                    <header>Copy Wallet Address</header>
-                    <CopyIcon class="w-4 h-4" />
-                  </div>
-                </template>
-              </CopyToClipboard>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
             <DropdownMenuItem MenuItem @select="toggleQRCode" >
               <div ItemWrapper>
                 <header>View Wallet QR Code</header>
@@ -75,11 +67,12 @@
                 </div>
               </DropdownMenuItem>
             </template>
-            <template v-if="walletType !== WalletType.defaultArgon">
+            <template v-if="props.selection.walletType !== WalletType.defaultArgon">
               <DropdownMenuSeparator divider class="my-1 h-[1px] w-full bg-slate-400/30" />
               <DropdownMenuItem MenuItem @click="() => disconnectWallet()">
                 <div ItemWrapper>
                   <header>Disconnect Wallet from App</header>
+                  <LinkSlashIcon class="h-4 w-4" />
                 </div>
               </DropdownMenuItem>
             </template>
@@ -105,18 +98,18 @@ import {
 import type { PointerDownOutsideEvent } from 'reka-ui';
 import basicEmitter from '../../emitters/basicEmitter.ts';
 import { WalletType } from '../../lib/Wallet.ts';
-import { KeyIcon, WindowIcon, QrCodeIcon, ShieldCheckIcon } from '@heroicons/vue/24/outline';
-import CopyIcon from '../../assets/copy.svg';
+import { KeyIcon, LinkSlashIcon, WindowIcon, QrCodeIcon, ShieldCheckIcon } from '@heroicons/vue/24/outline';
 import QRCode from 'qrcode';
-import CopyToClipboard from '../../components/CopyToClipboard.vue';
 import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
+import { isEthereumWalletSelection, type IWalletSelection } from '../walletOverlayState.ts';
 
 const props = withDefaults(
   defineProps<{
+    selection: IWalletSelection;
     wallet: { address: string };
-    walletType: WalletType;
     walletIsOpen?: boolean;
     canExportPrivateKey?: boolean;
+    testIdPrefix?: string;
     showBorders?: boolean;
   }>(),
   {
@@ -129,10 +122,6 @@ const props = withDefaults(
 const rootRef = Vue.ref<HTMLElement>();
 const isOpen = Vue.ref(false);
 const floatingZIndex = useFloatingZIndex();
-const walletAddressTestId = Vue.computed(() =>
-  props.walletIsOpen && props.walletType === WalletType.defaultArgon ? 'defaultArgonWalletAddress' : undefined,
-);
-
 const showQrCode = Vue.ref(false);
 const qrCode = Vue.ref('');
 
@@ -167,8 +156,16 @@ function openEthereumPrivateKeyExport() {
   basicEmitter.emit('openSecuritySettingsOverlay', { screen: 'ethereum-export' });
 }
 
-function openWallet(walletType: WalletType) {
-  basicEmitter.emit('openWalletOverlay', { walletType: walletType as any });
+function openWallet() {
+  if (isEthereumWalletSelection(props.selection)) {
+    basicEmitter.emit('openWalletOverlay', {
+      walletType: WalletType.ethereum,
+      ethereumWalletRecordId: props.selection.walletRecord.id,
+    });
+    return;
+  }
+
+  basicEmitter.emit('openWalletOverlay', { walletType: props.selection.walletType });
 }
 
 function openProfileOverlay(): void {

--- a/src-vue/wallets/components/NavHeader.vue
+++ b/src-vue/wallets/components/NavHeader.vue
@@ -1,13 +1,22 @@
 <template>
-  <div class="flex grow flex-row items-center gap-x-2">
-    <header class="grow px-2 text-left text-xl font-bold text-slate-800/70">
-      {{ props.name }}
-    </header>
-    <ExtraMenu
-      :walletType="walletType"
+  <div class="flex min-w-0 grow flex-row items-center gap-x-3.5">
+    <WalletSelector
+      :selectedWallet="props.selection"
+      :walletSelections="props.walletSelections"
+      :testIdPrefix="`WalletOverlay.${props.closeSide}WalletMenu`"
+      class="min-w-0 grow px-2 text-left text-xl font-bold text-slate-800/70"
+      @click.stop
+      @pointerdown.stop
+      @mousedown.stop
+      @select="emit('select', $event)"
+    />
+    <WalletActions
+      :selection="props.selection"
       :wallet="props.wallet"
       :walletIsOpen="true"
       :canExportPrivateKey="props.canExportPrivateKey"
+      :walletAddressTestId="walletAddressTestId"
+      class="h-[34px] shrink-0"
       @click.stop
       @pointerdown.stop
       @mousedown.stop
@@ -28,21 +37,30 @@
 
 <script setup lang="ts">
 import { XMarkIcon } from '@heroicons/vue/24/outline';
-import ExtraMenu from './ExtraMenu.vue';
+import { computed } from 'vue';
 import { type IWallet, WalletType } from '../../lib/Wallet.ts';
+import WalletActions from './WalletActions.vue';
+import WalletSelector from './WalletSelector.vue';
+import { getWalletSelectionKey, type IWalletSelection } from '../walletOverlayState.ts';
 
 const emit = defineEmits<{
   (e: 'close'): void;
+  (e: 'select', wallet: IWalletSelection): void;
 }>();
 
 const props = defineProps<{
   wallet: IWallet;
-  walletType: WalletType;
-  name: string;
+  selection: IWalletSelection;
+  walletSelections: IWalletSelection[];
   canExportPrivateKey?: boolean;
   showClose?: boolean;
   closeSide: 'left' | 'right';
 }>();
+
+const walletAddressTestId = computed(() => {
+  if (props.selection.walletType === WalletType.defaultArgon) return 'defaultArgonWalletAddress';
+  return `WalletOverlay.${props.closeSide}.${getWalletSelectionKey(props.selection)}Address`;
+});
 
 function close() {
   emit('close');

--- a/src-vue/wallets/components/WalletActions.vue
+++ b/src-vue/wallets/components/WalletActions.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="flex flex-row items-center gap-x-3.5">
+    <CopyToClipboard :content="props.wallet.address" :data-testid="props.walletAddressTestId" class="cursor-pointer">
+      <CopyIcon class="h-4 opacity-80" />
+      <template #copying>
+        <CopyIcon class="h-4 opacity-100" />
+      </template>
+    </CopyToClipboard>
+    <ExtraMenu
+      :selection="props.selection"
+      :wallet="props.wallet"
+      :walletIsOpen="props.walletIsOpen"
+      :canExportPrivateKey="props.canExportPrivateKey"
+      :testIdPrefix="props.walletAddressTestId"
+    >
+      <template #trigger>
+        <MoreIcon class="h-4 opacity-80" />
+      </template>
+    </ExtraMenu>
+  </div>
+</template>
+
+<script setup lang="ts">
+import CopyIcon from '../../assets/copy.svg';
+import MoreIcon from '../../assets/more.svg';
+import CopyToClipboard from '../../components/CopyToClipboard.vue';
+import type { IWallet } from '../../lib/Wallet.ts';
+import type { IWalletSelection } from '../walletOverlayState.ts';
+import ExtraMenu from './ExtraMenu.vue';
+
+const props = defineProps<{
+  selection: IWalletSelection;
+  wallet: IWallet;
+  walletAddressTestId: string;
+  walletIsOpen?: boolean;
+  canExportPrivateKey?: boolean;
+}>();
+</script>

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -4,12 +4,20 @@
       <div class="text-7xl font-bold">
         <FormattedMoney :isLoaded="walletValueIsLoaded" :value="walletTotalValue" />
       </div>
-      <div
-        v-if="props.selection.walletType === WalletType.defaultArgon"
-        class="mx-auto mt-2 w-fit border-t border-slate-500/30 pt-2 text-sm opacity-50"
-      >
-        Includes {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }} waiting
-        to mint
+      <div class="mt-2 h-[29px] shrink-0">
+        <div
+          v-if="props.selection.walletType === WalletType.defaultArgon"
+          class="mx-auto w-fit border-t border-slate-500/30 pt-2 text-sm opacity-50"
+        >
+          Includes {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }} waiting
+          to mint
+        </div>
+        <div
+          v-else-if="props.selection.walletType === WalletType.ethereum"
+          class="mx-auto w-fit border-t border-slate-500/30 pt-2 text-sm opacity-50"
+        >
+          {{ currency.symbol }}{{ microgonToMoneyNm(nonNativeTokenValue).format('0,0.00') }} non-native tokens
+        </div>
       </div>
     </div>
 
@@ -82,5 +90,8 @@ const walletValueIsLoaded = Vue.computed(() => {
 const walletTotalValue = Vue.computed(() => {
   if (props.selection.walletType === WalletType.defaultArgon) return financials.savingsTotalValue;
   return getWalletTotalValue(props.wallet, currency);
+});
+const nonNativeTokenValue = Vue.computed(() => {
+  return props.wallet.otherTokens.reduce((total, token) => total + currency.convertOtherToMicrogon(token), 0n);
 });
 </script>

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="flex h-full flex-col text-black/90">
-    <div class="mx-1 border-t border-slate-300 px-4 py-6 text-center text-7xl font-bold">
-      <FormattedMoney :value="props.wallet.availableMicrogons" />
+    <div class="mx-1 border-t border-slate-300 px-4 py-6 text-center">
+      <div class="text-7xl font-bold">
+        <FormattedMoney :isLoaded="walletValueIsLoaded" :value="walletTotalValue" />
+      </div>
+      <div
+        v-if="props.selection.walletType === WalletType.defaultArgon"
+        class="mx-auto mt-2 w-fit border-t border-slate-500/30 pt-2 text-sm opacity-50"
+      >
+        Includes {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }} waiting
+        to mint
+      </div>
     </div>
 
     <div class="relative py-2">
@@ -35,13 +44,17 @@
 <script setup lang="ts">
 import type { IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
 import type { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
-import { type IWallet, WalletType } from '../../lib/Wallet.ts';
+import { getWalletTotalValue, type IWallet, WalletType } from '../../lib/Wallet.ts';
 import type { IWalletGuidanceContext } from '../../emitters/basicEmitter.ts';
 import FormattedMoney from '../../components/FormattedMoney.vue';
 import ArgonBottom from './ArgonBottom.vue';
 import ArgonTokens from './ArgonTokens.vue';
 import EthereumBottom from './EthereumBottom.vue';
 import type { IWalletSelection } from '../walletOverlayState.ts';
+import * as Vue from 'vue';
+import { useFinancials } from '../../stores/financials.ts';
+import { getCurrency } from '../../stores/currency.ts';
+import { createNumeralHelpers } from '../../lib/numeral.ts';
 
 const props = defineProps<{
   selection: IWalletSelection;
@@ -57,4 +70,17 @@ const props = defineProps<{
 const emit = defineEmits<{
   (event: 'openTransferOverlay', transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint }): void;
 }>();
+
+const financials = useFinancials();
+const currency = getCurrency();
+const { microgonToMoneyNm } = createNumeralHelpers(currency);
+
+const walletValueIsLoaded = Vue.computed(() => {
+  if (props.selection.walletType === WalletType.defaultArgon) return financials.savingsIsLoaded;
+  return true;
+});
+const walletTotalValue = Vue.computed(() => {
+  if (props.selection.walletType === WalletType.defaultArgon) return financials.savingsTotalValue;
+  return getWalletTotalValue(props.wallet, currency);
+});
 </script>

--- a/src-vue/wallets/components/WalletSelector.vue
+++ b/src-vue/wallets/components/WalletSelector.vue
@@ -1,0 +1,100 @@
+<template>
+  <DropdownMenuRoot>
+    <DropdownMenuTrigger
+      v-bind="$attrs"
+      :data-testid="`${props.testIdPrefix}.open()`"
+      class="flex min-w-0 cursor-pointer items-center focus:outline-none"
+    >
+      <span class="truncate">{{ getWalletName(props.selectedWallet) }}</span>
+      <ChevronDownIcon class="ml-1.5 w-4 shrink-0" />
+    </DropdownMenuTrigger>
+
+    <DropdownMenuPortal>
+      <DropdownMenuContent
+        align="start"
+        :side="props.side"
+        :sideOffset="8"
+        :style="floatingZIndex"
+        class="bg-argon-menu-bg min-w-64 rounded p-1 text-sm/6 font-semibold text-gray-900 shadow-lg ring-1 ring-gray-900/20"
+      >
+        <DropdownMenuItem
+          v-for="wallet in props.walletSelections"
+          :key="getWalletSelectionKey(wallet)"
+          :data-testid="`${props.testIdPrefix}.select(${getWalletSelectionKey(wallet)})`"
+          class="focus:bg-argon-menu-hover flex cursor-pointer items-center rounded px-3 py-2 focus:outline-none"
+          @select="emit('select', wallet)"
+        >
+          <CheckIcon
+            class="mr-2 h-4 w-4 shrink-0"
+            :class="getWalletSelectionKey(wallet) === selectedWalletKey ? 'visible' : 'invisible'"
+          />
+          <span class="min-w-0 grow">
+            <strong class="block truncate text-slate-800">{{ getWalletName(wallet) }}</strong>
+            <span class="block font-mono text-xs font-normal text-slate-500">
+              {{ abbreviateAddress(getWalletAddress(wallet), 8) }}
+            </span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuArrow :width="18" :height="10" class="fill-white stroke-gray-300" />
+      </DropdownMenuContent>
+    </DropdownMenuPortal>
+  </DropdownMenuRoot>
+</template>
+
+<script setup lang="ts">
+import { CheckIcon } from '@heroicons/vue/20/solid';
+import { ChevronDownIcon } from '@heroicons/vue/24/outline';
+import {
+  DropdownMenuArrow,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+} from 'reka-ui';
+import { computed } from 'vue';
+import { abbreviateAddress } from '../../lib/Utils.ts';
+import { WalletType } from '../../lib/Wallet.ts';
+import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
+import { useWallets } from '../../stores/wallets.ts';
+import {
+  getWalletSelectionKey,
+  getWalletSelectionName,
+  isEthereumWalletSelection,
+  type IWalletSelection,
+} from '../walletOverlayState.ts';
+
+defineOptions({ inheritAttrs: false });
+
+const props = withDefaults(
+  defineProps<{
+    selectedWallet: IWalletSelection;
+    walletSelections: IWalletSelection[];
+    testIdPrefix: string;
+    side?: 'top' | 'right' | 'bottom' | 'left';
+    getName?: (wallet: IWalletSelection) => string;
+  }>(),
+  {
+    side: 'bottom',
+  },
+);
+
+const emit = defineEmits<{
+  (event: 'select', wallet: IWalletSelection): void;
+}>();
+
+const wallets = useWallets();
+const floatingZIndex = useFloatingZIndex();
+const selectedWalletKey = computed(() => getWalletSelectionKey(props.selectedWallet));
+
+function getWalletName(wallet: IWalletSelection) {
+  return props.getName?.(wallet) ?? getWalletSelectionName(wallet);
+}
+
+function getWalletAddress(wallet: IWalletSelection) {
+  if (isEthereumWalletSelection(wallet)) return wallet.walletRecord.address;
+  return wallet.walletType === WalletType.miningBot
+    ? wallets.miningBotWallet.address
+    : wallets.defaultArgonWallet.address;
+}
+</script>

--- a/src-vue/wallets/walletOverlayState.ts
+++ b/src-vue/wallets/walletOverlayState.ts
@@ -57,6 +57,25 @@ export function closeWalletOverlaySide(state: IWalletOverlayState, side: 'left' 
   return state.leftWallet ? { leftWallet: state.leftWallet } : {};
 }
 
+export function selectWalletOverlaySide(
+  state: IWalletOverlayState,
+  side: 'left' | 'right',
+  wallet: IWalletSelection,
+): IWalletOverlayState {
+  const walletKey = getWalletSelectionKey(wallet);
+  if (side === 'left') {
+    if (state.rightWallet && getWalletSelectionKey(state.rightWallet) === walletKey) {
+      return { leftWallet: wallet };
+    }
+    return state.rightWallet ? { leftWallet: wallet, rightWallet: state.rightWallet } : { leftWallet: wallet };
+  }
+
+  if (state.leftWallet && getWalletSelectionKey(state.leftWallet) === walletKey) {
+    return { rightWallet: wallet };
+  }
+  return state.leftWallet ? { leftWallet: state.leftWallet, rightWallet: wallet } : { rightWallet: wallet };
+}
+
 export function getWalletSelectionKey(wallet: IWalletSelection): string {
   if (wallet.walletType === WalletType.ethereum) {
     return `ethereum:${wallet.walletRecord.id}`;


### PR DESCRIPTION
## Summary

The sidebar wallet card can now switch between the default Argon wallet, an activated mining wallet, and every configured Ethereum wallet. Its displayed value, copied address, and opened wallet stay aligned with the selection, and selecting an Ethereum account refreshes its balance.

Wallet totals now value ARGN, ARGNOT, and non-native tokens consistently. Default Argon totals also include pending mint value, with that amount always called out beneath the total.

## Validation

- Vue typecheck passes.
- Wallet-selection tests pass (9/9).
