### PR TITLE
fix(app): wire vaulting navigation actions

### DIFF
--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -284,9 +284,10 @@
                   <OnboardingIcon class="w-5.5 opacity-70" />
                 </div>
                 <div class="grow">Onboarding</div>
-                <div class="opacity-60">
-                  {{ currency.symbol
-                  }}{{ microgonToMoneyNm(controller.operationalOverview.rewardsEarnedAmount).format('0,0.00') }}
+                <div v-if="currency.isLoaded" class="opacity-60">
+                  {{
+                    `${currency.symbol}${microgonToMoneyNm(controller.operationalOverview.rewardsEarnedAmount).format('0,0.00')}`
+                  }}
                 </div>
               </div>
               <div v-if="controller.selectedTab === TopTab.Invites" class="text-md -mb-1.5">

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -239,7 +239,11 @@
               </div>
               <div v-if="controller.selectedTab === TopTab.Vaulting" class="text-md -mb-1.5">
                 <div class="flex flex-row">
-                  <div class="mt-0.5 flex grow flex-row items-center">
+                  <button
+                    type="button"
+                    @click.stop="openSecuritization"
+                    class="mt-0.5 flex grow cursor-pointer flex-row items-center text-left"
+                  >
                     <div class="Connector" />
                     <div class="flex grow flex-row items-center border-t border-slate-400/30">
                       <div class="grow py-1 text-slate-600/80">
@@ -247,7 +251,7 @@
                       </div>
                       <ExternalIcon class="w-3.5 opacity-50" />
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div class="flex flex-row">
                   <div class="flex grow flex-row items-center">
@@ -280,7 +284,10 @@
                   <OnboardingIcon class="w-5.5 opacity-70" />
                 </div>
                 <div class="grow">Onboarding</div>
-                <div class="opacity-60">{{ currency.symbol }}0.00</div>
+                <div class="opacity-60">
+                  {{ currency.symbol
+                  }}{{ microgonToMoneyNm(controller.operationalOverview.rewardsEarnedAmount).format('0,0.00') }}
+                </div>
               </div>
               <div v-if="controller.selectedTab === TopTab.Invites" class="text-md -mb-1.5">
                 <div class="flex flex-row">
@@ -409,6 +416,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
+import { MoveTo } from '@argonprotocol/apps-core';
 import { MiningSetupStatus, TopTab, VaultingSetupStatus } from '../interfaces/IConfig.ts';
 import {
   OperationalStepId,
@@ -552,6 +560,13 @@ function formatFinancialGroupValue(group: FinancialGroup): string {
 
 function openDefaultArgonWallet() {
   basicEmitter.emit('openWalletOverlay', { walletType: WalletType.defaultArgon });
+}
+
+function openSecuritization() {
+  basicEmitter.emit('openMoveCapitalOverlay', {
+    walletType: WalletType.defaultArgon,
+    moveTo: MoveTo.VaultingSecurity,
+  });
 }
 
 function openLink(url: string) {

--- a/src-vue/screens/vaulting-screen/Dashboard.vue
+++ b/src-vue/screens/vaulting-screen/Dashboard.vue
@@ -91,7 +91,7 @@
                   Settings
                 </button>
                 <div class="w-px h-8/12 bg-slate-600/30" />
-                <button class="flex flex-row items-center font-light text-base cursor-pointer group hover:opacity-80">
+                <button @click="openSecuritization" class="flex flex-row items-center font-light text-base cursor-pointer group hover:opacity-80">
                   Securitization
                 </button>
                 <div class="w-px h-8/12 bg-slate-600/30" />
@@ -99,7 +99,7 @@
                   Staking
                 </button>
                 <div class="w-px h-8/12 bg-slate-600/30" />
-                <button @click="openNetworkTab" class="flex flex-row items-center font-light text-base cursor-pointer group hover:opacity-80">
+                <button @click="controller.setTab(TopTab.Invites)" class="flex flex-row items-center font-light text-base cursor-pointer group hover:opacity-80">
                   Users
                 </button>
               </div>
@@ -268,7 +268,7 @@ import { TICK_MILLIS } from '../../lib/Env.ts';
 import VaultEditOverlay from '../../overlays/VaultEditOverlay.vue';
 import BitcoinLockDetailOverlay from '../../overlays/BitcoinLockDetailOverlay.vue';
 import BondDetailOverlay from '../../overlays/BondDetailOverlay.vue';
-import { BondLot, NetworkConfig, TreasuryBonds, type IFrameBondLot } from '@argonprotocol/apps-core';
+import { BondLot, MoveTo, NetworkConfig, TreasuryBonds, type IFrameBondLot } from '@argonprotocol/apps-core';
 import { BigNumber } from 'bignumber.js';
 import { TooltipProvider, TooltipRoot, TooltipTrigger, TooltipContent, TooltipArrow } from 'reka-ui';
 import { getMainchainClient, getMiningFrames } from '../../stores/mainchain.ts';
@@ -284,6 +284,7 @@ import { TopTab } from '../../interfaces/IConfig.ts';
 import { OperationalStepId, useCertificationController } from '../../stores/certificationController.ts';
 import ArrowCalloutButton from '../../components/ArrowCalloutButton.vue';
 import { useFinancials } from '../../stores/financials.ts';
+import { WalletType } from '../../lib/Wallet.ts';
 
 dayjs.extend(utc);
 
@@ -724,8 +725,11 @@ function openVaultEditOverlay() {
   showEditOverlay.value = true;
 }
 
-function openNetworkTab() {
-  controller.setTab(TopTab.Network);
+function openSecuritization() {
+  basicEmitter.emit('openMoveCapitalOverlay', {
+    walletType: WalletType.defaultArgon,
+    moveTo: MoveTo.VaultingSecurity,
+  });
 }
 
 const miningFrames = getMiningFrames();


### PR DESCRIPTION
## Summary

Vault operators can now manage Bitcoin securitization from either the vault dashboard or the expanded Vaulting navigation. The Users shortcut opens Onboarding, where the navigation total now reflects earned operational rewards instead of a placeholder.

## Validation

Prettier and Vue TypeScript checks pass. UI clickthrough was not run.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this only connects existing local UI actions and display state.
