### PR TITLE
fix: harden installer readiness and troubleshooting exports

### DIFF
--- a/bot/src/BlockSync.ts
+++ b/bot/src/BlockSync.ts
@@ -718,7 +718,10 @@ export class BlockSync {
 
   private calculateProgress(tick: number | undefined, tickRange: [number, number] | undefined): number {
     if (!tick || !tickRange) return 0;
-    const progress = tick ? (tick - tickRange[0]) / (tickRange[1] - tickRange[0]) : 0;
+    const [startTick, endTick] = tickRange;
+    if (endTick <= startTick) return tick >= endTick ? 100 : 0;
+
+    const progress = Math.min(Math.max((tick - startTick) / (endTick - startTick), 0), 1);
     return Math.round(progress * 10000) / 100;
   }
 }

--- a/bot/src/server.ts
+++ b/bot/src/server.ts
@@ -67,6 +67,14 @@ export class BotServer {
       sendJson(res, bot.isReady);
     });
 
+    app.get('/sync-status', async (_req, res) => {
+      sendJson(res, {
+        isReady: bot.isReady,
+        isSyncing: bot.isSyncing,
+        syncProgress: bot.blockSync?.calculateSyncProgress() ?? 0,
+      });
+    });
+
     app.post('/bitcoin-lock-coupons', express.text({ type: '*/*' }), async (req, res) => {
       await safeJsonRoute(res, async () => {
         const request = requireBody<ICreateBitcoinLockCouponRequest>(req.body);

--- a/router/__test__/RouterServer.test.ts
+++ b/router/__test__/RouterServer.test.ts
@@ -68,6 +68,25 @@ describe('RouterServer', () => {
     mainchainMocks.getClient.mockReset();
   });
 
+  it('publicly exposes the bot sync status', async () => {
+    routerDb = createDb('router-server-bot-sync-status-');
+    const botSyncStatus = {
+      isReady: false,
+      isSyncing: true,
+      syncProgress: 42.5,
+    };
+    const handleBotRequest = vi.fn(() => ({ status: 200, body: botSyncStatus }));
+    const started = await startRouterServer(routerDb, handleBotRequest);
+    routerServer = started.routerServer;
+    botServer = started.botServer;
+
+    const response = await fetch(`http://${started.routerAddress.host}:${started.routerAddress.port}/bot-sync-status`);
+
+    expect(response.status).toBe(200);
+    expect(JsonExt.parse(await response.text())).toEqual(botSyncStatus);
+    expect(handleBotRequest).toHaveBeenCalledWith({ method: 'GET', path: '/sync-status', body: undefined });
+  });
+
   it('rolls back invite rows when coupon creation fails', async () => {
     routerDb = createDb('router-server-create-rollback-');
 
@@ -264,10 +283,9 @@ describe('RouterServer', () => {
         }),
       ],
     ]);
-    const bondLotsByVault = vi.fn().mockResolvedValue([
-      { bondLotId: registry.createType('u64', 1) },
-      { bondLotId: registry.createType('u64', 2) },
-    ]);
+    const bondLotsByVault = vi
+      .fn()
+      .mockResolvedValue([{ bondLotId: registry.createType('u64', 1) }, { bondLotId: registry.createType('u64', 2) }]);
     const bondLotIdsByAccount = vi.fn(async (accountId: string) => {
       const id = accountId === memberOne.address ? 1 : 2;
       return [{ args: [null, registry.createType('u64', id)] }];
@@ -407,17 +425,13 @@ describe('RouterServer', () => {
     routerServer = started.routerServer;
     botServer = started.botServer;
 
-    const response = await requestJson(
-      started.routerAddress,
-      `/invites/${invite.inviteCode}/regenerate`,
-      {
-        vaultId: 12,
-        maxSatoshis: 25_000n,
-        estimatedGiftUsd: 16.25,
-        btcPctFee: 2.5,
-        expiresAfterTicks: 60,
-      },
-    );
+    const response = await requestJson(started.routerAddress, `/invites/${invite.inviteCode}/regenerate`, {
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 16.25,
+      btcPctFee: 2.5,
+      expiresAfterTicks: 60,
+    });
     expect(response.status).toBe(200);
 
     const regeneratedInvite = JsonExt.parse<IInviteResponse>(await response.text()).invite;
@@ -501,21 +515,25 @@ describe('RouterServer', () => {
       btcPctFee: 2.5,
     });
 
-    const started = await startRouterServer(routerDb, request => {
-      if (request.method === 'POST' && request.path === '/bitcoin-lock-coupons/activate') {
-        return {
-          status: 200,
-          body: activatedCoupon,
-        };
-      }
+    const started = await startRouterServer(
+      routerDb,
+      request => {
+        if (request.method === 'POST' && request.path === '/bitcoin-lock-coupons/activate') {
+          return {
+            status: 200,
+            body: activatedCoupon,
+          };
+        }
 
-      return {
-        status: 404,
-        body: { error: 'Not Found' },
-      };
-    }, {
-      adminOperatorAccountId: operator.address,
-    });
+        return {
+          status: 404,
+          body: { error: 'Not Found' },
+        };
+      },
+      {
+        adminOperatorAccountId: operator.address,
+      },
+    );
     routerServer = started.routerServer;
     botServer = started.botServer;
 
@@ -578,7 +596,10 @@ describe('RouterServer', () => {
     expect(authenticatedResponse.status).toBe(200);
 
     const verifyResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/admin`, session.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/admin`,
+        session.sessionId,
+      ),
     );
     expect(verifyResponse.status).toBe(204);
     expect(verifyResponse.headers.get('x-user-id')).toBe(operator.address);
@@ -614,19 +635,28 @@ describe('RouterServer', () => {
 
     const { session } = await login(started.routerAddress, member, UserRole.Member, memberAuth);
     const substrateVerifyResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/substrate`, session.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/substrate`,
+        session.sessionId,
+      ),
     );
     expect(substrateVerifyResponse.status).toBe(204);
     expect(substrateVerifyResponse.headers.get('x-user-id')).toBe(member.address);
     expect(substrateVerifyResponse.headers.get('x-user-role')).toBe(UserRole.Member);
 
     const memberVerifyResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/member`, session.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/member`,
+        session.sessionId,
+      ),
     );
     expect(memberVerifyResponse.status).toBe(204);
 
     const adminVerifyResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/admin`, session.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/auth/verify/admin`,
+        session.sessionId,
+      ),
     );
     expect(adminVerifyResponse.status).toBe(403);
 
@@ -705,12 +735,7 @@ describe('RouterServer', () => {
     botServer = started.botServer;
 
     const { session } = await login(started.routerAddress, member, UserRole.Member, memberAuth);
-    const { session: otherSession } = await login(
-      started.routerAddress,
-      otherMember,
-      UserRole.Member,
-      otherMemberAuth,
-    );
+    const { session: otherSession } = await login(started.routerAddress, otherMember, UserRole.Member, otherMemberAuth);
 
     const listUrl = `http://${started.routerAddress.host}:${started.routerAddress.port}/invites/me/bitcoin-lock-coupons`;
     const unauthenticatedListResponse = await fetch(listUrl);
@@ -808,7 +833,10 @@ describe('RouterServer', () => {
     const { session: memberSession } = await login(started.routerAddress, member, UserRole.Member, memberAuth);
 
     const inviteResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/invites/me`, memberSession.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/invites/me`,
+        memberSession.sessionId,
+      ),
     );
     expect(inviteResponse.status).toBe(200);
     expect(JsonExt.parse<IInviteResponse>(await inviteResponse.text()).invite.inviteCode).toBe(invite.inviteCode);
@@ -820,9 +848,7 @@ describe('RouterServer', () => {
     const firstUpgradeRequest = await fetch(requestUpgradeUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JsonExt.stringify(
-        createRequestOperationsUpgradeBody(member, memberAuth, operationalAccount),
-      ),
+      body: JsonExt.stringify(createRequestOperationsUpgradeBody(member, memberAuth, operationalAccount)),
     });
     expect(firstUpgradeRequest.status).toBe(200);
     const firstUpgradeBody = JsonExt.parse<{ operationsUpgradeRequestedAt: Date }>(await firstUpgradeRequest.text());
@@ -838,9 +864,7 @@ describe('RouterServer', () => {
     const secondUpgradeRequest = await fetch(requestUpgradeUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JsonExt.stringify(
-        createRequestOperationsUpgradeBody(member, memberAuth, operationalAccount),
-      ),
+      body: JsonExt.stringify(createRequestOperationsUpgradeBody(member, memberAuth, operationalAccount)),
     });
     expect(secondUpgradeRequest.status).toBe(200);
     const secondUpgradeBody = JsonExt.parse<{ operationsUpgradeRequestedAt: Date }>(await secondUpgradeRequest.text());
@@ -947,13 +971,19 @@ describe('RouterServer', () => {
     expect(unauthenticatedStatusResponse.status).toBe(401);
 
     const adminStatusResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/ethereum-relay-status`, adminSession.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/ethereum-relay-status`,
+        adminSession.sessionId,
+      ),
     );
     expect(adminStatusResponse.status).toBe(200);
     expect(JsonExt.parse(await adminStatusResponse.text())).toEqual(relayStatus);
 
     const memberStatusResponse = await fetch(
-      withSessionId(`http://${started.routerAddress.host}:${started.routerAddress.port}/ethereum-relay-status`, memberSession.sessionId),
+      withSessionId(
+        `http://${started.routerAddress.host}:${started.routerAddress.port}/ethereum-relay-status`,
+        memberSession.sessionId,
+      ),
     );
     expect(memberStatusResponse.status).toBe(200);
     expect(JsonExt.parse(await memberStatusResponse.text())).toEqual(relayStatus);
@@ -963,7 +993,11 @@ describe('RouterServer', () => {
       throughGatewayActivityNonce: 7n,
     };
 
-    const unauthenticatedRequestResponse = await requestJson(started.routerAddress, '/ethereum-relay-request', relayBody);
+    const unauthenticatedRequestResponse = await requestJson(
+      started.routerAddress,
+      '/ethereum-relay-request',
+      relayBody,
+    );
     expect(unauthenticatedRequestResponse.status).toBe(401);
 
     const adminRequestResponse = await requestJson(
@@ -1066,11 +1100,7 @@ async function login(
   return { session };
 }
 
-function createOpenInviteBody(
-  inviteCode: string,
-  member: KeyringPair,
-  authAccount: KeyringPair,
-) {
+function createOpenInviteBody(inviteCode: string, member: KeyringPair, authAccount: KeyringPair) {
   const authBindingExpiresAt = Date.now() + 60_000;
   const binding = {
     inviteCode,
@@ -1087,7 +1117,11 @@ function createOpenInviteBody(
   };
 }
 
-function createRequestOperationsUpgradeBody(member: KeyringPair, authAccount: KeyringPair, operationalAccount: KeyringPair) {
+function createRequestOperationsUpgradeBody(
+  member: KeyringPair,
+  authAccount: KeyringPair,
+  operationalAccount: KeyringPair,
+) {
   const authBindingExpiresAt = Date.now() + 60_000;
   const binding = {
     accountId: member.address,

--- a/router/src/BotUpstreamClient.ts
+++ b/router/src/BotUpstreamClient.ts
@@ -4,6 +4,7 @@ import {
   type IEthereumGatewayCatchUpRequest,
   type IEthereumGatewayCatchUpResponse,
   type IEthereumGatewayRelayStatus,
+  type IBotStateStarting,
 } from '@argonprotocol/apps-core';
 import type {
   IActivateBitcoinLockCouponRequest,
@@ -83,6 +84,10 @@ export class BotUpstreamClient {
 
   public async getEthereumGatewayRelayStatus(): Promise<IEthereumGatewayRelayStatus> {
     return await this.request('/ethereum-relay-status');
+  }
+
+  public async getSyncStatus(): Promise<Pick<IBotStateStarting, 'isReady' | 'isSyncing' | 'syncProgress'>> {
+    return await this.request('/sync-status');
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/router/src/RouterServer.ts
+++ b/router/src/RouterServer.ts
@@ -70,7 +70,8 @@ export class RouterServer {
     const botClient = new BotUpstreamClient(botInternalUrl);
     const inviteService = new UserInviteService(db);
     const inviteProgressNodeUrl = this.options.mainNodeUrl ?? this.options.localNodeUrl;
-    const adminOperatorAccountId = this.options.auth?.adminOperatorAccountId?.trim() || ADMIN_OPERATOR_ACCOUNT_ID?.trim();
+    const adminOperatorAccountId =
+      this.options.auth?.adminOperatorAccountId?.trim() || ADMIN_OPERATOR_ACCOUNT_ID?.trim();
     const getInviteProgressClient = async () => {
       if (!inviteProgressNodeUrl) {
         throw new RouterError('A mainchain node is required to approve operations access.', 503);
@@ -189,9 +190,16 @@ export class RouterServer {
       safeJsonRoute(async () => BitcoinApis.syncStatus()),
     );
     app.get(
+      '/bot-sync-status',
+      safeJsonRoute(async () => botClient.getSyncStatus()),
+    );
+    app.get(
       '/bitcoin/recentblocks',
       safeJsonRoute(async req => {
-        const blockCount = Number(String(req.query.blockCount ?? '10'));
+        const requestedBlockCount = Number(String(req.query.blockCount ?? '10'));
+        const blockCount = Number.isFinite(requestedBlockCount)
+          ? Math.min(Math.max(Math.floor(requestedBlockCount), 1), 100)
+          : 10;
         return BitcoinApis.recentBlocks(blockCount);
       }),
     );
@@ -651,10 +659,7 @@ export class RouterServer {
 
         return await botClient.getEthereumGatewayRelayStatus().catch(error => {
           if (error instanceof RouterError) {
-            throw new RouterError(
-              error.message || 'Bot request failed to load Ethereum relay status.',
-              error.status,
-            );
+            throw new RouterError(error.message || 'Bot request failed to load Ethereum relay status.', error.status);
           }
           throw error;
         });

--- a/server/scripts/create_troubleshooting_gz.sh
+++ b/server/scripts/create_troubleshooting_gz.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 # set -x
 # Point this to your install logs directory (override with env if needed)
 DIRNAME="$(dirname "$0")"
@@ -10,7 +10,16 @@ STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 HOST="$(hostname -s || echo host)"
 OUTROOT="/tmp/troubleshooting-${HOST}-${STAMP}"
 OUT="${OUTROOT}"
-mkdir -p "${OUT}"/{docker,install,logs}
+mkdir -p "${OUT}"/{data,docker,install,logs}
+COLLECTION_ERRORS="${OUT}/collection-errors.txt"
+: > "$COLLECTION_ERRORS"
+exec 3>&2
+exec 2> >(tee -a "$COLLECTION_ERRORS" >&3)
+COLLECTION_ERRORS_TEE_PID=$!
+
+record_collection_error() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2
+}
 
 # --- System snapshots ---
 {
@@ -196,10 +205,31 @@ SINCE="$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -v -4
 
 # Data folders
 echo "[*] Copying data folders"
-rsync -a --delete "$ROOT_DIR"/data/argon/bot* "$OUT/data" | true
+shopt -s nullglob
+bot_data_paths=("$ROOT_DIR"/data/argon/bot*)
+shopt -u nullglob
+
+if (( ${#bot_data_paths[@]} )); then
+  if ! rsync -a --delete "${bot_data_paths[@]}" "$OUT/data"; then
+    record_collection_error "Some bot data files could not be copied. Continuing with a partial bundle."
+  fi
+else
+  record_collection_error "No bot data paths matched $ROOT_DIR/data/argon/bot*. Continuing without bot data."
+fi
+
+exec 2>&3
+wait "$COLLECTION_ERRORS_TEE_PID"
+exec 3>&-
+
+if [[ ! -s "$COLLECTION_ERRORS" ]]; then
+  echo "No collection errors." > "$COLLECTION_ERRORS"
+fi
 
 echo "[*] Creating archive"
 ARCHIVE="${OUTROOT}.tar.gz"
-tar -C "$(dirname "$OUTROOT")" -czf "$ARCHIVE" "$(basename "$OUTROOT")"
+if ! tar -C "$(dirname "$OUTROOT")" -czf "$ARCHIVE" "$(basename "$OUTROOT")"; then
+  echo "[x] Failed to create archive: $ARCHIVE" >&2
+  exit 1
+fi
 
 echo "[✓] Bundle ready: $ARCHIVE"

--- a/src-vue/NativeMenu.ts
+++ b/src-vue/NativeMenu.ts
@@ -305,9 +305,10 @@ export async function createMenu() {
     if (!config.isLoaded) return;
 
     const isCreated = !!config.serverDetails?.ipAddress && config.serverDetails.ipAddress !== '0.0.0.0';
-    const items = await troubleshootingMenu.items();
-    void (items[0] as MenuItem)?.setEnabled(isCreated);
-    void (items[3] as MenuItem)?.setEnabled(isCreated);
+    const sshMenuItem = (await troubleshootingMenu.get('ssh')) as MenuItem | null;
+    const serverDiagnosticsMenuItem = (await troubleshootingMenu.get('server-diagnostics')) as MenuItem | null;
+    void sshMenuItem?.setEnabled(isCreated);
+    void serverDiagnosticsMenuItem?.setEnabled(isCreated);
 
     if (!isWatchingServerDetails) {
       isWatchingServerDetails = true;

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -6,6 +6,7 @@ import Installer, { ReasonsToSkipInstall, resetInstaller } from '../lib/Installe
 import { createMockedDbPromise } from './helpers/db';
 import { IInstallStepStatuses, InstallStepStatusType } from '../lib/ServerAdmin';
 import {
+  type IConfigInstallStep,
   InstallStepErrorType,
   InstallStepKey,
   InstallStepStatus,
@@ -19,6 +20,7 @@ import { WalletKeys } from '../lib/WalletKeys.ts';
 import { getTransactionTracker } from '../stores/transactions.ts';
 import { createMockWalletKeys, createTestWallet } from './helpers/wallet.ts';
 import { TICK_MILLIS } from '../lib/Env.ts';
+import { ServerApiClient } from '../lib/ServerApiClient.ts';
 
 vi.mock('../stores/transactions.ts', () => ({
   getTransactionTracker: vi.fn(),
@@ -46,7 +48,7 @@ it('should skip install if server is not connected', async () => {
   expect(installer.reasonToSkipInstall).toBe('ServerNotConnected');
 });
 
-it('keeps the installer loadable when the configured server health check fails', async () => {
+it('keeps the installer loadable when a server check fails and clears the error after reconnecting', async () => {
   const { walletKeys } = createTestWallet('//Alice');
   const config = new Config(
     createMockedDbPromise({
@@ -64,7 +66,9 @@ it('keeps the installer loadable when the configured server health check fails',
   await config.load();
 
   const installer = new Installer(config, walletKeys);
-  vi.spyOn(installer as any, 'getServer').mockRejectedValue(new Error('SSH authentication failed'));
+  const getServer = vi
+    .spyOn(installer as any, 'getServer')
+    .mockRejectedValueOnce(new Error('SSH authentication failed'));
 
   await expect(installer.load()).resolves.toBeUndefined();
   await expect(installer.isLoadedPromise).resolves.toBeUndefined();
@@ -73,6 +77,17 @@ it('keeps the installer loadable when the configured server health check fails',
     errorType: InstallStepErrorType.ServerConnect,
     errorMessage: 'SSH authentication failed',
   });
+
+  getServer.mockResolvedValue({
+    downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+  });
+  vi.spyOn(installer as any, 'calculateIsReadyToRun').mockResolvedValue(false);
+  vi.spyOn(installer as any, 'calculateIsRunning').mockResolvedValue(false);
+
+  await installer.load();
+
+  expect(config.serverInstaller.errorType).toBeNull();
+  expect(config.serverInstaller.errorMessage).toBeNull();
 });
 
 it('should skip install if install is already running', async () => {
@@ -391,6 +406,46 @@ it('should run through entire install process', async () => {
   expect(config.serverInstaller.ServerConnect.status).toBe('Completed');
 });
 
+it('uses a brief startup estimate until bot sync progress is available', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(createMockedDbPromise({}), walletKeys);
+  await config.load();
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+  config.serverInstaller.MiningLaunch.startDate = new Date(Date.now() - 60 * 60 * 1000);
+
+  const installer = new Installer(config, walletKeys);
+  const installerCheck = Reflect.get(installer, 'installerCheck') as InstallerCheck;
+  const calculateWorkingStepProgress = Reflect.get(installerCheck, 'calculateWorkingStepProgress') as (
+    stepName: InstallStepKey,
+    stepPending: IConfigInstallStep,
+    estimatedMinutes: number,
+  ) => Promise<number>;
+  vi.spyOn(ServerApiClient, 'getBotInstallProgress')
+    .mockRejectedValueOnce(new Error('Bot gateway is starting'))
+    .mockResolvedValue(37.5);
+  vi.spyOn(installer, 'refreshLocalGatewayPort').mockResolvedValue(undefined);
+
+  await expect(
+    calculateWorkingStepProgress.call(
+      installerCheck,
+      InstallStepKey.MiningLaunch,
+      config.serverInstaller.MiningLaunch,
+      0.2,
+    ),
+  ).resolves.toBe(5);
+  await expect(
+    calculateWorkingStepProgress.call(
+      installerCheck,
+      InstallStepKey.MiningLaunch,
+      config.serverInstaller.MiningLaunch,
+      0.2,
+    ),
+  ).resolves.toBe(37.5);
+});
+
 it('persists SSH details before later installation work can fail', async () => {
   const dbPromise = createMockedDbPromise({ serverAdd: '{ "localComputer": {} }' });
   const db = await dbPromise;
@@ -463,6 +518,36 @@ it('does not resume installer polling when the remote installer is no longer run
   expect(installerCheck.start).not.toHaveBeenCalled();
   expect(installer.isRunning).toBe(false);
   expect(config.isServerInstalling).toBe(false);
+});
+
+it('resumes installer polling when cached progress is 100 but the final step is still working', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(createMockedDbPromise({}), walletKeys);
+  await config.load();
+
+  const installer = new Installer(config, walletKeys);
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+  config.serverInstaller.ServerConnect.progress = 100;
+  config.serverInstaller.MiningLaunch.progress = 100;
+  config.serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
+  config.isServerInstalling = true;
+
+  const server = {
+    isInstallerScriptRunning: vi.fn().mockResolvedValue(true),
+  };
+  const installerCheck = (installer as any).installerCheck as InstallerCheck;
+  const start = vi.spyOn(installerCheck, 'start').mockImplementation(() => undefined);
+  vi.spyOn(installerCheck, 'noThrowWaitForInstallToComplete').mockResolvedValue(undefined);
+  vi.spyOn(installer as any, 'getServer').mockResolvedValue(server);
+  vi.spyOn(installer as any, 'saveLocalGatewayPortWhenReady').mockResolvedValue(undefined);
+
+  // @ts-expect-error - test private method
+  await installer.activateInstallerCheck(false);
+
+  expect(start).toHaveBeenCalledOnce();
 });
 
 it('keeps installer failures visible when the remote installer is no longer running', async () => {

--- a/src-vue/__test__/ServerAdmin.test.ts
+++ b/src-vue/__test__/ServerAdmin.test.ts
@@ -2,6 +2,64 @@ import { expect, it, vi } from 'vitest';
 import { InstallStepKey, ServerType } from '../interfaces/IConfig.ts';
 import { ServerAdmin } from '../lib/ServerAdmin.ts';
 
+it('advances server collection progress without completing it before the archive is ready', async () => {
+  vi.useFakeTimers();
+  let rejectCollection: (error: Error) => void = () => undefined;
+  const connection = {
+    runCommandWithTimeout: vi.fn().mockReturnValue(
+      new Promise((_, reject) => {
+        rejectCollection = reject;
+      }),
+    ),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+  const onProgress = vi.fn();
+
+  try {
+    const download = server.downloadTroubleshootingPackage(onProgress);
+
+    expect(onProgress).toHaveBeenLastCalledWith(5);
+    await vi.advanceTimersByTimeAsync(60e3);
+    const progressAtOneMinute = onProgress.mock.lastCall?.[0] as number;
+    expect(progressAtOneMinute).toBeGreaterThan(5);
+    expect(progressAtOneMinute).toBeLessThan(24);
+
+    await vi.advanceTimersByTimeAsync(30e3);
+    expect(onProgress.mock.lastCall?.[0]).toBeGreaterThan(progressAtOneMinute);
+    expect(onProgress.mock.lastCall?.[0]).toBeLessThan(24);
+
+    rejectCollection(new Error('collection stopped'));
+    await expect(download).rejects.toThrow('collection stopped');
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it('reports troubleshooting script output when the remote bundle cannot be created', async () => {
+  const connection = {
+    runCommandWithTimeout: vi.fn().mockResolvedValue(['Copying data folders\nArchive creation failed', 1]),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+
+  await expect(server.downloadTroubleshootingPackage(vi.fn())).rejects.toThrow('Archive creation failed');
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledWith(
+    'sudo /root/server/scripts/create_troubleshooting_gz.sh',
+    180e3,
+    0,
+  );
+});
+
 it('reads installer failure details from the case-sensitive failure marker', async () => {
   const connection = {
     runCommandWithTimeout: vi

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -119,6 +119,12 @@ export default class Installer {
             );
             await tauriExit(0);
           }
+          if (this.config.serverInstaller.errorType === InstallStepErrorType.ServerConnect) {
+            this.config.serverInstaller.errorType = null;
+            this.config.serverInstaller.errorMessage = null;
+            this.config.serverInstaller = this.config.serverInstaller;
+            await this.config.save();
+          }
 
           stage = 'calculateIsReadyToRun';
           const isReadyToRun = await this.calculateIsReadyToRun(false, accountAddressOnServer);
@@ -579,7 +585,7 @@ export default class Installer {
     }
 
     const hasProgress = this.config.serverInstaller.ServerConnect.progress > 0.0;
-    const isComplete = this.config.serverInstaller.MiningLaunch.progress >= 100;
+    const isComplete = this.installerCheck.isServerInstallComplete;
     if (!hasProgress || isComplete) return;
 
     const server = await this.getServer();

--- a/src-vue/lib/InstallerCheck.ts
+++ b/src-vue/lib/InstallerCheck.ts
@@ -76,12 +76,12 @@ export class InstallerCheck {
 
   public get isServerInstallComplete(): boolean {
     return (
-      this.config.serverInstaller.UbuntuCheck.progress >= 100 &&
-      this.config.serverInstaller.FileUpload.progress >= 100 &&
-      this.config.serverInstaller.DockerInstall.progress >= 100 &&
-      this.config.serverInstaller.BitcoinInstall.progress >= 100 &&
-      this.config.serverInstaller.ArgonInstall.progress >= 100 &&
-      this.config.serverInstaller.MiningLaunch.progress >= 100
+      this.config.serverInstaller.UbuntuCheck.status === InstallStepStatus.Completed &&
+      this.config.serverInstaller.FileUpload.status === InstallStepStatus.Completed &&
+      this.config.serverInstaller.DockerInstall.status === InstallStepStatus.Completed &&
+      this.config.serverInstaller.BitcoinInstall.status === InstallStepStatus.Completed &&
+      this.config.serverInstaller.ArgonInstall.status === InstallStepStatus.Completed &&
+      this.config.serverInstaller.MiningLaunch.status === InstallStepStatus.Completed
     );
   }
 
@@ -168,6 +168,7 @@ export class InstallerCheck {
 
       if (
         stepNewData.progress >= 100 &&
+        filenameStatus === InstallStepStatusType.Finished &&
         stepNewData.status !== InstallStepStatus.Completed &&
         stepNewData.status !== InstallStepStatus.Failed
       ) {
@@ -247,6 +248,20 @@ export class InstallerCheck {
         await this.installer.refreshLocalGatewayPort().catch(() => undefined);
         return stepPending.progress;
       });
+    }
+
+    if (stepName === InstallStepKey.MiningLaunch) {
+      const startDate = dayjs.utc(stepPending.startDate);
+      // Reserve the first 5% for the expected 12-second container startup. Only a Finished marker reaches 100%.
+      const startupProgress = InstallerCheck.calculateStepProgress(startDate, estimatedMinutes) * 0.05;
+      const syncProgress = this.config.serverDetails.ipAddress
+        ? await ServerApiClient.getBotInstallProgress(this.config.serverDetails).catch(async () => {
+            await this.installer.refreshLocalGatewayPort().catch(() => undefined);
+            return undefined;
+          })
+        : undefined;
+
+      return Math.min(Math.max(stepPending.progress, startupProgress, syncProgress ?? 0), 99);
     }
 
     const startDate = dayjs.utc(stepPending.startDate);

--- a/src-vue/lib/SSHConnection.ts
+++ b/src-vue/lib/SSHConnection.ts
@@ -54,6 +54,7 @@ export class SSHConnection {
           !this.isDestroyed &&
           (error instanceof InvokeTimeout ||
             errorString.includes('connection refused') ||
+            errorString.includes('disconnected') ||
             errorString.includes('host unreachable') ||
             errorString.includes('timed out'));
         if (shouldRetry) {

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -32,6 +32,8 @@ const DEV_DOCKER_SERVER_ENV_KEYS = [
   'BITCOIN_ADDNODE',
   'NOTEBOOK_ARCHIVE_HOSTS',
 ] as const;
+const TROUBLESHOOTING_COLLECTION_EXPECTED_MS = 30e3;
+const TROUBLESHOOTING_COLLECTION_TIMEOUT_MS = 180e3;
 
 export class ServerAdmin {
   private readonly connection: SSHConnection;
@@ -82,16 +84,30 @@ export class ServerAdmin {
   public async downloadTroubleshootingPackage(onProgress: (progress: number) => void): Promise<string> {
     let totalProgress = 5;
     onProgress(totalProgress);
-    const [output] = await this.connection.runCommandWithTimeout(
-      `sudo ${this.workDir}/server/scripts/create_troubleshooting_gz.sh`,
-      20e3,
-    );
+    const collectionStartedAt = Date.now();
+    const collectionProgressTimer = setInterval(() => {
+      const elapsedRatio = (Date.now() - collectionStartedAt) / TROUBLESHOOTING_COLLECTION_EXPECTED_MS;
+      totalProgress = 5 + 18 * (1 - Math.exp(-elapsedRatio));
+      onProgress(totalProgress);
+    }, 1e3);
+    let output = '';
+
+    try {
+      [output] = await this.connection.runCommandWithTimeout(
+        `sudo ${this.workDir}/server/scripts/create_troubleshooting_gz.sh`,
+        TROUBLESHOOTING_COLLECTION_TIMEOUT_MS,
+        0,
+      );
+    } finally {
+      clearInterval(collectionProgressTimer);
+    }
+
     const file = output.match(/Bundle ready: (.+\.tar\.gz)/);
     if (!file || !file[1]) {
       console.error('Failed to create troubleshooting package:', output);
-      throw new Error('Failed to create troubleshooting package');
+      throw new Error(`Failed to create troubleshooting package: ${output.trim() || 'No script output was returned'}`);
     }
-    totalProgress += 20;
+    totalProgress = 25;
     onProgress(totalProgress);
     const filename = file[1].trim();
     const localFilename = filename.split('/').pop() || 'troubleshooting.tar.gz';

--- a/src-vue/lib/ServerApiClient.ts
+++ b/src-vue/lib/ServerApiClient.ts
@@ -2,6 +2,7 @@ import {
   getObjectStringProperty,
   JsonExt,
   fetch,
+  type IBotStateStarting,
   type IEthereumGatewayCatchUpRequest,
   type IEthereumGatewayCatchUpResponse,
   type IEthereumGatewayRelayStatus,
@@ -307,6 +308,13 @@ export class ServerApiClient {
   public static async getArgonInstallProgress(serverDetails: ServerGatewayDetails): Promise<number> {
     const result = await this.request<ISyncStatus>(serverDetails, '/argon/syncstatus', { timeoutMs: 30e3 });
     return result?.syncPercent ?? 0;
+  }
+
+  public static async getBotInstallProgress(serverDetails: ServerGatewayDetails): Promise<number> {
+    const result = await this.request<Pick<IBotStateStarting, 'syncProgress'>>(serverDetails, '/bot-sync-status', {
+      timeoutMs: 30e3,
+    });
+    return result.syncProgress;
   }
 
   private static async request<T>(

--- a/src-vue/overlays/SyncingOverlay.vue
+++ b/src-vue/overlays/SyncingOverlay.vue
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <TransitionRoot class="absolute inset-0 pointer-events-none" :show="isOpen">
-    <BgOverlay :showWindowControls="false" :style="{ zIndex: overlayZIndex.backdropZIndex }" />
+    <BgOverlay :showWindowControls="false" :style="{ zIndex: topBarMenuZIndex.zIndex - 1 }" />
 
     <div
       class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
@@ -57,12 +57,13 @@ import ProgressBar from '../components/ProgressBar.vue';
 import AlertIcon from '../assets/alert.svg?component';
 import { getBot } from '../stores/bot.ts';
 import Draggable from './helpers/Draggable.ts';
-import { useOverlayZIndex } from './helpers/OverlayZIndex.ts';
+import { useFloatingZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(true);
 const isRetrying = Vue.ref(false);
 const bot = getBot();
 const overlayZIndex = useOverlayZIndex(() => true);
+const topBarMenuZIndex = useFloatingZIndex();
 
 const draggable = Vue.reactive(new Draggable());
 

--- a/src-vue/overlays/troubleshooting/DebugPackage.vue
+++ b/src-vue/overlays/troubleshooting/DebugPackage.vue
@@ -10,6 +10,9 @@
       <span v-if="troubleshootingError" class="text-sm text-red-500">
         {{ troubleshootingError }}
       </span>
+      <span v-if="troubleshootingWarning" class="text-sm text-amber-600">
+        {{ troubleshootingWarning }}
+      </span>
       <div class="mt-5 flex flex-row items-center gap-2">
         <button
           @click="downloadTroubleshooting"
@@ -58,54 +61,79 @@ const localLogDir = Vue.ref('');
 const troubleshootingProgress = Vue.ref(0);
 const isCreatingTroubleshootingPackage = Vue.ref(false);
 const troubleshootingError = Vue.ref('');
+const troubleshootingWarning = Vue.ref('');
 const includeWalletMnemonics = Vue.ref(false);
 
 async function downloadTroubleshooting() {
   isCreatingTroubleshootingPackage.value = true;
   troubleshootingProgress.value = 0;
   troubleshootingError.value = '';
+  troubleshootingWarning.value = '';
   const removeOnFinish: { path: string; recursive?: boolean }[] = [];
   let unsubZipProgress: (() => void) | undefined;
 
   try {
-    let zipPath = `argon_${INSTANCE_NAME}_troubleshooting_${Date.now()}.zip`;
+    const timestamp = Date.now();
+    const troubleshootingRoot = await join(await tempDir(), `argon_${INSTANCE_NAME}_troubleshooting_${timestamp}`);
+    const dataSnapshotDir = await join(troubleshootingRoot, 'data');
+    const osProfilePath = await join(troubleshootingRoot, 'os-profile.json');
+    const collectionErrorsPath = await join(troubleshootingRoot, 'collection-errors.txt');
+    const collectionErrors: string[] = [];
+    let zipPath = await join(await tempDir(), `argon_${INSTANCE_NAME}_troubleshooting_${timestamp}.zip`);
     let serverPackagePath: string | undefined;
+    let hasOsProfile = false;
+
+    removeOnFinish.push({ path: troubleshootingRoot, recursive: true });
+    await mkdir(dataSnapshotDir, { recursive: true });
 
     if (diagnostics.hasServer()) {
-      await diagnostics.load();
-      const downloadPath = await diagnostics.downloadTroubleshootingPackage(x => {
-        troubleshootingProgress.value = Math.min(60, x);
-      });
-      serverPackagePath = downloadPath;
-      removeOnFinish.push({ path: downloadPath });
-      zipPath = downloadPath.replace('.tar.gz', '.zip');
+      try {
+        await diagnostics.load();
+        const downloadPath = await diagnostics.downloadTroubleshootingPackage(x => {
+          troubleshootingProgress.value = Math.min(60, x);
+        });
+        serverPackagePath = downloadPath;
+        removeOnFinish.push({ path: downloadPath });
+        zipPath = downloadPath.replace('.tar.gz', '.zip');
+      } catch (error) {
+        console.warn('Unable to include server troubleshooting package:', error);
+        collectionErrors.push(`Server troubleshooting package: ${String(error)}`);
+        troubleshootingWarning.value = 'Server diagnostics failed. The downloaded package contains local diagnostics.';
+        troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 15);
+      }
     } else {
-      zipPath = await join(await tempDir(), zipPath);
       troubleshootingProgress.value = 15;
     }
 
-    const troubleshootingRoot = await join(await tempDir(), `argon_${INSTANCE_NAME}_troubleshooting_${Date.now()}`);
-    const dataSnapshotDir = await join(troubleshootingRoot, 'data');
-    const osProfilePath = await join(troubleshootingRoot, 'os-profile.json');
-
-    removeOnFinish.push({ path: troubleshootingRoot, recursive: true });
-
-    await mkdir(dataSnapshotDir, { recursive: true });
-    await copyDirectorySnapshot(await getInstanceConfigDir(), dataSnapshotDir, includeWalletMnemonics.value);
+    await copyDirectorySnapshot(
+      await getInstanceConfigDir(),
+      dataSnapshotDir,
+      includeWalletMnemonics.value,
+      collectionErrors,
+    );
     troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 75);
 
-    const osProfile = await invokeWithTimeout<string>('collect_troubleshooting_os_profile', {}, 15e3);
-    await writeTextFile(osProfilePath, osProfile);
+    try {
+      const osProfile = await invokeWithTimeout<string>('collect_troubleshooting_os_profile', {}, 15e3);
+      await writeTextFile(osProfilePath, osProfile);
+      hasOsProfile = true;
+    } catch (error) {
+      collectionErrors.push(`Local OS profile: ${String(error)}`);
+    }
     troubleshootingProgress.value = Math.max(troubleshootingProgress.value, 85);
 
     const pathsWithPrefixes: [string, string][] = [
       ['logs', localLogDir.value],
       ['data', dataSnapshotDir],
-      ['profile', osProfilePath],
     ];
 
+    if (hasOsProfile) pathsWithPrefixes.push(['profile', osProfilePath]);
     if (serverPackagePath) {
       pathsWithPrefixes.push(['server', serverPackagePath]);
+    }
+    if (collectionErrors.length) {
+      await writeTextFile(collectionErrorsPath, collectionErrors.join('\n\n'));
+      pathsWithPrefixes.push(['errors', collectionErrorsPath]);
     }
 
     const zipProgressEventKey = `troubleshooting_zip_progress_${Date.now()}`;
@@ -147,17 +175,32 @@ async function downloadTroubleshooting() {
   }
 }
 
-async function copyDirectorySnapshot(sourceDir: string, destinationDir: string, includeMnemonic: boolean) {
-  await mkdir(destinationDir, { recursive: true });
+async function copyDirectorySnapshot(
+  sourceDir: string,
+  destinationDir: string,
+  includeMnemonic: boolean,
+  collectionErrors: string[],
+) {
+  await mkdir(destinationDir, { recursive: true }).catch(error => {
+    collectionErrors.push(`Create local snapshot directory ${destinationDir}: ${String(error)}`);
+  });
 
-  for (const entry of await readDir(sourceDir)) {
+  const entries = await readDir(sourceDir).catch(error => {
+    collectionErrors.push(`Read local data directory ${sourceDir}: ${String(error)}`);
+    return [];
+  });
+
+  for (const entry of entries) {
     if (!entry.name) {
       continue;
     }
     if (entry.name === '.DS_Store') {
       continue;
     }
-    if (!includeMnemonic && entry.name === 'mnemonic') {
+    if (entry.isDirectory && entry.name === 'virtual-machine') {
+      continue;
+    }
+    if (!includeMnemonic && entry.name.toLowerCase().startsWith('mnemonic')) {
       continue;
     }
 
@@ -165,11 +208,13 @@ async function copyDirectorySnapshot(sourceDir: string, destinationDir: string, 
     const destinationPath = await join(destinationDir, entry.name);
 
     if (entry.isDirectory) {
-      await copyDirectorySnapshot(sourcePath, destinationPath, includeMnemonic);
+      await copyDirectorySnapshot(sourcePath, destinationPath, includeMnemonic, collectionErrors);
       continue;
     }
     if (entry.isFile) {
-      await copyFile(sourcePath, destinationPath);
+      await copyFile(sourcePath, destinationPath).catch(error => {
+        collectionErrors.push(`Copy local data file ${sourcePath}: ${String(error)}`);
+      });
     }
   }
 }

--- a/src-vue/stores/config.ts
+++ b/src-vue/stores/config.ts
@@ -71,8 +71,11 @@ export function getConfig(): Vue.Reactive<Config> {
         });
       })
       .catch(handleFatalError.bind('useConfig'));
-    SSH.setConfig(config as Config);
   }
+
+  // Config survives Vite HMR, but SSH's static state may not. Reconnect them whenever
+  // a consumer retrieves the retained singleton.
+  SSH.setConfig(config as Config);
 
   return config;
 }


### PR DESCRIPTION
## Summary

Mining setup now stays in the installer until the bot and gateway are genuinely ready, while the final step reports bot catch-up instead of simulated completion. Troubleshooting downloads also produce a useful local package when remote collection fails, with partial collection errors included instead of aborting the export.

The package continues to include `wallet.json`, excludes mnemonic-prefixed files recursively unless explicitly requested, and reports remote archive failures with actionable output. This also restores SSH state after hot reload, keeps top-bar menus usable during mining sync, and bounds recent Bitcoin block requests.

## Validation

- Focused installer, router, and troubleshooting tests passed: 38 tests across 3 files.
- Vue type-check, troubleshooting Bash syntax, and staged diff checks passed.
- Manual testnet install, troubleshooting export, and bot-wipe recovery were exercised. The post-install bot wipe used the normal sync overlay and did not conclusively validate the new installer sync-status route.
- A fresh install for an account with substantial history is the recommended final manual check for the installer sync-status path.
