### PR TITLE
fix: correct bitcoin returns after ratcheting

### DIFF
--- a/src-vue/__test__/Financials.test.ts
+++ b/src-vue/__test__/Financials.test.ts
@@ -913,10 +913,10 @@ describe('financial position accounting', () => {
         receivedLiquidity: 35n,
         valueBeyondLiquidity: 30n,
         startingCapital: 100n,
-        endingCapital: 100n,
+        endingCapital: 120n,
         totalFees: 15n,
         unlockAmount: 60n,
-        totalReturn: 0,
+        totalReturn: 20,
       });
       expect(positions.map(position => position.id)).toEqual([
         `bitcoin-asset:${lock.uuid}`,
@@ -930,8 +930,94 @@ describe('financial position accounting', () => {
       expect(positions[0]).toMatchObject({ investedCost: 100n, paidIncome: 20n });
       expect(bitcoin).toMatchObject({ grossAssets: 160n, grossLiabilities: 60n, currentValue: 100n });
       expect(bitcoin?.returnSummary.paidIncome).toBe(20n);
-      expect(bitcoin?.returnSummary.returnAmount).toBe(0n);
-      expect(bitcoin?.returnSummary.percent).toBe(0);
+      expect(bitcoin?.returnSummary.returnAmount).toBe(20n);
+      expect(bitcoin?.returnSummary.percent).toBe(20);
+    } finally {
+      redemption.mockRestore();
+    }
+  });
+
+  it('keeps total Bitcoin return at breakeven after a down-ratchet offsets the price loss', () => {
+    const lock = {
+      uuid: 'down-ratchet',
+      status: BitcoinLockStatus.LockedAndIsMinting,
+      satoshis: 10_000n,
+      lockedTargetPrice: 100n,
+      ratchets: [
+        {
+          mintAmount: 120n,
+          mintPending: 0n,
+          liquidityPromised: 120n,
+          lockedTargetPrice: 120n,
+          securityFee: 0n,
+          txFee: 0n,
+          burned: 0n,
+          blockHeight: 1,
+          oracleBitcoinBlockHeight: 1,
+        },
+        {
+          mintAmount: 100n,
+          mintPending: 100n,
+          liquidityPromised: 100n,
+          lockedTargetPrice: 100n,
+          securityFee: 0n,
+          txFee: 0n,
+          burned: 100n,
+          blockHeight: 2,
+          oracleBitcoinBlockHeight: 2,
+        },
+      ],
+      lockDetails: { couponFeesPaid: 0n },
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as unknown as IBitcoinLockRecord;
+    const currency = {
+      priceIndex: {},
+      convertSatToBtc: vi.fn(() => 0.0001),
+      convertBtcToMicrogon: vi.fn(() => 100n),
+    } as unknown as Currency;
+    const bitcoinLocks = new BitcoinLocks(
+      Promise.resolve({} as never),
+      {} as never,
+      {} as never,
+      currency,
+      {} as never,
+      {} as never,
+    );
+    vi.spyOn(bitcoinLocks, 'getMismatchViewState').mockReturnValue({
+      phase: 'none',
+      candidateCount: 0,
+      isFundingExpired: false,
+      candidates: [],
+    });
+    vi.spyOn(bitcoinLocks, 'getLockProcessingDetails').mockReturnValue({ confirmations: 3 } as never);
+    vi.spyOn(bitcoinLocks, 'getLockProcessingError').mockReturnValue('');
+    vi.spyOn(bitcoinLocks, 'hasObservedFundingSignal').mockReturnValue(true);
+    const redemption = vi.spyOn(BitcoinLock, 'calculateRedemptionAmountFromSatoshis').mockReturnValue(100n);
+
+    try {
+      const summary = bitcoinLocks.createLockSummary(lock);
+      const positions = bitcoinFinancials.createFinancialPositions({ summaries: [summary], hasCurrentPrice: true });
+      const bitcoin = reduceFinancialPositions(readySnapshots(positions)).groupSummaries.bitcoin;
+
+      expect(summary).toMatchObject({
+        valueOfBtc: 100n,
+        pendingLiquidity: 100n,
+        receivedLiquidity: 20n,
+        startingCapital: 120n,
+        endingCapital: 120n,
+        totalReturn: 0,
+      });
+      expect(bitcoin).toMatchObject({
+        grossAssets: 200n,
+        grossLiabilities: 100n,
+        currentValue: 100n,
+      });
+      expect(bitcoin.returnSummary).toMatchObject({
+        investedCost: 120n,
+        paidIncome: 20n,
+        returnAmount: 0n,
+        percent: 0,
+      });
     } finally {
       redemption.mockRestore();
     }
@@ -956,7 +1042,7 @@ describe('financial position accounting', () => {
       receivedLiquidity: 30n,
       totalFees: 5n,
       unlockAmount: 1n,
-      createdAt: lock.createdAt,
+      endingCapital: 124n,
       record: lock,
     } as IBitcoinLockSummary;
 
@@ -1000,7 +1086,6 @@ describe('financial position accounting', () => {
       totalFees: 5n,
       unlockAmount: 999n,
       endingCapital: 999n,
-      createdAt: lock.createdAt,
       record: lock,
     } as IBitcoinLockSummary;
 
@@ -1053,7 +1138,6 @@ describe('financial position accounting', () => {
       totalFees: 5n,
       unlockAmount: 999n,
       endingCapital: 999n,
-      createdAt: lock.createdAt,
       record: lock,
     } as IBitcoinLockSummary;
 
@@ -1099,7 +1183,6 @@ describe('financial position accounting', () => {
       totalFees: 5n,
       unlockAmount: 40n,
       endingCapital: 125n,
-      createdAt: lock.createdAt,
       record: lock,
     } as IBitcoinLockSummary;
     const spentLock = {

--- a/src-vue/interfaces/IBitcoinLockSummary.ts
+++ b/src-vue/interfaces/IBitcoinLockSummary.ts
@@ -29,7 +29,7 @@ export interface IBitcoinLockSummary {
   valueBeyondLiquidity: bigint;
   startingCapital: bigint;
   endingCapital: bigint;
-  hodlingReturn: number;
+  ratchetPercent: number;
   totalReturn: number;
   totalFees: bigint;
   unlockAmount: bigint;

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -42,7 +42,6 @@ import { BITCOIN_BLOCK_MILLIS, ESPLORA_HOST } from './Env.ts';
 import { UpstreamOperatorClient } from './UpstreamOperatorClient.ts';
 import {
   bigNumberToBigInt,
-  bigIntMax,
   BlockWatch,
   createDeferred,
   Currency as CurrencyBase,
@@ -63,6 +62,7 @@ import { MyVault } from './MyVault.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from './db/BitcoinUtxosTable.ts';
 import type { IBitcoinLockProcessingDetails, IBitcoinLockSummary } from '../interfaces/IBitcoinLockSummary.ts';
 import { BitcoinLockRecovery } from './recovery/BitcoinLocks.ts';
+import { calculateBitcoinLockValuation, calculateBitcoinReturn } from './financials/BitcoinLocks.ts';
 
 export type IBitcoinMismatchPhase =
   | 'none'
@@ -252,26 +252,7 @@ export default class BitcoinLocks {
 
   public createLockSummary(lock: IBitcoinLockRecord): IBitcoinLockSummary {
     const lockProcessingDetails = this.getLockProcessingDetails(lock);
-    const btc = this.#currency.convertSatToBtc(lock.satoshis);
-    const valueOfBtc = this.#currency.convertBtcToMicrogon(btc);
-    const grossFees = lock.ratchets.reduce((total, ratchet) => total + ratchet.txFee + ratchet.securityFee, 0n);
-    // couponFeesPaid is the lock's canonical cumulative reimbursement, so subtract it once rather than per ratchet.
-    const totalFees = bigIntMax(grossFees - (lock.lockDetails?.couponFeesPaid ?? 0n), 0n);
-    const totalLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintAmount, 0n);
-    const pendingLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintPending, 0n);
-    const burnedLiquidity = lock.ratchets.reduce((total, ratchet) => total + (ratchet.burned ?? 0n), 0n);
-    const receivedLiquidity = totalLiquidity - pendingLiquidity - burnedLiquidity;
-    const startingCapital = lock.ratchets[0]?.lockedTargetPrice ?? lock.lockedTargetPrice;
-    const initialLiquidity = lock.ratchets[0]?.mintAmount ?? lock.liquidityPromised;
-    const valueBeyondLiquidity = bigIntMax(valueOfBtc - lock.lockedTargetPrice, 0n);
-    const returnLiquidity = receivedLiquidity + pendingLiquidity + valueBeyondLiquidity;
-    const unlockAmount =
-      BitcoinLock.calculateRedemptionAmountFromSatoshis(
-        this.#currency.priceIndex,
-        lock.satoshis,
-        lock.lockedTargetPrice,
-      ) || 0n;
-    const endingCapital = startingCapital + returnLiquidity - unlockAmount - totalFees;
+    const valuation = calculateBitcoinLockValuation({ lock, currency: this.#currency });
 
     return {
       uuid: lock.uuid,
@@ -281,17 +262,8 @@ export default class BitcoinLocks {
       lockProcessingDetails,
       lockProcessingError: this.getLockProcessingError(lock),
       satoshis: lock.satoshis,
-      valueOfBtc,
-      totalLiquidity,
-      pendingLiquidity,
-      receivedLiquidity,
-      valueBeyondLiquidity,
-      startingCapital,
-      endingCapital: lock.ratchets[0] ? endingCapital : initialLiquidity,
-      hodlingReturn: calculateBitcoinReturn(lock.lockedTargetPrice, valueOfBtc),
-      totalReturn: calculateBitcoinReturn(startingCapital, endingCapital),
-      totalFees,
-      unlockAmount,
+      ...valuation,
+      ratchetPercent: calculateBitcoinReturn(lock.lockedTargetPrice, valuation.valueOfBtc),
       createdAt: lock.createdAt,
       record: lock,
     };
@@ -3448,12 +3420,6 @@ export type IBitcoinLocksUnlockReleaseInspect = Pick<
 >;
 export type IBitcoinLocksUnlockDetailsInspect = Pick<BitcoinLocks, 'load' | 'getVaultUnlockStateDetails'>;
 export type IBitcoinLocksVarianceInspect = Pick<BitcoinLocks, 'load' | 'getLockSatoshiAllowedVariance'>;
-
-function calculateBitcoinReturn(investment: bigint, currentValue: bigint): number {
-  if (investment <= 0n) return 0;
-
-  return getPercent(currentValue - investment, investment);
-}
 
 function isBitcoinLockRelayStatus(status: IBitcoinLockCouponStatus['status']): status is BitcoinLockRelayStatus {
   return status === 'Submitted' || status === 'InBlock' || status === 'Finalized' || status === 'Failed';

--- a/src-vue/lib/financials/BitcoinLocks.ts
+++ b/src-vue/lib/financials/BitcoinLocks.ts
@@ -6,8 +6,10 @@ import {
   type IFinancialPositionSource,
 } from '../../interfaces/IFinancialPosition.ts';
 import type { IBitcoinLockSummary } from '../../interfaces/IBitcoinLockSummary.ts';
+import type { IBitcoinLockRecord } from '../../interfaces/IBitcoinLockRecord.ts';
 import type BitcoinLocks from '../BitcoinLocks.ts';
-import { bigIntMax, SATOSHIS_PER_BITCOIN } from '@argonprotocol/apps-core';
+import { BitcoinLock } from '@argonprotocol/mainchain';
+import { bigIntMax, getPercent, SATOSHIS_PER_BITCOIN, type Currency } from '@argonprotocol/apps-core';
 
 const activeBitcoinLockStatuses = [BitcoinLockStatus.LockedAndIsMinting, BitcoinLockStatus.LockedAndMinted];
 
@@ -51,7 +53,7 @@ function createBitcoinLockPositions(
 
   if (record.removalReason || summary.status === BitcoinLockStatus.Released) {
     const isReleased = record.removalReason === 'released';
-    const removalBtcValue = valueSatoshisAtRate(summary.satoshis, record.btcPriceAtRemovalMicrogons);
+    const removalBtcValue = valueSatoshisAtRate(record.satoshis, record.btcPriceAtRemovalMicrogons);
     const bitcoinNetworkFee = record.fundingUtxoRecord?.releaseBitcoinNetworkFee;
     const bitcoinNetworkFeeValue = valueSatoshisAtRate(bitcoinNetworkFee, record.btcPriceAtRemovalMicrogons);
     const releaseRedemption = record.releaseRedemptionMicrogons;
@@ -79,16 +81,14 @@ function createBitcoinLockPositions(
     ) {
       hasCompleteReleaseHistory = true;
       settledPrincipalValue = removalBtcValue - releaseRedemption - bitcoinNetworkFeeValue;
-      performanceEndingCapital =
-        summary.startingCapital +
-        bigIntMax(removalBtcValue - record.lockedTargetPrice, 0n) +
-        summary.receivedLiquidity +
-        summary.pendingLiquidity -
-        releaseRedemption -
-        summary.totalFees -
-        releaseArgonTxFee +
-        releaseCompensation -
-        bitcoinNetworkFeeValue;
+      performanceEndingCapital = calculateBitcoinEndingCapital({
+        bitcoinValue: removalBtcValue,
+        receivedLiquidity: summary.receivedLiquidity,
+        pendingLiquidity: summary.pendingLiquidity,
+        redemptionAmount: releaseRedemption,
+        fees: summary.totalFees + releaseArgonTxFee + bitcoinNetworkFeeValue,
+        compensation: releaseCompensation,
+      });
     }
 
     let label = 'Removed Bitcoin lock';
@@ -109,11 +109,11 @@ function createBitcoinLockPositions(
       createFinancialPosition(
         'bitcoin-asset',
         {
-          id: `bitcoin-asset:${summary.uuid}`,
+          id: `bitcoin-asset:${record.uuid}`,
           label,
           lifecycle,
           performanceEndingCapital,
-          startedAt: summary.createdAt,
+          startedAt: record.createdAt,
           endedAt: record.removalBlockTime,
           lock: record,
         },
@@ -136,11 +136,11 @@ function createBitcoinLockPositions(
     createFinancialPosition(
       'bitcoin-asset',
       {
-        id: `bitcoin-asset:${summary.uuid}`,
+        id: `bitcoin-asset:${record.uuid}`,
         label: 'Locked Bitcoin',
         lifecycle: isReleasing ? 'releasing' : 'active',
         performanceEndingCapital: summary.endingCapital,
-        startedAt: summary.createdAt,
+        startedAt: record.createdAt,
         lock: summary.record,
       },
       {
@@ -151,13 +151,77 @@ function createBitcoinLockPositions(
       },
     ),
     createFinancialPosition('bitcoin-liability', {
-      id: `bitcoin-liability:${summary.uuid}`,
+      id: `bitcoin-liability:${record.uuid}`,
       label: 'Bitcoin redemption',
       lifecycle: isReleasing ? 'releasing' : 'active',
       currentValue: hasCurrentPrice ? -summary.unlockAmount : undefined,
       lock: summary.record,
     }),
   ];
+}
+
+export function calculateBitcoinLockValuation({ lock, currency }: { lock: IBitcoinLockRecord; currency: Currency }) {
+  const btc = currency.convertSatToBtc(lock.satoshis);
+  const valueOfBtc = currency.convertBtcToMicrogon(btc);
+  const unlockAmount =
+    BitcoinLock.calculateRedemptionAmountFromSatoshis(currency.priceIndex, lock.satoshis, lock.lockedTargetPrice) || 0n;
+  const grossFees = lock.ratchets.reduce((total, ratchet) => total + ratchet.txFee + ratchet.securityFee, 0n);
+  // couponFeesPaid is the lock's canonical cumulative reimbursement, so subtract it once rather than per ratchet.
+  const totalFees = bigIntMax(grossFees - (lock.lockDetails?.couponFeesPaid ?? 0n), 0n);
+  const totalLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintAmount, 0n);
+  const pendingLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintPending, 0n);
+  const burnedLiquidity = lock.ratchets.reduce((total, ratchet) => total + (ratchet.burned ?? 0n), 0n);
+  const receivedLiquidity = totalLiquidity - pendingLiquidity - burnedLiquidity;
+  const startingCapital = lock.ratchets[0]?.lockedTargetPrice ?? lock.lockedTargetPrice;
+  const initialLiquidity = lock.ratchets[0]?.mintAmount ?? lock.liquidityPromised;
+  const valueBeyondLiquidity = bigIntMax(valueOfBtc - lock.lockedTargetPrice, 0n);
+  const currentEndingCapital = calculateBitcoinEndingCapital({
+    bitcoinValue: valueOfBtc,
+    receivedLiquidity,
+    pendingLiquidity,
+    redemptionAmount: unlockAmount,
+    fees: totalFees,
+  });
+  const endingCapital = lock.ratchets[0] ? currentEndingCapital : initialLiquidity;
+
+  return {
+    valueOfBtc,
+    totalLiquidity,
+    pendingLiquidity,
+    receivedLiquidity,
+    valueBeyondLiquidity,
+    startingCapital,
+    endingCapital,
+    totalFees,
+    unlockAmount,
+    totalReturn: calculateBitcoinReturn(startingCapital, endingCapital),
+  };
+}
+
+export function calculateBitcoinEndingCapital({
+  bitcoinValue,
+  receivedLiquidity,
+  pendingLiquidity,
+  redemptionAmount,
+  fees,
+  compensation = 0n,
+}: {
+  bitcoinValue: bigint;
+  receivedLiquidity: bigint;
+  pendingLiquidity: bigint;
+  redemptionAmount: bigint;
+  fees: bigint;
+  compensation?: bigint;
+}): bigint {
+  const totalProceeds = bitcoinValue + receivedLiquidity + pendingLiquidity + compensation;
+  const totalCosts = redemptionAmount + fees;
+  return totalProceeds - totalCosts;
+}
+
+export function calculateBitcoinReturn(investment: bigint, currentValue: bigint): number {
+  if (investment <= 0n) return 0;
+
+  return getPercent(currentValue - investment, investment);
 }
 
 function valueSatoshisAtRate(satoshis?: bigint, microgonsPerBitcoin?: bigint): bigint | undefined {

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -150,15 +150,15 @@
             <button
               @click.stop="openRatchetingOverlay($event, lockSummary)"
               :class="[
-                lockSummary.hodlingReturn
+                lockSummary.ratchetPercent
                   ? 'bg-argon-600 border-argon-800 hover:bg-argon-700 text-white hover:shadow-lg'
                   : 'cursor-default border-slate-800/20 text-slate-600/40',
               ]"
               class="cursor-pointer rounded-md border px-2"
             >
-              <span v-if="lockSummary.hodlingReturn">
-                Ratchet {{ lockSummary.hodlingReturn > 0 ? '+' : ''
-                }}{{ numeral(lockSummary.hodlingReturn).format('0,0.[00]') }}%
+              <span v-if="lockSummary.ratchetPercent">
+                Ratchet {{ lockSummary.ratchetPercent > 0 ? '+' : ''
+                }}{{ numeral(lockSummary.ratchetPercent).format('0,0.[00]') }}%
               </span>
               <template v-else>Price Is at Par</template>
             </button>
@@ -243,7 +243,7 @@ function expirationDate(lock: IBitcoinLockRecord) {
 }
 
 function openRatchetingOverlay(event: MouseEvent, lock: IBitcoinLockSummary) {
-  if (!props.lockSummary.hodlingReturn) return;
+  if (!props.lockSummary.ratchetPercent) return;
   emit('ratchet', event, lock);
 }
 


### PR DESCRIPTION
Bitcoin locks could report a positive return after a downward ratchet even when the BTC price loss exactly offset the liquidity received.

Returns now account for the current BTC value, all ratchet mint and burn flows, pending liquidity, the current redemption liability, and fees. A lock moving from $120 to $100 therefore remains at 0% when its liquidity flows restore the original $120 capital.

Active and released positions share the same ending-capital calculation, and the ratchet UI field is named for its actual purpose.
