### PR TITLE
fix: recover inconsistent account state

### DIFF
--- a/src-tauri/migrations/28-bitcoin-reused-hd-path/up.sql
+++ b/src-tauri/migrations/28-bitcoin-reused-hd-path/up.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idxBitcoinLocksHdPath;
+
+CREATE UNIQUE INDEX idxBitcoinLocksHdPath ON BitcoinLocks (hdPath) WHERE utxoId IS NULL;

--- a/src-vue/__test__/BitcoinHdPathMigration.test.ts
+++ b/src-vue/__test__/BitcoinHdPathMigration.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { readdir, readFile } from 'node:fs/promises';
+import Path from 'node:path';
+import { TestSqliteDb } from './helpers/db.ts';
+
+const MIGRATIONS_DIR = Path.resolve(__dirname, '../../src-tauri/migrations');
+
+describe('28-bitcoin-reused-hd-path migration', () => {
+  it('allows historical locks to share an owner key while keeping pending locks unique', async () => {
+    const db = new TestSqliteDb(':memory:');
+
+    try {
+      const migrationDirs = (await readdir(MIGRATIONS_DIR)).sort();
+      for (const migrationDir of migrationDirs.filter(x => x < '28-bitcoin-reused-hd-path')) {
+        await db.exec(await readFile(Path.join(MIGRATIONS_DIR, migrationDir, 'up.sql'), 'utf8'));
+      }
+
+      const insertLock = async (uuid: string, utxoId: number) => {
+        await db.run(
+          `INSERT INTO BitcoinLocks (uuid, status, utxoId, satoshis, cosignVersion, network, hdPath, vaultId)
+           VALUES (?, 'Released', ?, 10000, 'v1', 'bitcoin', ?, 17)`,
+          [uuid, utxoId, "m/1018'/0'/17'/0/1'"],
+        );
+      };
+
+      await insertLock('old-lock', 26);
+      await expect(insertLock('current-lock', 41)).rejects.toThrow();
+
+      await db.exec(await readFile(Path.join(MIGRATIONS_DIR, '28-bitcoin-reused-hd-path', 'up.sql'), 'utf8'));
+      await insertLock('current-lock', 41);
+
+      const locks = await db.all<{ uuid: string; utxoId: number }[]>(
+        'SELECT uuid, utxoId FROM BitcoinLocks ORDER BY utxoId',
+      );
+      expect(locks).toEqual([
+        { uuid: 'old-lock', utxoId: 26 },
+        { uuid: 'current-lock', utxoId: 41 },
+      ]);
+
+      const insertPendingLock = async (uuid: string) => {
+        await db.run(
+          `INSERT INTO BitcoinLocks (uuid, status, satoshis, cosignVersion, network, hdPath, vaultId)
+           VALUES (?, 'LockIsProcessingOnArgon', 10000, 'v1', 'bitcoin', ?, 17)`,
+          [uuid, "m/1018'/0'/17'/0/2'"],
+        );
+      };
+
+      await insertPendingLock('pending-lock');
+      await expect(insertPendingLock('duplicate-pending-lock')).rejects.toThrow();
+    } finally {
+      await db.close();
+    }
+  });
+});

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -411,7 +411,22 @@ describe('BitcoinLocks recovery', () => {
       status: BitcoinLockStatus.LockPendingFunding,
       createdAt: '2026-01-01T00:00:00Z',
     });
-    record.lockDetails = createdLock;
+    record.lockDetails = new BitcoinLock({
+      ...createHistoricalLock({ accountId, liquidityPromised: 9_000n }),
+      utxoId: 41,
+    });
+    record.ratchets = [
+      {
+        mintAmount: 9_000n,
+        mintPending: 9_000n,
+        lockedTargetPrice: 1_000n,
+        securityFee: 20n,
+        txFee: 56_584n,
+        burned: 0n,
+        blockHeight: 583_481,
+        oracleBitcoinBlockHeight: 500,
+      },
+    ];
     store.data.locksByUtxoId[7] = record;
     const table = {
       getByUtxoId: vi.fn().mockResolvedValueOnce(undefined).mockResolvedValue(record),
@@ -532,6 +547,7 @@ describe('BitcoinLocks recovery', () => {
 
     const recovered = store.data.locksByUtxoId[7];
     expect(recovered).toBe(record);
+    expect(recovered.lockDetails.utxoId).toBe(7);
     expect(recovered.ratchets).toEqual([
       expect.objectContaining({ mintAmount: 1_000n, mintPending: 0n, txFee: 11n, extrinsicIndex: 2 }),
       expect.objectContaining({ mintAmount: 200n, mintPending: 0n, burned: 50n, txFee: 13n, extrinsicIndex: 2 }),
@@ -649,7 +665,7 @@ describe('BitcoinLocks recovery', () => {
     let saveAttempt = 0;
     const table = {
       getByUtxoId: vi.fn(async () => durable),
-      findLockByHdPath: vi.fn(async () => pending),
+      findPendingByHdPath: vi.fn(async () => pending),
       finalizePending: vi.fn(async () => {
         durable = {
           ...pending,

--- a/src-vue/__test__/BitcoinLocksTable.test.ts
+++ b/src-vue/__test__/BitcoinLocksTable.test.ts
@@ -19,7 +19,7 @@ async function createPendingLock(overrides: Partial<IBitcoinLockRecord> = {}) {
 }
 
 describe('BitcoinLocksTable', () => {
-  it('treats repeated finalizePending for the same utxo as idempotent', async () => {
+  it('finalizes idempotently and finds a new pending lock that reuses the owner key', async () => {
     const { table, lock } = await createPendingLock({ uuid: 'finalize-idempotent' });
 
     const bitcoinLock = {
@@ -42,11 +42,21 @@ describe('BitcoinLocksTable', () => {
       createdAtArgonBlockHeight: 12,
       finalFee: 2n,
     });
+    const next = await table.insertPending({
+      uuid: 'same-owner-next-lock',
+      status: BitcoinLockStatus.LockIsProcessingOnArgon,
+      satoshis: lock.satoshis,
+      cosignVersion: lock.cosignVersion,
+      network: lock.network,
+      hdPath: lock.hdPath,
+      vaultId: lock.vaultId,
+    });
 
     expect(first.utxoId).toBe(7);
     expect(second.utxoId).toBe(7);
     expect(second.status).toBe(BitcoinLockStatus.LockPendingFunding);
     expect(second.ratchets[0]).toEqual(expect.objectContaining({ blockHeight: 12 }));
+    expect(await table.findPendingByHdPath(lock.hdPath)).toMatchObject({ uuid: next.uuid, utxoId: null });
   });
 
   it('persists release economics separately from the terminal removal mark', async () => {

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -290,9 +290,9 @@ describe('FinancialHistoryImporter', () => {
       SyncStateKeys.FinancialHistory,
       expect.objectContaining({
         asOfBlock: 100,
-        recoveryVersions: { bitcoin: 2 },
+        recoveryVersions: { bitcoin: 3 },
         domainCheckpoints: {
-          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 2 },
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
         },
       }),
     );

--- a/src-vue/__test__/Financials.test.ts
+++ b/src-vue/__test__/Financials.test.ts
@@ -725,12 +725,29 @@ describe('financial position accounting', () => {
       }),
       createWalletTransfer({
         id: 2,
+        amount: -5_000_000n,
+        otherParty: '5legacy',
+        isInternal: true,
+        blockNumber: 100,
+        blockTime: committedAt,
+      }),
+      createWalletTransfer({
+        id: 3,
+        amount: -5_000_000n,
+        otherParty: '5legacy',
+        isInternal: true,
+        blockNumber: 101,
+        blockTime: committedAt,
+      }),
+      createWalletTransfer({
+        id: 4,
+        walletAddress: '5legacy',
         amount: -10_000_000n,
         otherParty: '5miner',
         isInternal: true,
         extrinsicIndex: 2,
         microgonsForArgonot: 3_000_000n,
-        blockNumber: 100,
+        blockNumber: 102,
         blockTime: committedAt,
       }),
     ];
@@ -758,6 +775,12 @@ describe('financial position accounting', () => {
     });
 
     const aggregate = reduceFinancialPositions(readySnapshots([...ordinary, ...mining]));
+    expect(ordinary).toContainEqual(
+      expect.objectContaining({
+        id: 'wallet-holding:transfer:1:exit:4',
+        nativeAmount: 10_000_000n,
+      }),
+    );
     expect(aggregate.groupSummaries.liquid.returnSummary).toMatchObject({
       availability: 'not-applicable',
       investmentPositionCount: 0,
@@ -1567,7 +1590,7 @@ describe('financial position accounting', () => {
     ).rejects.toThrow('ARGN holds exceed reserved balance');
   });
 
-  it('accepts the live vault ARGNOT hold as its committed stake', () => {
+  it('uses live vault holds while subscription data catches up', async () => {
     const registry = getOfflineRegistry();
     const account = createArgonAccount({
       reservedMicrogons: 8n,
@@ -1585,21 +1608,36 @@ describe('financial position accounting', () => {
         }),
       ],
     });
-    const positions = vaultFinancials.createFinancialPositions({
-      hasConfirmedHistoryCoverage: false,
+    const source = new VaultFinancials({
+      load: vi.fn(async () => undefined),
+      createdVault: { vaultId: 10, securitization: 8n, isClosed: false } as Vault,
+      data: {
+        pendingCollectRevenue: 100n,
+        argonotCommitment: { committedMicronots: 500n },
+      },
+      history: {
+        loadPositionHistory: vi.fn(async () => ({ capital: [], revenue: [] })),
+      },
+    } as any);
+    const positions = await source.loadPositions({
+      hasConfirmedHistoryCoverage: true,
       account,
-      liveVault: { vaultId: 10, securitization: 8n, isClosed: false } as Vault,
-      committedMicronots: 400n,
-      uncollectedRevenue: 0n,
       liveArgonotRateMicrogons: 1_000_000n,
     });
 
-    expect(positions).toContainEqual(
-      expect.objectContaining({
-        kind: 'vault-balance',
-        asset: 'ARGNOT',
-        amount: 400n,
-      }),
+    expect(positions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'vault-balance',
+          asset: 'ARGNOT',
+          amount: 400n,
+        }),
+        expect.objectContaining({
+          kind: 'vault',
+          id: 'vault:10',
+          uncollectedRevenue: 0n,
+        }),
+      ]),
     );
   });
 });

--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -1,7 +1,11 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { MoveFrom, MoveTo, MoveToken } from '@argonprotocol/apps-core';
 import { MoveCapital } from '../lib/MoveCapital.ts';
-import { existentialDepositMicrogons, defaultArgonOperationalReserveMicrogons } from '../lib/WalletForArgon.ts';
+import {
+  existentialDepositMicrogons,
+  existentialDepositMicronots,
+  defaultArgonOperationalReserveMicrogons,
+} from '../lib/WalletForArgon.ts';
 import { type IWallet } from '../lib/Wallet.ts';
 import * as MiningAccount from '../lib/MiningAccount.ts';
 import { Config } from '../lib/Config.ts';
@@ -119,7 +123,7 @@ describe('MoveCapital', () => {
     });
   });
 
-  it('keeps the default Argon operational reserve when sweeping to the bot', async () => {
+  it('keeps the default wallet reserves when sweeping to the bot', async () => {
     const { moveCapital, transactionTracker, postProcessMiningBidProxySetupSpy } = createMoveCapital();
     postProcessMiningBidProxySetupSpy.mockRestore();
     const calculateFeeSpy = vi.spyOn(moveCapital, 'calculateFee').mockResolvedValue(5n);
@@ -156,10 +160,10 @@ describe('MoveCapital', () => {
     } as any);
     const wallet = createWallet({
       availableMicrogons: 1_000_050n,
-      availableMicronots: 7n,
+      availableMicronots: existentialDepositMicronots + 7n,
     });
 
-    const result = await moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    const result = await moveCapital.moveConfiguredDefaultArgonToBot(createMiningTransferArgs(wallet));
 
     expect(calculateFeeSpy).toHaveBeenCalledWith(
       MoveFrom.DefaultArgon,
@@ -217,7 +221,7 @@ describe('MoveCapital', () => {
       availableMicrogons: defaultArgonOperationalReserveMicrogons + 2_000_105n,
     });
 
-    await moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    await moveCapital.moveConfiguredDefaultArgonToBot(createMiningTransferArgs(wallet));
 
     expect(buildTransactionSpy).toHaveBeenCalledWith(
       MoveFrom.DefaultArgon,
@@ -244,10 +248,10 @@ describe('MoveCapital', () => {
     transactionTracker.submitAndWatch.mockResolvedValue({} as any);
     const wallet = createWallet({
       availableMicrogons: defaultArgonOperationalReserveMicrogons + 3n,
-      availableMicronots: 4n,
+      availableMicronots: existentialDepositMicronots + 4n,
     });
 
-    await moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    await moveCapital.moveConfiguredDefaultArgonToBot(createMiningTransferArgs(wallet));
 
     expect(calculateFeeSpy).toHaveBeenNthCalledWith(
       1,
@@ -294,10 +298,10 @@ describe('MoveCapital', () => {
     transactionTracker.submitAndWatch.mockResolvedValue({} as any);
     const wallet = createWallet({
       availableMicrogons: defaultArgonOperationalReserveMicrogons + existentialDepositMicrogons + 5n,
-      availableMicronots: 4n,
+      availableMicronots: existentialDepositMicronots + 4n,
     });
 
-    await moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    await moveCapital.moveConfiguredDefaultArgonToBot(createMiningTransferArgs(wallet));
 
     expect(calculateFeeSpy).toHaveBeenNthCalledWith(
       1,
@@ -336,9 +340,12 @@ describe('MoveCapital', () => {
       return 0n;
     });
     const buildTransactionSpy = vi.spyOn(moveCapital, 'buildTransaction');
-    const wallet = createWallet({ availableMicrogons: 10n, availableMicronots: 4n });
+    const wallet = createWallet({
+      availableMicrogons: 10n,
+      availableMicronots: existentialDepositMicronots + 4n,
+    });
 
-    const result = await moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    const result = await moveCapital.moveConfiguredDefaultArgonToBot(createMiningTransferArgs(wallet));
 
     expect(buildTransactionSpy).not.toHaveBeenCalled();
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
@@ -380,9 +387,7 @@ describe('MoveCapital', () => {
     const buildTransactionSpy = vi.spyOn(moveCapital, 'buildTransaction');
 
     const result = await moveCapital.moveConfiguredDefaultArgonToBot(
-      createWallet({ availableMicronots: 4n }),
-      walletKeys,
-      config,
+      createMiningTransferArgs(createWallet({ availableMicronots: existentialDepositMicronots + 4n })),
     );
 
     expect(buildTransactionSpy).not.toHaveBeenCalled();
@@ -393,15 +398,22 @@ describe('MoveCapital', () => {
     });
   });
 
-  it('skips the sweep when there is nothing available to move', async () => {
+  it('skips the sweep when the mining bot already holds the configured requirement', async () => {
     const { moveCapital, transactionTracker } = createMoveCapital();
-    const feeSpy = vi.spyOn(moveCapital, 'calculateFee').mockResolvedValue(0n);
+    const feeSpy = vi.spyOn(moveCapital, 'calculateFee');
     const buildTransactionSpy = vi.spyOn(moveCapital, 'buildTransaction');
+    const defaultWallet = createWallet({
+      availableMicrogons: defaultArgonOperationalReserveMicrogons + 5_000_000n,
+      availableMicronots: existentialDepositMicronots + 5_000_000n,
+    });
+    const miningBotWallet = createWallet({
+      address: 'mining-bot-address',
+      reservedMicrogons: 2_000_000n,
+      reservedMicronots: 1_000_000n,
+    });
 
     const result = await moveCapital.moveConfiguredDefaultArgonToBot(
-      createWallet({ availableMicrogons: defaultArgonOperationalReserveMicrogons }),
-      walletKeys,
-      config,
+      createMiningTransferArgs(defaultWallet, miningBotWallet),
     );
 
     expect(feeSpy).not.toHaveBeenCalled();
@@ -441,11 +453,12 @@ describe('MoveCapital', () => {
     );
     const wallet = createWallet({
       availableMicrogons: defaultArgonOperationalReserveMicrogons + 50n,
-      availableMicronots: 7n,
+      availableMicronots: existentialDepositMicronots + 7n,
     });
 
-    const firstSweep = moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
-    const secondSweep = moveCapital.moveConfiguredDefaultArgonToBot(wallet, walletKeys, config);
+    const transferArgs = createMiningTransferArgs(wallet);
+    const firstSweep = moveCapital.moveConfiguredDefaultArgonToBot(transferArgs);
+    const secondSweep = moveCapital.moveConfiguredDefaultArgonToBot(transferArgs);
 
     await vi.waitFor(() => expect(transactionTracker.submitAndWatch).toHaveBeenCalledOnce());
 
@@ -470,12 +483,12 @@ describe('MoveCapital', () => {
     transactionTracker.getTxAttemptState.mockResolvedValue(TxAttemptState.Follow);
 
     const result = await moveCapital.moveConfiguredDefaultArgonToBot(
-      createWallet({
-        availableMicrogons: defaultArgonOperationalReserveMicrogons + 50n,
-        availableMicronots: 7n,
-      }),
-      walletKeys,
-      config,
+      createMiningTransferArgs(
+        createWallet({
+          availableMicrogons: defaultArgonOperationalReserveMicrogons + 50n,
+          availableMicronots: existentialDepositMicronots + 7n,
+        }),
+      ),
     );
 
     expect(transactionTracker.submitAndWatch).not.toHaveBeenCalled();
@@ -512,12 +525,12 @@ describe('MoveCapital', () => {
     transactionTracker.submitAndWatch.mockResolvedValue(newTxInfo);
 
     const result = await moveCapital.moveConfiguredDefaultArgonToBot(
-      createWallet({
-        availableMicrogons: defaultArgonOperationalReserveMicrogons + 50n,
-        availableMicronots: 7n,
-      }),
-      walletKeys,
-      config,
+      createMiningTransferArgs(
+        createWallet({
+          availableMicrogons: defaultArgonOperationalReserveMicrogons + 50n,
+          availableMicronots: existentialDepositMicronots + 7n,
+        }),
+      ),
     );
 
     expect(transactionTracker.submitAndWatch).toHaveBeenCalledOnce();
@@ -589,5 +602,16 @@ function createWallet(partial: Partial<IWallet>): IWallet {
     fetchErrorMsg: '',
     otherTokens: [],
     ...partial,
+  };
+}
+
+function createMiningTransferArgs(
+  defaultWallet: IWallet,
+  miningBotWallet = createWallet({ address: 'mining-bot-address' }),
+) {
+  return {
+    defaultWallet,
+    miningBotWallet,
+    config,
   };
 }

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -13,6 +13,7 @@ import {
 import { MyVault } from './MyVault.ts';
 import {
   existentialDepositMicrogons,
+  existentialDepositMicronots,
   getSpendableDefaultArgonMicrogons,
   getSpendableMicrogons,
 } from './WalletForArgon.ts';
@@ -108,15 +109,13 @@ export class MoveCapital {
   }
 
   public async moveConfiguredDefaultArgonToBot(
-    wallet: IWallet,
-    walletKeys: WalletKeys,
-    config: Config,
+    args: DefaultArgonMiningTransferArgs,
   ): Promise<DefaultArgonMiningTransferResult> {
     if (pendingDefaultArgonMiningTransferPromise) {
       return await pendingDefaultArgonMiningTransferPromise;
     }
 
-    const sweepPromise = this.moveConfiguredDefaultArgonToBotInner(wallet, walletKeys, config);
+    const sweepPromise = this.moveConfiguredDefaultArgonToBotInner(args);
     pendingDefaultArgonMiningTransferPromise = sweepPromise;
 
     try {
@@ -208,10 +207,10 @@ export class MoveCapital {
   }
 
   private async moveConfiguredDefaultArgonToBotInner(
-    wallet: IWallet,
-    walletKeys: WalletKeys,
-    config: Config,
+    args: DefaultArgonMiningTransferArgs,
   ): Promise<DefaultArgonMiningTransferResult> {
+    const { defaultWallet: wallet, miningBotWallet, config } = args;
+
     await this.transactionTracker.load();
     this.transactionError = '';
 
@@ -245,8 +244,14 @@ export class MoveCapital {
 
     const assetsToMove: IAssetsToMove = {};
     const spendableMicrogons = getSpendableDefaultArgonMicrogons(wallet.availableMicrogons);
-    const requiredMicrogons = config.biddingRules.initialMicrogonRequirement + MINING_BID_PROXY_FEE_FLOAT;
-    const requiredMicronots = config.biddingRules.initialMicronotRequirement;
+    const spendableMicronots = bigIntMax(wallet.availableMicronots - existentialDepositMicronots, 0n);
+    const miningBotMicrogons = miningBotWallet.availableMicrogons + miningBotWallet.reservedMicrogons;
+    const miningBotMicronots = miningBotWallet.availableMicronots + miningBotWallet.reservedMicronots;
+    const requiredMicrogons = bigIntMax(
+      config.biddingRules.initialMicrogonRequirement + MINING_BID_PROXY_FEE_FLOAT - miningBotMicrogons,
+      0n,
+    );
+    const requiredMicronots = bigIntMax(config.biddingRules.initialMicronotRequirement - miningBotMicronots, 0n);
 
     if (spendableMicrogons > 0n && requiredMicrogons > 0n) {
       assetsToMove[MoveToken.ARGN] = bigIntMax(
@@ -254,9 +259,8 @@ export class MoveCapital {
         0n,
       );
     }
-    if (wallet.availableMicronots > 0n && requiredMicronots > 0n) {
-      assetsToMove[MoveToken.ARGNOT] =
-        requiredMicronots < wallet.availableMicronots ? requiredMicronots : wallet.availableMicronots;
+    if (spendableMicronots > 0n && requiredMicronots > 0n) {
+      assetsToMove[MoveToken.ARGNOT] = requiredMicronots < spendableMicronots ? requiredMicronots : spendableMicronots;
     }
     if (!assetsToMove[MoveToken.ARGN] && !assetsToMove[MoveToken.ARGNOT]) {
       return { kind: 'noSpendableFundsToSweep' };
@@ -548,6 +552,12 @@ export interface ITransactionMoveMetadata {
   externalAddress?: string;
   assetsToMove: IAssetsToMove;
 }
+
+type DefaultArgonMiningTransferArgs = {
+  defaultWallet: IWallet;
+  miningBotWallet: IWallet;
+  config: Config;
+};
 
 export type DefaultArgonMiningTransferResult =
   | {

--- a/src-vue/lib/db/BitcoinLocksTable.ts
+++ b/src-vue/lib/db/BitcoinLocksTable.ts
@@ -64,9 +64,9 @@ export class BitcoinLocksTable extends BaseTable {
     return nanoid(5);
   }
 
-  public async findLockByHdPath(hdPath: string): Promise<IBitcoinLockRecord | undefined> {
+  public async findPendingByHdPath(hdPath: string): Promise<IBitcoinLockRecord | undefined> {
     const rawRecords = await this.db.select<IBitcoinLockRecord[]>(
-      'SELECT * FROM BitcoinLocks WHERE hdPath = ?',
+      'SELECT * FROM BitcoinLocks WHERE hdPath = ? AND utxoId IS NULL',
       toSqlParams([hdPath]),
     );
     if (rawRecords.length === 0) return undefined;

--- a/src-vue/lib/financials/MyVault.ts
+++ b/src-vue/lib/financials/MyVault.ts
@@ -32,8 +32,6 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
     return this.createFinancialPositions({
       ...args,
       liveVault,
-      committedMicronots: liveVault ? this.vault.data.argonotCommitment.committedMicronots : 0n,
-      uncollectedRevenue: liveVault ? this.vault.data.pendingCollectRevenue : 0n,
       capitalHistory: history.capital,
       revenueHistory: history.revenue,
     });
@@ -44,16 +42,25 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
       account?: IArgonAccountBalance;
       liveVault?: Vault;
       liveArgonotRateMicrogons?: bigint;
-      committedMicronots?: bigint;
-      uncollectedRevenue?: bigint;
       capitalHistory?: readonly IVaultCapitalHistoryRecord[];
       revenueHistory?: readonly IVaultRevenueEventsRecord[];
     },
   ): VaultPosition[] {
-    const committedMicronots = args.liveVault ? (args.committedMicronots ?? 0n) : 0n;
+    let securitization = args.liveVault?.securitization;
+    let committedMicronots = 0n;
+    let uncollectedRevenue = 0n;
     if (args.liveVault) {
       if (!args.account) throw new Error('Vault operator account is missing from the Argon wallet snapshot');
-      validateVaultHolds(args.account, args.liveVault, args.uncollectedRevenue ?? 0n, committedMicronots);
+
+      securitization = args.account.microgonHolds
+        .filter(hold => hold.id.isVaults && hold.id.asVaults.isEnterVault)
+        .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
+      uncollectedRevenue = args.account.microgonHolds
+        .filter(hold => hold.id.isVaults && hold.id.asVaults.isPendingCollect)
+        .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
+      committedMicronots = args.account.micronotHolds
+        .filter(hold => hold.id.isVaults && (hold.id.asVaults.isEnterVault || hold.id.asVaults.isPendingCollect))
+        .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
     }
 
     const capitalHistory = args.capitalHistory ?? [];
@@ -65,9 +72,8 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
     if (!args.liveVault && !hasClosed) return [];
 
     const revenueHistory = args.revenueHistory ?? [];
-    const uncollectedRevenue = args.liveVault ? (args.uncollectedRevenue ?? 0n) : 0n;
     const value = calculateVaultPositionValue({
-      securitization: args.liveVault?.securitization,
+      securitization,
       uncollectedRevenue,
       capitalHistory: vaultCapitalHistory,
       collectedRevenue: revenueHistory,
@@ -92,7 +98,7 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
           endedAt: lifecycle === 'completed' ? finalCapitalEvent?.blockTime : undefined,
           vaultId,
           vault: args.liveVault,
-          securitization: args.liveVault?.securitization ?? value.remainingPrincipal,
+          securitization: securitization ?? value.remainingPrincipal,
           uncollectedRevenue,
           capitalHistory: vaultCapitalHistory,
           revenueHistory,
@@ -118,29 +124,5 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
     }
 
     return positions;
-  }
-}
-
-function validateVaultHolds(
-  account: IArgonAccountBalance,
-  vault: Vault,
-  uncollectedRevenue: bigint,
-  committedMicronots: bigint,
-): void {
-  const enterVaultHolds = account.microgonHolds
-    .filter(hold => hold.id.isVaults && hold.id.asVaults.isEnterVault)
-    .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
-  const pendingCollectHolds = account.microgonHolds
-    .filter(hold => hold.id.isVaults && hold.id.asVaults.isPendingCollect)
-    .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
-  const micronotVaultHolds = account.micronotHolds
-    .filter(hold => hold.id.isVaults && (hold.id.asVaults.isEnterVault || hold.id.asVaults.isPendingCollect))
-    .reduce((sum, hold) => sum + hold.amount.toBigInt(), 0n);
-
-  if (enterVaultHolds !== vault.securitization) {
-    throw new Error('Vault capital holds do not match current securitization');
-  }
-  if (pendingCollectHolds !== uncollectedRevenue || micronotVaultHolds !== committedMicronots) {
-    throw new Error('Vault revenue holds do not match pending collect revenue');
   }
 }

--- a/src-vue/lib/financials/WalletBalances.ts
+++ b/src-vue/lib/financials/WalletBalances.ts
@@ -143,7 +143,18 @@ export class WalletFinancials
       }
 
       if (!transfer.isInternal || transfer.otherParty === miningBotAddress) {
-        for (const lot of lots) completedPositions.push(createCompletedWalletHoldingPosition(lot, transfer));
+        const completedLotsById = new Map<string, ArgonotHoldingLot>();
+        for (const lot of lots) {
+          const existing = completedLotsById.get(lot.id);
+          if (existing) {
+            existing.amount += lot.amount;
+          } else {
+            completedLotsById.set(lot.id, { ...lot });
+          }
+        }
+        for (const lot of completedLotsById.values()) {
+          completedPositions.push(createCompletedWalletHoldingPosition(lot, transfer));
+        }
         continue;
       }
 

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -160,7 +160,11 @@ export class BitcoinLockRecovery {
         // Restart replay from durable state rather than a stale in-memory observation.
         const persistedRecord = await table.getByUtxoId(utxoId);
         if (persistedRecord) await this.prepareHistoryRecoveryLock(persistedRecord, options.lockQueueOwnerUuid);
-        const existing = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.getRecoveryLock(utxoId);
+        let existing = persistedRecord ? this.applyRecoveredRecord(persistedRecord) : this.getRecoveryLock(utxoId);
+        if (existing?.lockDetails.utxoId !== undefined && existing.lockDetails.utxoId !== utxoId) {
+          existing = this.createDetachedRecord(existing);
+          existing.ratchets = [];
+        }
         if (existing) {
           if (existing.ratchets.length) {
             const creationRatchetIndex = existing.ratchets.findIndex(
@@ -205,12 +209,14 @@ export class BitcoinLockRecovery {
         }
 
         const transactionFee = this.readTransactionFee(eventRecords, eventIndex, block) ?? 0n;
-        const record = await this.recoverLock({
-          lock: chainLock,
-          createdAtArgonBlockHeight: block.blockNumber,
-          finalFee: transactionFee,
-          lockQueueOwnerUuid: options.lockQueueOwnerUuid,
-        });
+        const record =
+          existing ??
+          (await this.recoverLock({
+            lock: chainLock,
+            createdAtArgonBlockHeight: block.blockNumber,
+            finalFee: transactionFee,
+            lockQueueOwnerUuid: options.lockQueueOwnerUuid,
+          }));
         const recovered = this.createDetachedRecord(record);
         recovered.status = BitcoinLockStatus.LockPendingFunding;
         recovered.satoshis = chainLock.satoshis;
@@ -350,7 +356,7 @@ export class BitcoinLockRecovery {
     const derivedPubkey = await this.findDerivedPubkeyForOwner(args.lock.vaultId, args.lock.ownerPubkey);
     if (!derivedPubkey) throw new Error(`Unable to recover the HD path for Bitcoin lock ${args.lock.utxoId}`);
 
-    let record = await table.findLockByHdPath(derivedPubkey.hdPath);
+    let record = await table.findPendingByHdPath(derivedPubkey.hdPath);
     if (!record) {
       record = await this.insertPending({
         uuid: BitcoinLocksTable.createUuid(),

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -75,7 +75,7 @@ const earliestSupportedSpecVersions: Record<IFinancialHistoryDomain, number> = {
   vaulting: 116,
 };
 const historyRecoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {
-  bitcoin: 2,
+  bitcoin: 3,
   bonds: 1,
 };
 

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -236,11 +236,11 @@ async function ensureTrackedSetupTransfer(force = false) {
   lastEnsureSetupTransferAt = now;
 
   try {
-    const sweepResult = await moveCapital.moveConfiguredDefaultArgonToBot(
-      wallets.defaultArgonWallet,
-      walletKeys,
-      config as Config,
-    );
+    const sweepResult = await moveCapital.moveConfiguredDefaultArgonToBot({
+      defaultWallet: wallets.defaultArgonWallet,
+      miningBotWallet: wallets.miningBotWallet,
+      config: config as Config,
+    });
     if (sweepResult.kind === 'submitted' || sweepResult.kind === 'trackingExisting') {
       trackTxInfo(sweepResult.txInfo);
       return;


### PR DESCRIPTION
## Summary

Accounts with reused Bitcoin owner keys, lagging vault subscriptions, or split wallet lots can now rebuild a consistent financial view after updating instead of losing Bitcoin or vault positions or hitting duplicate-position errors. Mining initialization now funds only the bot's actual shortfall while preserving the default wallet's reserves, so an already-funded miner can finish setup without repeated failed full-balance transfers.

Bitcoin recovery now permits finalized locks to share an HD path, rebuilds overwritten records from chain history, and forces a one-time replay for existing installations. Vault values come from the block-consistent account snapshot, preventing transient subscription lag from hiding the vault.

## Validation

- 77 focused recovery, financial, migration, and mining tests pass.
- Type checking and linting pass.
