### PR TITLE
fix: recover operator accounts and server upgrades safely

### DIFF
--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -140,6 +140,38 @@ function historyEvent(
 }
 
 describe('BitcoinLocks recovery', () => {
+  it('recognizes and clears recovery flags restored from the database', async () => {
+    const store = createStore();
+    const lock = createLock({
+      uuid: 'loaded-lock',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const pendingLock = createLock({
+      uuid: 'loaded-pending-lock',
+      status: BitcoinLockStatus.LockIsProcessingOnArgon,
+      createdAt: '2026-01-02T00:00:00Z',
+    });
+    lock.isHistoryRecoveryPending = true;
+    pendingLock.isHistoryRecoveryPending = true;
+    store.data.locksByUtxoId[7] = lock;
+    store.data.pendingLocks.push(pendingLock);
+    const setHistoryRecoveryPending = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending } as never);
+
+    expect(store.recovery.hasPendingHistoryRecovery).toBe(true);
+
+    await store.recovery.beginHistoryReplay();
+    await store.recovery.commitHistoryReplay();
+
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(lock.uuid, false);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(pendingLock.uuid, false);
+    expect(lock.isHistoryRecoveryPending).toBeUndefined();
+    expect(pendingLock.isHistoryRecoveryPending).toBeUndefined();
+    expect(store.recovery.hasPendingHistoryRecovery).toBe(false);
+  });
+
   it('quarantines only recovering locks while regular locks remain active and syncable', async () => {
     const store = createStore();
     const record = createLock({
@@ -163,6 +195,14 @@ describe('BitcoinLocks recovery', () => {
       createdAt: '2026-02-01T00:00:00Z',
     });
     store.data.locksByUtxoId[8] = regularRecord;
+    vi.spyOn(store, 'getMismatchViewState').mockReturnValue({
+      phase: 'review',
+      candidateCount: 1,
+      isFundingExpired: false,
+    } as never);
+
+    expect(getBitcoinAlertNotices(store).map(alert => alert.lock)).toEqual([regularRecord]);
+
     const setStatus = vi.fn(async (lock: IBitcoinLockRecord, status: BitcoinLockStatus) => {
       lock.status = status;
     });
@@ -170,6 +210,7 @@ describe('BitcoinLocks recovery', () => {
 
     expect(store.getActiveLocks()).toEqual([regularRecord]);
     expect(store.getAllLocks()).toEqual([regularRecord]);
+    expect(store.getAllLocks({ includeHistoryRecoveryPending: true })).toEqual([regularRecord, record]);
     expect(store.getLockByUtxoId(7)).toBeUndefined();
     expect(store.getLockByUtxoId(8)).toBe(regularRecord);
     await expect(store.acknowledgeFailed(record)).rejects.toThrow('Bitcoin history recovery is still in progress');
@@ -201,6 +242,27 @@ describe('BitcoinLocks recovery', () => {
 
     delete record.isHistoryRecoveryPending;
     expect(store.getAllLocks()).toEqual([regularRecord, record]);
+  });
+
+  it('quarantines existing locks before a full history replay begins', async () => {
+    const store = createStore();
+    const record = createLock({
+      uuid: 'stale-lock',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    store.data.locksByUtxoId[7] = record;
+    const setHistoryRecoveryPending = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending } as never);
+
+    await store.recovery.beginHistoryReplay({ recoverExistingLocks: true });
+
+    expect(record.isHistoryRecoveryPending).toBe(true);
+    expect(store.getActiveLocks()).toEqual([]);
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, true);
+
+    await store.recovery.commitHistoryReplay();
   });
 
   it('serializes history replay with the affected lock queue without yielding or waiting behind itself', async () => {
@@ -239,7 +301,7 @@ describe('BitcoinLocks recovery', () => {
     expect(started).toBe(true);
     await admitted;
 
-    store.recovery.beginHistoryReplay();
+    await store.recovery.beginHistoryReplay();
     await expect(
       runInQueueForUtxo.call(
         store,
@@ -289,7 +351,7 @@ describe('BitcoinLocks recovery', () => {
 
     expect(setRelayMetadata).not.toHaveBeenCalled();
 
-    store.recovery.beginHistoryReplay();
+    await store.recovery.beginHistoryReplay();
     await store.recovery.commitHistoryReplay();
     await relaySync;
     expect(setRelayMetadata).toHaveBeenCalledOnce();
@@ -343,7 +405,7 @@ describe('BitcoinLocks recovery', () => {
       setHistoryRecoveryPending,
     } as never);
 
-    store.recovery.beginHistoryReplay();
+    await store.recovery.beginHistoryReplay();
     await store.recovery.recoverLock({
       lock: { utxoId: 7 } as BitcoinLock,
       createdAtArgonBlockHeight: 1,
@@ -366,7 +428,7 @@ describe('BitcoinLocks recovery', () => {
     expect(store.data.pendingLocks).toEqual([pending]);
     expect(store.getAllLocks()).toEqual([]);
 
-    store.recovery.beginHistoryReplay();
+    await store.recovery.beginHistoryReplay();
     await store.recovery.commitHistoryReplay();
 
     expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, true);
@@ -927,7 +989,7 @@ describe('BitcoinLocks recovery', () => {
       .mockResolvedValueOnce([1_000n]);
     findPendingMints.mockClear();
 
-    store.recovery.beginHistoryReplay();
+    await store.recovery.beginHistoryReplay();
     await store.recovery.recoverBlock(historyBlock(153), [
       historyEvent(153, 'mint', 'BitcoinMint', { accountId, utxoId: null, amount: 1_000n }),
     ]);

--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -5,7 +5,14 @@ import { createMockedDbPromise } from './helpers/db';
 import { instanceChecks } from '../lib/Utils.js';
 import { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestWallet } from './helpers/wallet.ts';
-import { MiningSetupStatus, ServerType } from '../interfaces/IConfig.ts';
+import {
+  type IConfig,
+  InstallStepStatus,
+  MiningSetupStatus,
+  ServerType,
+  VaultingSetupStatus,
+} from '../interfaces/IConfig.ts';
+import { JsonExt } from '@argonprotocol/apps-core';
 
 beforeAll(() => {
   WalletKeys.prototype.didWalletHavePreviousLife = vi.fn().mockResolvedValue(false);
@@ -72,4 +79,101 @@ it('migrates old server port field to sshPort', async () => {
 
   expect(config.serverDetails.sshPort).toBe(2222);
   expect((config.serverDetails as any).port).toBeUndefined();
+});
+
+it.each([MiningSetupStatus.Checklist, MiningSetupStatus.Installing])(
+  'finishes interrupted mining setup from %s when bidding rules and the server were already saved',
+  async miningSetupStatus => {
+    const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+    biddingRules.initialCapitalCommitment = 1n;
+    const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+    serverInstaller.MiningLaunch.status = InstallStepStatus.Completed;
+    const dbPromise = createMockedDbPromise({
+      miningSetupStatus: `"${miningSetupStatus}"`,
+      isServerInstalled: 'true',
+      biddingRules: JsonExt.stringify(biddingRules),
+      serverInstaller: JsonExt.stringify(serverInstaller),
+    });
+    const db = await dbPromise;
+    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
+    const { walletKeys } = createTestWallet('//Alice');
+    instanceChecks.delete(Config.prototype.constructor);
+    const config = new Config(dbPromise, walletKeys);
+
+    await config.load();
+
+    expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ miningSetupStatus: `"${MiningSetupStatus.Finished}"` }),
+    );
+  },
+);
+
+it('keeps mining setup active while the final server install step is still running', async () => {
+  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+  biddingRules.initialCapitalCommitment = 1n;
+  const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+  serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
+  const dbPromise = createMockedDbPromise({
+    miningSetupStatus: `"${MiningSetupStatus.Installing}"`,
+    isServerInstalled: 'true',
+    isServerInstalling: 'true',
+    biddingRules: JsonExt.stringify(biddingRules),
+    serverInstaller: JsonExt.stringify(serverInstaller),
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+
+  await config.load();
+
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Installing);
+});
+
+it.each([VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
+  'finishes interrupted vault setup from %s when vaulting rules and a vault were already saved',
+  async vaultingSetupStatus => {
+    const dbPromise = createMockedDbPromise({
+      vaultingSetupStatus: `"${vaultingSetupStatus}"`,
+      vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
+    });
+    const db = await dbPromise;
+    vi.spyOn(db.vaultsTable, 'get').mockResolvedValue({
+      id: 1,
+      hdPath: '//1',
+      createdAtBlockHeight: 10,
+      isClosed: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
+    const { walletKeys } = createTestWallet('//Alice');
+    instanceChecks.delete(Config.prototype.constructor);
+    const config = new Config(dbPromise, walletKeys);
+
+    await config.load();
+
+    expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"` }),
+    );
+  },
+);
+
+it('keeps interrupted setup active without durable evidence that creation finished', async () => {
+  const dbPromise = createMockedDbPromise({
+    miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,
+    isServerInstalled: 'true',
+    vaultingSetupStatus: `"${VaultingSetupStatus.Installing}"`,
+    biddingRules: JsonExt.stringify(Config.getDefault('biddingRules')),
+    vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+
+  await config.load();
+
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Checklist);
+  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Installing);
 });

--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -1,7 +1,7 @@
 import './helpers/mocks.ts';
 import { beforeAll, expect, it, vi } from 'vitest';
 import { Config } from '../lib/Config';
-import { createMockedDbPromise } from './helpers/db';
+import { createMockedDbPromise, createTestDb } from './helpers/db';
 import { instanceChecks } from '../lib/Utils.js';
 import { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestWallet } from './helpers/wallet.ts';
@@ -59,6 +59,92 @@ it('can load config from db state', async () => {
   await config.load();
   expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
   expect(config.postWelcomeLaunchCount).toBe(4);
+});
+
+it('trusts saved mining seats without querying cached activity', async () => {
+  const dbPromise = createMockedDbPromise({
+    miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+    hasMiningBids: 'false',
+    hasMiningSeats: 'true',
+  });
+  const db = await dbPromise;
+  vi.spyOn(db, 'select').mockRejectedValue(new Error('cached mining activity should not be queried'));
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+
+  await config.load();
+
+  expect(config.hasMiningBids).toBe(true);
+  expect(config.hasMiningSeats).toBe(true);
+});
+
+it('restores established mining flags from cached activity on app restart', async () => {
+  const db = await createTestDb();
+  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+  biddingRules.initialCapitalCommitment = 1n;
+  await db.configTable.insertOrReplace({
+    miningSetupStatus: `"${MiningSetupStatus.Installing}"`,
+    isServerInstalled: 'true',
+    isServerInstalling: 'true',
+    hasMiningBids: 'false',
+    hasMiningSeats: 'false',
+    biddingRules: JsonExt.stringify(biddingRules),
+  });
+  await db.frameBidsTable.insertOrUpdate(20, 200, [
+    {
+      address: '5cachedBid',
+      subAccountIndex: 1,
+      microgonsPerSeat: 10n,
+      micronotsStakedPerSeat: 20n,
+      bidPosition: 0,
+      lastBidAtTick: 100,
+    },
+  ]);
+  await db.framesTable.insertOrUpdate({
+    id: 19,
+    firstTick: 1,
+    rewardTicksRemaining: 0,
+    firstBlockNumber: 100,
+    lastBlockNumber: 199,
+    microgonToUsd: [],
+    microgonToBtc: [],
+    microgonToArgonot: [],
+    accruedMicrogonProfits: 0n,
+    accruedMicronotProfits: 0n,
+    progress: 100,
+  });
+  await db.cohortsTable.insertOrUpdate({
+    id: 19,
+    transactionFeesTotal: 0n,
+    micronotsStakedPerSeat: 20n,
+    microgonsBidPerSeat: 10n,
+    seatCountWon: 1,
+    microgonsToBeMinedPerSeat: 30n,
+    micronotsToBeMinedPerSeat: 40n,
+    argonotPriceAtBid: 50n,
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(Promise.resolve(db), walletKeys);
+
+  try {
+    await config.load();
+
+    expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
+    expect(config.hasMiningBids).toBe(true);
+    expect(config.hasMiningSeats).toBe(true);
+    await expect(db.configTable.fetchAllAsObject()).resolves.toEqual(
+      expect.objectContaining({
+        miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+        hasMiningBids: 'true',
+        hasMiningSeats: 'true',
+      }),
+    );
+  } finally {
+    await db.close();
+    instanceChecks.delete(db.constructor);
+  }
 });
 
 it('migrates old server port field to sshPort', async () => {
@@ -161,12 +247,17 @@ it.each([VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
 );
 
 it('keeps interrupted setup active without durable evidence that creation finished', async () => {
+  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
+  biddingRules.initialCapitalCommitment = 0n;
+  const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+  serverInstaller.MiningLaunch.status = InstallStepStatus.Completed;
   const dbPromise = createMockedDbPromise({
     miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,
     isServerInstalled: 'true',
     vaultingSetupStatus: `"${VaultingSetupStatus.Installing}"`,
-    biddingRules: JsonExt.stringify(Config.getDefault('biddingRules')),
+    biddingRules: JsonExt.stringify(biddingRules),
     vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
+    serverInstaller: JsonExt.stringify(serverInstaller),
   });
   const { walletKeys } = createTestWallet('//Alice');
   instanceChecks.delete(Config.prototype.constructor);

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AccountActivityKind } from '@argonprotocol/apps-core';
 import { needsFinancialHistoryRecovery, restoreFinancialHistory } from '../lib/recovery/index.ts';
 import { findAddressActivity } from '../lib/IndexerClient.ts';
@@ -6,6 +6,8 @@ import { SyncStateKeys } from '../lib/db/SyncStateTable.ts';
 import { optionCodec } from '../../core/__test__/helpers/codecs.ts';
 
 vi.mock('../lib/IndexerClient.ts', () => ({ findAddressActivity: vi.fn() }));
+
+afterEach(() => vi.mocked(findAddressActivity).mockReset());
 
 describe('FinancialHistoryImporter', () => {
   it('initializes recovery when an enabled domain trails the finalized target', async () => {
@@ -40,6 +42,31 @@ describe('FinancialHistoryImporter', () => {
     ).resolves.toBe(false);
   });
 
+  it('initializes Bitcoin recovery when a loaded lock is still quarantined', async () => {
+    const db = {
+      syncStateTable: {
+        get: vi.fn(async () => ({
+          accountId: '5owner',
+          asOfBlock: 100,
+          domains: ['bitcoin'],
+          domainCheckpoints: {
+            bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
+          },
+        })),
+      },
+    } as any;
+
+    await expect(
+      needsFinancialHistoryRecovery({
+        db,
+        accountId: '5owner',
+        enabledDomains: ['bitcoin'],
+        targetBlock: 100,
+        bitcoinLockRecovery: { hasPendingHistoryRecovery: true } as any,
+      }),
+    ).resolves.toBe(true);
+  });
+
   it('skips the v2 activity lookup when the saved checkpoint already covers finalized progress', async () => {
     const getCheckpoint = vi.fn(async () => ({
       accountId: '5owner',
@@ -64,6 +91,59 @@ describe('FinancialHistoryImporter', () => {
     ).resolves.toEqual({ importedBlockCount: 0, asOfBlock: 100, targetBlock: 100 });
     expect(getCheckpoint).toHaveBeenCalledOnce();
     expect(onCheckStart).not.toHaveBeenCalled();
+  });
+
+  it('replays a loaded Bitcoin recovery even when its checkpoint is current', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const beginHistoryReplay = vi.fn();
+    const commitHistoryReplay = vi.fn();
+    vi.mocked(findAddressActivity).mockResolvedValueOnce({
+      asOfBlock: 100,
+      definitionVersion: 2,
+      blocks: [],
+      coverage: { fromBlock: 100, toBlock: 100, gaps: [] },
+    });
+
+    await restoreFinancialHistory({
+      db: {
+        syncStateTable: {
+          get: vi.fn(async () => ({
+            accountId: '5owner',
+            asOfBlock: 100,
+            domains: ['bitcoin'],
+            domainCheckpoints: {
+              bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
+            },
+          })),
+          upsert,
+        },
+      } as any,
+      blockWatch: {
+        finalizedBlockHeader: { blockNumber: 100 },
+        getFinalizedApi: vi.fn(async () => ({})),
+      } as any,
+      accountId: '5owner',
+      argonBonds: {} as any,
+      bitcoinLockRecovery: {
+        hasPendingHistoryRecovery: true,
+        beginHistoryReplay,
+        findMissingActiveLockIds: vi.fn(async () => []),
+        commitHistoryReplay,
+        cancelHistoryReplay: vi.fn(),
+      } as any,
+      vaultHistory: {} as any,
+      enabledDomains: ['bitcoin'],
+      minimumAsOfBlock: 100,
+    });
+
+    expect(findAddressActivity).toHaveBeenCalledWith('5owner', {
+      afterBlock: 0,
+      toBlock: 100,
+      activityMask: AccountActivityKind.BitcoinLock | AccountActivityKind.BitcoinMint,
+    });
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: true });
+    expect(commitHistoryReplay).toHaveBeenCalledWith(true);
+    expect(upsert).toHaveBeenCalledOnce();
   });
 
   it('returns the minimum safe checkpoint across enabled financial domains', async () => {
@@ -297,6 +377,7 @@ describe('FinancialHistoryImporter', () => {
       }),
     );
     expect(beginHistoryReplay).toHaveBeenCalledOnce();
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: true });
     expect(commitHistoryReplay).toHaveBeenCalledOnce();
     expect(commitHistoryReplay).toHaveBeenCalledWith(true);
     expect(cancelHistoryReplay).not.toHaveBeenCalled();

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -406,6 +406,59 @@ it('should run through entire install process', async () => {
   expect(config.serverInstaller.ServerConnect.status).toBe('Completed');
 });
 
+it('preserves the remote Docker Compose project name across a core file replacement', async () => {
+  const dbPromise = createMockedDbPromise({});
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  config.serverDetails = {
+    ...config.serverDetails,
+    ipAddress: '127.0.0.1',
+  };
+
+  const installer = new Installer(config, walletKeys);
+  await installer.load();
+
+  const server = {
+    downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    getComposeProjectName: vi.fn().mockResolvedValue('mainnet-default'),
+    uploadAccountAddress: vi.fn().mockResolvedValue(undefined),
+    createLogsDir: vi.fn().mockResolvedValue(undefined),
+    startInstallerScript: vi.fn().mockResolvedValue(undefined),
+  };
+  const uploadCoreFiles = vi.spyOn(installer as any, 'uploadCoreFiles').mockResolvedValue(undefined);
+
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsRunning = vi.fn().mockResolvedValue(false);
+  // @ts-ignore - exercise the upgrade path directly
+  installer.calculateIsReadyToRun = vi.fn().mockResolvedValue(true);
+  // @ts-ignore - avoid real server setup in this unit test
+  installer.getServer = vi.fn().mockResolvedValue(server);
+  // @ts-ignore - avoid remote config uploads in this unit test
+  installer.uploadBotConfigFiles = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - avoid port polling in this unit test
+  installer.saveLocalGatewayPortWhenReady = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - drive the upload branch directly
+  installer.remoteFilesNeedUpdating = true;
+  // @ts-ignore - avoid log cleanup in this unit test
+  installer.clearStepFiles = vi.fn().mockResolvedValue(undefined);
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.start = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.activateServer = vi.fn();
+  // @ts-ignore - avoid background polling in this unit test
+  installer.installerCheck.noThrowWaitForInstallToComplete = vi.fn().mockResolvedValue(undefined);
+
+  await installer.run(false);
+
+  expect(server.getComposeProjectName).toHaveBeenCalledOnce();
+  expect(server.getComposeProjectName.mock.invocationCallOrder[0]).toBeLessThan(
+    uploadCoreFiles.mock.invocationCallOrder[0],
+  );
+  expect(server.startInstallerScript).toHaveBeenCalledWith({ composeProjectName: 'mainnet-default' });
+});
+
 it('uses a brief startup estimate until bot sync progress is available', async () => {
   const walletKeys = createMockWalletKeys();
   const config = new Config(createMockedDbPromise({}), walletKeys);
@@ -676,6 +729,7 @@ it('shows file-upload progress between 90 and 96 while waiting for proxy setup i
 
   const server = {
     downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    getComposeProjectName: vi.fn().mockResolvedValue('mainnet-default'),
     uploadAccountAddress: vi.fn().mockResolvedValue(undefined),
     createLogsDir: vi.fn().mockResolvedValue(undefined),
     startInstallerScript: vi.fn().mockResolvedValue(undefined),
@@ -787,6 +841,7 @@ it('does not start the remote installer after an app update is installed', async
 
   const server = {
     downloadAccountAddress: vi.fn().mockResolvedValue(walletKeys.miningBotAddress),
+    getComposeProjectName: vi.fn().mockResolvedValue('mainnet-default'),
     uploadAccountAddress: vi.fn().mockResolvedValue(undefined),
     createLogsDir: vi.fn().mockResolvedValue(undefined),
     startInstallerScript: vi.fn().mockResolvedValue(undefined),

--- a/src-vue/__test__/Installer.test.ts
+++ b/src-vue/__test__/Installer.test.ts
@@ -90,6 +90,80 @@ it('keeps the installer loadable when a server check fails and clears the error 
   expect(config.serverInstaller.errorMessage).toBeNull();
 });
 
+it('ensures the mining bid proxy is funded when an existing miner starts', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(
+    createMockedDbPromise({
+      miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+      isServerInstalled: 'true',
+    }),
+    walletKeys,
+  );
+  await config.load();
+  for (const stepKey of Object.values(InstallStepKey)) {
+    config.serverInstaller[stepKey].status = InstallStepStatus.Completed;
+  }
+  config.serverInstaller = config.serverInstaller;
+
+  const installer = new Installer(config, walletKeys);
+  const runSpy = vi.spyOn(installer, 'run').mockResolvedValue(undefined);
+  const transactionTracker = {
+    load: vi.fn().mockResolvedValue(undefined),
+  };
+  vi.mocked(getTransactionTracker).mockReturnValue(transactionTracker as any);
+  let resolveProxySetupInBlock: () => void = () => undefined;
+  const proxySetupInBlock = new Promise<void>(resolve => {
+    resolveProxySetupInBlock = resolve;
+  });
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup').mockResolvedValue({
+    kind: 'submitted',
+    txInfo: {
+      txResult: {
+        waitForInFirstBlock: proxySetupInBlock,
+      },
+      waitForPostProcessing: Promise.resolve(),
+    },
+  } as any);
+
+  const loadPromise = installer.load();
+
+  await vi.waitFor(() => expect(proxySetupSpy).toHaveBeenCalledOnce());
+
+  expect(transactionTracker.load).toHaveBeenCalledOnce();
+  expect(proxySetupSpy).toHaveBeenCalledWith({ transactionTracker, walletKeys });
+  expect(runSpy).not.toHaveBeenCalled();
+
+  resolveProxySetupInBlock();
+  await loadPromise;
+
+  expect(runSpy).toHaveBeenCalledOnce();
+});
+
+it('does not fund the mining bid proxy while the final mining install step is still running', async () => {
+  const walletKeys = createMockWalletKeys();
+  const config = new Config(
+    createMockedDbPromise({
+      miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+      isServerInstalled: 'true',
+    }),
+    walletKeys,
+  );
+  await config.load();
+  for (const stepKey of Object.values(InstallStepKey)) {
+    config.serverInstaller[stepKey].status = InstallStepStatus.Completed;
+  }
+  config.serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
+  config.serverInstaller = config.serverInstaller;
+
+  const installer = new Installer(config, walletKeys);
+  installer.isRunning = true;
+  const proxySetupSpy = vi.spyOn(MiningAccount, 'ensureMiningBidProxySetup');
+
+  await installer.load();
+
+  expect(proxySetupSpy).not.toHaveBeenCalled();
+});
+
 it('should skip install if install is already running', async () => {
   const dbPromise = createMockedDbPromise({ miningSetupStatus: `"${MiningSetupStatus.Installing}"` });
   const { walletKeys } = createTestWallet('//Alice');
@@ -738,9 +812,14 @@ it('shows file-upload progress between 90 and 96 while waiting for proxy setup i
   const uploadBotConfigFilesPromise = new Promise<void>(resolve => {
     resolveUploadBotConfigFiles = resolve;
   });
-  const uploadBotConfigFiles = vi
-    .spyOn(installer as any, 'uploadBotConfigFiles')
-    .mockImplementation(async () => await uploadBotConfigFilesPromise);
+  let resolveUploadBotConfigFilesStarted: () => void = () => undefined;
+  const uploadBotConfigFilesStarted = new Promise<void>(resolve => {
+    resolveUploadBotConfigFilesStarted = resolve;
+  });
+  const uploadBotConfigFiles = vi.spyOn(installer as any, 'uploadBotConfigFiles').mockImplementation(async () => {
+    resolveUploadBotConfigFilesStarted();
+    await uploadBotConfigFilesPromise;
+  });
   let resolveUploadReachedNinety: () => void = () => undefined;
   const uploadReachedNinety = new Promise<void>(resolve => {
     resolveUploadReachedNinety = resolve;
@@ -809,8 +888,7 @@ it('shows file-upload progress between 90 and 96 while waiting for proxy setup i
     expect(uploadBotConfigFiles).not.toHaveBeenCalled();
 
     resolveProxySetupInBlock();
-    await Promise.resolve();
-    await Promise.resolve();
+    await uploadBotConfigFilesStarted;
 
     expect(installer.fileUploadProgress).toBe(96);
     expect(uploadBotConfigFiles).toHaveBeenCalledOnce();

--- a/src-vue/__test__/ServerAdmin.test.ts
+++ b/src-vue/__test__/ServerAdmin.test.ts
@@ -102,6 +102,21 @@ it('preserves the existing Docker Compose project name when restarting the insta
   );
 });
 
+it('reads the Docker Compose project name from the remote server', async () => {
+  const connection = {
+    runCommandWithTimeout: vi.fn().mockResolvedValue(['COMPOSE_PROJECT_NAME=mainnet-existing\n', 0]),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+
+  await expect(server.getComposeProjectName()).resolves.toBe('mainnet-existing');
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledWith('cat /root/server/.env 2>/dev/null || true', 10e3);
+});
+
 it('rejects an invalid existing Docker Compose project name', async () => {
   const connection = {
     isDockerHostProxy: false,
@@ -116,4 +131,71 @@ it('rejects an invalid existing Docker Compose project name', async () => {
 
   await expect(server.startInstallerScript()).rejects.toThrow('Invalid Docker Compose project name');
   expect(connection.runCommandWithTimeout).toHaveBeenCalledOnce();
+});
+
+it('resyncs only the Argon chain data directory', async () => {
+  const connection = {
+    runCommandWithTimeout: vi.fn().mockResolvedValueOnce(['/root/data/argon\n', 0]).mockResolvedValue(['', 0]),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+
+  await server.resyncMiner();
+
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledWith(
+    'cd /root/server && sudo docker compose stop argon-miner',
+    60e3,
+  );
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledWith(
+    'set -euo pipefail && sudo find "/root/data/argon/chains" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
+    60e3,
+  );
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledWith(
+    'cd /root/server && sudo docker compose up argon-miner -d',
+    60e3,
+  );
+  expect(connection.runCommandWithTimeout).not.toHaveBeenCalledWith(
+    expect.stringContaining('"/root/data/argon"/*'),
+    expect.any(Number),
+  );
+});
+
+it('rejects contaminated Docker Compose output before an Argon resync', async () => {
+  const connection = {
+    runCommandWithTimeout: vi
+      .fn()
+      .mockResolvedValue(['time="2026-07-22T18:11:05Z" level=warning msg="UID is not set"\n/root/data/argon\n', 0]),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+
+  await expect(server.resyncMiner()).rejects.toThrow('Invalid data directory returned for argon-miner');
+  expect(connection.runCommandWithTimeout).toHaveBeenCalledOnce();
+});
+
+it('fails a directory cleanup when files remain', async () => {
+  const connection = {
+    runCommandWithTimeout: vi
+      .fn()
+      .mockResolvedValueOnce(['', 0])
+      .mockResolvedValueOnce(['/root/data/argon/chains/argon/db/full\n', 0]),
+  };
+  const server = new ServerAdmin(connection as any, {
+    ipAddress: '127.0.0.1',
+    sshUser: 'root',
+    type: ServerType.CustomServer,
+    workDir: '/root',
+  });
+
+  await expect(server.cleanDirectory('/root/data/argon/chains')).rejects.toThrow(
+    'Directory was not fully cleaned: /root/data/argon/chains',
+  );
 });

--- a/src-vue/__test__/WalletBalances.integration.test.ts
+++ b/src-vue/__test__/WalletBalances.integration.test.ts
@@ -78,11 +78,12 @@ describe
       try {
         await walletsForArgon.load();
         const onBalanceChange = vi.fn();
-        const didGetBalanceChange = createDeferred();
+        const didGetOperationalBalance = createDeferred();
         walletsForArgon.events.on('balance-change', (balanceChange, type) => {
-          console.log('Balance Change:', balanceChange);
           onBalanceChange(type);
-          didGetBalanceChange.resolve();
+          if (type === 'operational' && balanceChange.availableMicrogons === 5_000_000n) {
+            didGetOperationalBalance.resolve();
+          }
         });
         expect(walletsForArgon.operationalWallet.totalMicrogons).toBe(0n);
         expect(walletsForArgon.defaultArgonWallet.totalMicrogons).toBe(0n);
@@ -94,12 +95,12 @@ describe
           alice,
         ).submit();
         await result.waitForInFirstBlock;
-        await expect(didGetBalanceChange.promise).resolves.toBeUndefined();
+        transferBlocks = [result.blockNumber!];
+        await expect(didGetOperationalBalance.promise).resolves.toBeUndefined();
         expect(walletsForArgon.operationalWallet.availableMicrogons).toBe(5_000_000n);
         expect(onBalanceChange).toHaveBeenCalledWith('operational');
         expect(walletsForArgon.defaultArgonWallet.totalMicrogons).toBe(0n);
         await result.waitForFinalizedBlock;
-        transferBlocks = [result.blockNumber!];
         if (!walletsForArgon.finalizedBlock || walletsForArgon.finalizedBlock.blockNumber < result.blockNumber!) {
           await new Promise(resolve => {
             const unsub = walletsForArgon.events.on('sync:finalized', h => {

--- a/src-vue/__test__/WalletRecovery.test.ts
+++ b/src-vue/__test__/WalletRecovery.test.ts
@@ -1,0 +1,27 @@
+import { expect, it, vi } from 'vitest';
+import { WalletRecovery } from '../lib/WalletRecovery.ts';
+
+it('scans mining history during restore when the mining wallet is currently empty', async () => {
+  const miningHistory = [
+    {
+      frameId: 20,
+      bids: [{ bidPosition: 0, microgonsBid: 10n, micronotsStaked: 20n }],
+      seats: [],
+    },
+  ];
+  const walletsForArgon = {
+    load: vi.fn().mockResolvedValue(undefined),
+    defaultArgonWallet: { hasValue: () => false },
+    miningBotWallet: { hasValue: () => false },
+  };
+  const recovery = new WalletRecovery(
+    {} as any,
+    {} as any,
+    walletsForArgon as any,
+    {} as any,
+    { load: vi.fn().mockResolvedValue(undefined) } as any,
+  );
+  vi.spyOn(recovery as any, 'loadMiningHistory').mockResolvedValue(miningHistory);
+
+  await expect(recovery.findHistory()).resolves.toEqual({ miningHistory, vaultingRules: undefined });
+});

--- a/src-vue/__test__/helpers/db.ts
+++ b/src-vue/__test__/helpers/db.ts
@@ -138,5 +138,8 @@ export async function createMockedDbPromise(allAsObject: { [key: string]: string
       fetchAllAsObject: async () => allAsObject,
       insertOrReplace: async (obj: Partial<IConfigStringified>) => {},
     },
+    vaultsTable: {
+      get: async () => undefined,
+    },
   }) as Db;
 }

--- a/src-vue/__test__/helpers/db.ts
+++ b/src-vue/__test__/helpers/db.ts
@@ -134,6 +134,7 @@ function toNodeSqliteParams(bindValues?: unknown[]): (string | number | Uint8Arr
 
 export async function createMockedDbPromise(allAsObject: { [key: string]: string } = {}): Promise<Db> {
   return Object.assign(Object.create(Db.prototype), {
+    select: async () => [{ hasMiningBids: 0, hasMiningSeats: 0 }],
     configTable: {
       fetchAllAsObject: async () => allAsObject,
       insertOrReplace: async (obj: Partial<IConfigStringified>) => {},

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -253,11 +253,13 @@ export default class BitcoinLocks {
     return this.getAllLocks().filter(lock => !this.isInactiveForVaultDisplay(lock));
   }
 
-  public getAllLocks(): IBitcoinLockRecord[] {
+  public getAllLocks({
+    includeHistoryRecoveryPending = false,
+  }: { includeHistoryRecoveryPending?: boolean } = {}): IBitcoinLockRecord[] {
     const locks = Object.values(this.data.locksByUtxoId);
     locks.unshift(...this.data.pendingLocks);
     return locks
-      .filter(lock => !lock.isHistoryRecoveryPending)
+      .filter(lock => includeHistoryRecoveryPending || !lock.isHistoryRecoveryPending)
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }
 

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -244,14 +244,40 @@ export class Config implements IConfig {
         await this._injectFirstTimeAppData(loadedData, rawData, fieldsToSave);
       }
 
-      if (
+      let hasMiningSeats = loadedData.hasMiningSeats;
+      let hasMiningBids = loadedData.hasMiningBids || hasMiningSeats;
+      if (!hasMiningSeats) {
+        const [savedMiningActivity] = await db.select<[{ hasMiningBids: number; hasMiningSeats: number }]>(`
+          SELECT
+            EXISTS(SELECT 1 FROM FrameBids WHERE json_array_length(bidsJson) > 0) AS hasMiningBids,
+            EXISTS(SELECT 1 FROM Cohorts WHERE seatCountWon > 0) AS hasMiningSeats
+        `);
+        hasMiningSeats = !!savedMiningActivity?.hasMiningSeats;
+        hasMiningBids ||= !!savedMiningActivity?.hasMiningBids || hasMiningSeats;
+      }
+      if (hasMiningSeats !== loadedData.hasMiningSeats) {
+        loadedData.hasMiningSeats = hasMiningSeats;
+        fieldsToSave.add(dbFields.hasMiningSeats);
+        rawData[dbFields.hasMiningSeats] = JsonExt.stringify(hasMiningSeats, 2);
+      }
+      if (hasMiningBids !== loadedData.hasMiningBids) {
+        loadedData.hasMiningBids = hasMiningBids;
+        fieldsToSave.add(dbFields.hasMiningBids);
+        rawData[dbFields.hasMiningBids] = JsonExt.stringify(hasMiningBids, 2);
+      }
+
+      if (hasMiningBids && loadedData.miningSetupStatus !== MiningSetupStatus.Finished) {
+        loadedData.miningSetupStatus = MiningSetupStatus.Finished;
+        fieldsToSave.add(dbFields.miningSetupStatus);
+        rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
+      } else if (
         (loadedData.miningSetupStatus === MiningSetupStatus.Checklist ||
           loadedData.miningSetupStatus === MiningSetupStatus.Installing) &&
         loadedData.isServerInstalled &&
         !loadedData.isServerInstalling &&
         loadedData.serverInstaller.MiningLaunch.status === InstallStepStatus.Completed &&
         rawData[dbFields.biddingRules] &&
-        loadedData.biddingRules.initialCapitalCommitment !== undefined
+        (loadedData.biddingRules.initialCapitalCommitment ?? 0n) > 0n
       ) {
         loadedData.miningSetupStatus = MiningSetupStatus.Finished;
         fieldsToSave.add(dbFields.miningSetupStatus);

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -244,6 +244,33 @@ export class Config implements IConfig {
         await this._injectFirstTimeAppData(loadedData, rawData, fieldsToSave);
       }
 
+      if (
+        (loadedData.miningSetupStatus === MiningSetupStatus.Checklist ||
+          loadedData.miningSetupStatus === MiningSetupStatus.Installing) &&
+        loadedData.isServerInstalled &&
+        !loadedData.isServerInstalling &&
+        loadedData.serverInstaller.MiningLaunch.status === InstallStepStatus.Completed &&
+        rawData[dbFields.biddingRules] &&
+        loadedData.biddingRules.initialCapitalCommitment !== undefined
+      ) {
+        loadedData.miningSetupStatus = MiningSetupStatus.Finished;
+        fieldsToSave.add(dbFields.miningSetupStatus);
+        rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
+      }
+
+      if (
+        (loadedData.vaultingSetupStatus === VaultingSetupStatus.Checklist ||
+          loadedData.vaultingSetupStatus === VaultingSetupStatus.Installing) &&
+        rawData[dbFields.vaultingRules]
+      ) {
+        const savedVault = await db.vaultsTable.get();
+        if (savedVault && !savedVault.isClosed) {
+          loadedData.vaultingSetupStatus = VaultingSetupStatus.Finished;
+          fieldsToSave.add(dbFields.vaultingSetupStatus);
+          rawData[dbFields.vaultingSetupStatus] = JsonExt.stringify(loadedData.vaultingSetupStatus, 2);
+        }
+      }
+
       const hasLegacyAccountState =
         loadedData.isServerInstalled ||
         loadedData.miningSetupStatus !== MiningSetupStatus.None ||

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -66,6 +66,7 @@ export default class Installer {
 
   private isFreshInstall: boolean = true;
   private remoteFilesNeedUpdating: boolean = false;
+  private miningBidProxyIsReady: boolean = false;
 
   private isLoadedDeferred!: IDeferred<void>;
   private installerCheck: InstallerCheck;
@@ -103,6 +104,21 @@ export default class Installer {
     await this.config.isLoadedPromise;
 
     try {
+      if (
+        this.config.miningSetupStatus === MiningSetupStatus.Finished &&
+        this.config.isServerInstalled &&
+        !this.config.isServerInstalling &&
+        this.installerCheck.isServerInstallComplete
+      ) {
+        try {
+          await this.ensureMiningBidProxyIsReady();
+        } catch (error) {
+          console.warn('[Installer] Unable to ensure the mining bid proxy during startup', {
+            error: getErrorDiagnostics(error),
+          });
+        }
+      }
+
       if (this.config.isServerAdded && !this.isRunning) {
         const hasServerDetails = !!this.config.serverDetails.ipAddress;
         if (hasServerDetails) {
@@ -282,55 +298,7 @@ export default class Installer {
         if (await this.pauseForAppUpdate()) return;
       }
       if (!this.isFreshInstall && this.config.miningSetupStatus === MiningSetupStatus.Finished) {
-        const transactionTracker = getTransactionTracker();
-        await transactionTracker.load();
-
-        const proxySetup = await ensureMiningBidProxySetup({
-          transactionTracker,
-          walletKeys: this.walletKeys,
-        });
-
-        if (proxySetup.kind === 'insufficientFunds') {
-          console.warn(
-            '[Installer] Skipping mining bid proxy migration until the mining funding account is topped up',
-            {
-              error: proxySetup.error,
-            },
-          );
-        } else if (proxySetup.kind === 'submitted' || proxySetup.kind === 'trackingExisting') {
-          let uploadProgressInterval: ReturnType<typeof setInterval> | undefined;
-          if (this.remoteFilesNeedUpdating) {
-            const waitForBlockStartedAt = Date.now();
-            const updateWaitProgress = () => {
-              const elapsed = Date.now() - waitForBlockStartedAt;
-              const progressRatio = Math.min(1, Math.max(0, elapsed / (TICK_MILLIS * 2)));
-              this.fileUploadProgress = Math.max(this.fileUploadProgress, 90 + progressRatio * 5);
-            };
-
-            updateWaitProgress();
-            uploadProgressInterval = setInterval(
-              updateWaitProgress,
-              Math.min(1000, Math.max(100, Math.ceil(TICK_MILLIS / 60))),
-            );
-          }
-
-          // The bot already holds off bidding until the mining bid proxy is ready, so first inclusion is
-          // enough to let the installer continue without waiting for full finality here.
-          try {
-            await proxySetup.txInfo.txResult.waitForInFirstBlock;
-          } finally {
-            if (uploadProgressInterval) clearInterval(uploadProgressInterval);
-            if (this.remoteFilesNeedUpdating) {
-              this.fileUploadProgress = Math.max(this.fileUploadProgress, 96);
-            }
-          }
-
-          void proxySetup.txInfo.waitForPostProcessing.catch(error => {
-            console.warn('[Installer] Mining bid proxy setup is still pending finalization', {
-              error: getErrorDiagnostics(error),
-            });
-          });
-        }
+        await this.ensureMiningBidProxyIsReady();
       }
       if (await this.pauseForAppUpdate()) return;
 
@@ -441,6 +409,64 @@ export default class Installer {
       this._server = new ServerAdmin(connection, this.config.serverDetails);
     }
     return this._server;
+  }
+
+  private async ensureMiningBidProxyIsReady(): Promise<void> {
+    if (this.miningBidProxyIsReady) return;
+
+    const transactionTracker = getTransactionTracker();
+    await transactionTracker.load();
+
+    const proxySetup = await ensureMiningBidProxySetup({
+      transactionTracker,
+      walletKeys: this.walletKeys,
+    });
+
+    if (proxySetup.kind === 'insufficientFunds') {
+      console.warn('[Installer] Skipping mining bid proxy migration until the mining funding account is topped up', {
+        error: proxySetup.error,
+      });
+      return;
+    }
+
+    if (proxySetup.kind === 'ready') {
+      this.miningBidProxyIsReady = true;
+      return;
+    }
+
+    let uploadProgressInterval: ReturnType<typeof setInterval> | undefined;
+    if (this.remoteFilesNeedUpdating) {
+      const waitForBlockStartedAt = Date.now();
+      const updateWaitProgress = () => {
+        const elapsed = Date.now() - waitForBlockStartedAt;
+        const progressRatio = Math.min(1, Math.max(0, elapsed / (TICK_MILLIS * 2)));
+        this.fileUploadProgress = Math.max(this.fileUploadProgress, 90 + progressRatio * 5);
+      };
+
+      updateWaitProgress();
+      uploadProgressInterval = setInterval(
+        updateWaitProgress,
+        Math.min(1000, Math.max(100, Math.ceil(TICK_MILLIS / 60))),
+      );
+    }
+
+    // The bot already holds off bidding until the mining bid proxy is ready, so first inclusion is
+    // enough to let the installer continue without waiting for full finality here.
+    try {
+      await proxySetup.txInfo.txResult.waitForInFirstBlock;
+      this.miningBidProxyIsReady = true;
+    } finally {
+      if (uploadProgressInterval) clearInterval(uploadProgressInterval);
+      if (this.remoteFilesNeedUpdating) {
+        this.fileUploadProgress = Math.max(this.fileUploadProgress, 96);
+      }
+    }
+
+    void proxySetup.txInfo.waitForPostProcessing.catch(error => {
+      console.warn('[Installer] Mining bid proxy setup is still pending finalization', {
+        error: getErrorDiagnostics(error),
+      });
+    });
   }
 
   private async saveLocalGatewayPortWhenReady(

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -266,7 +266,11 @@ export default class Installer {
       this.serverConnectProgress = 100;
 
       installPhase = InstallStepErrorType.FileUpload;
+      let composeProjectName: string | undefined;
       if (this.remoteFilesNeedUpdating) {
+        // Core file upload replaces the remote server directory, including the .env that identifies its Compose project.
+        composeProjectName = await server.getComposeProjectName();
+
         console.info('Uploading account address');
         await server.uploadAccountAddress(this.walletKeys.miningBotAddress);
         this.fileUploadProgress = 2;
@@ -339,7 +343,7 @@ export default class Installer {
 
       console.info('Starting remote script');
       await server.createLogsDir();
-      await server.startInstallerScript();
+      await server.startInstallerScript({ composeProjectName });
       installPhase = undefined;
       this.fileUploadProgress = 99;
       this.isRunningInBackground = true;

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -210,23 +210,37 @@ export class ServerAdmin {
   }
 
   public async getDataDir(service: string): Promise<string> {
-    const [dataDir] = await this.runComposeCommand(
-      `config ${service} --format json | jq -r '.services.["${service}"].volumes[0].source'`,
+    const [output, code] = await this.runComposeCommand(
+      `config ${service} --format json 2>/dev/null | jq -er '.services.["${service}"].volumes[0].source'`,
       10e3,
     );
-    return dataDir.trim();
+    const dataDir = output.trim();
+    if (code !== 0 || !dataDir.startsWith('/') || dataDir.includes('\n') || dataDir.includes('\r')) {
+      throw new Error(`Invalid data directory returned for ${service}`);
+    }
+    return dataDir;
   }
 
   public async cleanDirectory(directory: string): Promise<void> {
-    if (!directory || directory === '/') {
+    if (!directory.startsWith('/') || directory === '/' || directory.includes('\n') || directory.includes('\r')) {
       throw new Error('Invalid directory to clean');
     }
     console.info(`Cleaning directory: ${directory}`);
-    await this.connection.runCommandWithTimeout(`set -euo pipefail && sudo rm -rf -- "${directory}"/*`, 10e3);
+    await this.connection.runCommandWithTimeout(
+      `set -euo pipefail && sudo find "${directory}" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
+      60e3,
+    );
+    const [remainingFiles, code] = await this.connection.runCommandWithTimeout(
+      `sudo find "${directory}" -mindepth 1 -maxdepth 1 -print -quit`,
+      10e3,
+    );
+    if (code !== 0 || remainingFiles.trim()) {
+      throw new Error(`Directory was not fully cleaned: ${directory}`);
+    }
   }
 
   public async stopMiningDockers(): Promise<void> {
-    await this.runComposeCommand(`stop argon-miner `);
+    await this.runComposeCommand(`stop argon-miner`);
   }
 
   public async startMiningDockers(): Promise<void> {
@@ -234,12 +248,11 @@ export class ServerAdmin {
   }
 
   public async resyncMiner(): Promise<void> {
-    const dataDir = await this.getDataDir('argon-miner').catch(() => null);
-    if (dataDir) {
-      await this.stopMiningDockers();
-      console.info(`Wiping Argon Miner data directory: ${dataDir}`);
-      await this.cleanDirectory(dataDir);
-    }
+    const dataDir = await this.getDataDir('argon-miner');
+    const chainDataDir = `${dataDir}/chains`;
+    await this.stopMiningDockers();
+    console.info(`Wiping Argon chain data directory: ${chainDataDir}`);
+    await this.cleanDirectory(chainDataDir);
     await this.removeLogStep(InstallStepKey.ArgonInstall);
     await this.startMiningDockers();
   }
@@ -253,12 +266,10 @@ export class ServerAdmin {
   }
 
   public async resyncBitcoin(): Promise<void> {
-    const dataDir = await this.getDataDir('bitcoin-node').catch(() => null);
-    if (dataDir) {
-      await this.stopBitcoinDocker();
-      console.info(`Wiping Bitcoin data directory: ${dataDir}`);
-      await this.cleanDirectory(dataDir);
-    }
+    const dataDir = await this.getDataDir('bitcoin-node');
+    await this.stopBitcoinDocker();
+    console.info(`Wiping Bitcoin data directory: ${dataDir}`);
+    await this.cleanDirectory(dataDir);
     await this.removeLogStep(InstallStepKey.BitcoinInstall);
     await this.startBitcoinDocker();
   }
@@ -307,7 +318,20 @@ export class ServerAdmin {
     await this.connection.runCommandWithTimeout(`rm -rf ${this.workDir}/logs/step-${stepKey}.*`, 60e3);
   }
 
-  public async startInstallerScript(): Promise<void> {
+  public async getComposeProjectName(): Promise<string> {
+    const [existingEnv] = await this.connection.runCommandWithTimeout(
+      `cat ${this.workDir}/server/.env 2>/dev/null || true`,
+      10e3,
+    );
+    const composeProjectName = parseEnv(existingEnv).COMPOSE_PROJECT_NAME?.trim() || DOCKER_COMPOSE_PROJECT_NAME;
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(composeProjectName)) {
+      throw new Error('Invalid Docker Compose project name in the existing server configuration');
+    }
+
+    return composeProjectName;
+  }
+
+  public async startInstallerScript(options: { composeProjectName?: string } = {}): Promise<void> {
     const remoteScriptPath = this.installerScriptPath;
     const remoteScriptLogPath = `${this.workDir}/logs/installer.log`;
     const [existingEnv] = await this.connection.runCommandWithTimeout(
@@ -315,7 +339,8 @@ export class ServerAdmin {
       10e3,
     );
     const existingEnvVars = parseEnv(existingEnv);
-    const composeProjectName = existingEnvVars.COMPOSE_PROJECT_NAME?.trim() || DOCKER_COMPOSE_PROJECT_NAME;
+    const composeProjectName =
+      options.composeProjectName?.trim() || existingEnvVars.COMPOSE_PROJECT_NAME?.trim() || DOCKER_COMPOSE_PROJECT_NAME;
     if (!/^[a-z0-9][a-z0-9_-]*$/.test(composeProjectName)) {
       throw new Error('Invalid Docker Compose project name in the existing server configuration');
     }

--- a/src-vue/lib/WalletRecovery.ts
+++ b/src-vue/lib/WalletRecovery.ts
@@ -32,10 +32,9 @@ export class WalletRecovery {
     await this.miningFrames.load();
 
     const hasVaultHistory = walletsForArgon.defaultArgonWallet.hasValue();
-    const hasMiningHistory = walletsForArgon.miningBotWallet.hasValue();
 
     let vaultProgress = hasVaultHistory ? 0 : 100;
-    let miningProgress = hasMiningHistory ? 0 : 100;
+    let miningProgress = 0;
     onLoadHistoryProgress?.(0);
     const onProgress = (source: 'miner' | 'vault', progressPct: number) => {
       if (source === 'miner') miningProgress = progressPct;
@@ -43,11 +42,8 @@ export class WalletRecovery {
       onLoadHistoryProgress?.(Math.round(100 * ((vaultProgress + miningProgress) / 2)) / 100);
     };
 
-    let miningHistoryPromise: Promise<IMiningAccountPreviousHistoryRecord[] | undefined> = Promise.resolve(undefined);
-    if (hasMiningHistory) {
-      const liveClient = await this.clients.archiveClientPromise;
-      miningHistoryPromise = this.loadMiningHistory(liveClient, pct => onProgress('miner', pct));
-    }
+    const liveClient = await this.clients.archiveClientPromise;
+    const miningHistoryPromise = this.loadMiningHistory(liveClient, pct => onProgress('miner', pct));
 
     let vaultingHistoryPromise: Promise<IVaultingRules | undefined> = Promise.resolve(undefined);
     if (hasVaultHistory) {

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -25,6 +25,7 @@ export class BitcoinLockRecovery {
   >;
   private historyReplayLocksByUtxoId?: Record<number, IBitcoinLockRecord>;
   private readonly historyRecoveryPendingUtxoIds = new Set<number>();
+  private readonly historyRecoveryPendingUuids = new Set<string>();
   private readonly insertPending: (
     details: Pick<IBitcoinLockRecord, 'uuid' | 'satoshis' | 'vaultId' | 'hdPath'>,
   ) => Promise<IBitcoinLockRecord>;
@@ -63,14 +64,27 @@ export class BitcoinLockRecovery {
     this.trackDerivedBitcoinLockKey = args.trackDerivedBitcoinLockKey;
   }
 
-  public beginHistoryReplay(): void {
+  public get hasPendingHistoryRecovery(): boolean {
+    return [...Object.values(this.locksByUtxoId), ...this.pendingLocks].some(lock => lock.isHistoryRecoveryPending);
+  }
+
+  public async beginHistoryReplay({
+    recoverExistingLocks = false,
+  }: { recoverExistingLocks?: boolean } = {}): Promise<void> {
     if (this.historyReplayLocksByUtxoId) throw new Error('Bitcoin lock history replay is already running');
 
     this.historyReplayLocksByUtxoId = {};
+    for (const lock of [...Object.values(this.locksByUtxoId), ...this.pendingLocks]) {
+      if (!lock.isHistoryRecoveryPending) continue;
+
+      this.historyRecoveryPendingUuids.add(lock.uuid);
+      if (lock.utxoId !== undefined) this.historyRecoveryPendingUtxoIds.add(lock.utxoId);
+    }
+
+    if (!recoverExistingLocks) return;
+
     for (const lock of Object.values(this.locksByUtxoId)) {
-      if (lock.isHistoryRecoveryPending && lock.utxoId !== undefined) {
-        this.historyRecoveryPendingUtxoIds.add(lock.utxoId);
-      }
+      await this.prepareHistoryRecoveryLock(lock);
     }
   }
 
@@ -84,25 +98,25 @@ export class BitcoinLockRecovery {
       return;
     }
 
-    const recoveredLocks = [...this.historyRecoveryPendingUtxoIds]
-      .map(utxoId => stagedLocks[utxoId] ?? this.locksByUtxoId[utxoId])
-      .filter(lock => !!lock);
     const table = await this.getTable();
-    await Promise.all(recoveredLocks.map(lock => table.setHistoryRecoveryPending(lock.uuid, false)));
+    await Promise.all([...this.historyRecoveryPendingUuids].map(uuid => table.setHistoryRecoveryPending(uuid, false)));
 
     this.historyReplayLocksByUtxoId = undefined;
     for (const recovered of Object.values(stagedLocks)) this.applyRecoveredRecord(recovered);
     const completedLocks: IBitcoinLockRecord[] = [];
-    for (const lock of recoveredLocks) {
-      const liveLock = this.locksByUtxoId[lock.utxoId!];
+    for (const uuid of this.historyRecoveryPendingUuids) {
+      const liveLock =
+        Object.values(this.locksByUtxoId).find(lock => lock.uuid === uuid) ??
+        this.pendingLocks.find(lock => lock.uuid === uuid);
       if (!liveLock) continue;
 
       const pendingIndex = this.pendingLocks.findIndex(pending => pending.uuid === liveLock.uuid);
-      if (pendingIndex >= 0) this.pendingLocks.splice(pendingIndex, 1);
+      if (liveLock.utxoId !== undefined && pendingIndex >= 0) this.pendingLocks.splice(pendingIndex, 1);
       delete liveLock.isHistoryRecoveryPending;
       completedLocks.push(liveLock);
     }
     this.historyRecoveryPendingUtxoIds.clear();
+    this.historyRecoveryPendingUuids.clear();
     this.onHistoryRecoveryComplete(completedLocks);
   }
 
@@ -530,6 +544,7 @@ export class BitcoinLockRecovery {
     if (stagedLocks) {
       recovered.isHistoryRecoveryPending = true;
       this.historyRecoveryPendingUtxoIds.add(utxoId);
+      this.historyRecoveryPendingUuids.add(recovered.uuid);
     }
     const liveRecord = this.locksByUtxoId[utxoId];
     const current =
@@ -563,6 +578,7 @@ export class BitcoinLockRecovery {
     const pendingLock = this.pendingLocks.find(record => record.uuid === lock.uuid);
     if (pendingLock) pendingLock.isHistoryRecoveryPending = true;
     this.historyRecoveryPendingUtxoIds.add(utxoId);
+    this.historyRecoveryPendingUuids.add(lock.uuid);
     if (lock.uuid !== lockQueueOwnerUuid) await this.waitForLockIdle(lock);
   }
 

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -38,11 +38,14 @@ export async function needsFinancialHistoryRecovery(args: {
   accountId: string;
   enabledDomains: readonly IFinancialHistoryDomain[];
   targetBlock: number;
+  bitcoinLockRecovery?: Pick<BitcoinLockRecovery, 'hasPendingHistoryRecovery'>;
 }): Promise<boolean> {
   const savedState = await args.db.syncStateTable.get(SyncStateKeys.FinancialHistory);
   const domainCheckpoints = getDomainCheckpoints(savedState, args.accountId);
 
   return args.enabledDomains.some(domain => {
+    if (domain === 'bitcoin' && args.bitcoinLockRecovery?.hasPendingHistoryRecovery) return true;
+
     const checkpoint = domainCheckpoints[domain];
     const recoveryVersion = historyRecoveryVersions[domain];
     return (
@@ -101,6 +104,8 @@ export async function restoreFinancialHistory(args: {
   const domainCheckpoints = getDomainCheckpoints(savedState, accountId);
 
   const domainsToRestore = enabledDomains.filter(domain => {
+    if (domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery) return true;
+
     const checkpoint = domainCheckpoints[domain];
     const recoveryVersion = historyRecoveryVersions[domain];
     const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint?.recoveryVersion !== recoveryVersion;
@@ -122,8 +127,6 @@ export async function restoreFinancialHistory(args: {
     const isBitcoinReplay = domain === 'bitcoin' && !!bitcoinLockRecovery;
 
     try {
-      if (isBitcoinReplay) bitcoinLockRecovery.beginHistoryReplay();
-
       const result = await restoreFinancialHistoryDomain({
         db,
         blockWatch,
@@ -322,7 +325,9 @@ async function restoreFinancialHistoryDomain(args: {
   const { db, blockWatch, accountId, argonBonds, bitcoinLockRecovery, vaultHistory, domain, checkpoint } = args;
   const recoveryVersion = historyRecoveryVersions[domain];
   const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint?.recoveryVersion !== recoveryVersion;
-  let afterBlock = args.force || !checkpoint || recoveryVersionChanged ? 0 : checkpoint.asOfBlock;
+  const hasIncompleteBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
+  let afterBlock =
+    args.force || !checkpoint || recoveryVersionChanged || hasIncompleteBitcoinRecovery ? 0 : checkpoint.asOfBlock;
   let indexedHistory = await findAddressActivity(accountId, {
     afterBlock,
     toBlock: args.targetBlock,
@@ -344,6 +349,10 @@ async function restoreFinancialHistoryDomain(args: {
     throw new Error(
       `Investment history index has a coverage gap from block ${firstGap.fromBlock.toLocaleString()} to ${firstGap.toBlock.toLocaleString()}: ${firstGap.reason}`,
     );
+  }
+
+  if (domain === 'bitcoin' && bitcoinLockRecovery) {
+    await bitcoinLockRecovery.beginHistoryReplay({ recoverExistingLocks: afterBlock === 0 });
   }
 
   const backlog =

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -3,7 +3,7 @@
     <div v-if="!isLoaded" class="flex grow items-center justify-center text-slate-500">Loading...</div>
 
     <!-- Blank state -->
-    <div v-else-if="!financials.liquidAllRecords.length" class="flex grow flex-col">
+    <div v-else-if="!financials.bitcoinLockDisplayRecords.length" class="flex grow flex-col">
       <div class="flex grow flex-col items-center justify-center">
         <div class="flex w-8/12 max-w-200 flex-col items-center py-10">
           <header class="text-argon-600 pb-3 text-xl font-bold">
@@ -125,8 +125,8 @@
         <div class="flex grow flex-col overflow-y-auto pt-10">
           <div class="flex flex-row items-center px-9 text-slate-800/70">
             <span class="grow">
-              You have {{ financials.liquidVisibleRecords.length }} BTC transaction{{
-                financials.liquidVisibleRecords.length === 1 ? '' : 's'
+              You have {{ financials.bitcoinLockDisplayRecords.length }} BTC transaction{{
+                financials.bitcoinLockDisplayRecords.length === 1 ? '' : 's'
               }}...
             </span>
             <div class="flex flex-row items-stretch gap-x-3">
@@ -150,7 +150,7 @@
           <section class="mt-4 flex grow flex-col gap-y-3 px-9 pb-10">
             <BitcoinRecord
               :data-testid="`BitcoinLocks.lockEntry.${lockSummary.uuid}`"
-              v-for="lockSummary in financials.liquidVisibleRecords"
+              v-for="lockSummary in financials.bitcoinLockDisplayRecords"
               :key="lockSummary.uuid ?? lockSummary.utxoId"
               :lockSummary="lockSummary"
               @click="openDetail(lockSummary)"
@@ -255,6 +255,8 @@ const canStartLocking = Vue.computed(() => {
 });
 
 function openDetail(lock: IBitcoinLockSummary) {
+  if (lock.record.isHistoryRecoveryPending) return;
+
   selectedLock.value = lock;
   if (bitcoinLocks.isLockedStatus(lock.record) || bitcoinLocks.isFinishedStatus(lock.record)) {
     showDetailOverlay.value = true;

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -188,12 +188,11 @@ function trackTxInfo(txInfo: TransactionInfo) {
     txProgressLabel.value = `Submitted to Argon Miners: ${args.progressMessage}`;
     txProgressPct.value = Math.max(txProgressPct.value, args.progressPct);
 
-    if (args.progressPct === 100) {
-      if (error) {
-        transactionErrorMessage.value = error.message;
-      }
-      void ensureTrackedSetupTransfer();
+    if (args.progressPct === 100 && error) {
+      transactionErrorMessage.value = error.message;
     }
+
+    void ensureTrackedSetupTransfer();
   });
 
   void txInfo.waitForPostProcessing

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -35,6 +35,7 @@ import { getTransactionTracker } from '../../stores/transactions.ts';
 import { MoveCapital, type ITransactionMoveMetadata } from '../../lib/MoveCapital.ts';
 import { ExtrinsicType } from '../../lib/db/TransactionsTable.ts';
 import type { TransactionInfo } from '../../lib/TransactionInfo.ts';
+import { TxAttemptState } from '../../lib/TransactionTracker.ts';
 import { getMyVault } from '../../stores/vaults.ts';
 import type { Config } from '../../lib/Config.ts';
 import { getMiningFundingState } from './miningFunding.ts';
@@ -187,11 +188,12 @@ function trackTxInfo(txInfo: TransactionInfo) {
     txProgressLabel.value = `Submitted to Argon Miners: ${args.progressMessage}`;
     txProgressPct.value = Math.max(txProgressPct.value, args.progressPct);
 
-    if (args.progressPct === 100 && error) {
-      transactionErrorMessage.value = error.message;
+    if (args.progressPct === 100) {
+      if (error) {
+        transactionErrorMessage.value = error.message;
+      }
+      void ensureTrackedSetupTransfer();
     }
-
-    void ensureTrackedSetupTransfer();
   });
 
   void txInfo.waitForPostProcessing
@@ -222,12 +224,18 @@ async function finalizeMiningSetup() {
 }
 
 async function ensureTrackedSetupTransfer(force = false) {
+  if (!hasEnteredTransactionPhase.value) return;
+
   const txInfo = findLatestSetupTxInfo();
   if (txInfo) {
-    trackTxInfo(txInfo);
+    const txAttemptState = await transactionTracker.getTxAttemptState(txInfo, 2);
+    if (txAttemptState === TxAttemptState.Follow) {
+      trackTxInfo(txInfo);
+      return;
+    }
   }
 
-  if (!hasEnteredTransactionPhase.value || !wallets.isLoaded || isEnsuringSetupTransfer.value) return;
+  if (!wallets.isLoaded || isEnsuringSetupTransfer.value) return;
 
   const now = Date.now();
   if (!force && now - lastEnsureSetupTransferAt < 3_000) return;

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -1,6 +1,20 @@
 <template>
   <div class="BitcoinRecord Component flex flex-col">
-    <section PendingRecord v-if="lockSummary.status === BitcoinLockStatus.LockIsProcessingOnArgon">
+    <section RecoveryRecord v-if="lockSummary.record.isHistoryRecoveryPending">
+      <BitcoinIcon MainIcon class="bitcoin-spin" />
+      <div ContentWrapper>
+        <div FirstRow>
+          <header>{{ satToBtcNm(lockSummary.satoshis).format('0,0.[00000000]') }} of BTC</header>
+          <span class="inline-flex items-center gap-2 font-semibold text-slate-500">
+            <Spinner class="h-4 w-4" />
+            Syncing...
+          </span>
+        </div>
+        <div SecondRow>Restoring this Bitcoin transaction from chain history.</div>
+      </div>
+    </section>
+
+    <section PendingRecord v-else-if="lockSummary.status === BitcoinLockStatus.LockIsProcessingOnArgon">
       <BitcoinIcon MainIcon class="bitcoin-spin" />
       <div ContentWrapper>
         <div FirstRow>
@@ -267,6 +281,10 @@ async function acknowledgeExpiredNotice() {
 @reference "../../../main.css";
 
 .BitcoinRecord.Component {
+  section[RecoveryRecord] {
+    @apply flex cursor-wait flex-row items-center gap-2.5 rounded border border-slate-900/20 bg-slate-100 px-3.5 py-2 opacity-60;
+  }
+
   section[PendingRecord] {
     @apply flex cursor-pointer flex-row items-center gap-2.5 rounded border-[1.5px] border-dashed border-slate-900/30 bg-white px-3.5 py-2 hover:bg-slate-50/50;
     [MainIcon] {

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -606,7 +606,20 @@ export const useFinancials = defineStore('financials', () => {
   });
 
   const liquidVisibleRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
-    return liquidAllRecords.value.filter(l => !bitcoinLocks.isInactiveForVaultDisplay(l.record));
+    return liquidAllRecords.value.filter(
+      lock => !lock.record.isHistoryRecoveryPending && !bitcoinLocks.isInactiveForVaultDisplay(lock.record),
+    );
+  });
+
+  const bitcoinLockDisplayRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
+    const recoveringRecords = bitcoinLocks
+      .getAllLocks({ includeHistoryRecoveryPending: true })
+      .filter(lock => lock.isHistoryRecoveryPending && !bitcoinLocks.isInactiveForVaultDisplay(lock))
+      .map(lock => bitcoinLocks.createLockSummary(lock));
+
+    return [...liquidVisibleRecords.value, ...recoveringRecords].sort(
+      (left, right) => right.createdAt.getTime() - left.createdAt.getTime(),
+    );
   });
 
   const liquidLockedRecords = Vue.computed(() => {
@@ -917,6 +930,7 @@ export const useFinancials = defineStore('financials', () => {
       accountId: wallets.defaultArgonWallet.address,
       enabledDomains,
       targetBlock,
+      bitcoinLockRecovery: bitcoinLocks.recovery,
     });
     if (needsRecovery) {
       await restoreFinancialHistory(false, targetBlock);
@@ -1026,6 +1040,7 @@ export const useFinancials = defineStore('financials', () => {
     bondSummariesByAsset,
 
     liquidAllRecords,
+    bitcoinLockDisplayRecords,
     liquidVisibleRecords,
     liquidInvisibleRecords,
     liquidLockedRecords,


### PR DESCRIPTION
## Summary

Restored operator accounts now return to their established mining, vaulting, and Bitcoin state instead of falling back into setup screens or hiding transactions indefinitely. Server upgrades and node resyncs also preserve the existing deployment identity and fail safely when remote data cannot be cleaned.

- Mining and vaulting completion is rebuilt from durable bids, seats, rules, and vault records. Mining history is scanned even when the bot wallet is currently empty, while interrupted funding and bid-proxy work resumes without following stale failed attempts.
- Bitcoin records undergoing history recovery remain visible as disabled syncing rows, and only those records have actions and alerts suppressed. A persisted recovery marker now forces a complete Bitcoin history replay even when its checkpoint appears current, then clears the marker by record identity.
- Server upgrades retain the remote Docker Compose project before replacing files. Resyncs validate the Compose data path, stop the affected service before cleanup, verify that cleanup completed, and limit Argon deletion to chain state so other persistent server data remains intact.

## Validation

- 665 unit tests passed across 106 files.
- Bitcoin lock integration completed successfully during the broader integration run.
- Type checking and the full lint/pre-commit checks passed.
- The unrelated full Ethereum and desktop e2e matrix was not run to completion.
