### PR TITLE
Fix Bitcoin lock history recovery isolation

### DIFF
--- a/src-tauri/migrations/27-bitcoin-history-recovery/up.sql
+++ b/src-tauri/migrations/27-bitcoin-history-recovery/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE BitcoinLocks ADD COLUMN isHistoryRecoveryPending BOOLEAN NOT NULL DEFAULT 0;

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -11,6 +11,8 @@ import { BitcoinLock, hexToU8a, type IBitcoinLock } from '@argonprotocol/maincha
 import { createHistoricalEventData } from '../../indexer/__test__/helpers/historicalEvents.ts';
 import { bigintCodec, numberCodec, optionCodec } from '../../core/__test__/helpers/codecs.ts';
 import { encodeAddress } from '@polkadot/util-crypto';
+import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
+import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
 
 function createStore(
   options: { blockWatch?: BlockWatch; transactionTracker?: TransactionTracker; walletKeys?: WalletKeys } = {},
@@ -137,7 +139,247 @@ function historyEvent(
   };
 }
 
-describe('BitcoinLocks getActiveLocks', () => {
+describe('BitcoinLocks recovery', () => {
+  it('quarantines only recovering locks while regular locks remain active and syncable', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'interim-release',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.fundingUtxoRecord = {
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+      statusError: 'PSBT finalize error',
+    } as never;
+    record.isHistoryRecoveryPending = true;
+    store.data.locksByUtxoId[7] = record;
+    expect(getBitcoinAlertNotices(store)).toEqual([]);
+
+    const regularRecord = createLock({
+      uuid: 'regular-lock',
+      utxoId: 8,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-02-01T00:00:00Z',
+    });
+    store.data.locksByUtxoId[8] = regularRecord;
+    const setStatus = vi.fn(async (lock: IBitcoinLockRecord, status: BitcoinLockStatus) => {
+      lock.status = status;
+    });
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setStatus } as never);
+
+    expect(store.getActiveLocks()).toEqual([regularRecord]);
+    expect(store.getAllLocks()).toEqual([regularRecord]);
+    expect(store.getLockByUtxoId(7)).toBeUndefined();
+    expect(store.getLockByUtxoId(8)).toBe(regularRecord);
+    await expect(store.acknowledgeFailed(record)).rejects.toThrow('Bitcoin history recovery is still in progress');
+
+    const releasingRecord = { status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin } as never;
+    await store.syncLockReleaseStatusFromFundingRecord(record, releasingRecord);
+    await store.syncLockReleaseStatusFromFundingRecord(regularRecord, releasingRecord);
+
+    expect(record.status).toBe(BitcoinLockStatus.LockPendingFunding);
+    expect(regularRecord.status).toBe(BitcoinLockStatus.Releasing);
+    expect(setStatus).toHaveBeenCalledOnce();
+    expect(setStatus).toHaveBeenCalledWith(regularRecord, BitcoinLockStatus.Releasing);
+
+    vi.spyOn(store, 'load').mockResolvedValue();
+    const regularSummary = {
+      record: regularRecord,
+      status: regularRecord.status,
+      unlockAmount: 0n,
+    } as ReturnType<typeof store.createLockSummary>;
+    const createLockSummaryAt = vi.spyOn(store, 'createLockSummaryAt').mockResolvedValue(regularSummary);
+    const financials = await new BitcoinFinancials(store).loadSnapshot({
+      clientAt: Object.create(null),
+      hasCurrentPrice: false,
+    });
+
+    expect(createLockSummaryAt).toHaveBeenCalledOnce();
+    expect(createLockSummaryAt).toHaveBeenCalledWith(regularRecord, expect.anything());
+    expect(financials.summaries).toEqual([regularSummary]);
+
+    delete record.isHistoryRecoveryPending;
+    expect(store.getAllLocks()).toEqual([regularRecord, record]);
+  });
+
+  it('serializes history replay with the affected lock queue without yielding or waiting behind itself', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'queue-owned-recovery',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    store.data.locksByUtxoId[7] = record;
+    const setHistoryRecoveryPending = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      getByUtxoId: vi.fn(async () => record),
+      setHistoryRecoveryPending,
+    } as never);
+
+    const runInQueueForUtxo = Reflect.get(store, 'runInQueueForUtxo') as (
+      lock: IBitcoinLockRecord,
+      timeoutMs: number,
+      task: () => Promise<IBitcoinLockRecord>,
+      options: { waitForHistoryRecovery: boolean },
+    ) => Promise<IBitcoinLockRecord>;
+    let started = false;
+    const admitted = runInQueueForUtxo.call(
+      store,
+      record,
+      1_000,
+      async () => {
+        started = true;
+        return record;
+      },
+      { waitForHistoryRecovery: true },
+    );
+
+    expect(started).toBe(true);
+    await admitted;
+
+    store.recovery.beginHistoryReplay();
+    await expect(
+      runInQueueForUtxo.call(
+        store,
+        record,
+        1_000,
+        async () => {
+          return await store.recovery.recoverLock({
+            lock: { utxoId: 7 } as BitcoinLock,
+            createdAtArgonBlockHeight: 1,
+            finalFee: 0n,
+            lockQueueOwnerUuid: record.uuid,
+          });
+        },
+        { waitForHistoryRecovery: true },
+      ),
+    ).resolves.toMatchObject({ uuid: record.uuid });
+    await store.recovery.commitHistoryReplay();
+
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, true);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, false);
+  });
+
+  it('resumes one-shot relay work after the affected lock finishes recovery', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'relay-recovery',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.isHistoryRecoveryPending = true;
+    record.relayMetadataJson = { operatorHost: 'http://relay.test', offerCode: 'offer-1', status: 'Submitted' };
+    store.data.locksByUtxoId[7] = record;
+    const setHistoryRecoveryPending = vi.fn();
+    const setRelayMetadata = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending, setRelayMetadata } as never);
+    vi.spyOn(store as any, 'runPendingLoadReconciliation').mockResolvedValue(undefined);
+
+    const syncRelayBackedPendingLock = Reflect.get(store, 'syncRelayBackedPendingLock') as (
+      lock: IBitcoinLockRecord,
+      relay: object,
+    ) => Promise<void>;
+    const relaySync = syncRelayBackedPendingLock.call(store, record, {
+      status: 'Failed',
+      coupon: { offerCode: 'offer-1' },
+    });
+
+    expect(setRelayMetadata).not.toHaveBeenCalled();
+
+    store.recovery.beginHistoryReplay();
+    await store.recovery.commitHistoryReplay();
+    await relaySync;
+    expect(setRelayMetadata).toHaveBeenCalledOnce();
+  });
+
+  it('keeps recovered expired locks in history without processing them as active', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'expired-lock',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.removalReason = 'expired';
+    store.data.locksByUtxoId[7] = record;
+
+    expect(store.getActiveLocks()).toEqual([]);
+    expect(store.getAllLocks()).toEqual([record]);
+    expect(store.getLockByUtxoId(7)).toBe(record);
+    const setStatus = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setStatus } as never);
+
+    await store.syncLockReleaseStatusFromFundingRecord(record, {
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+    } as never);
+
+    expect(setStatus).not.toHaveBeenCalled();
+    expect(record.status).toBe(BitcoinLockStatus.LockPendingFunding);
+  });
+
+  it('publishes existing and out-of-order locks only after history replay is committed', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'settled-lock',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const pending = createLock({
+      uuid: 'out-of-order-lock',
+      status: BitcoinLockStatus.LockIsProcessingOnArgon,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const recoveredRecord = { ...record, status: BitcoinLockStatus.LockPendingFunding };
+    const recoveredPending = { ...pending, utxoId: 8, status: BitcoinLockStatus.LockPendingFunding };
+    store.data.locksByUtxoId[7] = record;
+    store.data.pendingLocks.push(pending);
+    const setHistoryRecoveryPending = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      getByUtxoId: vi.fn(async utxoId => (utxoId === 7 ? recoveredRecord : recoveredPending)),
+      setHistoryRecoveryPending,
+    } as never);
+
+    store.recovery.beginHistoryReplay();
+    await store.recovery.recoverLock({
+      lock: { utxoId: 7 } as BitcoinLock,
+      createdAtArgonBlockHeight: 1,
+      finalFee: 0n,
+    });
+    await store.recovery.recoverLock({
+      lock: { utxoId: 8 } as BitcoinLock,
+      createdAtArgonBlockHeight: 1,
+      finalFee: 0n,
+    });
+
+    expect(record.status).toBe(BitcoinLockStatus.LockedAndMinted);
+    expect(record.isHistoryRecoveryPending).toBe(true);
+    expect(pending.isHistoryRecoveryPending).toBe(true);
+    expect(store.getAllLocks()).toEqual([]);
+
+    await store.recovery.commitHistoryReplay(false);
+
+    expect(record.status).toBe(BitcoinLockStatus.LockPendingFunding);
+    expect(store.data.pendingLocks).toEqual([pending]);
+    expect(store.getAllLocks()).toEqual([]);
+
+    store.recovery.beginHistoryReplay();
+    await store.recovery.commitHistoryReplay();
+
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, true);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, false);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(pending.uuid, true);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(pending.uuid, false);
+    expect(record.isHistoryRecoveryPending).toBeUndefined();
+    expect(store.data.locksByUtxoId[7]).toBe(record);
+    expect(store.data.pendingLocks).toEqual([]);
+    expect(store.data.locksByUtxoId[8].isHistoryRecoveryPending).toBeUndefined();
+    expect(store.getAllLocks()).toHaveLength(2);
+  });
+
   it('replays creation, ratchet, mint, and release with historical codec events', async () => {
     const accountId = encodeAddress(new Uint8Array(32).fill(0x33));
     const getApi = vi.fn();
@@ -149,7 +391,6 @@ describe('BitcoinLocks getActiveLocks', () => {
       blockWatch,
       walletKeys: {
         defaultArgonAddress: accountId,
-        vaultingAddress: accountId,
         miningBotAddress: encodeAddress(new Uint8Array(32).fill(0x44)),
         operationalAddress: encodeAddress(new Uint8Array(32).fill(0x55)),
       } as WalletKeys,
@@ -357,7 +598,7 @@ describe('BitcoinLocks getActiveLocks', () => {
     };
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => api) } as unknown as BlockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
     const saveRecoveredHistory = vi.fn();
@@ -440,7 +681,7 @@ describe('BitcoinLocks getActiveLocks', () => {
     };
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     vi.spyOn(store, 'getTable').mockResolvedValue(table as never);
     vi.spyOn(store, 'getDerivedPubkey').mockResolvedValue({
@@ -502,7 +743,7 @@ describe('BitcoinLocks getActiveLocks', () => {
     const updateMintState = vi.fn(async () => undefined);
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     vi.spyOn(store, 'getTable').mockResolvedValue({
       getByUtxoId: vi.fn(async () => record),
@@ -552,7 +793,7 @@ describe('BitcoinLocks getActiveLocks', () => {
     const updateMintState = vi.fn(async () => undefined);
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
     vi.spyOn(store, 'getTable').mockResolvedValue({ updateMintState } as never);
@@ -591,7 +832,7 @@ describe('BitcoinLocks getActiveLocks', () => {
     const updateMintState = vi.fn(async () => undefined);
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
     vi.spyOn(store, 'getTable').mockResolvedValue({ getByUtxoId, updateMintState } as never);
@@ -646,22 +887,44 @@ describe('BitcoinLocks getActiveLocks', () => {
         oracleBitcoinBlockHeight: 500,
       },
     ];
+    const untouchedRecord = createLock({
+      uuid: 'unrelated-pending-mint',
+      utxoId: 8,
+      status: BitcoinLockStatus.LockedAndIsMinting,
+      createdAt: '2026-01-02T00:00:00Z',
+    });
+    untouchedRecord.ratchets = record.ratchets.map(ratchet => ({ ...ratchet }));
     const blockWatch = { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch;
     const store = createStore({
       blockWatch,
-      walletKeys: { vaultingAddress: accountId } as WalletKeys,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
-    vi.spyOn(store, 'getTable').mockResolvedValue({ updateMintState: vi.fn() } as never);
-    const findPendingMints = vi.spyOn(BitcoinLock.prototype, 'findPendingMints').mockResolvedValue([]);
+    store.data.locksByUtxoId[8] = untouchedRecord;
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      setHistoryRecoveryPending: vi.fn(),
+      updateMintState: vi.fn(),
+    } as never);
+    const findPendingMints = vi
+      .spyOn(BitcoinLock.prototype, 'findPendingMints')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([1_000n]);
     findPendingMints.mockClear();
 
+    store.recovery.beginHistoryReplay();
     await store.recovery.recoverBlock(historyBlock(153), [
       historyEvent(153, 'mint', 'BitcoinMint', { accountId, utxoId: null, amount: 1_000n }),
     ]);
 
-    expect(findPendingMints).toHaveBeenCalledOnce();
+    expect(findPendingMints).toHaveBeenCalledTimes(2);
+    expect(store.data.locksByUtxoId[7].ratchets[0].mintPending).toBe(1_000n);
+    expect(record.isHistoryRecoveryPending).toBe(true);
+    expect(untouchedRecord.isHistoryRecoveryPending).toBeUndefined();
+
+    await store.recovery.commitHistoryReplay(false);
+
     expect(store.data.locksByUtxoId[7].ratchets[0].mintPending).toBe(0n);
+    expect(record.isHistoryRecoveryPending).toBe(true);
   });
 
   it('reads active pending mint state at the supplied financial block without advancing the settled record', async () => {

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -149,6 +149,12 @@ describe('FinancialHistoryImporter', () => {
 
   it('preserves a successful domain checkpoint when another domain fails', async () => {
     const upsert = vi.fn(async () => undefined);
+    const beginHistoryReplay = vi.fn();
+    const recoverBlock = vi.fn(async () => {
+      throw new Error('archive unavailable');
+    });
+    const commitHistoryReplay = vi.fn();
+    const cancelHistoryReplay = vi.fn();
     vi.mocked(findAddressActivity)
       .mockResolvedValueOnce({
         asOfBlock: 10,
@@ -195,9 +201,10 @@ describe('FinancialHistoryImporter', () => {
           refreshHistory: vi.fn(async () => undefined),
         } as any,
         bitcoinLockRecovery: {
-          recoverBlock: vi.fn(async () => {
-            throw new Error('archive unavailable');
-          }),
+          beginHistoryReplay,
+          recoverBlock,
+          commitHistoryReplay,
+          cancelHistoryReplay,
         } as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds', 'bitcoin'],
@@ -211,11 +218,19 @@ describe('FinancialHistoryImporter', () => {
         domainCheckpoints: { bonds: { asOfBlock: 10, definitionVersion: 2, recoveryVersion: 1 } },
       }),
     );
+    expect(beginHistoryReplay).toHaveBeenCalledOnce();
+    expect(commitHistoryReplay).not.toHaveBeenCalled();
+    expect(cancelHistoryReplay).toHaveBeenCalledOnce();
+    expect(beginHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(recoverBlock.mock.invocationCallOrder[0]);
+    expect(recoverBlock.mock.invocationCallOrder[0]).toBeLessThan(cancelHistoryReplay.mock.invocationCallOrder[0]);
   });
 
   it('replays only index-selected Bitcoin blocks when its app recovery version changes', async () => {
+    const beginHistoryReplay = vi.fn();
     const recoverBlock = vi.fn(async () => undefined);
     const upsert = vi.fn(async () => undefined);
+    const commitHistoryReplay = vi.fn();
+    const cancelHistoryReplay = vi.fn();
     vi.mocked(findAddressActivity).mockResolvedValueOnce({
       asOfBlock: 100,
       definitionVersion: 2,
@@ -238,6 +253,9 @@ describe('FinancialHistoryImporter', () => {
             asOfBlock: 100,
             definitionVersion: 2,
             domains: ['bitcoin'],
+            domainCheckpoints: {
+              bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 1 },
+            },
           })),
           upsert,
         },
@@ -250,7 +268,13 @@ describe('FinancialHistoryImporter', () => {
       } as any,
       accountId: '5owner',
       argonBonds: {} as any,
-      bitcoinLockRecovery: { recoverBlock, findMissingActiveLockIds: vi.fn(async () => []) } as any,
+      bitcoinLockRecovery: {
+        beginHistoryReplay,
+        recoverBlock,
+        findMissingActiveLockIds: vi.fn(async () => []),
+        commitHistoryReplay,
+        cancelHistoryReplay,
+      } as any,
       vaultHistory: {} as any,
       enabledDomains: ['bitcoin'],
       minimumAsOfBlock: 100,
@@ -266,12 +290,19 @@ describe('FinancialHistoryImporter', () => {
       SyncStateKeys.FinancialHistory,
       expect.objectContaining({
         asOfBlock: 100,
-        recoveryVersions: { bitcoin: 1 },
+        recoveryVersions: { bitcoin: 2 },
         domainCheckpoints: {
-          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 1 },
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 2 },
         },
       }),
     );
+    expect(beginHistoryReplay).toHaveBeenCalledOnce();
+    expect(commitHistoryReplay).toHaveBeenCalledOnce();
+    expect(commitHistoryReplay).toHaveBeenCalledWith(true);
+    expect(cancelHistoryReplay).not.toHaveBeenCalled();
+    expect(beginHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(recoverBlock.mock.invocationCallOrder[0]);
+    expect(recoverBlock.mock.invocationCallOrder[0]).toBeLessThan(commitHistoryReplay.mock.invocationCallOrder[0]);
+    expect(commitHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(upsert.mock.invocationCallOrder[0]);
   });
 
   it('does not let another account checkpoint hide missing active bond history', async () => {

--- a/src-vue/__test__/HistoryRecoveryScheduler.test.ts
+++ b/src-vue/__test__/HistoryRecoveryScheduler.test.ts
@@ -37,15 +37,15 @@ describe('FinalizedHistoryScheduler', () => {
     await scheduler.close();
   });
 
-  it('stops retrying an unavailable source after three attempts', async () => {
+  it('keeps retrying an unavailable source with capped backoff', async () => {
     vi.useFakeTimers();
     const refresh = vi.fn().mockRejectedValue(new Error('indexer unavailable'));
     const scheduler = new FinalizedHistoryScheduler(refresh, 10);
 
     scheduler.queue(12);
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(120);
 
-    expect(refresh).toHaveBeenCalledTimes(4);
+    expect(refresh).toHaveBeenCalledTimes(5);
     await scheduler.close();
   });
 });

--- a/src-vue/__test__/helpers/bitcoinLocksHarness.ts
+++ b/src-vue/__test__/helpers/bitcoinLocksHarness.ts
@@ -114,7 +114,7 @@ export async function createBitcoinLocksHarness(args: {
   const fundingMicrogons = args.walletFundingMicrogons ?? walletFundingMicrogons;
 
   await sudoFundWallet({
-    address: walletKeys.vaultingAddress,
+    address: walletKeys.defaultArgonAddress,
     microgons: fundingMicrogons,
     micronots: 0n,
     archiveUrl,
@@ -125,7 +125,7 @@ export async function createBitcoinLocksHarness(args: {
     const finalizedHead = await archiveClient.rpc.chain.getFinalizedHead();
     const finalizedClient = await archiveClient.at(finalizedHead);
     const balance = await finalizedClient.query.system
-      .account(walletKeys.vaultingAddress)
+      .account(walletKeys.defaultArgonAddress)
       .then(x => x.data.free.toBigInt());
     if (balance < fundingMicrogons) return;
     return balance;

--- a/src-vue/interfaces/IBitcoinLockRecord.ts
+++ b/src-vue/interfaces/IBitcoinLockRecord.ts
@@ -75,6 +75,7 @@ export interface IBitcoinLockRecord {
   removalExtrinsicIndex?: number;
   removalReason?: 'released' | 'spent' | 'expired';
   btcPriceAtRemovalMicrogons?: bigint;
+  isHistoryRecoveryPending?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -51,6 +51,7 @@ import {
   IDeferred,
   MiningFrames,
   NetworkConfig,
+  readEventField,
   SATOSHIS_PER_BITCOIN,
   SingleFileQueue,
 } from '@argonprotocol/apps-core';
@@ -167,8 +168,7 @@ export default class BitcoinLocks {
   }
 
   public get recordCount() {
-    const activeLocks = Object.values(this.locksByUtxoId).filter(lock => !this.isInactiveForVaultDisplay(lock)).length;
-    return activeLocks + this.data.pendingLocks.length;
+    return this.getActiveLocks().length;
   }
 
   private get locksByUtxoId() {
@@ -196,6 +196,7 @@ export default class BitcoinLocks {
   #transactionTracker: TransactionTracker;
   #blockQueue = new SingleFileQueue();
   #txQueueByUuid: { [uuid: string]: SingleFileQueue } = {};
+  #historyRecoveryWaitersByUuid: Record<string, IDeferred<void>> = {};
   #relayPollingUuids = new Set<string>();
   #mempool: BitcoinMempool;
   #reportedMissingFundingForReleaseLocks = new Set<string>();
@@ -233,7 +234,14 @@ export default class BitcoinLocks {
       blockWatch,
       currency,
       locksByUtxoId: this.data.locksByUtxoId,
+      pendingLocks: this.data.pendingLocks,
       utxoTracking: this.utxoTracking,
+      waitForLockIdle: async lock => {
+        this.#historyRecoveryWaitersByUuid[lock.uuid] ??= createDeferred<void>();
+        const queue = this.#txQueueByUuid[lock.uuid];
+        if (queue) await queue.add(async () => undefined).promise;
+      },
+      onHistoryRecoveryComplete: locks => this.resumeAfterHistoryRecovery(locks),
       insertPending: this.insertPending.bind(this),
       getTable: () => this.getTable(),
       getDerivedPubkey: (vaultId, index) => this.getDerivedPubkey(vaultId, index),
@@ -242,17 +250,15 @@ export default class BitcoinLocks {
   }
 
   public getActiveLocks(): IBitcoinLockRecord[] {
-    const locks = Object.values(this.data.locksByUtxoId);
-    locks.unshift(...this.data.pendingLocks);
-    locks.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-    return locks.filter(lock => !this.isInactiveForVaultDisplay(lock));
+    return this.getAllLocks().filter(lock => !this.isInactiveForVaultDisplay(lock));
   }
 
   public getAllLocks(): IBitcoinLockRecord[] {
     const locks = Object.values(this.data.locksByUtxoId);
     locks.unshift(...this.data.pendingLocks);
-    locks.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-    return locks;
+    return locks
+      .filter(lock => !lock.isHistoryRecoveryPending)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }
 
   public createLockSummary(lock: IBitcoinLockRecord): IBitcoinLockSummary {
@@ -300,7 +306,8 @@ export default class BitcoinLocks {
   }
 
   public getLockByUtxoId(utxoId: number): IBitcoinLockRecord | undefined {
-    return this.data.locksByUtxoId[utxoId];
+    const lock = this.data.locksByUtxoId[utxoId];
+    return lock && !this.isHistoryRecoveryPendingForLock(lock) ? lock : undefined;
   }
 
   public unlockDeadlineTime(lock: IBitcoinLockRecord): number {
@@ -419,8 +426,10 @@ export default class BitcoinLocks {
         this.utxoTracking.getAcceptedFundingRecordForLock(lock);
       }
       for (const lock of Object.values(this.locksByUtxoId)) {
-        if (!this.isFinishedStatus(lock)) {
-          await this.checkForMissingBitcoinLockState(lock);
+        if (!this.isTerminalLock(lock)) {
+          await this.checkForMissingBitcoinLockState(lock).catch(error => {
+            console.warn(`[BitcoinLocks] Unable to reconcile lock ${lock.uuid} during startup`, error);
+          });
         }
       }
 
@@ -430,21 +439,43 @@ export default class BitcoinLocks {
       const pendingTxInfosOldestFirst = [...this.#transactionTracker.pendingBlockTxInfosAtLoad].reverse();
       for (const txInfo of pendingTxInfosOldestFirst) {
         const { tx } = txInfo;
-        if (tx.extrinsicType === ExtrinsicType.BitcoinRequestLock) {
-          const result = await this.onBitcoinLockFinalized(txInfo);
-          if (result) {
-            await this.checkForMissingBitcoinLockState(result);
+        try {
+          let recoveryLock: IBitcoinLockRecord | { uuid: string } | undefined;
+          let processing: Promise<void> | undefined;
+
+          if (tx.extrinsicType === ExtrinsicType.BitcoinRequestLock) {
+            const { uuid } = tx.metadataJson.bitcoin;
+            recoveryLock = { uuid };
+            processing = this.onBitcoinLockFinalized(txInfo).then(async result => {
+              if (result) await this.checkForMissingBitcoinLockState(result);
+            });
+          } else if (tx.extrinsicType === ExtrinsicType.BitcoinRequestRelease) {
+            const { utxoId } = tx.metadataJson!;
+            const lock = this.locksByUtxoId[utxoId];
+            if (lock) {
+              recoveryLock = lock;
+              processing = this.onRequestedReleaseInBlock(lock, txInfo);
+            }
+          } else if (tx.extrinsicType === ExtrinsicType.BitcoinRatchet) {
+            const { utxoId } = tx.metadataJson;
+            const lock = this.locksByUtxoId[utxoId];
+            if (lock) {
+              recoveryLock = lock;
+              processing = this.onRatchetFinalized(lock, txInfo);
+            }
           }
-        } else if (tx.extrinsicType === ExtrinsicType.BitcoinRequestRelease) {
-          const { utxoId } = tx.metadataJson!;
-          const lock = this.locksByUtxoId[utxoId];
-          await this.onRequestedReleaseInBlock(lock, txInfo);
-        } else if (tx.extrinsicType === ExtrinsicType.BitcoinRatchet) {
-          const { utxoId } = tx.metadataJson;
-          const lock = this.locksByUtxoId[utxoId];
-          if (lock) {
-            await this.onRatchetFinalized(lock, txInfo);
+
+          if (!recoveryLock || !processing) continue;
+          if (this.isHistoryRecoveryPendingForLock(recoveryLock)) {
+            // History recovery starts after this store loads, so awaiting here would deadlock startup.
+            void processing.catch(error => {
+              console.warn(`[BitcoinLocks] Unable to resume transaction #${tx.id} after history recovery`, error);
+            });
+            continue;
           }
+          await processing;
+        } catch (error) {
+          console.warn(`[BitcoinLocks] Unable to restore transaction #${tx.id}; continuing startup`, error);
         }
       }
 
@@ -471,7 +502,15 @@ export default class BitcoinLocks {
         }
         const settledRelay = relay as IBitcoinLockCouponStatus & { status: BitcoinLockRelayStatus };
 
-        await this.syncRelayBackedPendingLock(pendingLock, settledRelay);
+        const relaySync = this.syncRelayBackedPendingLock(pendingLock, settledRelay).catch(error => {
+          console.warn(`[BitcoinLocks] Unable to reconcile relay lock ${pendingLock.uuid}`, error);
+        });
+        if (this.isHistoryRecoveryPendingForLock(pendingLock)) {
+          // History recovery starts after this store loads; relaySync owns its error and resumes when the lock clears.
+          void relaySync;
+          continue;
+        }
+        await relaySync;
       }
 
       await this.blockWatch.start();
@@ -514,6 +553,8 @@ export default class BitcoinLocks {
 
     try {
       for (const lock of Object.values(this.locksByUtxoId)) {
+        if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) continue;
+
         await this.reconcileMismatchState(lock);
         await this.reconcileMismatchReturnOnBlock(lock);
         await this.reconcileAcceptedFundingReleaseOnBlock(lock, false);
@@ -527,7 +568,7 @@ export default class BitcoinLocks {
   }
 
   private async checkForMissingBitcoinLockState(lock: IBitcoinLockRecord): Promise<void> {
-    if (!lock.utxoId) {
+    if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock) || !lock.utxoId) {
       return;
     }
     if (!lock.fundingUtxoRecord && lock.fundingUtxoRecordId) {
@@ -833,19 +874,19 @@ export default class BitcoinLocks {
     lock: IBitcoinLockRecord,
     relay: IBitcoinLockCouponStatus & { status: BitcoinLockRelayStatus },
   ): Promise<TransactionInfo<IBitcoinRequestLockMetadata> | undefined> {
+    await this.waitForHistoryRecovery(lock);
+
     const table = await this.getTable();
     await table.setRelayMetadata(
       lock,
       this.toRelayMetadata(lock.relayMetadataJson?.operatorHost, relay.coupon.offerCode, relay),
     );
 
-    if (relay.status === 'Failed') {
-      return undefined;
-    }
+    if (relay.status === 'Failed') return;
 
     if (relay.status === 'Finalized') {
       await this.finalizePendingFromRelay(lock, relay);
-      return undefined;
+      return;
     }
 
     const txInfo = await this.trackSubmittedRelay(lock, relay);
@@ -904,7 +945,9 @@ export default class BitcoinLocks {
       },
     });
 
-    void this.onBitcoinLockFinalized(txInfo);
+    void this.onBitcoinLockFinalized(txInfo).catch(error => {
+      console.warn(`[BitcoinLocks] Unable to finalize relay transaction #${txInfo.tx.id}`, error);
+    });
     return txInfo;
   }
 
@@ -923,6 +966,7 @@ export default class BitcoinLocks {
   }
 
   private async pollRelayUntilSettled(uuid: string): Promise<void> {
+    await this.waitForHistoryRecovery({ uuid });
     if (this.#relayPollingUuids.has(uuid)) return;
     this.#relayPollingUuids.add(uuid);
 
@@ -971,6 +1015,8 @@ export default class BitcoinLocks {
 
         await new Promise(resolve => setTimeout(resolve, 2_500));
       }
+    } catch (error) {
+      console.warn(`[BitcoinLocks] Relay polling stopped for lock ${uuid}`, error);
     } finally {
       this.#relayPollingUuids.delete(uuid);
     }
@@ -1024,20 +1070,24 @@ export default class BitcoinLocks {
     const { bitcoin: bitcoinMeta } = txInfo.tx.metadataJson;
     const pendingLock = await this.insertPending(bitcoinMeta);
     this.data.pendingLocks.push(pendingLock);
-    void this.onBitcoinLockFinalized(txInfo);
+    void this.onBitcoinLockFinalized(txInfo).catch(error => {
+      console.warn(`[BitcoinLocks] Unable to finalize lock transaction #${txInfo.tx.id}`, error);
+    });
   }
 
   private async onBitcoinLockFinalized(txInfo: TransactionInfo<IBitcoinRequestLockMetadata>) {
+    const uuid = txInfo.tx.metadataJson.bitcoin.uuid;
     const postProcessor = txInfo.createPostProcessor();
+
     try {
       const genericClient = await getMainchainClient(true);
       const txResult = txInfo.txResult;
       const blockHash = await txResult.waitForFinalizedBlock.catch(error => {
         if (!txResult.extrinsicError) throw error;
       });
-      const uuid = txInfo.tx.metadataJson.bitcoin.uuid;
-      const table = await this.getTable();
+      await this.waitForHistoryRecovery({ uuid });
 
+      const table = await this.getTable();
       if (txResult.extrinsicError) {
         const errorJson = BitcoinLocks.toBlockExtrinsicErrorJson(txResult.extrinsicError);
         const pendingLock = this.data.pendingLocks.find(lock => lock.uuid === uuid);
@@ -1068,7 +1118,6 @@ export default class BitcoinLocks {
         },
       );
       postProcessor.resolve();
-
       return record;
     } catch (error) {
       postProcessor.reject(error as Error);
@@ -1099,15 +1148,31 @@ export default class BitcoinLocks {
       const error = txInfo.getStatus().error;
       if (!error) continue;
 
-      const pendingLock = this.data.pendingLocks.find(lock => lock.uuid === uuid);
-      if (
-        pendingLock &&
-        !pendingLock.utxoId &&
-        pendingLock.status !== BitcoinLockStatus.LockFailed &&
-        pendingLock.status !== BitcoinLockStatus.LockFailedAcknowledged
-      ) {
-        await table.setLockFailed(pendingLock, BitcoinLocks.toBlockExtrinsicErrorJson(error));
+      const processing = this.runInQueueForUtxo(
+        { uuid },
+        30e3,
+        async () => {
+          const pendingLock = this.data.pendingLocks.find(lock => lock.uuid === uuid);
+          if (
+            pendingLock &&
+            !pendingLock.utxoId &&
+            pendingLock.status !== BitcoinLockStatus.LockFailed &&
+            pendingLock.status !== BitcoinLockStatus.LockFailedAcknowledged
+          ) {
+            await table.setLockFailed(pendingLock, BitcoinLocks.toBlockExtrinsicErrorJson(error));
+          }
+        },
+        { waitForHistoryRecovery: true },
+      );
+      const ownedProcessing = processing.catch(syncError => {
+        console.warn(`[BitcoinLocks] Unable to restore failed lock transaction #${txInfo.tx.id}`, syncError);
+      });
+      if (this.isHistoryRecoveryPendingForLock({ uuid })) {
+        // History recovery starts after this store loads; ownedProcessing resumes afterward and owns its error.
+        void ownedProcessing;
+        continue;
       }
+      await ownedProcessing;
     }
   }
 
@@ -1345,6 +1410,7 @@ export default class BitcoinLocks {
     if (!txInfo.isPostProcessed) return;
 
     const postProcessor = txInfo.createPostProcessor();
+
     try {
       const blockHash = await txInfo.txResult.waitForFinalizedBlock.catch(error => {
         if (!txInfo.txResult.extrinsicError) throw error;
@@ -1354,19 +1420,51 @@ export default class BitcoinLocks {
         return;
       }
 
-      const blockHeight = txInfo.txResult.blockNumber ?? txInfo.tx.blockHeight;
-      if (blockHeight === undefined) {
-        throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized without a block height`);
-      }
+      await this.runInQueueForUtxo(
+        lock,
+        60e3,
+        async () => {
+          if (this.isTerminalLock(lock)) {
+            postProcessor.resolve();
+            return;
+          }
 
-      const block = await this.blockWatch.getHeaderByBlockNumber(blockHeight);
-      if (block.blockHash.toLowerCase() !== u8aToHex(blockHash).toLowerCase()) {
-        throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized in an unexpected block`);
-      }
+          const blockHeight = txInfo.txResult.blockNumber ?? txInfo.tx.blockHeight;
+          if (blockHeight === undefined) {
+            throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized without a block height`);
+          }
 
-      const events = await this.blockWatch.getEvents(block);
-      await this.recovery.recoverBlock(block, events);
-      postProcessor.resolve();
+          const block = await this.blockWatch.getHeaderByBlockNumber(blockHeight);
+          if (block.blockHash.toLowerCase() !== u8aToHex(blockHash).toLowerCase()) {
+            throw new Error(`Ratchet transaction #${txInfo.tx.id} finalized in an unexpected block`);
+          }
+
+          const blockEvents = await this.blockWatch.getEvents(block);
+          let extrinsicIndex = txInfo.tx.blockExtrinsicIndex ?? txInfo.txResult.extrinsicIndex;
+          if (extrinsicIndex === undefined) {
+            const ratchetEvent = blockEvents.find(event => {
+              if (!event.phase.isApplyExtrinsic) return false;
+              if (event.event.section !== 'bitcoinLocks' || event.event.method !== 'BitcoinLockRatcheted') return false;
+
+              return Number(readEventField(event.event, 'utxoId')?.toString().replace(/,/g, '')) === lock.utxoId;
+            });
+            extrinsicIndex = ratchetEvent?.phase.asApplyExtrinsic.toNumber();
+          }
+          if (extrinsicIndex === undefined) {
+            console.warn(
+              `[BitcoinLocks] Ratchet transaction #${txInfo.tx.id} finalized without recoverable event identity; leaving it for history recovery`,
+            );
+            postProcessor.resolve();
+            return;
+          }
+          const events = blockEvents.filter(event => {
+            return event.phase.isApplyExtrinsic && event.phase.asApplyExtrinsic.toNumber() === extrinsicIndex;
+          });
+          await this.recovery.recoverBlock(block, events, { lockQueueOwnerUuid: lock.uuid });
+          postProcessor.resolve();
+        },
+        { waitForHistoryRecovery: true },
+      );
     } catch (error) {
       postProcessor.reject(error as Error);
       throw error;
@@ -1374,6 +1472,8 @@ export default class BitcoinLocks {
   }
 
   private async ownerCosignAndSendToBitcoin(lock: IBitcoinLockRecord): Promise<void> {
+    if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) return;
+
     const fundingRecord = await this.getFundingRecordOrThrow(lock);
     if (!this.utxoTracking.canSubmitFundingRecordReleaseToBitcoin(fundingRecord)) return;
 
@@ -1838,8 +1938,13 @@ export default class BitcoinLocks {
     return lock.status === BitcoinLockStatus.Released;
   }
 
-  public isInactiveForVaultDisplay(lock: Pick<IBitcoinLockRecord, 'status'>): boolean {
+  public isInactiveForVaultDisplay(lock: Pick<IBitcoinLockRecord, 'status' | 'removalReason'>): boolean {
+    return this.isTerminalLock(lock);
+  }
+
+  public isTerminalLock(lock: Pick<IBitcoinLockRecord, 'status' | 'removalReason'>): boolean {
     return (
+      !!lock.removalReason ||
       this.isFinishedStatus(lock) ||
       lock.status === BitcoinLockStatus.LockExpiredWaitingForFundingAcknowledged ||
       lock.status === BitcoinLockStatus.LockFailedAcknowledged
@@ -2004,7 +2109,9 @@ export default class BitcoinLocks {
     });
     // Run post-finalization reconciliation even when reusing an existing tx so release metadata
     // is backfilled if a previous run exited before writing it (for example after an app restart).
-    void this.onRequestedReleaseInBlock(lockRecord, txInfo);
+    void this.onRequestedReleaseInBlock(lockRecord, txInfo).catch(error => {
+      console.warn(`[BitcoinLocks] Unable to reconcile release transaction #${txInfo.tx.id}`, error);
+    });
     return txInfo;
   }
 
@@ -2034,6 +2141,8 @@ export default class BitcoinLocks {
   }
 
   public async acknowledgeFailed(lock: IBitcoinLockRecord): Promise<void> {
+    this.ensureBitcoinActionsAvailable(lock);
+
     const lockTable = await this.getTable();
     await lockTable.setLockFailedAcknowledged(lock);
   }
@@ -2403,31 +2512,42 @@ export default class BitcoinLocks {
   private async onRequestedReleaseInBlock(lock: IBitcoinLockRecord, txInfo: TransactionInfo): Promise<void> {
     const { txResult } = txInfo;
     const postProcessor = txInfo.createPostProcessor();
-    await this.ensureLockReleaseProcessing(lock);
 
     try {
+      await this.runInQueueForUtxo(lock, 30e3, () => this.ensureLockReleaseProcessing(lock), {
+        waitForHistoryRecovery: true,
+      });
       const blockHash = await txResult.waitForFinalizedBlock;
-      const client = await getMainchainClient(true);
-      const api = await client.at(blockHash);
-      const bitcoinLock = new BitcoinLock(lock.lockDetails);
-      const releaseRequest = await bitcoinLock.getReleaseRequest(api);
-      if (!releaseRequest) {
-        console.warn(`[BitcoinLocks] Missing canonical release request for ${lock.uuid} after finalization`);
-        return;
-      }
-      const requestedReleaseAtTick = await api.query.ticks.currentTick().then(x => x.toNumber());
-      const fundingRecord = await this.getFundingRecordOrThrow(lock);
-      const table = await this.getTable();
-      await table.recordReleaseRequest(lock, {
-        releaseRedemptionMicrogons: releaseRequest.redemptionAmount,
-        releaseArgonTxFeeMicrogons: txResult.finalFee ?? txInfo.tx.txFeePlusTip,
-      });
-      await this.utxoTracking.setReleaseRequest(fundingRecord, {
-        requestedReleaseAtTick,
-        releaseToDestinationAddress: releaseRequest.toScriptPubkey,
-        releaseBitcoinNetworkFee: releaseRequest.bitcoinNetworkFee,
-      });
-      await this.ensureLockReleaseProcessing(lock);
+      await this.runInQueueForUtxo(
+        lock,
+        60e3,
+        async () => {
+          if (this.isTerminalLock(lock)) return;
+
+          const client = await getMainchainClient(true);
+          const api = await client.at(blockHash);
+          const bitcoinLock = new BitcoinLock(lock.lockDetails);
+          const releaseRequest = await bitcoinLock.getReleaseRequest(api);
+          if (!releaseRequest) {
+            console.warn(`[BitcoinLocks] Missing canonical release request for ${lock.uuid} after finalization`);
+            return;
+          }
+          const requestedReleaseAtTick = await api.query.ticks.currentTick().then(x => x.toNumber());
+          const fundingRecord = await this.getFundingRecordOrThrow(lock);
+          const table = await this.getTable();
+          await table.recordReleaseRequest(lock, {
+            releaseRedemptionMicrogons: releaseRequest.redemptionAmount,
+            releaseArgonTxFeeMicrogons: txResult.finalFee ?? txInfo.tx.txFeePlusTip,
+          });
+          await this.utxoTracking.setReleaseRequest(fundingRecord, {
+            requestedReleaseAtTick,
+            releaseToDestinationAddress: releaseRequest.toScriptPubkey,
+            releaseBitcoinNetworkFee: releaseRequest.bitcoinNetworkFee,
+          });
+          await this.ensureLockReleaseProcessing(lock);
+        },
+        { waitForHistoryRecovery: true },
+      );
     } finally {
       postProcessor.resolve();
     }
@@ -2517,18 +2637,14 @@ export default class BitcoinLocks {
   ): Promise<void> {
     try {
       await txInfo.txResult.waitForInFirstBlock;
+      await this.waitForHistoryRecovery(lock);
+      if (this.isTerminalLock(lock)) return;
+
       const txFailure = this.getTxFailureMessage(txInfo);
-      if (txFailure) {
-        return;
-      }
-      if (txInfo.txResult.blockNumber == null) {
-        return;
-      }
+      if (txFailure || txInfo.txResult.blockNumber == null) return;
 
       const fundingRecord = this.getAcceptedFundingRecord(lock);
-      if (!fundingRecord) {
-        return;
-      }
+      if (!fundingRecord) return;
 
       await this.utxoTracking.setReleaseCosign(fundingRecord, {
         releaseCosignVaultSignature: vaultSignature,
@@ -2546,7 +2662,7 @@ export default class BitcoinLocks {
     const lockTable = await this.getTable();
     for (const lock of Object.values(locksByUtxoId)) {
       if (!lock.utxoId) continue;
-      if (lock.status === BitcoinLockStatus.Released) continue;
+      if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) continue;
       const fundingRecord = this.getAcceptedFundingRecord(lock);
       if (!fundingRecord) {
         this.reportMissingFundingRecordForReleasingLock(lock);
@@ -2578,6 +2694,8 @@ export default class BitcoinLocks {
     lock: IBitcoinLockRecord,
     hasNewOracleBitcoinBlockHeight: boolean,
   ): Promise<void> {
+    if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) return;
+
     let fundingRecord = this.getAcceptedFundingRecord(lock);
     if (!fundingRecord) {
       this.reportMissingFundingRecordForReleasingLock(lock);
@@ -2695,6 +2813,8 @@ export default class BitcoinLocks {
     lock: IBitcoinLockRecord,
     fundingRecord?: IBitcoinUtxoRecord,
   ): Promise<void> {
+    if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) return;
+
     const record = fundingRecord ?? this.getAcceptedFundingRecord(lock);
     if (!record) return;
 
@@ -2712,13 +2832,28 @@ export default class BitcoinLocks {
   }
 
   private async runInQueueForUtxo<T>(
-    lockRecord: Pick<IBitcoinLockRecord, 'uuid'>,
+    lockRecord: Pick<IBitcoinLockRecord, 'uuid'> & Partial<Pick<IBitcoinLockRecord, 'status' | 'removalReason'>>,
     timeoutMs: number,
     task: () => Promise<T>,
+    options: { waitForHistoryRecovery?: boolean } = {},
   ): Promise<T> {
+    if (options.waitForHistoryRecovery) {
+      const historyRecovery = this.waitForHistoryRecovery(lockRecord);
+      if (historyRecovery) {
+        await historyRecovery;
+        return await this.runInQueueForUtxo(lockRecord, timeoutMs, task, options);
+      }
+    }
+
     const { uuid } = lockRecord;
     this.#txQueueByUuid[uuid] ??= new SingleFileQueue();
-    return this.#txQueueByUuid[uuid].add(task, { timeoutMs }).promise;
+    return this.#txQueueByUuid[uuid].add(
+      async () => {
+        if (!options.waitForHistoryRecovery) this.ensureBitcoinActionsAvailable(lockRecord);
+        return await task();
+      },
+      { timeoutMs },
+    ).promise;
   }
 
   private async finalizePendingRecord(
@@ -2729,25 +2864,30 @@ export default class BitcoinLocks {
       finalFee: bigint;
     },
   ): Promise<IBitcoinLockRecord> {
-    return await this.runInQueueForUtxo(pendingLock, 60e3, async () => {
-      let record = this.locksByUtxoId[args.lock.utxoId];
-      if (!record) {
-        const table = await this.getTable();
-        record = await table.finalizePending({
-          uuid: pendingLock.uuid,
-          lock: args.lock,
-          createdAtArgonBlockHeight: args.createdAtArgonBlockHeight,
-          finalFee: args.finalFee,
-        });
-      }
+    return await this.runInQueueForUtxo(
+      pendingLock,
+      60e3,
+      async () => {
+        let record = this.locksByUtxoId[args.lock.utxoId];
+        if (!record) {
+          const table = await this.getTable();
+          record = await table.finalizePending({
+            uuid: pendingLock.uuid,
+            lock: args.lock,
+            createdAtArgonBlockHeight: args.createdAtArgonBlockHeight,
+            finalFee: args.finalFee,
+          });
+        }
 
-      this.locksByUtxoId[record.utxoId!] = record;
-      const pendingIdx = this.data.pendingLocks.findIndex(lock => lock.uuid === pendingLock.uuid);
-      if (pendingIdx >= 0) {
-        this.data.pendingLocks.splice(pendingIdx, 1);
-      }
-      return record;
-    });
+        this.locksByUtxoId[record.utxoId!] = record;
+        const pendingIdx = this.data.pendingLocks.findIndex(lock => lock.uuid === pendingLock.uuid);
+        if (pendingIdx >= 0) {
+          this.data.pendingLocks.splice(pendingIdx, 1);
+        }
+        return record;
+      },
+      { waitForHistoryRecovery: true },
+    );
   }
 
   private async checkIncomingArgonBlock(
@@ -2778,6 +2918,9 @@ export default class BitcoinLocks {
 
       const promises = Object.values(this.data.locksByUtxoId)
         .map(lockRecord => {
+          if (this.isHistoryRecoveryPendingForLock(lockRecord) || this.isTerminalLock(lockRecord)) {
+            return undefined;
+          }
           if (lockRecord.status === BitcoinLockStatus.LockIsProcessingOnArgon) {
             // waiting for a utxo to be found
             return undefined;
@@ -2990,8 +3133,59 @@ export default class BitcoinLocks {
   }
 
   private async ensureLockReleaseProcessing(lock: IBitcoinLockRecord): Promise<void> {
+    if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) return;
+
     const lockTable = await this.getTable();
     await lockTable.setStatus(lock, BitcoinLockStatus.Releasing);
+  }
+
+  private ensureBitcoinActionsAvailable(
+    lock: Pick<IBitcoinLockRecord, 'uuid'> & Partial<Pick<IBitcoinLockRecord, 'status' | 'removalReason'>>,
+  ): void {
+    if (this.isHistoryRecoveryPendingForLock(lock)) {
+      throw new Error('Bitcoin history recovery is still in progress. Please wait for it to finish.');
+    }
+    if (
+      lock.removalReason ||
+      (lock.status && this.isTerminalLock({ status: lock.status, removalReason: lock.removalReason }))
+    ) {
+      throw new Error('This Bitcoin lock is already settled.');
+    }
+  }
+
+  private isHistoryRecoveryPendingForLock(
+    lock: Pick<IBitcoinLockRecord, 'uuid'> & Partial<Pick<IBitcoinLockRecord, 'isHistoryRecoveryPending'>>,
+  ): boolean {
+    if (lock.isHistoryRecoveryPending) return true;
+
+    const pendingLock = this.data?.pendingLocks?.find(record => record.uuid === lock.uuid);
+    if (pendingLock?.isHistoryRecoveryPending) return true;
+
+    return Object.values(this.data?.locksByUtxoId ?? {}).some(record => {
+      return record.uuid === lock.uuid && !!record.isHistoryRecoveryPending;
+    });
+  }
+
+  private waitForHistoryRecovery(lock: Pick<IBitcoinLockRecord, 'uuid'>): Promise<void> | undefined {
+    if (!this.isHistoryRecoveryPendingForLock(lock)) return;
+
+    this.#historyRecoveryWaitersByUuid[lock.uuid] ??= createDeferred<void>();
+    return this.#historyRecoveryWaitersByUuid[lock.uuid].promise;
+  }
+
+  private resumeAfterHistoryRecovery(locks: IBitcoinLockRecord[]): void {
+    for (const lock of locks) {
+      this.#historyRecoveryWaitersByUuid[lock.uuid]?.resolve();
+      delete this.#historyRecoveryWaitersByUuid[lock.uuid];
+    }
+    if (!locks.length) return;
+
+    this.#needsLoadReconciliation = true;
+    void this.#blockQueue
+      .add(async () => this.runPendingLoadReconciliation())
+      .promise.catch(error =>
+        console.warn('[BitcoinLocks] Unable to resume reconciliation after history recovery', error),
+      );
   }
 
   private async buildMismatchAcceptTx(args: {

--- a/src-vue/lib/db/BitcoinLocksTable.ts
+++ b/src-vue/lib/db/BitcoinLocksTable.ts
@@ -29,6 +29,7 @@ export class BitcoinLocksTable extends BaseTable {
       'releaseCompensationMicrogons',
       'btcPriceAtRemovalMicrogons',
     ],
+    boolean: ['isHistoryRecoveryPending'],
     json: ['lockDetails', 'ratchets', 'relayMetadataJson', 'blockExtrinsicErrorJson'],
     date: ['removalBlockTime', 'createdAt', 'updatedAt'],
   };
@@ -179,6 +180,13 @@ export class BitcoinLocksTable extends BaseTable {
     );
     if (rawRecords.length === 0) return undefined;
     return this.toLockRecord(rawRecords[0]);
+  }
+
+  public async setHistoryRecoveryPending(uuid: string, isPending: boolean): Promise<void> {
+    await this.db.execute(
+      'UPDATE BitcoinLocks SET isHistoryRecoveryPending = ? WHERE uuid = ?',
+      toSqlParams([isPending, uuid]),
+    );
   }
 
   public async fetchAll(): Promise<IBitcoinLockRecord[]> {

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -16,11 +16,15 @@ export class BitcoinLockRecovery {
   private readonly blockWatch: BlockWatch;
   private readonly currency: Pick<Currency, 'fetchMainchainRatesAtBlock'>;
   private readonly locksByUtxoId: Record<number, IBitcoinLockRecord>;
+  private readonly pendingLocks: IBitcoinLockRecord[];
+  private readonly waitForLockIdle: (lock: IBitcoinLockRecord) => Promise<void>;
+  private readonly onHistoryRecoveryComplete: (locks: IBitcoinLockRecord[]) => void;
   private readonly utxoTracking: Pick<
     BitcoinUtxoTracking,
     'getAcceptedFundingRecordForLock' | 'setAcceptedFundingRecordForLock' | 'setReleaseRequest' | 'upsertUtxoRecord'
   >;
-  private readonly replayedLockIds = new Set<number>();
+  private historyReplayLocksByUtxoId?: Record<number, IBitcoinLockRecord>;
+  private readonly historyRecoveryPendingUtxoIds = new Set<number>();
   private readonly insertPending: (
     details: Pick<IBitcoinLockRecord, 'uuid' | 'satoshis' | 'vaultId' | 'hdPath'>,
   ) => Promise<IBitcoinLockRecord>;
@@ -36,6 +40,9 @@ export class BitcoinLockRecovery {
     blockWatch: BlockWatch;
     currency: Pick<Currency, 'fetchMainchainRatesAtBlock'>;
     locksByUtxoId: Record<number, IBitcoinLockRecord>;
+    pendingLocks: IBitcoinLockRecord[];
+    waitForLockIdle: BitcoinLockRecovery['waitForLockIdle'];
+    onHistoryRecoveryComplete: BitcoinLockRecovery['onHistoryRecoveryComplete'];
     utxoTracking: BitcoinLockRecovery['utxoTracking'];
     insertPending: BitcoinLockRecovery['insertPending'];
     getTable: () => Promise<BitcoinLocksTable>;
@@ -46,6 +53,9 @@ export class BitcoinLockRecovery {
     this.blockWatch = args.blockWatch;
     this.currency = args.currency;
     this.locksByUtxoId = args.locksByUtxoId;
+    this.pendingLocks = args.pendingLocks;
+    this.waitForLockIdle = args.waitForLockIdle;
+    this.onHistoryRecoveryComplete = args.onHistoryRecoveryComplete;
     this.utxoTracking = args.utxoTracking;
     this.insertPending = args.insertPending;
     this.getTable = args.getTable;
@@ -53,9 +63,57 @@ export class BitcoinLockRecovery {
     this.trackDerivedBitcoinLockKey = args.trackDerivedBitcoinLockKey;
   }
 
+  public beginHistoryReplay(): void {
+    if (this.historyReplayLocksByUtxoId) throw new Error('Bitcoin lock history replay is already running');
+
+    this.historyReplayLocksByUtxoId = {};
+    for (const lock of Object.values(this.locksByUtxoId)) {
+      if (lock.isHistoryRecoveryPending && lock.utxoId !== undefined) {
+        this.historyRecoveryPendingUtxoIds.add(lock.utxoId);
+      }
+    }
+  }
+
+  public async commitHistoryReplay(isComplete = true): Promise<void> {
+    const stagedLocks = this.historyReplayLocksByUtxoId;
+    if (!stagedLocks) return;
+
+    if (!isComplete) {
+      this.historyReplayLocksByUtxoId = undefined;
+      for (const recovered of Object.values(stagedLocks)) this.applyRecoveredRecord(recovered);
+      return;
+    }
+
+    const recoveredLocks = [...this.historyRecoveryPendingUtxoIds]
+      .map(utxoId => stagedLocks[utxoId] ?? this.locksByUtxoId[utxoId])
+      .filter(lock => !!lock);
+    const table = await this.getTable();
+    await Promise.all(recoveredLocks.map(lock => table.setHistoryRecoveryPending(lock.uuid, false)));
+
+    this.historyReplayLocksByUtxoId = undefined;
+    for (const recovered of Object.values(stagedLocks)) this.applyRecoveredRecord(recovered);
+    const completedLocks: IBitcoinLockRecord[] = [];
+    for (const lock of recoveredLocks) {
+      const liveLock = this.locksByUtxoId[lock.utxoId!];
+      if (!liveLock) continue;
+
+      const pendingIndex = this.pendingLocks.findIndex(pending => pending.uuid === liveLock.uuid);
+      if (pendingIndex >= 0) this.pendingLocks.splice(pendingIndex, 1);
+      delete liveLock.isHistoryRecoveryPending;
+      completedLocks.push(liveLock);
+    }
+    this.historyRecoveryPendingUtxoIds.clear();
+    this.onHistoryRecoveryComplete(completedLocks);
+  }
+
+  public cancelHistoryReplay(): void {
+    this.historyReplayLocksByUtxoId = undefined;
+  }
+
   public async recoverBlock(
     block: IBlockHeaderInfo,
     eventRecords: readonly BitcoinRecoveryEventRecord[],
+    options: { lockQueueOwnerUuid?: string } = {},
   ): Promise<void> {
     const api = await this.blockWatch.getApi(block);
     const table = await this.getTable();
@@ -70,33 +128,39 @@ export class BitcoinLockRecovery {
 
       const utxoId = this.readUtxoId(event, block);
       if (isBitcoinMint && utxoId === undefined) {
-        if (readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.vaultingAddress) continue;
+        if (readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.defaultArgonAddress)
+          continue;
 
-        const candidateIds = new Set([...this.replayedLockIds, ...Object.keys(this.locksByUtxoId).map(Number)]);
+        const candidateIds = new Set([
+          ...Object.keys(this.locksByUtxoId).map(Number),
+          ...Object.keys(this.historyReplayLocksByUtxoId ?? {}).map(Number),
+        ]);
         for (const recoveryId of candidateIds) {
-          const record = this.locksByUtxoId[recoveryId];
-          if (record) await this.reconcilePendingMint(record, api, table);
+          const record = this.getRecoveryLock(recoveryId);
+          if (record) await this.reconcilePendingMint(record, api, table, options.lockQueueOwnerUuid);
         }
         continue;
       }
       if (utxoId === undefined) continue;
       if (
-        (isBitcoinMint || event.method === 'BitcoinLockRatcheted') &&
-        readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.vaultingAddress
+        (isBitcoinMint || event.method === 'BitcoinLockCreated' || event.method === 'BitcoinLockRatcheted') &&
+        readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.defaultArgonAddress
       ) {
         continue;
       }
 
-      if (event.method === 'BitcoinLockCreated') {
-        if (readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.vaultingAddress) continue;
+      const liveRecord = this.locksByUtxoId[utxoId];
+      if (liveRecord) await this.prepareHistoryRecoveryLock(liveRecord, options.lockQueueOwnerUuid);
 
+      if (event.method === 'BitcoinLockCreated') {
         const chainLock = await BitcoinLock.get(api, utxoId);
         if (!chainLock) throw new Error(`Bitcoin lock ${utxoId} is unavailable at its creation block`);
         chainLock.couponFeesPaid = bigIntMax(chainLock.couponFeesPaid, this.readUnchargedSecurityFee(event, block));
 
         // Restart replay from durable state rather than a stale in-memory observation.
         const persistedRecord = await table.getByUtxoId(utxoId);
-        const existing = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.locksByUtxoId[utxoId];
+        if (persistedRecord) await this.prepareHistoryRecoveryLock(persistedRecord, options.lockQueueOwnerUuid);
+        const existing = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.getRecoveryLock(utxoId);
         if (existing) {
           if (existing.ratchets.length) {
             const creationRatchetIndex = existing.ratchets.findIndex(
@@ -136,7 +200,6 @@ export class BitcoinLockRecovery {
               await table.saveRecoveredHistory(recovered, new Date(block.blockTime));
               this.applyRecoveredRecord(recovered);
             }
-            this.replayedLockIds.add(utxoId);
             continue;
           }
         }
@@ -146,6 +209,7 @@ export class BitcoinLockRecovery {
           lock: chainLock,
           createdAtArgonBlockHeight: block.blockNumber,
           finalFee: transactionFee,
+          lockQueueOwnerUuid: options.lockQueueOwnerUuid,
         });
         const recovered = this.createDetachedRecord(record);
         recovered.status = BitcoinLockStatus.LockPendingFunding;
@@ -171,12 +235,12 @@ export class BitcoinLockRecovery {
         this.assertSafePendingMint(recovered);
         await table.saveRecoveredHistory(recovered, new Date(block.blockTime));
         this.applyRecoveredRecord(recovered);
-        this.replayedLockIds.add(utxoId);
         continue;
       }
 
-      const persistedRecord = this.locksByUtxoId[utxoId] ? undefined : await table.getByUtxoId(utxoId);
-      const record = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.locksByUtxoId[utxoId];
+      const persistedRecord = this.getRecoveryLock(utxoId) ? undefined : await table.getByUtxoId(utxoId);
+      if (persistedRecord) await this.prepareHistoryRecoveryLock(persistedRecord, options.lockQueueOwnerUuid);
+      const record = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.getRecoveryLock(utxoId);
       if (!record) {
         // Release events only identify a UTXO, and the indexer returns the full block selected for this account.
         // An unrelated account's release can therefore appear beside owned activity without an ownership field.
@@ -269,10 +333,17 @@ export class BitcoinLockRecovery {
     lock: BitcoinLock;
     createdAtArgonBlockHeight: number;
     finalFee: bigint;
+    lockQueueOwnerUuid?: string;
   }): Promise<IBitcoinLockRecord> {
+    const liveRecord = this.locksByUtxoId[args.lock.utxoId];
+    if (this.historyReplayLocksByUtxoId && liveRecord) {
+      await this.prepareHistoryRecoveryLock(liveRecord, args.lockQueueOwnerUuid);
+    }
+
     const table = await this.getTable();
     const existing = await table.getByUtxoId(args.lock.utxoId);
     if (existing) {
+      await this.prepareHistoryRecoveryLock(existing, args.lockQueueOwnerUuid);
       return this.applyRecoveredRecord(existing);
     }
 
@@ -296,6 +367,7 @@ export class BitcoinLockRecovery {
         finalFee: args.finalFee,
       });
     }
+    await this.prepareHistoryRecoveryLock(record, args.lockQueueOwnerUuid);
     return this.applyRecoveredRecord(record);
   }
 
@@ -304,11 +376,11 @@ export class BitcoinLockRecovery {
     const missing: number[] = [];
 
     for (const [storageKey, lockOption] of chainLocks) {
-      if (lockOption.isNone || lockOption.unwrap().ownerAccount.toString() !== this.walletKeys.vaultingAddress)
+      if (lockOption.isNone || lockOption.unwrap().ownerAccount.toString() !== this.walletKeys.defaultArgonAddress)
         continue;
 
       const utxoId = storageKey.args[0].toNumber();
-      const record = this.locksByUtxoId[utxoId];
+      const record = this.getRecoveryLock(utxoId);
       const chainLock = lockOption.unwrap();
       if (
         !record ||
@@ -447,15 +519,45 @@ export class BitcoinLockRecovery {
   }
 
   private applyRecoveredRecord(recovered: IBitcoinLockRecord): IBitcoinLockRecord {
-    const current = this.locksByUtxoId[recovered.utxoId!];
+    const utxoId = recovered.utxoId!;
+    const stagedLocks = this.historyReplayLocksByUtxoId;
+    if (stagedLocks) {
+      recovered.isHistoryRecoveryPending = true;
+      this.historyRecoveryPendingUtxoIds.add(utxoId);
+    }
+    const liveRecord = this.locksByUtxoId[utxoId];
+    const current =
+      stagedLocks?.[utxoId] ?? (stagedLocks && liveRecord ? this.createDetachedRecord(liveRecord) : liveRecord);
     if (current) {
       recovered.fundingUtxoRecord ??= current.fundingUtxoRecord;
       Object.assign(current, recovered);
+      if (stagedLocks) stagedLocks[utxoId] = current;
       return current;
     }
 
-    this.locksByUtxoId[recovered.utxoId!] = recovered;
+    if (stagedLocks) stagedLocks[utxoId] = recovered;
+    else this.locksByUtxoId[utxoId] = recovered;
     return recovered;
+  }
+
+  private getRecoveryLock(utxoId: number): IBitcoinLockRecord | undefined {
+    return this.historyReplayLocksByUtxoId?.[utxoId] ?? this.locksByUtxoId[utxoId];
+  }
+
+  private async prepareHistoryRecoveryLock(lock: IBitcoinLockRecord, lockQueueOwnerUuid?: string): Promise<void> {
+    if (!this.historyReplayLocksByUtxoId) return;
+
+    const utxoId = lock.utxoId;
+    if (utxoId === undefined || this.historyRecoveryPendingUtxoIds.has(utxoId)) return;
+
+    const table = await this.getTable();
+    await table.setHistoryRecoveryPending(lock.uuid, true);
+
+    lock.isHistoryRecoveryPending = true;
+    const pendingLock = this.pendingLocks.find(record => record.uuid === lock.uuid);
+    if (pendingLock) pendingLock.isHistoryRecoveryPending = true;
+    this.historyRecoveryPendingUtxoIds.add(utxoId);
+    if (lock.uuid !== lockQueueOwnerUuid) await this.waitForLockIdle(lock);
   }
 
   private hasCompleteRatchetEconomics(
@@ -565,7 +667,6 @@ export class BitcoinLockRecovery {
     const payer = readRequiredEventField(feeEvent, 'who', block).toString();
     const ownedAccounts = new Set([
       this.walletKeys.defaultArgonAddress,
-      this.walletKeys.vaultingAddress,
       this.walletKeys.miningBotAddress,
       this.walletKeys.operationalAddress,
     ]);
@@ -621,17 +722,20 @@ export class BitcoinLockRecovery {
     record: IBitcoinLockRecord,
     api: ApiDecoration<'promise'>,
     table: BitcoinLocksTable,
+    lockQueueOwnerUuid?: string,
   ): Promise<void> {
     const recovered = this.createDetachedRecord(record);
     const chainPendingMints = await new BitcoinLock(recovered.lockDetails).findPendingMints(api);
     const chainPendingMint = chainPendingMints.reduce((sum, amount) => sum + amount, 0n);
     const recoveredPendingMint = recovered.ratchets.reduce((sum, ratchet) => sum + ratchet.mintPending, 0n);
     if (chainPendingMint > recoveredPendingMint) {
+      await this.prepareHistoryRecoveryLock(record, lockQueueOwnerUuid);
       throw new Error(`Bitcoin lock ${record.utxoId} pending mint exceeds recovered history`);
     }
     this.assertSafePendingMint(recovered);
     if (chainPendingMint === recoveredPendingMint) return;
 
+    await this.prepareHistoryRecoveryLock(record, lockQueueOwnerUuid);
     let fulfilled = recoveredPendingMint - chainPendingMint;
     for (const ratchet of recovered.ratchets) {
       if (fulfilled <= 0n) break;

--- a/src-vue/lib/recovery/Scheduler.ts
+++ b/src-vue/lib/recovery/Scheduler.ts
@@ -84,9 +84,9 @@ export class FinalizedHistoryScheduler {
           Math.min(reachedBlockNumber, finalizedBlockNumber),
         );
       } catch (error) {
-        if (this.retryAttempts < 3 && isRetryableHistoryRecoveryError(error)) {
+        if (isRetryableHistoryRecoveryError(error)) {
           this.retryAttempts += 1;
-          nextDelayMs = this.delayMs * 2 ** (this.retryAttempts - 1);
+          nextDelayMs = this.delayMs * 2 ** Math.min(this.retryAttempts - 1, 2);
         }
         if (surfaceError) throw error;
       } finally {

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -75,7 +75,7 @@ const earliestSupportedSpecVersions: Record<IFinancialHistoryDomain, number> = {
   vaulting: 116,
 };
 const historyRecoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {
-  bitcoin: 1,
+  bitcoin: 2,
   bonds: 1,
 };
 
@@ -119,8 +119,11 @@ export async function restoreFinancialHistory(args: {
   args.onProgress?.(0);
   for (const domain of domainsToRestore) {
     const checkpoint = domainCheckpoints[domain];
+    const isBitcoinReplay = domain === 'bitcoin' && !!bitcoinLockRecovery;
 
     try {
+      if (isBitcoinReplay) bitcoinLockRecovery.beginHistoryReplay();
+
       const result = await restoreFinancialHistoryDomain({
         db,
         blockWatch,
@@ -146,6 +149,9 @@ export async function restoreFinancialHistory(args: {
         if (recoveryVersion !== undefined) recoveryVersions[enabledDomain] = recoveryVersion;
       }
 
+      if (isBitcoinReplay) {
+        await bitcoinLockRecovery.commitHistoryReplay(result.checkpoint.asOfBlock >= targetBlock);
+      }
       await db.syncStateTable.upsert(SyncStateKeys.FinancialHistory, {
         accountId,
         asOfBlock: aggregateAsOfBlock,
@@ -157,6 +163,7 @@ export async function restoreFinancialHistory(args: {
         domainCheckpoints,
       });
     } catch (error) {
+      if (isBitcoinReplay) bitcoinLockRecovery.cancelHistoryReplay();
       recoveryErrors.push(error instanceof Error ? error.message : `Unable to restore ${domain} history`);
     }
   }

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -196,7 +196,7 @@ const securityFee = Vue.ref(0n);
 const hasEditedAmounts = Vue.ref(false);
 
 const isVaultOperator = Vue.computed(() => {
-  return walletKeys.vaultingAddress === props.vault.operatorAccountId;
+  return walletKeys.defaultArgonAddress === props.vault.operatorAccountId;
 });
 
 const hasCouponForVault = Vue.computed(() => {

--- a/src-vue/stores/certificationController.ts
+++ b/src-vue/stores/certificationController.ts
@@ -214,7 +214,7 @@ export const useCertificationController = defineStore('certificationController',
 
   const certificationStepCount = allCertificationStepIds.length;
   const hasBitcoinFundingSeenOnBitcoin = Vue.computed(() => {
-    return Object.values(bitcoinLocks.data.locksByUtxoId).some(lock => {
+    return bitcoinLocks.getAllLocks().some(lock => {
       const fundingRecord =
         bitcoinLocks.getAcceptedFundingRecord(lock) ??
         lock.fundingUtxoRecord ??
@@ -257,7 +257,7 @@ export const useCertificationController = defineStore('certificationController',
     );
   });
   const hasCompletedOwnBitcoinLock = Vue.computed(() => {
-    const completedOwnBitcoinLockAmount = Object.values(bitcoinLocks.data.locksByUtxoId).reduce((total, lock) => {
+    const completedOwnBitcoinLockAmount = bitcoinLocks.getAllLocks().reduce((total, lock) => {
       if (lock.lockDetails.ownerAccount !== walletKeys.defaultArgonAddress) return total;
       if (
         ![


### PR DESCRIPTION
## Summary

- Quarantine only the Bitcoin locks touched by historical replay until their canonical history is committed
- Hide recovering locks from actions, alerts, financial totals, and certification state
- Serialize recovery with each lock's transaction queue without blocking startup or regular Bitcoin syncing
- Preserve recovery state across partial or failed runs and resume pending transaction and relay work afterward

## Context

Older and settled Bitcoin locks could briefly appear in intermediate lifecycle states during history recovery, producing invalid actions, alerts, and portfolio values. Recovery work could also wait on startup processing in a cycle. This keeps interim records unpublished and lets unrelated locks and application startup continue normally.