### PR TITLE
fix(indexer): accept newer seed checkpoints

### DIFF
--- a/indexer/src/createSeedManifest.ts
+++ b/indexer/src/createSeedManifest.ts
@@ -74,12 +74,7 @@ for (const network of networks) {
     }
     const targetBlockNumber = seedState.targetBlockNumber ?? seedState.blockNumber;
     const targetBlockHash = seedState.targetBlockHash ?? seedState.blockHash;
-    if (
-      seedState.blockNumber === targetBlockNumber &&
-      seedState.blockHash.toLowerCase() !== targetBlockHash.toLowerCase()
-    ) {
-      throw new Error(`${databaseFile} caught-up checkpoint does not match its captured finalized target hash`);
-    }
+    const caughtUp = seedState.blockNumber >= targetBlockNumber;
 
     const schema = database.prepare('SELECT COALESCE(MAX(version), 0) AS version FROM SchemaVersion').get() as {
       version: number;
@@ -93,14 +88,22 @@ for (const network of networks) {
       );
     }
 
-    const checkpointBlock = database
-      .prepare('SELECT blockHash FROM Blocks WHERE blockNumber = ?')
-      .get(sync.blockNumber) as { blockHash: Uint8Array } | undefined;
+    const blockHashQuery = database.prepare('SELECT blockHash FROM Blocks WHERE blockNumber = ?');
+    const checkpointBlock = blockHashQuery.get(sync.blockNumber) as { blockHash: Uint8Array } | undefined;
     const checkpointHash = checkpointBlock ? `0x${Buffer.from(checkpointBlock.blockHash).toString('hex')}` : undefined;
     if (checkpointHash?.toLowerCase() !== seedState.blockHash.toLowerCase()) {
       throw new Error(
         `${databaseFile} checkpoint hash ${checkpointHash ?? 'missing'} does not match captured seed hash ${seedState.blockHash}`,
       );
+    }
+    if (caughtUp) {
+      const targetBlock = blockHashQuery.get(targetBlockNumber) as { blockHash: Uint8Array } | undefined;
+      const databaseTargetHash = targetBlock ? `0x${Buffer.from(targetBlock.blockHash).toString('hex')}` : undefined;
+      if (databaseTargetHash?.toLowerCase() !== targetBlockHash.toLowerCase()) {
+        throw new Error(
+          `${databaseFile} target hash ${databaseTargetHash ?? 'missing'} does not match captured finalized target hash ${targetBlockHash}`,
+        );
+      }
     }
 
     const accountBlocks = database.prepare('SELECT COUNT(*) AS count FROM AccountBlocks').get() as { count: number };
@@ -114,7 +117,7 @@ for (const network of networks) {
       schemaVersion: schema.version,
       blockCount: blocks.count,
       accountBlockCount: accountBlocks.count,
-      caughtUp: seedState.blockNumber >= targetBlockNumber,
+      caughtUp,
       targetBlockNumber,
       targetBlockHash,
     };

--- a/indexer/src/createSeedManifest.ts
+++ b/indexer/src/createSeedManifest.ts
@@ -114,7 +114,7 @@ for (const network of networks) {
       schemaVersion: schema.version,
       blockCount: blocks.count,
       accountBlockCount: accountBlocks.count,
-      caughtUp: seedState.blockNumber === targetBlockNumber,
+      caughtUp: seedState.blockNumber >= targetBlockNumber,
       targetBlockNumber,
       targetBlockHash,
     };

--- a/indexer/src/syncSeed.ts
+++ b/indexer/src/syncSeed.ts
@@ -50,9 +50,6 @@ for (const seed of seeds.filter(seed => !requestedNetworks.size || requestedNetw
     if (indexer.coverageGap) {
       throw new Error(`Unable to complete ${seed.network} seed: ${indexer.coverageGap.reason}`);
     }
-    if (db.latestSyncedBlock > targetBlock) {
-      throw new Error(`Invalid ${seed.network} seed: indexed ${db.latestSyncedBlock}, target ${targetBlock}`);
-    }
 
     const checkpointBlock = db.latestSyncedBlock;
     const checkpointHash = (await client.rpc.chain.getBlockHash(checkpointBlock)).toHex();
@@ -71,11 +68,11 @@ for (const seed of seeds.filter(seed => !requestedNetworks.size || requestedNetw
       })}\n`,
     );
 
-    if (checkpointBlock !== targetBlock && !maxSyncMinutes) {
+    if (checkpointBlock < targetBlock && !maxSyncMinutes) {
       throw new Error(`Incomplete ${seed.network} seed: indexed ${db.latestSyncedBlock}, expected ${targetBlock}`);
     }
 
-    const result = checkpointBlock === targetBlock ? 'Completed' : 'Checkpointed';
+    const result = checkpointBlock >= targetBlock ? 'Completed' : 'Checkpointed';
     console.log(`${result} ${seed.network} seed at block ${checkpointBlock} of ${targetBlock}`);
   } finally {
     db.close();


### PR DESCRIPTION
Hourly indexer refreshes no longer fail when a restored seed advances past the finalized target captured at startup. Checkpoints at or beyond the target are now treated as caught up, while genuinely incomplete checkpoints retain the existing resumable or failure behavior.

The failing second run restored mainnet at block 827684 and indexed through 827865 while its target snapshot was 827864: [Actions job](https://github.com/argonprotocol/apps/actions/runs/29608114650/job/87986986476).

Validated with the focused indexer tests (7 passing) and the production indexer build.
