### PR TITLE
Wallet Fixes

### DIFF
--- a/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
@@ -76,6 +76,7 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
           if (addDefaultEthereum.clickable) {
             requestedDefaultEthereumWallet = true;
             await flow.click('WalletOverlay.addNewWallet()', { timeoutMs: 15_000 });
+            await flow.click('WalletOverlay.createDefaultEthereum()', { timeoutMs: 15_000 });
           }
         }
       },

--- a/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
@@ -844,9 +844,14 @@ describe('EthereumInboundTransferTracker integration', () => {
     expect(activeTransfer?.transferState.progress.currentStepHint).toBeUndefined();
   });
 
-  it('finalizes a resumed transfer once another runner has already proven the gateway activity', async () => {
+  it('resumes a transfer to the legacy Native Argon address after the default wallet address changes', async () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
+    const legacyNativeArgonAddress = walletKeys.legacyVaultingAddress;
+    walletKeys.configureDefaultArgonWallet({
+      address: 'current-native-argon-address',
+      keyReference: '//default',
+    });
     const mainchainClient = createMainchainClient({
       getProvenNonce: () => 9n,
     });
@@ -854,7 +859,7 @@ describe('EthereumInboundTransferTracker integration', () => {
     const persistedRecord = await insertTransferRecord(db, walletKeys.ethereumAddress, {
       id: 'eth-transfer-1',
       token: MoveToken.ARGNOT,
-      argonDestinationAddress: walletKeys.vaultingAddress,
+      argonDestinationAddress: legacyNativeArgonAddress,
       sourceTxHash: `0x${'55'.repeat(32)}`,
       sourceBlockNumber: 54,
       sourceBlockHash: `0x${'66'.repeat(32)}`,

--- a/src-vue/__test__/WalletOverlayState.test.ts
+++ b/src-vue/__test__/WalletOverlayState.test.ts
@@ -3,12 +3,14 @@ import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 import { WalletType } from '../lib/Wallet.ts';
 import {
   getAvailableWalletSelections,
+  getInitialAddWalletOverlayState,
   getInitialWalletOverlayState,
   getWalletSelectionKey,
   getWalletSelectionName,
   returnToTransferWalletChooser,
   selectPrimaryWallet,
   selectTransferWallet,
+  showAddWalletOnTransferSide,
   toggleWalletTransferDirection,
   type IWalletOverlayState,
   type IWalletSelection,
@@ -70,6 +72,10 @@ describe('wallet overlay state', () => {
     expect(getInitialWalletOverlayState(primaryWallet)).toEqual({ primaryWallet });
   });
 
+  it('opens Add Wallet as the main panel without a primary wallet', () => {
+    expect(getInitialAddWalletOverlayState('choice')).toEqual({ primaryAddWalletStep: 'choice' });
+  });
+
   it('opens and closes a transfer direction without changing the primary wallet', () => {
     const open = toggleWalletTransferDirection({ primaryWallet }, 'out');
     expect(open).toEqual({ primaryWallet, transferOut: {} });
@@ -97,6 +103,15 @@ describe('wallet overlay state', () => {
     expect(returnToTransferWalletChooser({ primaryWallet, transferIn: { wallet: transferWallet } }, 'in')).toEqual({
       primaryWallet,
       transferIn: {},
+    });
+  });
+
+  it('replaces one sidecar chooser with Add Wallet without changing the other side', () => {
+    const state = { primaryWallet, transferIn: {}, transferOut: { wallet: transferWallet } };
+    expect(showAddWalletOnTransferSide(state, 'in', 'external')).toEqual({
+      primaryWallet,
+      transferIn: { addWalletStep: 'external' },
+      transferOut: { wallet: transferWallet },
     });
   });
 

--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -281,7 +281,10 @@ export class EthereumInboundTransferTracker {
       targetWalletType = WalletType.defaultArgon;
     } else if (record.argonDestinationAddress === this.walletKeys.miningBotAddress) {
       targetWalletType = WalletType.miningBot;
-    } else if (record.argonDestinationAddress === this.walletKeys.vaultingAddress) {
+    } else if (
+      record.argonDestinationAddress === this.walletKeys.vaultingAddress ||
+      record.argonDestinationAddress === this.walletKeys.legacyVaultingAddress
+    ) {
       targetWalletType = WalletType.defaultArgon;
     }
     transfer.persistedRecord = record;

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -336,7 +336,7 @@
         </div>
         <div class="text-argon-600 mt-2 flex flex-row items-center justify-center gap-x-2">
           <a
-            href="http://localhost:5173/docs/desktop-app/access-and-upgrades"
+            href="https://argon.network/docs/desktop-app/access-and-upgrades"
             target="_blank"
             class="cursor-pointer opacity-50 hover:opacity-100"
           >
@@ -365,7 +365,7 @@
         </div>
         <div class="text-argon-600 mt-2 flex flex-row items-center justify-center gap-x-2">
           <a
-            href="http://localhost:5173/docs/desktop-app/access-and-upgrades"
+            href="https://argon.network/docs/desktop-app/access-and-upgrades"
             target="_blank"
             class="cursor-pointer opacity-50 hover:opacity-100"
           >
@@ -380,7 +380,7 @@
       <div v-else class="relative flex grow flex-col items-center justify-center text-center text-slate-700/30">
         <div class="relative flex flex-row items-center text-center whitespace-nowrap">Explore</div>
         <div class="relative mt-px">
-          <a href="http://localhost:5173/docs" target="_blank" class="cursor-pointer opacity-50 hover:opacity-100">
+          <a href="https://argon.network/docs" target="_blank" class="cursor-pointer opacity-50 hover:opacity-100">
             Docs
           </a>
           <span class="text-slate-600/40">and</span>

--- a/src-vue/wallets/EthereumWalletImportOverlay.vue
+++ b/src-vue/wallets/EthereumWalletImportOverlay.vue
@@ -1,139 +1,131 @@
 <template>
-  <div v-if="ethereumImportStep" class="fixed inset-0 z-[1300] flex items-center justify-center bg-black/30">
-    <div class="w-[520px] rounded-lg border border-slate-300 bg-white p-5 shadow-2xl">
-      <div class="flex items-center justify-between">
-        <h2 class="text-xl font-bold text-slate-800">
-          <template v-if="ethereumImportStep === 'external'">Connect External Wallet</template>
-          <template v-else>Add Ethereum Wallet</template>
-        </h2>
-        <button type="button" class="text-2xl leading-none text-slate-500" @click="closeEthereumImport">&times;</button>
-      </div>
+  <div class="h-full overflow-y-auto p-5 text-left">
+    <div v-if="ethereumImportStep === 'choice'" class="mt-5 grid grid-cols-2 gap-3">
+      <button
+        data-testid="WalletOverlay.createDefaultEthereum()"
+        type="button"
+        class="rounded-md border border-slate-300 px-4 py-3 text-left hover:bg-slate-50"
+        @click="createDefaultEthereum"
+      >
+        <div class="font-bold">Create Native Wallet</div>
+        <div class="mt-1 text-sm text-slate-500">Use the Ethereum wallet from this app's core account.</div>
+      </button>
+      <button
+        data-testid="WalletOverlay.connectExternalEthereum()"
+        type="button"
+        class="rounded-md border border-slate-300 px-4 py-3 text-left hover:bg-slate-50"
+        @click="ethereumImportStep = 'external'"
+      >
+        <div class="font-bold">Connect External Wallet</div>
+        <div class="mt-1 text-sm text-slate-500">Import by private key or mnemonic.</div>
+      </button>
+    </div>
 
-      <div v-if="ethereumImportStep === 'choice'" class="mt-5 grid grid-cols-2 gap-3">
+    <div v-else-if="ethereumImportStep === 'external'" class="mt-5">
+      <div class="mb-3 flex gap-2">
         <button
           type="button"
-          class="rounded-md border border-slate-300 px-4 py-3 text-left hover:bg-slate-50"
-          @click="createDefaultEthereum"
+          class="rounded-md border px-3 py-1.5"
+          :class="ethereumImportMode === 'privateKey' ? 'border-argon-500 bg-argon-50' : 'border-slate-300'"
+          @click="ethereumImportMode = 'privateKey'"
         >
-          <div class="font-bold">Create Native Wallet</div>
-          <div class="mt-1 text-sm text-slate-500">Use the Ethereum wallet from this app's core account.</div>
+          Private Key
         </button>
         <button
           type="button"
-          class="rounded-md border border-slate-300 px-4 py-3 text-left hover:bg-slate-50"
+          class="rounded-md border px-3 py-1.5"
+          :class="ethereumImportMode === 'mnemonic' ? 'border-argon-500 bg-argon-50' : 'border-slate-300'"
+          @click="ethereumImportMode = 'mnemonic'"
+        >
+          Mnemonic
+        </button>
+      </div>
+      <label v-if="ethereumImportMode === 'privateKey'" class="mb-3 block">
+        <span class="mb-1 block text-sm font-semibold text-slate-700">Wallet Name</span>
+        <input
+          v-model="ethereumWalletNameInput"
+          class="focus:border-argon-500 w-full rounded-md border border-slate-300 px-3 py-2 outline-none"
+          placeholder="Name this wallet"
+        />
+      </label>
+      <textarea
+        v-model="ethereumSecretInput"
+        class="focus:border-argon-500 h-28 w-full resize-none rounded-md border border-slate-300 p-3 font-mono text-sm outline-none"
+        :placeholder="ethereumImportMode === 'privateKey' ? 'Paste private key' : 'Paste mnemonic'"
+      />
+      <div v-if="ethereumImportError" class="mt-2 text-sm text-red-600">{{ ethereumImportError }}</div>
+      <div class="mt-4 flex justify-end gap-2">
+        <button
+          v-if="startedFromChoiceStep"
+          type="button"
+          class="rounded-md border border-slate-300 px-4 py-2"
+          @click="ethereumImportStep = 'choice'"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          class="bg-argon-600 rounded-md px-4 py-2 font-bold text-white disabled:opacity-50"
+          :disabled="isImportingEthereum"
+          @click="continueExternalImport"
+        >
+          {{ ethereumImportMode === 'privateKey' ? 'Import' : 'Preview Accounts' }}
+        </button>
+      </div>
+    </div>
+
+    <div v-else-if="ethereumImportStep === 'mnemonicAccounts'" class="mt-5">
+      <div class="mb-3 flex items-center justify-between">
+        <div class="font-bold">Select an account</div>
+        <button
+          type="button"
+          class="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          :disabled="isScanningBalances"
+          @click="scanMnemonicBalances"
+        >
+          {{ isScanningBalances ? 'Scanning...' : 'Scan Balances' }}
+        </button>
+      </div>
+      <div class="max-h-72 overflow-y-auto rounded-md border border-slate-200">
+        <button
+          v-for="account in mnemonicAccounts"
+          :key="account.derivationPath"
+          type="button"
+          class="flex w-full flex-col border-b border-slate-100 px-3 py-2 text-left last:border-b-0 hover:bg-slate-50"
+          :class="selectedMnemonicPath === account.derivationPath ? 'bg-argon-50' : ''"
+          @click="selectedMnemonicPath = account.derivationPath"
+        >
+          <span class="font-mono text-sm">{{ account.address }}</span>
+          <span class="text-xs text-slate-500">
+            {{ account.derivationPath }}
+            <template v-if="account.balanceSummary">· {{ account.balanceSummary }}</template>
+          </span>
+        </button>
+      </div>
+      <label class="mt-4 block">
+        <span class="mb-1 block text-sm font-semibold text-slate-700">Wallet Name</span>
+        <input
+          v-model="ethereumWalletNameInput"
+          class="focus:border-argon-500 w-full rounded-md border border-slate-300 px-3 py-2 outline-none"
+          placeholder="Name this wallet"
+        />
+      </label>
+      <div class="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-slate-300 px-4 py-2"
           @click="ethereumImportStep = 'external'"
         >
-          <div class="font-bold">Connect External Wallet</div>
-          <div class="mt-1 text-sm text-slate-500">Import by private key or mnemonic.</div>
+          Back
         </button>
-      </div>
-
-      <div v-else-if="ethereumImportStep === 'external'" class="mt-5">
-        <div class="mb-3 flex gap-2">
-          <button
-            type="button"
-            class="rounded-md border px-3 py-1.5"
-            :class="ethereumImportMode === 'privateKey' ? 'border-argon-500 bg-argon-50' : 'border-slate-300'"
-            @click="ethereumImportMode = 'privateKey'"
-          >
-            Private Key
-          </button>
-          <button
-            type="button"
-            class="rounded-md border px-3 py-1.5"
-            :class="ethereumImportMode === 'mnemonic' ? 'border-argon-500 bg-argon-50' : 'border-slate-300'"
-            @click="ethereumImportMode = 'mnemonic'"
-          >
-            Mnemonic
-          </button>
-        </div>
-        <label v-if="ethereumImportMode === 'privateKey'" class="mb-3 block">
-          <span class="mb-1 block text-sm font-semibold text-slate-700">Wallet Name</span>
-          <input
-            v-model="ethereumWalletNameInput"
-            class="focus:border-argon-500 w-full rounded-md border border-slate-300 px-3 py-2 outline-none"
-            placeholder="Name this wallet"
-          />
-        </label>
-        <textarea
-          v-model="ethereumSecretInput"
-          class="focus:border-argon-500 h-28 w-full resize-none rounded-md border border-slate-300 p-3 font-mono text-sm outline-none"
-          :placeholder="ethereumImportMode === 'privateKey' ? 'Paste private key' : 'Paste mnemonic'"
-        />
-        <div v-if="ethereumImportError" class="mt-2 text-sm text-red-600">{{ ethereumImportError }}</div>
-        <div class="mt-4 flex justify-end gap-2">
-          <button
-            v-if="startedFromChoiceStep"
-            type="button"
-            class="rounded-md border border-slate-300 px-4 py-2"
-            @click="ethereumImportStep = 'choice'"
-          >
-            Back
-          </button>
-          <button
-            type="button"
-            class="bg-argon-600 rounded-md px-4 py-2 font-bold text-white disabled:opacity-50"
-            :disabled="isImportingEthereum"
-            @click="continueExternalImport"
-          >
-            {{ ethereumImportMode === 'privateKey' ? 'Import' : 'Preview Accounts' }}
-          </button>
-        </div>
-      </div>
-
-      <div v-else-if="ethereumImportStep === 'mnemonicAccounts'" class="mt-5">
-        <div class="mb-3 flex items-center justify-between">
-          <div class="font-bold">Select an account</div>
-          <button
-            type="button"
-            class="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
-            :disabled="isScanningBalances"
-            @click="scanMnemonicBalances"
-          >
-            {{ isScanningBalances ? 'Scanning...' : 'Scan Balances' }}
-          </button>
-        </div>
-        <div class="max-h-72 overflow-y-auto rounded-md border border-slate-200">
-          <button
-            v-for="account in mnemonicAccounts"
-            :key="account.derivationPath"
-            type="button"
-            class="flex w-full flex-col border-b border-slate-100 px-3 py-2 text-left last:border-b-0 hover:bg-slate-50"
-            :class="selectedMnemonicPath === account.derivationPath ? 'bg-argon-50' : ''"
-            @click="selectedMnemonicPath = account.derivationPath"
-          >
-            <span class="font-mono text-sm">{{ account.address }}</span>
-            <span class="text-xs text-slate-500">
-              {{ account.derivationPath }}
-              <template v-if="account.balanceSummary">· {{ account.balanceSummary }}</template>
-            </span>
-          </button>
-        </div>
-        <label class="mt-4 block">
-          <span class="mb-1 block text-sm font-semibold text-slate-700">Wallet Name</span>
-          <input
-            v-model="ethereumWalletNameInput"
-            class="focus:border-argon-500 w-full rounded-md border border-slate-300 px-3 py-2 outline-none"
-            placeholder="Name this wallet"
-          />
-        </label>
-        <div class="mt-4 flex justify-end gap-2">
-          <button
-            type="button"
-            class="rounded-md border border-slate-300 px-4 py-2"
-            @click="ethereumImportStep = 'external'"
-          >
-            Back
-          </button>
-          <button
-            type="button"
-            class="bg-argon-600 rounded-md px-4 py-2 font-bold text-white disabled:opacity-50"
-            :disabled="!selectedMnemonicPath || isImportingEthereum"
-            @click="importSelectedMnemonicAccount"
-          >
-            Import Selected
-          </button>
-        </div>
+        <button
+          type="button"
+          class="bg-argon-600 rounded-md px-4 py-2 font-bold text-white disabled:opacity-50"
+          :disabled="!selectedMnemonicPath || isImportingEthereum"
+          @click="importSelectedMnemonicAccount"
+        >
+          Import Selected
+        </button>
       </div>
     </div>
   </div>
@@ -141,14 +133,15 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import basicEmitter from '../emitters/basicEmitter.ts';
 import { useWallets } from '../stores/wallets.ts';
 import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 
 const wallets = useWallets();
+const props = defineProps<{
+  initialStep: 'choice' | 'external';
+}>();
 const emit = defineEmits<{
   complete: [walletRecord: IWalletRecord];
-  cancel: [];
 }>();
 
 const ethereumImportStep = Vue.ref<'choice' | 'external' | 'mnemonicAccounts'>();
@@ -171,11 +164,6 @@ function openEthereumImport(step: 'choice' | 'external') {
   ethereumImportMode.value = 'privateKey';
   ethereumWalletNameInput.value = '';
   ethereumImportError.value = '';
-}
-
-function closeEthereumImport() {
-  resetEthereumImport();
-  emit('cancel');
 }
 
 function resetEthereumImport() {
@@ -270,9 +258,5 @@ async function importSelectedMnemonicAccount() {
   }
 }
 
-basicEmitter.on('openEthereumWalletImportOverlay', openEthereumImport);
-
-Vue.onUnmounted(() => {
-  basicEmitter.off('openEthereumWalletImportOverlay', openEthereumImport);
-});
+Vue.watch(() => props.initialStep, openEthereumImport, { immediate: true });
 </script>

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -32,6 +32,7 @@
               v-if="props.transferIn"
               direction="in"
               :walletSelection="props.transferIn.wallet"
+              :addWalletStep="props.transferIn.addWalletStep"
               :wallet="props.transferIn.wallet ? getWallet(props.transferIn.wallet) : undefined"
               :availableWallets="props.availableWallets"
               :canAddDefaultEthereum="props.canAddDefaultEthereum"
@@ -42,12 +43,16 @@
               class="relative mt-7 -mr-px mb-7"
               @select="emit('selectTransferWallet', 'in', $event)"
               @closeWallet="emit('returnToTransferWalletChooser', 'in')"
+              @cancelAddWallet="emit('returnToTransferWalletChooser', 'in')"
+              @completeAddWallet="emit('completeAddWallet', 'in', $event)"
               @minimize="emit('toggleTransferDirection', 'in')"
               @addNewWallet="emit('addNewWallet', 'in')"
               @addDefaultEthereum="emit('addDefaultEthereum', 'in')"
               @addExternalEthereum="emit('addExternalEthereum', 'in')"
               @openTransferOverlay="
-                props.transferIn.wallet && openTransferOverlay(props.transferIn.wallet, props.primaryWallet, $event)
+                props.transferIn.wallet &&
+                props.primaryWallet &&
+                openTransferOverlay(props.transferIn.wallet, props.primaryWallet, $event)
               "
             />
           </Transition>
@@ -56,10 +61,10 @@
             class="relative z-20 flex min-h-140 w-120 shrink-0 flex-col overflow-visible rounded-lg border border-black/40 bg-white shadow-2xl"
           >
             <button
-              v-if="!props.transferIn"
+              v-if="props.primaryWallet && !props.transferIn"
               data-testid="WalletOverlay.toggleTransferIn()"
               type="button"
-              class="absolute top-24 right-full flex h-76 w-14 cursor-pointer flex-col items-center justify-between rounded-l-lg border border-r-0 border-black/50 bg-gray-900/70 py-10 text-lg font-bold text-white/60 shadow-lg hover:bg-gray-900/90 focus:outline-none"
+              class="absolute top-24 right-full flex h-76 w-14 cursor-pointer flex-col items-center justify-between rounded-l-lg border border-r-0 border-dashed border-white/60 bg-gray-900/70 py-10 text-lg font-bold text-white/60 shadow-lg hover:bg-gray-900/90 focus:outline-none"
               @click="emit('toggleTransferDirection', 'in')"
             >
               <ArrowLeftIcon class="h-7 w-7" />
@@ -67,10 +72,10 @@
               <ArrowLeftIcon class="h-7 w-7" />
             </button>
             <button
-              v-if="!props.transferOut"
+              v-if="props.primaryWallet && !props.transferOut"
               data-testid="WalletOverlay.toggleTransferOut()"
               type="button"
-              class="absolute top-24 left-full flex h-76 w-14 cursor-pointer flex-col items-center justify-between rounded-r-lg border border-l-0 border-black/50 bg-gray-900/70 py-10 text-lg font-bold text-white/60 shadow-lg hover:bg-gray-900/90 focus:outline-none"
+              class="absolute top-24 left-full flex h-76 w-14 cursor-pointer flex-col items-center justify-between rounded-r-lg border border-l-0 border-dashed border-white/60 bg-gray-900/70 py-10 text-lg font-bold text-white/60 shadow-lg hover:bg-gray-900/90 focus:outline-none"
               @click="emit('toggleTransferDirection', 'out')"
             >
               <ArrowRightIcon class="h-7 w-7" />
@@ -84,6 +89,7 @@
               @mousedown="draggable.onMouseDown"
             >
               <NavHeader
+                v-if="props.primaryWallet"
                 :selection="props.primaryWallet"
                 :walletSelections="props.walletSelections"
                 :wallet="getWallet(props.primaryWallet)"
@@ -93,8 +99,19 @@
                 @select="emit('selectPrimaryWallet', $event)"
                 @close="emit('close')"
               />
+              <div v-else class="flex min-w-0 grow items-center gap-x-2.5 px-2">
+                <span class="min-w-0 grow truncate text-left text-xl font-bold text-slate-800/70">Add Wallet</span>
+                <button
+                  type="button"
+                  class="relative z-10 flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-md border border-slate-400/60 hover:border-slate-500/60 hover:bg-[#f1f3f7] focus:outline-none"
+                  @click="emit('close')"
+                >
+                  <XMarkIcon class="pointer-events-none h-5 w-5 stroke-2 text-slate-500/60" />
+                </button>
+              </div>
             </h2>
             <WalletPanel
+              v-if="props.primaryWallet"
               :selection="props.primaryWallet"
               :wallet="getWallet(props.primaryWallet)"
               :mode="props.transferOut?.wallet ? 'transfer' : 'chooser'"
@@ -104,6 +121,12 @@
               :indentTokensRight="!!props.transferOut?.wallet"
               class="grow"
             />
+            <EthereumWalletSetup
+              v-else
+              :initialStep="props.primaryAddWalletStep ?? 'choice'"
+              class="min-h-0 grow border-t border-slate-300"
+              @complete="emit('completeAddWallet', 'primary', $event)"
+            />
           </section>
 
           <Transition name="wallet-sidecar-right">
@@ -111,8 +134,9 @@
               v-if="props.transferOut"
               direction="out"
               :walletSelection="props.transferOut.wallet"
+              :addWalletStep="props.transferOut.addWalletStep"
               :wallet="props.transferOut.wallet ? getWallet(props.transferOut.wallet) : undefined"
-              :moveWallet="getWallet(props.primaryWallet)"
+              :moveWallet="props.primaryWallet ? getWallet(props.primaryWallet) : undefined"
               :availableWallets="props.availableWallets"
               :canAddDefaultEthereum="props.canAddDefaultEthereum"
               :isSource="false"
@@ -122,12 +146,16 @@
               class="relative mt-7 mb-7 -ml-px"
               @select="emit('selectTransferWallet', 'out', $event)"
               @closeWallet="emit('returnToTransferWalletChooser', 'out')"
+              @cancelAddWallet="emit('returnToTransferWalletChooser', 'out')"
+              @completeAddWallet="emit('completeAddWallet', 'out', $event)"
               @minimize="emit('toggleTransferDirection', 'out')"
               @addNewWallet="emit('addNewWallet', 'out')"
               @addDefaultEthereum="emit('addDefaultEthereum', 'out')"
               @addExternalEthereum="emit('addExternalEthereum', 'out')"
               @openTransferOverlay="
-                props.transferOut.wallet && openTransferOverlay(props.primaryWallet, props.transferOut.wallet, $event)
+                props.transferOut.wallet &&
+                props.primaryWallet &&
+                openTransferOverlay(props.primaryWallet, props.transferOut.wallet, $event)
               "
             />
           </Transition>
@@ -142,9 +170,10 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
-import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/vue/24/outline';
+import { ArrowLeftIcon, ArrowRightIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui';
 import type { IArgonWalletType, IEthereumMoveToken } from '../interfaces/IEthereumInboundTransferTracker.ts';
+import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 import { type IWallet, WalletType } from '../lib/Wallet.ts';
 import Draggable from '../overlays/helpers/Draggable.ts';
 import { getOverlayBackdropZIndex, provideOverlayContentZIndex } from '../overlays/helpers/OverlayZIndex.ts';
@@ -155,16 +184,19 @@ import NavHeader from './components/NavHeader.vue';
 import WalletPanel from './components/WalletPanel.vue';
 import WalletTransferOverlay from './components/WalletTransferOverlay.vue';
 import WalletTransferSidecar from './components/WalletTransferSidecar.vue';
+import EthereumWalletSetup from './EthereumWalletImportOverlay.vue';
 import {
   getWalletSelectionKey,
   isEthereumWalletSelection,
   type IWalletSelection,
+  type IWalletSetupStep,
   type IWalletTransferSideState,
   type IWalletTransferDirection,
 } from './walletOverlayState.ts';
 
 const props = defineProps<{
-  primaryWallet: IWalletSelection;
+  primaryWallet?: IWalletSelection;
+  primaryAddWalletStep?: IWalletSetupStep;
   transferIn?: IWalletTransferSideState;
   transferOut?: IWalletTransferSideState;
   walletSelections: IWalletSelection[];
@@ -184,6 +216,7 @@ const emit = defineEmits<{
   (event: 'addNewWallet', direction: IWalletTransferDirection): void;
   (event: 'addDefaultEthereum', direction: IWalletTransferDirection): void;
   (event: 'addExternalEthereum', direction: IWalletTransferDirection): void;
+  (event: 'completeAddWallet', target: 'primary' | IWalletTransferDirection, walletRecord: IWalletRecord): void;
   (event: 'close'): void;
 }>();
 
@@ -199,10 +232,14 @@ const activeTransferOverlay = Vue.ref<{
 }>();
 
 const transferInConfig = Vue.computed(() =>
-  props.transferIn?.wallet ? getTransferConfig(props.transferIn.wallet, props.primaryWallet) : undefined,
+  props.transferIn?.wallet && props.primaryWallet
+    ? getTransferConfig(props.transferIn.wallet, props.primaryWallet)
+    : undefined,
 );
 const transferOutConfig = Vue.computed(() =>
-  props.transferOut?.wallet ? getTransferConfig(props.primaryWallet, props.transferOut.wallet) : undefined,
+  props.transferOut?.wallet && props.primaryWallet
+    ? getTransferConfig(props.primaryWallet, props.transferOut.wallet)
+    : undefined,
 );
 
 function getTransferConfig(source: IWalletSelection, recipient: IWalletSelection) {
@@ -259,7 +296,7 @@ function setWalletRef(element: Element | Vue.ComponentPublicInstance | null) {
 
 Vue.watch(
   () => [
-    getWalletSelectionKey(props.primaryWallet),
+    props.primaryWallet ? getWalletSelectionKey(props.primaryWallet) : undefined,
     props.transferIn?.wallet ? getWalletSelectionKey(props.transferIn.wallet) : undefined,
     props.transferOut?.wallet ? getWalletSelectionKey(props.transferOut.wallet) : undefined,
   ],

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -2,6 +2,7 @@
   <WalletDialog
     v-if="openWallet"
     :primaryWallet="openWallet.primaryWallet"
+    :primaryAddWalletStep="openWallet.primaryAddWalletStep"
     :transferIn="openWallet.transferIn"
     :transferOut="openWallet.transferOut"
     :walletSelections="walletSelections"
@@ -18,11 +19,8 @@
     @addNewWallet="addNewWallet"
     @addDefaultEthereum="addDefaultEthereum"
     @addExternalEthereum="addExternalEthereum"
+    @completeAddWallet="completeAddWallet"
     @close="closeOverlay"
-  />
-  <EthereumWalletImportOverlay
-    @complete="completeEthereumWalletSetup"
-    @cancel="pendingEthereumWalletAction = undefined"
   />
 </template>
 
@@ -41,16 +39,17 @@ import { releaseOverlayZIndex, reserveOverlayZIndex } from '../overlays/helpers/
 import { useBasics } from '../stores/basics.ts';
 import { getConfig } from '../stores/config.ts';
 import { useWallets } from '../stores/wallets.ts';
-import EthereumWalletImportOverlay from './EthereumWalletImportOverlay.vue';
 import WalletDialog from './WalletDialog.vue';
 import {
   getAvailableWalletSelections,
+  getInitialAddWalletOverlayState,
   getInitialWalletOverlayState,
   getWalletSelectionKey,
   isEthereumWalletSelection,
   returnToTransferWalletChooser as getChooserState,
   selectPrimaryWallet,
   selectTransferWallet,
+  showAddWalletOnTransferSide,
   toggleWalletTransferDirection,
   type IWalletOverlayState,
   type IWalletSelection,
@@ -67,15 +66,12 @@ const basics = useBasics();
 const config = getConfig();
 const walletStore = useWallets();
 const openWallet = Vue.ref<IOpenWallet>();
-const pendingEthereumWalletAction = Vue.ref<
-  { type: 'open'; request: IWalletOverlayRequest } | { type: 'transfer'; direction: IWalletTransferDirection }
->();
 
 const walletSelections = Vue.computed(() =>
   getAvailableWalletSelections(walletStore.walletRecords, [], config.hasExtensionOperations),
 );
 const availableWallets = Vue.computed(() => {
-  if (!openWallet.value) return [];
+  if (!openWallet.value?.primaryWallet) return [];
   return getAvailableWalletSelections(
     walletStore.walletRecords,
     [openWallet.value.primaryWallet],
@@ -95,6 +91,7 @@ async function setPrimaryWallet(wallet: IWalletSelection) {
   if (!openWallet.value) return;
   await activateEthereumWallet(wallet);
   Object.assign(openWallet.value, selectPrimaryWallet(openWallet.value, wallet));
+  openWallet.value.primaryAddWalletStep = undefined;
   openWallet.value.transferIn = undefined;
   openWallet.value.transferOut = undefined;
 }
@@ -127,16 +124,18 @@ async function addDefaultEthereum(direction: IWalletTransferDirection) {
 }
 
 function addExternalEthereum(direction: IWalletTransferDirection) {
-  pendingEthereumWalletAction.value = { type: 'transfer', direction };
-  basicEmitter.emit('openEthereumWalletImportOverlay', 'external');
+  showSidecarAddWallet(direction, 'external');
 }
 
 function addNewWallet(direction: IWalletTransferDirection) {
-  if (canAddDefaultEthereum.value) {
-    void addDefaultEthereum(direction);
-    return;
-  }
-  addExternalEthereum(direction);
+  showSidecarAddWallet(direction, canAddDefaultEthereum.value ? 'choice' : 'external');
+}
+
+function showSidecarAddWallet(direction: IWalletTransferDirection, initialStep: 'choice' | 'external') {
+  if (!openWallet.value) return;
+  const nextState = showAddWalletOnTransferSide(openWallet.value, direction, initialStep);
+  openWallet.value.transferIn = nextState.transferIn;
+  openWallet.value.transferOut = nextState.transferOut;
 }
 
 const openWalletOverlay = async (request: IWalletOverlayRequest, ethereumWalletRecord?: IWalletRecord) => {
@@ -148,14 +147,16 @@ const openWalletOverlay = async (request: IWalletOverlayRequest, ethereumWalletR
 
   const wallet = getRequestedWallet(request, ethereumWalletRecord);
   if (!wallet) {
-    pendingEthereumWalletAction.value = { type: 'open', request };
-    basicEmitter.emit('openEthereumWalletImportOverlay', 'choice');
+    await openAddWalletPanel('choice', request.showGuidance ?? false, request.guidanceContext);
     return;
   }
 
   await activateEthereumWallet(wallet);
   if (openWallet.value) {
-    if (getWalletSelectionKey(openWallet.value.primaryWallet) !== getWalletSelectionKey(wallet)) {
+    if (
+      !openWallet.value.primaryWallet ||
+      getWalletSelectionKey(openWallet.value.primaryWallet) !== getWalletSelectionKey(wallet)
+    ) {
       await setPrimaryWallet(wallet);
     }
     openWallet.value.showGuidance = request.showGuidance ?? false;
@@ -173,15 +174,42 @@ const openWalletOverlay = async (request: IWalletOverlayRequest, ethereumWalletR
   syncOverlayState();
 };
 
-async function completeEthereumWalletSetup(walletRecord: IWalletRecord) {
-  const action = pendingEthereumWalletAction.value;
-  pendingEthereumWalletAction.value = undefined;
-  if (!action) return;
-  if (action.type === 'open') {
-    await openWalletOverlay(action.request, walletRecord);
-  } else {
-    await setTransferWallet(action.direction, { walletType: WalletType.ethereum, walletRecord });
+async function completeAddWallet(target: 'primary' | IWalletTransferDirection, walletRecord: IWalletRecord) {
+  const wallet = { walletType: WalletType.ethereum, walletRecord } as const;
+  if (target === 'primary') {
+    await setPrimaryWallet(wallet);
+    return;
   }
+  await setTransferWallet(target, wallet);
+}
+
+async function openAddWalletPanel(
+  initialStep: 'choice' | 'external',
+  showGuidance = false,
+  guidanceContext?: IWalletGuidanceContext,
+) {
+  try {
+    await walletStore.load();
+  } catch (error) {
+    console.error('Failed to load wallets before opening Add Wallet', error);
+  }
+  if (openWallet.value) {
+    openWallet.value.primaryWallet = undefined;
+    openWallet.value.primaryAddWalletStep = initialStep;
+    openWallet.value.transferIn = undefined;
+    openWallet.value.transferOut = undefined;
+    openWallet.value.showGuidance = showGuidance;
+    openWallet.value.guidanceContext = guidanceContext;
+    focusWallet();
+    return;
+  }
+  openWallet.value = {
+    ...getInitialAddWalletOverlayState(initialStep),
+    showGuidance,
+    guidanceContext,
+    zIndex: reserveOverlayZIndex(),
+  };
+  syncOverlayState();
 }
 
 function getRequestedWallet(
@@ -218,8 +246,10 @@ function syncOverlayState() {
 }
 
 basicEmitter.on('openWalletOverlay', openWalletOverlay);
+basicEmitter.on('openEthereumWalletImportOverlay', openAddWalletPanel);
 Vue.onUnmounted(() => {
   basicEmitter.off('openWalletOverlay', openWalletOverlay);
+  basicEmitter.off('openEthereumWalletImportOverlay', openAddWalletPanel);
   closeOverlay();
 });
 </script>

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -188,10 +188,12 @@ async function openAddWalletPanel(
   showGuidance = false,
   guidanceContext?: IWalletGuidanceContext,
 ) {
-  try {
-    await walletStore.load();
-  } catch (error) {
-    console.error('Failed to load wallets before opening Add Wallet', error);
+  if (!walletStore.isLoaded) {
+    try {
+      await walletStore.load();
+    } catch (error) {
+      console.error('Failed to load wallets before opening Add Wallet', error);
+    }
   }
   if (openWallet.value) {
     openWallet.value.primaryWallet = undefined;

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="flex h-full flex-col text-black/90">
     <div class="mx-1 border-t border-slate-300 px-4 py-6 text-center">
-      <div class="text-argon-700/70 text-7xl font-bold">
+      <div class="text-argon-700/70 text-6xl font-bold">
+        {{ currency.symbol }}
         <FormattedMoney :isLoaded="walletValueIsLoaded" :value="walletTotalValue" />
       </div>
       <div class="mt-2 h-[29px] shrink-0">

--- a/src-vue/wallets/components/WalletTransferSidecar.vue
+++ b/src-vue/wallets/components/WalletTransferSidecar.vue
@@ -3,16 +3,19 @@
     class="flex h-auto w-90 shrink-0 flex-col overflow-visible border border-black/40 shadow-2xl transition-colors duration-150"
     :class="[
       props.direction === 'in' ? 'rounded-l-lg' : 'rounded-r-lg',
-      props.wallet ? 'bg-white' : 'bg-gray-900/70 text-white/70',
+      props.wallet || props.addWalletStep ? 'bg-white' : 'bg-gray-900/70 text-white/70',
     ]"
     :data-testid="`WalletOverlay.transfer${capitalizedDirection}Panel`"
   >
     <header
       class="mx-1 flex h-14 shrink-0 items-center gap-x-2.5 border-b px-3"
-      :class="props.wallet ? 'border-slate-300' : 'border-white/25'"
+      :class="props.wallet || props.addWalletStep ? 'border-slate-300' : 'border-white/25'"
     >
       <div class="min-w-0 grow" :class="props.direction === 'in' ? 'order-3 text-right' : 'order-1 text-left'">
-        <div class="truncate text-xl font-bold" :class="props.wallet ? 'text-slate-800/70' : 'text-white/70'">
+        <div
+          class="truncate text-xl font-bold"
+          :class="props.wallet || props.addWalletStep ? 'text-slate-800/70' : 'text-white/70'"
+        >
           {{ headerTitle }}
         </div>
       </div>
@@ -29,10 +32,12 @@
       <button
         :data-testid="`WalletOverlay.transfer${capitalizedDirection}Minimize()`"
         type="button"
-        :title="props.wallet ? 'Close wallet' : 'Minimize transfer panel'"
+        :title="
+          props.wallet ? 'Close wallet' : props.addWalletStep ? 'Cancel adding wallet' : 'Minimize transfer panel'
+        "
         class="hover:bg-argon-300/10 relative z-10 flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-sm/6 font-semibold hover:border-slate-500/60 focus:outline-none"
         :class="props.direction === 'in' ? 'order-1' : 'order-3'"
-        @click="props.wallet ? emit('closeWallet') : emit('minimize')"
+        @click="props.wallet ? emit('closeWallet') : props.addWalletStep ? emit('cancelAddWallet') : emit('minimize')"
       >
         <XMarkIcon class="pointer-events-none h-5 w-5 stroke-2 text-slate-400/80" />
       </button>
@@ -82,6 +87,12 @@
         class="px-5"
       />
     </template>
+    <EthereumWalletSetup
+      v-else-if="props.addWalletStep"
+      :initialStep="props.addWalletStep"
+      class="min-h-0 grow"
+      @complete="emit('completeAddWallet', $event)"
+    />
     <WalletChooser
       v-else
       :availableWallets="props.availableWallets"
@@ -102,6 +113,7 @@ import { computed } from 'vue';
 import { XMarkIcon } from '@heroicons/vue/24/outline';
 import type { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
 import type { IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
+import type { IWalletRecord } from '../../lib/db/WalletsTable.ts';
 import { getWalletTotalValue, WalletType, type IWallet } from '../../lib/Wallet.ts';
 import CopyIcon from '../../assets/copy.svg';
 import CopyToClipboard from '../../components/CopyToClipboard.vue';
@@ -109,14 +121,16 @@ import FormattedMoney from '../../components/FormattedMoney.vue';
 import { getCurrency } from '../../stores/currency.ts';
 import { useFinancials } from '../../stores/financials.ts';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
-import type { IWalletSelection, IWalletTransferDirection } from '../walletOverlayState.ts';
+import type { IWalletSelection, IWalletSetupStep, IWalletTransferDirection } from '../walletOverlayState.ts';
 import ArgonTokens from './ArgonTokens.vue';
 import WalletChooser from './WalletChooser.vue';
 import EthereumBottom from './EthereumBottom.vue';
+import EthereumWalletSetup from '../EthereumWalletImportOverlay.vue';
 
 const props = defineProps<{
   direction: IWalletTransferDirection;
   walletSelection?: IWalletSelection;
+  addWalletStep?: IWalletSetupStep;
   wallet?: IWallet;
   moveWallet?: IWallet;
   availableWallets: IWalletSelection[];
@@ -131,6 +145,8 @@ const emit = defineEmits<{
   (event: 'select', wallet: IWalletSelection): void;
   (event: 'minimize'): void;
   (event: 'closeWallet'): void;
+  (event: 'cancelAddWallet'): void;
+  (event: 'completeAddWallet', walletRecord: IWalletRecord): void;
   (event: 'addNewWallet'): void;
   (event: 'addDefaultEthereum'): void;
   (event: 'addExternalEthereum'): void;
@@ -154,7 +170,11 @@ const nonNativeTokenValue = computed(
   () => props.wallet?.otherTokens.reduce((total, token) => total + currency.convertOtherToMicrogon(token), 0n) ?? 0n,
 );
 const headerTitle = computed(() =>
-  props.walletSelection ? getName(props.walletSelection) : `TRANSFER ${props.direction.toUpperCase()}`,
+  props.addWalletStep
+    ? 'Add Wallet'
+    : props.walletSelection
+      ? getName(props.walletSelection)
+      : `TRANSFER ${props.direction.toUpperCase()}`,
 );
 
 function getName(selection: IWalletSelection) {

--- a/src-vue/wallets/components/WalletTransferSidecar.vue
+++ b/src-vue/wallets/components/WalletTransferSidecar.vue
@@ -51,13 +51,17 @@
         </div>
         <div class="mt-2 h-[29px] shrink-0 text-sm opacity-50">
           <div
-            v-if="
-              [WalletType.defaultArgon, WalletType.miningBot].includes(props.walletSelection?.walletType as WalletType)
-            "
+            v-if="props.walletSelection?.walletType === WalletType.defaultArgon"
             class="border-t border-slate-500/30 pt-2"
           >
             Includes {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }}
             waiting to mint
+          </div>
+          <div
+            v-if="props.walletSelection?.walletType === WalletType.miningBot"
+            class="border-t border-slate-500/30 pt-2"
+          >
+            Includes {{ currency.symbol }}0.00 waiting to mint
           </div>
           <div
             v-else-if="props.walletSelection?.walletType === WalletType.ethereum"

--- a/src-vue/wallets/components/WalletTransferSidecar.vue
+++ b/src-vue/wallets/components/WalletTransferSidecar.vue
@@ -44,13 +44,16 @@
     </header>
 
     <template v-if="props.wallet">
-      <div class="flex h-[136px] shrink-0 flex-col items-center justify-center">
-        <div class="text-argon-700/70 text-6xl font-bold">
+      <div class="flex h-[120px] shrink-0 flex-col items-center justify-center">
+        <div class="text-argon-700/70 text-5xl font-bold">
+          {{ currency.symbol }}
           <FormattedMoney :isLoaded="walletValueIsLoaded" :value="walletTotalValue" />
         </div>
         <div class="mt-2 h-[29px] shrink-0 text-sm opacity-50">
           <div
-            v-if="props.walletSelection?.walletType === WalletType.defaultArgon"
+            v-if="
+              [WalletType.defaultArgon, WalletType.miningBot].includes(props.walletSelection?.walletType as WalletType)
+            "
             class="border-t border-slate-500/30 pt-2"
           >
             Includes {{ currency.symbol }}{{ microgonToMoneyNm(financials.savingsTotalPending).format('0,0.00') }}

--- a/src-vue/wallets/walletOverlayState.ts
+++ b/src-vue/wallets/walletOverlayState.ts
@@ -8,10 +8,15 @@ export type IWalletSelection =
   | { walletType: WalletType.ethereum; walletRecord: IWalletRecord };
 
 export type IWalletTransferDirection = 'in' | 'out';
-export type IWalletTransferSideState = { wallet?: IWalletSelection };
+export type IWalletSetupStep = 'choice' | 'external';
+export type IWalletTransferSideState = {
+  wallet?: IWalletSelection;
+  addWalletStep?: IWalletSetupStep;
+};
 
 export type IWalletOverlayState = {
-  primaryWallet: IWalletSelection;
+  primaryWallet?: IWalletSelection;
+  primaryAddWalletStep?: IWalletSetupStep;
   transferIn?: IWalletTransferSideState;
   transferOut?: IWalletTransferSideState;
 };
@@ -43,11 +48,16 @@ export function selectPrimaryWallet(state: IWalletOverlayState, wallet: IWalletS
   return { primaryWallet: wallet };
 }
 
+export function getInitialAddWalletOverlayState(initialStep: IWalletSetupStep): IWalletOverlayState {
+  return { primaryAddWalletStep: initialStep };
+}
+
 export function toggleWalletTransferDirection(
   state: IWalletOverlayState,
   direction: IWalletTransferDirection,
 ): IWalletOverlayState {
   const key = direction === 'in' ? 'transferIn' : 'transferOut';
+  if (!state.primaryWallet) return state;
   return { ...state, [key]: state[key] ? undefined : {} };
 }
 
@@ -57,7 +67,11 @@ export function selectTransferWallet(
   wallet: IWalletSelection,
 ): IWalletOverlayState {
   const key = direction === 'in' ? 'transferIn' : 'transferOut';
-  if (!state[key] || getWalletSelectionKey(state.primaryWallet) === getWalletSelectionKey(wallet)) {
+  if (
+    !state.primaryWallet ||
+    !state[key] ||
+    getWalletSelectionKey(state.primaryWallet) === getWalletSelectionKey(wallet)
+  ) {
     return state;
   }
 
@@ -70,6 +84,15 @@ export function returnToTransferWalletChooser(
 ): IWalletOverlayState {
   const key = direction === 'in' ? 'transferIn' : 'transferOut';
   return state[key] ? { ...state, [key]: {} } : state;
+}
+
+export function showAddWalletOnTransferSide(
+  state: IWalletOverlayState,
+  direction: IWalletTransferDirection,
+  initialStep: IWalletSetupStep,
+): IWalletOverlayState {
+  const key = direction === 'in' ? 'transferIn' : 'transferOut';
+  return state[key] ? { ...state, [key]: { addWalletStep: initialStep } } : state;
 }
 
 export function getWalletSelectionKey(wallet: IWalletSelection): string {


### PR DESCRIPTION
This PR integrates Ethereum wallet setup directly into the wallet overlay instead of displaying it in a separate modal.
It:
- Supports adding an Ethereum wallet from either the primary wallet panel or a transfer sidecar.
- Adds explicit overlay state for wallet-setup steps and preserves the opposite transfer side when adding a wallet.
- Updates the transfer-out E2E flow to explicitly create the default Ethereum wallet.
- Allows pending Ethereum inbound transfers targeting the legacy Native Argon address to resume after the default wallet address changes.
- Replaces local documentation URLs in the navigation with production links.