### PR TITLE
fix: recover completed mining and vault setup

### DIFF
--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -5,7 +5,14 @@ import { createMockedDbPromise } from './helpers/db';
 import { instanceChecks } from '../lib/Utils.js';
 import { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestWallet } from './helpers/wallet.ts';
-import { MiningSetupStatus, ServerType } from '../interfaces/IConfig.ts';
+import {
+  type IConfig,
+  InstallStepStatus,
+  MiningSetupStatus,
+  ServerType,
+  VaultingSetupStatus,
+} from '../interfaces/IConfig.ts';
+import { JsonExt } from '@argonprotocol/apps-core';
 
 beforeAll(() => {
   WalletKeys.prototype.didWalletHavePreviousLife = vi.fn().mockResolvedValue(false);
@@ -72,4 +79,101 @@ it('migrates old server port field to sshPort', async () => {
 
   expect(config.serverDetails.sshPort).toBe(2222);
   expect((config.serverDetails as any).port).toBeUndefined();
+});
+
+it.each([MiningSetupStatus.Checklist, MiningSetupStatus.Installing])(
+  'finishes interrupted mining setup from %s when bidding rules and the server were already saved',
+  async miningSetupStatus => {
+    const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+    biddingRules.initialCapitalCommitment = 1n;
+    const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+    serverInstaller.MiningLaunch.status = InstallStepStatus.Completed;
+    const dbPromise = createMockedDbPromise({
+      miningSetupStatus: `"${miningSetupStatus}"`,
+      isServerInstalled: 'true',
+      biddingRules: JsonExt.stringify(biddingRules),
+      serverInstaller: JsonExt.stringify(serverInstaller),
+    });
+    const db = await dbPromise;
+    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
+    const { walletKeys } = createTestWallet('//Alice');
+    instanceChecks.delete(Config.prototype.constructor);
+    const config = new Config(dbPromise, walletKeys);
+
+    await config.load();
+
+    expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ miningSetupStatus: `"${MiningSetupStatus.Finished}"` }),
+    );
+  },
+);
+
+it('keeps mining setup active while the final server install step is still running', async () => {
+  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+  biddingRules.initialCapitalCommitment = 1n;
+  const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+  serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
+  const dbPromise = createMockedDbPromise({
+    miningSetupStatus: `"${MiningSetupStatus.Installing}"`,
+    isServerInstalled: 'true',
+    isServerInstalling: 'true',
+    biddingRules: JsonExt.stringify(biddingRules),
+    serverInstaller: JsonExt.stringify(serverInstaller),
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+
+  await config.load();
+
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Installing);
+});
+
+it.each([VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
+  'finishes interrupted vault setup from %s when vaulting rules and a vault were already saved',
+  async vaultingSetupStatus => {
+    const dbPromise = createMockedDbPromise({
+      vaultingSetupStatus: `"${vaultingSetupStatus}"`,
+      vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
+    });
+    const db = await dbPromise;
+    vi.spyOn(db.vaultsTable, 'get').mockResolvedValue({
+      id: 1,
+      hdPath: '//1',
+      createdAtBlockHeight: 10,
+      isClosed: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
+    const { walletKeys } = createTestWallet('//Alice');
+    instanceChecks.delete(Config.prototype.constructor);
+    const config = new Config(dbPromise, walletKeys);
+
+    await config.load();
+
+    expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"` }),
+    );
+  },
+);
+
+it('keeps interrupted setup active without durable evidence that creation finished', async () => {
+  const dbPromise = createMockedDbPromise({
+    miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,
+    isServerInstalled: 'true',
+    vaultingSetupStatus: `"${VaultingSetupStatus.Installing}"`,
+    biddingRules: JsonExt.stringify(Config.getDefault('biddingRules')),
+    vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+
+  await config.load();
+
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Checklist);
+  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Installing);
 });

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -90,6 +90,80 @@ it('keeps the installer loadable when a server check fails and clears the error 
   expect(config.serverInstaller.errorMessage).toBeNull();
 });
 
+it('ensures the mining bid proxy is funded when an existing miner starts', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(
+    createMockedDbPromise({
+      miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+      isServerInstalled: 'true',
+    }),
+    walletKeys,
+  );
+  await config.load();
+  for (const stepKey of Object.values(InstallStepKey)) {
+    config.serverInstaller[stepKey].status = InstallStepStatus.Completed;
+  }
+  config.serverInstaller = config.serverInstaller;
+
+  const installer = new Installer(config, walletKeys);
+  const runSpy = vi.spyOn(installer, 'run').mockResolvedValue(undefined);
+  const transactionTracker = {
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  vi.mocked(getTransactionTracker).mockReturnValue(transactionTracker as any);
+  let resolveProxySetupInBlock: () => void = () => undefined;
+  const proxySetupInBlock = new Promise<void>(resolve => {
+    resolveProxySetupInBlock = resolve;
+  });
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({
+    kind: 'submitted',
+    txInfo: {
+      txResult: {
+        waitForInFirstBlock: proxySetupInBlock,
+      },
+      waitForPostProcessing: Promise.resolve(),
+    },
+  } as any);
+
+  const loadPromise = installer.load();
+
+  await vi.waitFor(() => expect(proxySetupSpy).toHaveBeenCalledOnce());
+
+  expect(transactionTracker.load).toHaveBeenCalledOnce();
+  expect(proxySetupSpy).toHaveBeenCalledWith({ transactionTracker, walletKeys });
+  expect(runSpy).not.toHaveBeenCalled();
+
+  resolveProxySetupInBlock();
+  await loadPromise;
+
+  expect(runSpy).toHaveBeenCalledOnce();
+});
+
+it('does not fund the mining bid proxy while the final mining install step is still running', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(
+    createMockedDbPromise({
+      miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+      isServerInstalled: 'true',
+    }),
+    walletKeys,
+  );
+  await config.load();
+  for (const stepKey of Object.values(InstallStepKey)) {
+    config.serverInstaller[stepKey].status = InstallStepStatus.Completed;
+  }
+  config.serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
+  config.serverInstaller = config.serverInstaller;
+
+  const installer = new Installer(config, walletKeys);
+  installer.isRunning = true;
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup');
+
+  await installer.load();
+
+  expect(proxySetupSpy).not.toHaveBeenCalled();
+});
+
 it('should skip install if install is already running', async () => {
   const dbPromise = createMockedDbPromise({ miningSetupStatus: `"${MiningSetupStatus.Installing}"` });
   const { walletKeys } = createTestWallet('//Alice');
@@ -684,9 +758,14 @@ it('shows file-upload progress between 90 and 96 while waiting for proxy setup i
   const uploadBotConfigFilesPromise = new Promise<void>(resolve => {
     resolveUploadBotConfigFiles = resolve;
   });
-  const uploadBotConfigFiles = vi
-    .spyOn(installer as any, 'uploadBotConfigFiles')
-    .mockImplementation(async () => await uploadBotConfigFilesPromise);
+  let resolveUploadBotConfigFilesStarted: () => void = () => undefined;
+  const uploadBotConfigFilesStarted = new Promise<void>(resolve => {
+    resolveUploadBotConfigFilesStarted = resolve;
+  });
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockImplementation(async () => {
+    resolveUploadBotConfigFilesStarted();
+    await uploadBotConfigFilesPromise;
+  });
   let resolveUploadReachedNinety: () => void = () => undefined;
   const uploadReachedNinety = new Promise<void>(resolve => {
     resolveUploadReachedNinety = resolve;
@@ -755,8 +834,7 @@ it('shows file-upload progress between 90 and 96 while waiting for proxy setup i
     expect(uploadBotConfigFiles).not.toHaveBeenCalled();
 
     resolveProxySetupInBlock();
-    await Promise.resolve();
-    await Promise.resolve();
+    await uploadBotConfigFilesStarted;
 
     expect(installer.fileUploadProgress).toBe(96);
     expect(uploadBotConfigFiles).toHaveBeenCalledOnce();

--- a/src-vue/__test__/helpers/db.ts
+++ b/src-vue/__test__/helpers/db.ts
@@ -138,5 +138,8 @@ export async function createMockedDbPromise(allAsObject: { [key: string]: string
       fetchAllAsObject: async () => allAsObject,
       insertOrReplace: async (obj: Partial<IConfigStringified>) => {},
     },
+    vaultsTable: {
+      get: async () => undefined,
+    },
   }) as Db;
 }

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -244,6 +244,33 @@ export class Config implements IConfig {
         await this._injectFirstTimeAppData(loadedData, rawData, fieldsToSave);
       }
 
+      if (
+        (loadedData.miningSetupStatus === MiningSetupStatus.Checklist ||
+          loadedData.miningSetupStatus === MiningSetupStatus.Installing) &&
+        loadedData.isServerInstalled &&
+        !loadedData.isServerInstalling &&
+        loadedData.serverInstaller.MiningLaunch.status === InstallStepStatus.Completed &&
+        rawData[dbFields.biddingRules] &&
+        loadedData.biddingRules.initialCapitalCommitment !== undefined
+      ) {
+        loadedData.miningSetupStatus = MiningSetupStatus.Finished;
+        fieldsToSave.add(dbFields.miningSetupStatus);
+        rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
+      }
+
+      if (
+        (loadedData.vaultingSetupStatus === VaultingSetupStatus.Checklist ||
+          loadedData.vaultingSetupStatus === VaultingSetupStatus.Installing) &&
+        rawData[dbFields.vaultingRules]
+      ) {
+        const savedVault = await db.vaultsTable.get();
+        if (savedVault && !savedVault.isClosed) {
+          loadedData.vaultingSetupStatus = VaultingSetupStatus.Finished;
+          fieldsToSave.add(dbFields.vaultingSetupStatus);
+          rawData[dbFields.vaultingSetupStatus] = JsonExt.stringify(loadedData.vaultingSetupStatus, 2);
+        }
+      }
+
       const hasLegacyAccountState =
         loadedData.isServerInstalled ||
         loadedData.miningSetupStatus !== MiningSetupStatus.None ||

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -66,6 +66,7 @@ export default class Installer {
 
   private isFreshInstall: boolean = true;
   private remoteFilesNeedUpdating: boolean = false;
+  private miningBidProxyIsReady: boolean = false;
 
   private isLoadedDeferred!: IDeferred<void>;
   private installerCheck: InstallerCheck;
@@ -103,6 +104,21 @@ export default class Installer {
     await this.config.isLoadedPromise;
 
     try {
+      if (
+        this.config.miningSetupStatus === MiningSetupStatus.Finished &&
+        this.config.isServerInstalled &&
+        !this.config.isServerInstalling &&
+        this.installerCheck.isServerInstallComplete
+      ) {
+        try {
+          await this.ensureMiningBidProxyIsReady();
+        } catch (error) {
+          console.warn('[Installer] Unable to ensure the mining bid proxy during startup', {
+            error: getErrorDiagnostics(error),
+          });
+        }
+      }
+
       if (this.config.isServerAdded && !this.isRunning) {
         const hasServerDetails = !!this.config.serverDetails.ipAddress;
         if (hasServerDetails) {
@@ -278,55 +294,7 @@ export default class Installer {
         if (await this.pauseForAppUpdate()) return;
       }
       if (!this.isFreshInstall && this.config.miningSetupStatus === MiningSetupStatus.Finished) {
-        const transactionTracker = getTransactionTracker();
-        await transactionTracker.load();
-
-        const proxySetup = await ensureMiningBidProxySetup({
-          transactionTracker,
-          walletKeys: this.walletKeys,
-        });
-
-        if (proxySetup.kind === 'insufficientFunds') {
-          console.warn(
-            '[Installer] Skipping mining bid proxy migration until the mining funding account is topped up',
-            {
-              error: proxySetup.error,
-            },
-          );
-        } else if (proxySetup.kind === 'submitted' || proxySetup.kind === 'trackingExisting') {
-          let uploadProgressInterval: ReturnType<typeof setInterval> | undefined;
-          if (this.remoteFilesNeedUpdating) {
-            const waitForBlockStartedAt = Date.now();
-            const updateWaitProgress = () => {
-              const elapsed = Date.now() - waitForBlockStartedAt;
-              const progressRatio = Math.min(1, Math.max(0, elapsed / (TICK_MILLIS * 2)));
-              this.fileUploadProgress = Math.max(this.fileUploadProgress, 90 + progressRatio * 5);
-            };
-
-            updateWaitProgress();
-            uploadProgressInterval = setInterval(
-              updateWaitProgress,
-              Math.min(1000, Math.max(100, Math.ceil(TICK_MILLIS / 60))),
-            );
-          }
-
-          // The bot already holds off bidding until the mining bid proxy is ready, so first inclusion is
-          // enough to let the installer continue without waiting for full finality here.
-          try {
-            await proxySetup.txInfo.txResult.waitForInFirstBlock;
-          } finally {
-            if (uploadProgressInterval) clearInterval(uploadProgressInterval);
-            if (this.remoteFilesNeedUpdating) {
-              this.fileUploadProgress = Math.max(this.fileUploadProgress, 96);
-            }
-          }
-
-          void proxySetup.txInfo.waitForPostProcessing.catch(error => {
-            console.warn('[Installer] Mining bid proxy setup is still pending finalization', {
-              error: getErrorDiagnostics(error),
-            });
-          });
-        }
+        await this.ensureMiningBidProxyIsReady();
       }
       if (await this.pauseForAppUpdate()) return;
 
@@ -437,6 +405,64 @@ export default class Installer {
       this._server = new ServerAdmin(connection, this.config.serverDetails);
     }
     return this._server;
+  }
+
+  private async ensureMiningBidProxyIsReady(): Promise<void> {
+    if (this.miningBidProxyIsReady) return;
+
+    const transactionTracker = getTransactionTracker();
+    await transactionTracker.load();
+
+    const proxySetup = await ensureMiningBidProxySetup({
+      transactionTracker,
+      walletKeys: this.walletKeys,
+    });
+
+    if (proxySetup.kind === 'insufficientFunds') {
+      console.warn('[Installer] Skipping mining bid proxy migration until the mining funding account is topped up', {
+        error: proxySetup.error,
+      });
+      return;
+    }
+
+    if (proxySetup.kind === 'ready') {
+      this.miningBidProxyIsReady = true;
+      return;
+    }
+
+    let uploadProgressInterval: ReturnType<typeof setInterval> | undefined;
+    if (this.remoteFilesNeedUpdating) {
+      const waitForBlockStartedAt = Date.now();
+      const updateWaitProgress = () => {
+        const elapsed = Date.now() - waitForBlockStartedAt;
+        const progressRatio = Math.min(1, Math.max(0, elapsed / (TICK_MILLIS * 2)));
+        this.fileUploadProgress = Math.max(this.fileUploadProgress, 90 + progressRatio * 5);
+      };
+
+      updateWaitProgress();
+      uploadProgressInterval = setInterval(
+        updateWaitProgress,
+        Math.min(1000, Math.max(100, Math.ceil(TICK_MILLIS / 60))),
+      );
+    }
+
+    // The bot already holds off bidding until the mining bid proxy is ready, so first inclusion is
+    // enough to let the installer continue without waiting for full finality here.
+    try {
+      await proxySetup.txInfo.txResult.waitForInFirstBlock;
+      this.miningBidProxyIsReady = true;
+    } finally {
+      if (uploadProgressInterval) clearInterval(uploadProgressInterval);
+      if (this.remoteFilesNeedUpdating) {
+        this.fileUploadProgress = Math.max(this.fileUploadProgress, 96);
+      }
+    }
+
+    void proxySetup.txInfo.waitForPostProcessing.catch(error => {
+      console.warn('[Installer] Mining bid proxy setup is still pending finalization', {
+        error: getErrorDiagnostics(error),
+      });
+    });
   }
 
   private async saveLocalGatewayPortWhenReady(

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -35,6 +35,7 @@ import { getTransactionTracker } from '../../stores/transactions.ts';
 import { MoveCapital, type ITransactionMoveMetadata } from '../../lib/MoveCapital.ts';
 import { ExtrinsicType } from '../../lib/db/TransactionsTable.ts';
 import type { TransactionInfo } from '../../lib/TransactionInfo.ts';
+import { TxAttemptState } from '../../lib/TransactionTracker.ts';
 import { getMyVault } from '../../stores/vaults.ts';
 import type { Config } from '../../lib/Config.ts';
 import { getMiningFundingState } from './miningFunding.ts';
@@ -187,11 +188,12 @@ function trackTxInfo(txInfo: TransactionInfo) {
     txProgressLabel.value = `Submitted to Argon Miners: ${args.progressMessage}`;
     txProgressPct.value = Math.max(txProgressPct.value, args.progressPct);
 
-    if (args.progressPct === 100 && error) {
-      transactionErrorMessage.value = error.message;
+    if (args.progressPct === 100) {
+      if (error) {
+        transactionErrorMessage.value = error.message;
+      }
+      void ensureTrackedSetupTransfer();
     }
-
-    void ensureTrackedSetupTransfer();
   });
 
   void txInfo.waitForPostProcessing
@@ -222,12 +224,18 @@ async function finalizeMiningSetup() {
 }
 
 async function ensureTrackedSetupTransfer(force = false) {
+  if (!hasEnteredTransactionPhase.value) return;
+
   const txInfo = findLatestSetupTxInfo();
   if (txInfo) {
-    trackTxInfo(txInfo);
+    const txAttemptState = await transactionTracker.getTxAttemptState(txInfo, 2);
+    if (txAttemptState === TxAttemptState.Follow) {
+      trackTxInfo(txInfo);
+      return;
+    }
   }
 
-  if (!hasEnteredTransactionPhase.value || !wallets.isLoaded || isEnsuringSetupTransfer.value) return;
+  if (!wallets.isLoaded || isEnsuringSetupTransfer.value) return;
 
   const now = Date.now();
   if (!force && now - lastEnsureSetupTransferAt < 3_000) return;


### PR DESCRIPTION
## Summary

Users whose mining or vault setup already succeeded no longer return to a stuck initialization screen after relaunch. Mining recovery now requires a saved launch commitment, an installed server, no active install, and a completed MiningLaunch step. Vault recovery requires saved vaulting rules and an existing open vault.

Completed miners also ensure the mining bid proxy is funded and registered on startup before reconnecting. This startup work runs only after every server install step has completed, does not overlap an active install, and shares the existing tracked-transaction and first-block wait path used during upgrades.

Mining initialization also ignores historical failed transfer attempts until the server reaches the transfer phase, preventing a stale Frozen error from appearing while server files are still uploading. Existing funding-shortfall and existential-deposit calculations remain unchanged.

## Validation

- Targeted Config, Installer, and MoveCapital suites passed with 47 tests.
- TypeScript typechecking and formatting passed.