### PR TITLE
fix: track ratchets through finalization

### DIFF
--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -5,12 +5,15 @@ import type { Db } from '../lib/Db.ts';
 import type { TransactionTracker } from '../lib/TransactionTracker.ts';
 import type { WalletKeys } from '../lib/WalletKeys.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
+import { ExtrinsicType, TransactionStatus } from '../lib/db/TransactionsTable.ts';
 import { BitcoinLock, hexToU8a, type IBitcoinLock } from '@argonprotocol/mainchain';
 import { createHistoricalEventData } from '../../indexer/__test__/helpers/historicalEvents.ts';
 import { bigintCodec, numberCodec, optionCodec } from '../../core/__test__/helpers/codecs.ts';
 import { encodeAddress } from '@polkadot/util-crypto';
 
-function createStore(options: { blockWatch?: BlockWatch; walletKeys?: WalletKeys } = {}) {
+function createStore(
+  options: { blockWatch?: BlockWatch; transactionTracker?: TransactionTracker; walletKeys?: WalletKeys } = {},
+) {
   const blockWatch =
     options.blockWatch ??
     (Object.assign(Object.create(null), {
@@ -20,14 +23,16 @@ function createStore(options: { blockWatch?: BlockWatch; walletKeys?: WalletKeys
     }) as BlockWatch);
   const currency = Object.assign(Object.create(null), {
     load: async () => undefined,
-    priceIndex: {},
+    priceIndex: { getSatoshiPriceInTargetMicrogons: () => 2_000n },
     fetchMainchainRatesAtBlock: async () => ({ BTC: 4_000_000n, ARGNOT: 1_000_000n, USD: 1_000_000n }),
   }) as CurrencyBase;
-  const transactionTracker = Object.assign(Object.create(null), {
-    load: async () => undefined,
-    pendingBlockTxInfosAtLoad: [],
-    data: { txInfos: [], txInfosByType: {} },
-  }) as TransactionTracker;
+  const transactionTracker =
+    options.transactionTracker ??
+    (Object.assign(Object.create(null), {
+      load: async () => undefined,
+      pendingBlockTxInfosAtLoad: [],
+      data: { txInfos: [], txInfosByType: {} },
+    }) as TransactionTracker);
 
   return new BitcoinLocks(
     Promise.resolve(Object.create(null) as Db),
@@ -654,5 +659,82 @@ describe('BitcoinLocks getActiveLocks', () => {
 
     expect(findPendingMints).toHaveBeenCalledOnce();
     expect(store.data.locksByUtxoId[7].ratchets[0].mintPending).toBe(0n);
+  });
+});
+
+describe('BitcoinLocks ratchet transaction tracking', () => {
+  it('reuses a stored pending ratchet instead of submitting another transaction', async () => {
+    const pendingTxInfo = {
+      tx: {
+        extrinsicType: ExtrinsicType.BitcoinRatchet,
+        metadataJson: { utxoId: 7 },
+        status: TransactionStatus.Finalized,
+      },
+      txResult: {},
+      isPostProcessed: false,
+    };
+    const transactionTracker = Object.assign(Object.create(null), {
+      findLatestTxInfo: vi.fn((matches: (candidate: typeof pendingTxInfo) => boolean) => {
+        return matches(pendingTxInfo) ? pendingTxInfo : undefined;
+      }),
+    }) as TransactionTracker;
+    const store = createStore({ transactionTracker });
+    const lock = createLock({
+      uuid: 'pending-ratchet',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+
+    await expect(store.ratchet(lock, { address: 'owner' } as never)).resolves.toBe(pendingTxInfo);
+
+    pendingTxInfo.isPostProcessed = true;
+    expect(store.getPendingRatchetTxInfo(lock)).toBeUndefined();
+  });
+
+  it('returns after tracked submission without waiting for finalization', async () => {
+    const waitForFinalizedBlock = new Promise<Uint8Array>(() => undefined);
+    const txResult = { waitForFinalizedBlock };
+    const getRatchetResult = vi.fn(() => waitForFinalizedBlock);
+    const ratchet = vi.fn(async () => ({ txResult, getRatchetResult }));
+    const txInfo = {
+      tx: { id: 12 },
+      txResult,
+      createPostProcessor: () => ({ resolve: vi.fn(), reject: vi.fn() }),
+    };
+    const trackTxResult = vi.fn(async () => txInfo);
+    const transactionTracker = Object.assign(Object.create(null), {
+      data: { txInfos: [], txInfosByType: {} },
+      findLatestTxInfo: vi.fn(() => undefined),
+      trackTxResult,
+    }) as TransactionTracker;
+    const store = createStore({ transactionTracker });
+    const lock = createLock({
+      uuid: 'ratchet-submit',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const getRatchetContext = vi.fn(async () => ({
+      bitcoinLock: { ratchet },
+      client: {},
+      vault: {},
+    }));
+    Object.assign(store, { getRatchetContext });
+    vi.spyOn(store, 'getRatchetPreview').mockResolvedValue({ canRatchet: true } as never);
+
+    await expect(store.ratchet(lock, { address: 'owner' } as never)).resolves.toBe(txInfo);
+    expect(ratchet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disableAutomaticTxTracking: true,
+        microgonsAtTargetPerBtc: 2_000n,
+      }),
+    );
+    expect(trackTxResult).toHaveBeenCalledWith({
+      txResult,
+      extrinsicType: ExtrinsicType.BitcoinRatchet,
+      metadata: { utxoId: 7 },
+    });
+    expect(getRatchetResult).not.toHaveBeenCalled();
   });
 });

--- a/src-vue/interfaces/ITransactionRecord.ts
+++ b/src-vue/interfaces/ITransactionRecord.ts
@@ -13,6 +13,7 @@ export enum ExtrinsicType {
   OperationalClaimRewards = 'OperationalClaimRewards',
 
   BitcoinRequestLock = 'BitcoinRequestLock', // LockIsProcessingOnArgon
+  BitcoinRatchet = 'BitcoinRatchet',
   BitcoinRequestRelease = 'BitcoinRequestRelease', // funding UTXO enters release lifecycle on Argon
   VaultCosignBitcoinRelease = 'VaultCosignBitcoinRelease', // vault cosigns release request before bitcoin broadcast
   VaultCosignOrphanedUtxoRelease = 'VaultCosignOrphanedUtxoRelease',

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -108,6 +108,10 @@ export interface IBitcoinRatchetPreview {
   shortfall: bigint;
   vaultId: number;
 }
+
+export interface IBitcoinRatchetMetadata {
+  utxoId: number;
+}
 export type { IBitcoinUnlockReleaseState, IBitcoinVaultMismatchState, IBitcoinVaultUnlockStateDetails };
 
 export interface IOperatorBitcoinLockCouponRoute {
@@ -408,7 +412,8 @@ export default class BitcoinLocks {
       await this.#transactionTracker.load();
       await this.syncFailedBitcoinRequestLocksFromTransactions();
       await this.migrateLegacyBitcoinLockHdKeys();
-      for (const txInfo of this.#transactionTracker.pendingBlockTxInfosAtLoad) {
+      const pendingTxInfosOldestFirst = [...this.#transactionTracker.pendingBlockTxInfosAtLoad].reverse();
+      for (const txInfo of pendingTxInfosOldestFirst) {
         const { tx } = txInfo;
         if (tx.extrinsicType === ExtrinsicType.BitcoinRequestLock) {
           const result = await this.onBitcoinLockFinalized(txInfo);
@@ -419,6 +424,12 @@ export default class BitcoinLocks {
           const { utxoId } = tx.metadataJson!;
           const lock = this.locksByUtxoId[utxoId];
           await this.onRequestedReleaseInBlock(lock, txInfo);
+        } else if (tx.extrinsicType === ExtrinsicType.BitcoinRatchet) {
+          const { utxoId } = tx.metadataJson;
+          const lock = this.locksByUtxoId[utxoId];
+          if (lock) {
+            await this.onRatchetFinalized(lock, txInfo);
+          }
         }
       }
 
@@ -1257,7 +1268,9 @@ export default class BitcoinLocks {
 
   public async ratchet(lock: IBitcoinLockRecord, txSigner: TxSigningAccount, tip = 0n) {
     return await this.runInQueueForUtxo(lock, 180e3, async () => {
-      const table = await this.getTable();
+      const existingTxInfo = this.getPendingRatchetTxInfo(lock);
+      if (existingTxInfo) return existingTxInfo;
+
       if (!this.isLockedStatus(lock)) {
         throw new Error(`Lock with ID ${lock.utxoId} is not verified.`);
       }
@@ -1281,39 +1294,68 @@ export default class BitcoinLocks {
         txSigner,
         tip,
         vault,
+        disableAutomaticTxTracking: true,
       });
 
-      const {
-        burned,
-        securityFee,
-        bitcoinBlockHeight: oracleBitcoinBlockHeight,
-        blockHeight,
-        lockedTargetPrice,
-        liquidityPromised,
-        pendingMint,
-        txFee,
-      } = await result.getRatchetResult();
-
-      lock.ratchets.push({
-        mintAmount: pendingMint,
-        mintPending: pendingMint,
-        liquidityPromised,
-        lockedTargetPrice,
-        txFee,
-        burned,
-        securityFee,
-        blockHeight,
-        extrinsicIndex: result.txResult.extrinsicIndex,
-        oracleBitcoinBlockHeight,
+      const txInfo = await this.#transactionTracker.trackTxResult<IBitcoinRatchetMetadata>({
+        txResult: result.txResult,
+        extrinsicType: ExtrinsicType.BitcoinRatchet,
+        metadata: { utxoId: lock.utxoId! },
       });
 
-      lock.liquidityPromised = liquidityPromised;
-      lock.lockedTargetPrice = lockedTargetPrice;
-      lock.lockDetails.liquidityPromised = liquidityPromised;
-      lock.lockDetails.lockedTargetPrice = lockedTargetPrice;
-
-      await table.saveNewRatchet(lock);
+      void this.onRatchetFinalized(lock, txInfo).catch(error => {
+        console.error(`[BitcoinLocks] Error processing ratchet transaction #${txInfo.tx.id}`, error);
+      });
+      return txInfo;
     });
+  }
+
+  public getPendingRatchetTxInfo(
+    lock: Pick<IBitcoinLockRecord, 'utxoId'>,
+  ): TransactionInfo<IBitcoinRatchetMetadata> | undefined {
+    if (lock.utxoId === undefined) return undefined;
+
+    return this.#transactionTracker.findLatestTxInfo<IBitcoinRatchetMetadata>(txInfo => {
+      if (txInfo.tx.extrinsicType !== ExtrinsicType.BitcoinRatchet) return false;
+      if (txInfo.tx.metadataJson.utxoId !== lock.utxoId) return false;
+      if (this.getTxFailureMessage(txInfo)) return false;
+      return !txInfo.isPostProcessed;
+    });
+  }
+
+  private async onRatchetFinalized(
+    lock: IBitcoinLockRecord,
+    txInfo: TransactionInfo<IBitcoinRatchetMetadata>,
+  ): Promise<void> {
+    if (!txInfo.isPostProcessed) return;
+
+    const postProcessor = txInfo.createPostProcessor();
+    try {
+      const blockHash = await txInfo.txResult.waitForFinalizedBlock.catch(error => {
+        if (!txInfo.txResult.extrinsicError) throw error;
+      });
+      if (!blockHash || txInfo.txResult.extrinsicError) {
+        postProcessor.resolve();
+        return;
+      }
+
+      const blockHeight = txInfo.txResult.blockNumber ?? txInfo.tx.blockHeight;
+      if (blockHeight === undefined) {
+        throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized without a block height`);
+      }
+
+      const block = await this.blockWatch.getHeaderByBlockNumber(blockHeight);
+      if (block.blockHash.toLowerCase() !== u8aToHex(blockHash).toLowerCase()) {
+        throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized in an unexpected block`);
+      }
+
+      const events = await this.blockWatch.getEvents(block);
+      await this.recovery.recoverBlock(block, events);
+      postProcessor.resolve();
+    } catch (error) {
+      postProcessor.reject(error as Error);
+      throw error;
+    }
   }
 
   private async ownerCosignAndSendToBitcoin(lock: IBitcoinLockRecord): Promise<void> {

--- a/src-vue/overlays/BitcoinRatchetingOverlay.vue
+++ b/src-vue/overlays/BitcoinRatchetingOverlay.vue
@@ -43,11 +43,16 @@
     </div>
 
     <div class="px-5 py-5">
+      <div v-if="txInfo" class="mb-4 space-y-2">
+        <ProgressBar :progress="progressPct" :hasError="!!errorMessage" :showLabel="false" class="h-4" />
+        <div class="text-sm text-slate-500">{{ progressLabel }}</div>
+      </div>
       <button
         @click="submitRatchet"
         :disabled="isSubmitting || isLoadingPreview || !ratchetPreview?.canRatchet"
-        class="bg-argon-600 px-5 py-1 text-white border border-argon-800 rounded disabled:opacity-50 cursor-pointer"
+        class="bg-argon-600 inline-flex items-center px-5 py-1 text-white border border-argon-800 rounded disabled:opacity-50 cursor-pointer"
       >
+        <Spinner v-if="isSubmitting" class="mr-2 h-4 min-h-4 w-4 min-w-4" />
         {{ isSubmitting ? 'Ratchet pending...' : 'Finish Ratchet' }}
       </button>
       <div v-if="errorMessage" class="mt-3 text-sm text-red-600">{{ errorMessage }}</div>
@@ -64,7 +69,10 @@ import { IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
 import { getCurrency } from '../stores/currency.ts';
 import { getBitcoinLocks } from '../stores/bitcoin.ts';
-import type { IBitcoinRatchetPreview } from '../lib/BitcoinLocks.ts';
+import type { IBitcoinRatchetMetadata, IBitcoinRatchetPreview } from '../lib/BitcoinLocks.ts';
+import type { TransactionInfo } from '../lib/TransactionInfo.ts';
+import ProgressBar from '../components/ProgressBar.vue';
+import Spinner from '../components/Spinner.vue';
 
 const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
@@ -74,6 +82,10 @@ const isSubmitting = Vue.ref(false);
 const isLoadingPreview = Vue.ref(true);
 const errorMessage = Vue.ref('');
 const ratchetPreview = Vue.ref<IBitcoinRatchetPreview>();
+const txInfo = Vue.shallowRef<TransactionInfo<IBitcoinRatchetMetadata>>();
+const progressPct = Vue.ref(0);
+const progressLabel = Vue.ref('');
+let unsubscribeProgress: (() => void) | undefined;
 
 const props = defineProps<{
   personalLock: IBitcoinLockRecord;
@@ -81,7 +93,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void;
-  (e: 'submitted'): void;
+  (e: 'completed'): void;
 }>();
 
 async function loadRatchetPreview() {
@@ -106,17 +118,63 @@ async function submitRatchet() {
 
   try {
     const txSigner = await walletKeys.getLiquidLockingKeypair();
-    await bitcoinLocks.ratchet(props.personalLock, txSigner);
-    emit('submitted');
-    emit('close');
+    const info = await bitcoinLocks.ratchet(props.personalLock, txSigner);
+    trackTransaction(info);
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Unable to ratchet this Bitcoin lock.';
-  } finally {
     isSubmitting.value = false;
   }
 }
 
-Vue.onMounted(() => {
-  void loadRatchetPreview();
+function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
+  unsubscribeProgress?.();
+  txInfo.value = info;
+  isSubmitting.value = true;
+
+  const status = info.getStatus();
+  progressPct.value = status.progressPct;
+  progressLabel.value = status.isFinalized ? 'Finalizing ratchet details...' : 'Waiting for transaction status...';
+
+  unsubscribeProgress = info.subscribeToProgress((progress, error) => {
+    progressPct.value = progress.progressPct;
+    progressLabel.value = progress.progressMessage;
+    if (error) {
+      errorMessage.value = error.message;
+    }
+  });
+
+  void info.waitForPostProcessing.then(
+    () => {
+      const error = info.getStatus().error;
+      if (error) {
+        errorMessage.value = error.message;
+        isSubmitting.value = false;
+        return;
+      }
+
+      progressPct.value = 100;
+      emit('completed');
+    },
+    error => {
+      errorMessage.value = error instanceof Error ? error.message : 'Unable to save the completed ratchet.';
+      isSubmitting.value = false;
+    },
+  );
+}
+
+Vue.onMounted(async () => {
+  await bitcoinLocks.load();
+  const pendingTxInfo = bitcoinLocks.getPendingRatchetTxInfo(props.personalLock);
+  if (pendingTxInfo) {
+    isLoadingPreview.value = false;
+    trackTransaction(pendingTxInfo);
+    return;
+  }
+
+  await loadRatchetPreview();
+});
+
+Vue.onUnmounted(() => {
+  unsubscribeProgress?.();
 });
 </script>

--- a/src-vue/overlays/TransactionsOverlay.vue
+++ b/src-vue/overlays/TransactionsOverlay.vue
@@ -181,6 +181,8 @@ function transactionLabel(transaction: ITransactionRecord): string {
       return 'Claimed Operational Rewards';
     case ExtrinsicType.BitcoinRequestLock:
       return 'Created Bitcoin Lock';
+    case ExtrinsicType.BitcoinRatchet:
+      return 'Ratcheted Bitcoin Lock';
     case ExtrinsicType.BitcoinRequestRelease:
       return 'Requested Bitcoin Release';
     case ExtrinsicType.VaultCosignBitcoinRelease:

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -192,7 +192,7 @@
       v-if="showRatchetingOverlay && selectedLock"
       :personalLock="selectedLock.record"
       @close="showRatchetingOverlay = false"
-      @submitted="onRatchetSubmitted"
+      @completed="onRatchetCompleted"
     />
   </div>
 </template>
@@ -290,7 +290,7 @@ function openRatchetingOverlay(event: MouseEvent, lock: IBitcoinLockSummary) {
   showRatchetingOverlay.value = true;
 }
 
-async function onRatchetSubmitted() {
+async function onRatchetCompleted() {
   showRatchetingOverlay.value = false;
   await bitcoinLocks.load();
 }

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -150,13 +150,17 @@
             <button
               @click.stop="openRatchetingOverlay($event, lockSummary)"
               :class="[
-                lockSummary.ratchetPercent
+                lockSummary.ratchetPercent || isRatchetPending
                   ? 'bg-argon-600 border-argon-800 hover:bg-argon-700 text-white hover:shadow-lg'
                   : 'cursor-default border-slate-800/20 text-slate-600/40',
               ]"
-              class="cursor-pointer rounded-md border px-2"
+              class="inline-flex cursor-pointer items-center rounded-md border px-2"
             >
-              <span v-if="lockSummary.ratchetPercent">
+              <template v-if="isRatchetPending">
+                <Spinner class="mr-1.5 h-3 min-h-3 w-3 min-w-3" />
+                Ratcheting...
+              </template>
+              <span v-else-if="lockSummary.ratchetPercent">
                 Ratchet {{ lockSummary.ratchetPercent > 0 ? '+' : ''
                 }}{{ numeral(lockSummary.ratchetPercent).format('0,0.[00]') }}%
               </span>
@@ -207,6 +211,7 @@ import { getCurrency } from '../../../stores/currency.ts';
 import { getBitcoinLocks } from '../../../stores/bitcoin.ts';
 import ProgressBar from '../../../components/ProgressBar.vue';
 import BitcoinRecordMismatch from './BitcoinRecordMismatch.vue';
+import Spinner from '../../../components/Spinner.vue';
 
 dayjs.extend(utc);
 
@@ -226,6 +231,7 @@ const emit = defineEmits<{
 
 const isActionHovered = Vue.ref(false);
 const lockRecord = Vue.computed(() => props.lockSummary.record);
+const isRatchetPending = Vue.computed(() => !!bitcoinLocks.getPendingRatchetTxInfo(lockRecord.value));
 const mismatchAcceptProgress = Vue.computed(() => {
   if (!lockRecord.value.utxoId) {
     return { progressPct: 0, error: '' };
@@ -243,7 +249,7 @@ function expirationDate(lock: IBitcoinLockRecord) {
 }
 
 function openRatchetingOverlay(event: MouseEvent, lock: IBitcoinLockSummary) {
-  if (!props.lockSummary.ratchetPercent) return;
+  if (!props.lockSummary.ratchetPercent && !isRatchetPending.value) return;
   emit('ratchet', event, lock);
 }
 


### PR DESCRIPTION
## Summary

Ratchet requests no longer leave the button waiting until the local queue times out while the transaction finalizes. The app now returns after submission and uses the standard transaction tracker to show progress, resume pending ratchets after a restart, and prevent duplicate submissions for the same Bitcoin lock.

Finalized ratchets are recovered into local lock history before the overlay completes. Pending transactions resume oldest-first so multiple ratchets retain their chain order, while failed or completed attempts no longer block a later ratchet.

## Validation

- Full typecheck and lint checks pass.
- All 9 scoped Bitcoin lock recovery and ratchet transaction tests pass.
