### PR TITLE
fix(bitcoin): recover lock history and returns

### DIFF
--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -70,6 +70,26 @@ describe('BlockWatch archive recovery', () => {
     expect(result).toBe(historicalHeader);
   });
 
+  it('uses a known historical block hash without looking it up again', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    const historicalHeader = createHeaderInfo(108, '0x108', '0x107');
+    const archiveClient = {
+      rpc: {
+        chain: {
+          getBlockHash: vi.fn(),
+          getHeader: vi.fn().mockResolvedValue({ __info: historicalHeader }),
+        },
+      },
+    };
+    const blockWatch = new BlockWatch(createClients(archiveClient, archiveClient) as any);
+    blockWatch.latestHeaders = [createHeaderInfo(100, '0xfinalized', '0xfinalized-parent')];
+
+    await expect(blockWatch.getHeader({ blockNumber: 108, blockHash: '0x108' })).resolves.toBe(historicalHeader);
+    expect(archiveClient.rpc.chain.getBlockHash).not.toHaveBeenCalled();
+    expect(archiveClient.rpc.chain.getHeader).toHaveBeenCalledWith('0x108');
+  });
+
   it('retries historical header lookup on archive when the selected client query times out', async () => {
     vi.useFakeTimers();
     vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -286,13 +286,22 @@ export class BlockWatch {
     );
   }
 
-  public async getHeader(blockNumber: number): Promise<IBlockHeaderInfo> {
+  public async getHeader(
+    block: number | Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>,
+  ): Promise<IBlockHeaderInfo> {
+    const blockNumber = typeof block === 'number' ? block : block.blockNumber;
     if (blockNumber < 0) {
       throw new Error(`[BlockWatch] getHeader called with negative blockNumber (${blockNumber})`);
     }
     const best = this.latestHeaders.find(x => x.blockNumber === blockNumber);
-    if (best) {
+    if (best && (typeof block === 'number' || best.blockHash.toLowerCase() === block.blockHash.toLowerCase())) {
       return best;
+    }
+    if (typeof block !== 'number') {
+      const header = await this.readWithArchiveRetry(blockNumber, `getHeader(${blockNumber})`, client =>
+        client.rpc.chain.getHeader(block.blockHash),
+      );
+      return BlockWatch.readHeader(header, blockNumber <= this.finalizedBlockHeader.blockNumber);
     }
     return await this.getHeaderByBlockNumber(blockNumber);
   }

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BlockWatch, Currency as CurrencyBase } from '@argonprotocol/apps-core';
 import BitcoinLocks from '../lib/BitcoinLocks.ts';
 import type { Db } from '../lib/Db.ts';
@@ -7,7 +7,7 @@ import type { WalletKeys } from '../lib/WalletKeys.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import { BitcoinUtxoStatus } from '../lib/db/BitcoinUtxosTable.ts';
 import { ExtrinsicType, TransactionStatus } from '../lib/db/TransactionsTable.ts';
-import { BitcoinLock, hexToU8a, type IBitcoinLock } from '@argonprotocol/mainchain';
+import { BitcoinLock, hexToU8a, TxSubmitter, type IBitcoinLock } from '@argonprotocol/mainchain';
 import { createHistoricalEventData } from '../../indexer/__test__/helpers/historicalEvents.ts';
 import { bigintCodec, numberCodec, optionCodec } from '../../core/__test__/helpers/codecs.ts';
 import { encodeAddress } from '@polkadot/util-crypto';
@@ -457,10 +457,16 @@ describe('BitcoinLocks recovery', () => {
         operationalAddress: encodeAddress(new Uint8Array(32).fill(0x55)),
       } as WalletKeys,
     });
-    const fundingRecord = { id: 1 } as never;
+    const fundingRecord = { id: 1, status: BitcoinUtxoStatus.ReleaseComplete } as never;
     vi.spyOn(store.utxoTracking, 'getAcceptedFundingRecordForLock').mockReturnValue(fundingRecord);
-    const setReleaseRequest = vi.spyOn(store.utxoTracking, 'setReleaseRequest').mockResolvedValue();
+    const setReleaseRequest = vi.spyOn(store.utxoTracking, 'setReleaseRequest').mockImplementation(async funding => {
+      funding.status = BitcoinUtxoStatus.ReleaseIsProcessingOnArgon;
+    });
     const createdLock = new BitcoinLock(createHistoricalLock({ accountId, liquidityPromised: 1_000n }));
+    const verifiedLock = new BitcoinLock({
+      ...createHistoricalLock({ accountId, liquidityPromised: 900n, lockedTargetPrice: 900n }),
+      utxoSatoshis: 9_900n,
+    });
     const ratchetedLock = new BitcoinLock(
       createHistoricalLock({ accountId, liquidityPromised: 1_200n, lockedTargetPrice: 1_300n }),
     );
@@ -511,8 +517,10 @@ describe('BitcoinLocks recovery', () => {
     vi.spyOn(store.recovery, 'recoverLock').mockResolvedValue(record);
     vi.spyOn(BitcoinLock, 'get')
       .mockResolvedValueOnce(createdLock)
+      .mockResolvedValueOnce(verifiedLock)
       .mockResolvedValueOnce(ratchetedLock)
       .mockResolvedValueOnce(twiceRatchetedLock);
+    vi.spyOn(BitcoinLock.prototype, 'getFundingUtxoRef').mockResolvedValue(undefined);
     vi.spyOn(BitcoinLock.prototype, 'findPendingMints').mockResolvedValueOnce([]).mockResolvedValue([100n]);
     vi.spyOn(BitcoinLock.prototype, 'getReleaseRequest').mockResolvedValue({
       toScriptPubkey: '0x0014',
@@ -521,11 +529,26 @@ describe('BitcoinLocks recovery', () => {
       vaultId: 1,
       redemptionAmount: 900n,
     });
+    const ownerLockKeys = vi.fn(async () => [{ args: [{}, numberCodec(7)] }, { args: [{}, numberCodec(8)] }]);
+    const activeLocks = vi.fn(async () => [
+      optionCodec({
+        liquidityPromised: bigintCodec(1_400n),
+        lockedTargetPrice: bigintCodec(1_500n),
+      }),
+      optionCodec({
+        liquidityPromised: bigintCodec(2_000n),
+        lockedTargetPrice: bigintCodec(2_000n),
+      }),
+    ]);
     const api = {
       query: {
         ticks: { currentTick: vi.fn(async () => numberCodec(700)) },
         bitcoinUtxos: {
           confirmedBitcoinBlockTip: vi.fn(async () => optionCodec({ blockHeight: numberCodec(600) })),
+        },
+        bitcoinLocks: {
+          utxoIdsByOwnerAccount: { keys: ownerLockKeys },
+          locksByUtxoId: { multi: activeLocks },
         },
       },
     };
@@ -548,14 +571,18 @@ describe('BitcoinLocks recovery', () => {
       }),
     ]);
     await store.recovery.recoverBlock(historyBlock(152), [
-      historyEvent(152, 'mint', 'BitcoinMint', { accountId, utxoId: 7, amount: 1_000n }),
+      historyEvent(152, 'bitcoinUtxos', 'UtxoVerified', {
+        utxoId: 7,
+        satoshisReceived: 9_900n,
+      }),
+      historyEvent(152, 'mint', 'BitcoinMint', { accountId, utxoId: 7, amount: 900n }),
     ]);
     await store.recovery.recoverBlock(historyBlock(153), [
       historyEvent(152, 'bitcoinLocks', 'BitcoinLockRatcheted', {
         utxoId: 7,
         vaultId: 1,
         liquidityPromised: 1_200n,
-        oldTargetPrice: 1_000n,
+        oldTargetPrice: 900n,
         securityFee: 25n,
         newTargetPrice: 1_300n,
         amountBurned: 50n,
@@ -595,7 +622,7 @@ describe('BitcoinLocks recovery', () => {
       ),
     ]);
     await store.recovery.recoverBlock(historyBlock(154), [
-      historyEvent(153, 'mint', 'BitcoinMint', { accountId, utxoId: 7, amount: 300n }),
+      historyEvent(153, 'mint', 'BitcoinMint', { accountId, utxoId: 7, amount: 400n }),
     ]);
     await store.recovery.recoverBlock(historyBlock(155), [
       historyEvent(154, 'bitcoinLocks', 'BitcoinUtxoCosignRequested', { utxoId: 7, vaultId: 1 }),
@@ -604,15 +631,20 @@ describe('BitcoinLocks recovery', () => {
         actualFee: 19n,
         tip: 0n,
       }),
-      historyEvent(154, 'bitcoinLocks', 'BitcoinSpentAfterRelease', { utxoId: 7, vaultId: 1 }),
+      historyEvent(154, 'bitcoinLocks', 'BitcoinUtxoCosigned', {
+        utxoId: 7,
+        vaultId: 1,
+        signature: '0x11',
+      }),
     ]);
 
     const recovered = store.data.locksByUtxoId[7];
     expect(recovered).toBe(record);
     expect(recovered.lockDetails.utxoId).toBe(7);
+    expect(recovered.satoshis).toBe(9_900n);
     expect(recovered.ratchets).toEqual([
-      expect.objectContaining({ mintAmount: 1_000n, mintPending: 0n, txFee: 11n, extrinsicIndex: 2 }),
-      expect.objectContaining({ mintAmount: 200n, mintPending: 0n, burned: 50n, txFee: 13n, extrinsicIndex: 2 }),
+      expect.objectContaining({ mintAmount: 900n, mintPending: 0n, txFee: 11n, extrinsicIndex: 2 }),
+      expect.objectContaining({ mintAmount: 300n, mintPending: 0n, burned: 50n, txFee: 13n, extrinsicIndex: 2 }),
       expect.objectContaining({ mintAmount: 200n, mintPending: 100n, burned: 25n, txFee: 17n, extrinsicIndex: 3 }),
     ]);
     expect(recovered.status).toBe(BitcoinLockStatus.Released);
@@ -621,17 +653,17 @@ describe('BitcoinLocks recovery', () => {
       releaseArgonTxFeeMicrogons: 19n,
       removalBlockNumber: 155,
       removalBlockHash: '0x155',
+      removalBlockTime: new Date(historyBlock(155).blockTime),
       removalExtrinsicIndex: 2,
       removalReason: 'released',
       btcPriceAtRemovalMicrogons: 4_000_000n,
     });
-    expect(setReleaseRequest).toHaveBeenCalledWith(fundingRecord, {
-      requestedReleaseAtTick: 700,
-      releaseToDestinationAddress: '0x0014',
-      releaseBitcoinNetworkFee: 8n,
-    });
-    expect(table.saveRecoveredHistory).toHaveBeenCalledTimes(3);
+    expect(setReleaseRequest).not.toHaveBeenCalled();
+    expect(table.saveRecoveredHistory).toHaveBeenCalledTimes(4);
     expect(table.updateMintState).toHaveBeenCalledTimes(2);
+    await expect(store.recovery.findMissingActiveLockIds(api as never)).resolves.toEqual([8]);
+    expect(ownerLockKeys).toHaveBeenCalledWith(accountId);
+    expect(activeLocks).toHaveBeenCalledWith([7, 8]);
   });
 
   it('recovers a down-ratchet as a full remint at the new cumulative liquidity', async () => {
@@ -1066,9 +1098,112 @@ describe('BitcoinLocks recovery', () => {
     expect(summary.record).not.toBe(record);
     expect(record.ratchets[0].mintPending).toBe(1_000n);
   });
+
+  it('continues settling pending liquidity after a Bitcoin lock is released', async () => {
+    const clientAt = {
+      query: {
+        bitcoinUtxos: {
+          confirmedBitcoinBlockTip: vi.fn(async () => optionCodec({ blockHeight: numberCodec(600) })),
+        },
+      },
+    };
+    const blockWatch = {
+      getHeaderByBlockNumber: vi.fn(async () => historyBlock(152)),
+      getApi: vi.fn(async () => clientAt),
+    } as unknown as BlockWatch;
+    const store = createStore({ blockWatch });
+    const record = createLock({
+      uuid: 'released-with-pending-liquidity',
+      utxoId: 7,
+      status: BitcoinLockStatus.Released,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.removalReason = 'released';
+    record.ratchets = [
+      {
+        mintAmount: 1_000n,
+        mintPending: 1_000n,
+        lockedTargetPrice: 1_000n,
+        securityFee: 0n,
+        txFee: 0n,
+        burned: 0n,
+        blockHeight: 151,
+        oracleBitcoinBlockHeight: 500,
+      },
+    ];
+    store.data.locksByUtxoId[7] = record;
+    store.data.oracleBitcoinBlockHeight = 600;
+    const updateMintState = vi.fn(async () => undefined);
+    vi.spyOn(store, 'getTable').mockResolvedValue({ updateMintState } as never);
+    vi.spyOn(store.utxoTracking, 'getAcceptedFundingRecordForLock').mockReturnValue({
+      id: 1,
+      status: BitcoinUtxoStatus.ReleaseComplete,
+    } as never);
+    vi.spyOn(BitcoinLock.prototype, 'findPendingMints').mockResolvedValue([400n]);
+
+    await (
+      store as unknown as {
+        checkIncomingArgonBlock: (header: ReturnType<typeof historyBlock>) => Promise<void>;
+      }
+    ).checkIncomingArgonBlock(historyBlock(153));
+
+    expect(record.ratchets[0].mintPending).toBe(400n);
+    expect(updateMintState).toHaveBeenCalledOnce();
+  });
+});
+
+describe('BitcoinLocks ratchet preview', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    { operatorAccountId: 'vault-owner', expectedFee: 50n },
+    { operatorAccountId: 'bitcoin-owner', expectedFee: 0n },
+  ])('calculates costs for vault operator $operatorAccountId', async ({ operatorAccountId, expectedFee }) => {
+    const store = createStore();
+    const lock = createLock({
+      uuid: 'ratchet-preview',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    lock.lockedTargetPrice = 3_000n;
+
+    const client = {
+      query: {
+        bitcoinLocks: {
+          locksByUtxoId: vi.fn(async () => ({ isSome: false })),
+        },
+      },
+    };
+    const vault = {
+      operatorAccountId,
+      availableSecuritization: () => 10_000n,
+    };
+    const calculateRatchetingCosts = vi.fn(async () => ({ burnAmount: 1_500n, ratchetingFee: 50n }));
+    Object.assign(store, {
+      getRatchetContext: async () => ({
+        bitcoinLock: {
+          lockedTargetPrice: 3_000n,
+          liquidityPromised: 3_000n,
+          ownerAccount: 'bitcoin-owner',
+          calculateRatchetingCosts,
+        },
+        client,
+        vault,
+      }),
+    });
+    vi.spyOn(BitcoinLock, 'calculateRedemptionAmount').mockReturnValue(2_000n);
+
+    const preview = await store.getRatchetPreview(lock);
+
+    expect(calculateRatchetingCosts).toHaveBeenCalledWith(client, expect.anything(), vault, 2_000n);
+    expect(preview.ratchetingFee).toBe(expectedFee);
+  });
 });
 
 describe('BitcoinLocks ratchet transaction tracking', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('reuses a stored pending ratchet instead of submitting another transaction', async () => {
     const pendingTxInfo = {
       tx: {
@@ -1098,11 +1233,9 @@ describe('BitcoinLocks ratchet transaction tracking', () => {
     expect(store.getPendingRatchetTxInfo(lock)).toBeUndefined();
   });
 
-  it('returns after tracked submission without waiting for finalization', async () => {
+  it('submits using the preview balance without waiting for finalization', async () => {
     const waitForFinalizedBlock = new Promise<Uint8Array>(() => undefined);
     const txResult = { waitForFinalizedBlock };
-    const getRatchetResult = vi.fn(() => waitForFinalizedBlock);
-    const ratchet = vi.fn(async () => ({ txResult, getRatchetResult }));
     const txInfo = {
       tx: { id: 12 },
       txResult,
@@ -1121,26 +1254,58 @@ describe('BitcoinLocks ratchet transaction tracking', () => {
       status: BitcoinLockStatus.LockedAndMinted,
       createdAt: '2026-01-01T00:00:00Z',
     });
+    const ratchetTx = {};
+    const client = {
+      query: {
+        bitcoinLocks: {
+          locksByUtxoId: vi.fn(async () => ({
+            isSome: true,
+            unwrap: () => ({ securitizationRatio: { toBigInt: () => 0n } }),
+          })),
+        },
+      },
+      tx: {
+        bitcoinLocks: {
+          ratchet: vi.fn(() => ratchetTx),
+        },
+      },
+    };
+    const calculateRatchetingCosts = vi.fn(async () => ({ burnAmount: 400n, ratchetingFee: 0n }));
     const getRatchetContext = vi.fn(async () => ({
-      bitcoinLock: { ratchet },
-      client: {},
-      vault: {},
+      bitcoinLock: {
+        calculateRatchetingCosts,
+        liquidityPromised: 1_000n,
+        lockedTargetPrice: 1_000n,
+        ownerAccount: 'owner',
+      },
+      client,
+      vault: {
+        availableSecuritization: () => 1_000n,
+        operatorAccountId: 'owner',
+      },
     }));
     Object.assign(store, { getRatchetContext });
-    vi.spyOn(store, 'getRatchetPreview').mockResolvedValue({ canRatchet: true } as never);
+    vi.spyOn(BitcoinLock, 'calculateRedemptionAmount').mockReturnValue(1_000n);
+    const canAfford = vi.spyOn(TxSubmitter.prototype, 'canAfford').mockResolvedValue({
+      canAfford: true,
+      availableBalance: 500n,
+      txFee: 1n,
+    });
+    vi.spyOn(TxSubmitter.prototype, 'submit').mockResolvedValue(txResult as never);
 
     await expect(store.ratchet(lock, { address: 'owner' } as never)).resolves.toBe(txInfo);
-    expect(ratchet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        disableAutomaticTxTracking: true,
-        microgonsAtTargetPerBtc: 2_000n,
-      }),
-    );
+    expect(client.tx.bitcoinLocks.ratchet).toHaveBeenCalledWith(7, {
+      V1: { microgonsAtTargetPerBtc: 2_000n },
+    });
+    expect(canAfford).toHaveBeenCalledWith({
+      tip: 0n,
+      unavailableBalance: 400n,
+    });
+    expect(getRatchetContext).toHaveBeenCalledOnce();
     expect(trackTxResult).toHaveBeenCalledWith({
       txResult,
       extrinsicType: ExtrinsicType.BitcoinRatchet,
       metadata: { utxoId: 7 },
     });
-    expect(getRatchetResult).not.toHaveBeenCalled();
   });
 });

--- a/src-vue/__test__/BitcoinLocksTable.test.ts
+++ b/src-vue/__test__/BitcoinLocksTable.test.ts
@@ -19,7 +19,7 @@ async function createPendingLock(overrides: Partial<IBitcoinLockRecord> = {}) {
 }
 
 describe('BitcoinLocksTable', () => {
-  it('finalizes idempotently and finds a new pending lock that reuses the owner key', async () => {
+  it('finalizes idempotently, persists the verified amount, and allows the owner key to be reused', async () => {
     const { table, lock } = await createPendingLock({ uuid: 'finalize-idempotent' });
 
     const bitcoinLock = {
@@ -57,6 +57,14 @@ describe('BitcoinLocksTable', () => {
     expect(second.status).toBe(BitcoinLockStatus.LockPendingFunding);
     expect(second.ratchets[0]).toEqual(expect.objectContaining({ blockHeight: 12 }));
     expect(await table.findPendingByHdPath(lock.hdPath)).toMatchObject({ uuid: next.uuid, utxoId: null });
+
+    second.satoshis = 900n;
+    await table.setLockedAndIsMinting(second);
+
+    expect((await table.fetchAll()).find(record => record.uuid === second.uuid)).toMatchObject({
+      satoshis: 900n,
+      status: BitcoinLockStatus.LockedAndIsMinting,
+    });
   });
 
   it('persists release economics separately from the terminal removal mark', async () => {

--- a/src-vue/__test__/BitcoinUtxoTracking.test.ts
+++ b/src-vue/__test__/BitcoinUtxoTracking.test.ts
@@ -174,7 +174,7 @@ describe('BitcoinUtxoTracking', () => {
     expect(details.expectedConfirmations).toBe(9);
   });
 
-  it('tracks release lifecycle on the funding record', async () => {
+  it('tracks the release lifecycle and restores a missing funding-record pointer', async () => {
     const db = await createTestDb();
     const tracking = createTracking(db);
     const lock = createLock({ status: BitcoinLockStatus.LockedAndMinted });
@@ -202,6 +202,13 @@ describe('BitcoinUtxoTracking', () => {
 
     await tracking.setReleaseComplete(fundingRecord, 220);
     expect(tracking.isReleaseCompleteStatus(fundingRecord.status)).toBe(true);
+
+    lock.status = BitcoinLockStatus.Released;
+    lock.fundingUtxoRecordId = null;
+    lock.fundingUtxoRecord = undefined;
+
+    expect(tracking.getAcceptedFundingRecordForLock(lock)).toBe(fundingRecord);
+    expect(lock.fundingUtxoRecordId).toBe(fundingRecord.id);
   });
 
   it('hydrates on-chain candidates into the local table from the provided client', async () => {

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -10,17 +10,18 @@ vi.mock('../lib/IndexerClient.ts', () => ({ findAddressActivity: vi.fn() }));
 afterEach(() => vi.mocked(findAddressActivity).mockReset());
 
 describe('FinancialHistoryImporter', () => {
-  it('initializes recovery when an enabled domain trails the finalized target', async () => {
+  it('initializes recovery only when an enabled domain has incomplete coverage', async () => {
+    const get = vi.fn(async () => ({
+      accountId: '5owner',
+      asOfBlock: 99,
+      domains: ['bonds'],
+      domainCheckpoints: {
+        bonds: { asOfBlock: 99, definitionVersion: 2, recoveryVersion: 1, partialRecovery: true },
+      },
+    }));
     const db = {
       syncStateTable: {
-        get: vi.fn(async () => ({
-          accountId: '5owner',
-          asOfBlock: 99,
-          domains: ['bonds'],
-          domainCheckpoints: {
-            bonds: { asOfBlock: 99, definitionVersion: 2, recoveryVersion: 1 },
-          },
-        })),
+        get,
       },
     } as any;
 
@@ -29,15 +30,22 @@ describe('FinancialHistoryImporter', () => {
         db,
         accountId: '5owner',
         enabledDomains: ['bonds'],
-        targetBlock: 100,
       }),
     ).resolves.toBe(true);
+
+    get.mockResolvedValueOnce({
+      accountId: '5owner',
+      asOfBlock: 99,
+      domains: ['bonds'],
+      domainCheckpoints: {
+        bonds: { asOfBlock: 99, definitionVersion: 2, recoveryVersion: 1, partialRecovery: false },
+      },
+    });
     await expect(
       needsFinancialHistoryRecovery({
         db,
         accountId: '5owner',
         enabledDomains: ['bonds'],
-        targetBlock: 99,
       }),
     ).resolves.toBe(false);
   });
@@ -50,7 +58,7 @@ describe('FinancialHistoryImporter', () => {
           asOfBlock: 100,
           domains: ['bitcoin'],
           domainCheckpoints: {
-            bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
+            bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 4 },
           },
         })),
       },
@@ -61,7 +69,6 @@ describe('FinancialHistoryImporter', () => {
         db,
         accountId: '5owner',
         enabledDomains: ['bitcoin'],
-        targetBlock: 100,
         bitcoinLockRecovery: { hasPendingHistoryRecovery: true } as any,
       }),
     ).resolves.toBe(true);
@@ -93,7 +100,7 @@ describe('FinancialHistoryImporter', () => {
     expect(onCheckStart).not.toHaveBeenCalled();
   });
 
-  it('replays a loaded Bitcoin recovery even when its checkpoint is current', async () => {
+  it('resumes a loaded Bitcoin recovery from its saved partial checkpoint', async () => {
     const upsert = vi.fn(async () => undefined);
     const beginHistoryReplay = vi.fn();
     const commitHistoryReplay = vi.fn();
@@ -101,7 +108,7 @@ describe('FinancialHistoryImporter', () => {
       asOfBlock: 100,
       definitionVersion: 2,
       blocks: [],
-      coverage: { fromBlock: 100, toBlock: 100, gaps: [] },
+      coverage: { fromBlock: 90, toBlock: 100, gaps: [] },
     });
 
     await restoreFinancialHistory({
@@ -109,10 +116,15 @@ describe('FinancialHistoryImporter', () => {
         syncStateTable: {
           get: vi.fn(async () => ({
             accountId: '5owner',
-            asOfBlock: 100,
+            asOfBlock: 90,
             domains: ['bitcoin'],
             domainCheckpoints: {
-              bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
+              bitcoin: {
+                asOfBlock: 90,
+                definitionVersion: 2,
+                recoveryVersion: 5,
+                partialRecovery: true,
+              },
             },
           })),
           upsert,
@@ -137,11 +149,11 @@ describe('FinancialHistoryImporter', () => {
     });
 
     expect(findAddressActivity).toHaveBeenCalledWith('5owner', {
-      afterBlock: 0,
+      afterBlock: 90,
       toBlock: 100,
       activityMask: AccountActivityKind.BitcoinLock | AccountActivityKind.BitcoinMint,
     });
-    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: true });
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: false });
     expect(commitHistoryReplay).toHaveBeenCalledWith(true);
     expect(upsert).toHaveBeenCalledOnce();
   });
@@ -227,12 +239,10 @@ describe('FinancialHistoryImporter', () => {
     );
   });
 
-  it('preserves a successful domain checkpoint when another domain fails', async () => {
+  it('preserves completed domains and partial Bitcoin progress when an archive block fails to load', async () => {
     const upsert = vi.fn(async () => undefined);
     const beginHistoryReplay = vi.fn();
-    const recoverBlock = vi.fn(async () => {
-      throw new Error('archive unavailable');
-    });
+    const recoverBlock = vi.fn(async () => undefined);
     const commitHistoryReplay = vi.fn();
     const cancelHistoryReplay = vi.fn();
     vi.mocked(findAddressActivity)
@@ -259,6 +269,12 @@ describe('FinancialHistoryImporter', () => {
             specVersion: 151,
             activityMask: AccountActivityKind.BitcoinLock,
           },
+          {
+            blockNumber: 9,
+            blockHash: '0x9',
+            specVersion: 151,
+            activityMask: AccountActivityKind.BitcoinLock,
+          },
         ],
         coverage: { fromBlock: 0, toBlock: 10, gaps: [] },
       });
@@ -271,7 +287,10 @@ describe('FinancialHistoryImporter', () => {
         } as any,
         blockWatch: {
           finalizedBlockHeader: { blockNumber: 10 },
-          getHeader: vi.fn(async (blockNumber: number) => ({ blockNumber, blockHash: `0x${blockNumber}` })),
+          getHeader: vi.fn(async ({ blockNumber }: { blockNumber: number }) => {
+            if (blockNumber === 9) throw new Error('archive unavailable');
+            return { blockNumber, blockHash: `0x${blockNumber}` };
+          }),
           getEventsWithSpec: vi.fn(async () => ({ events: [], specVersion: 151 })),
         } as any,
         accountId: '5owner',
@@ -290,16 +309,25 @@ describe('FinancialHistoryImporter', () => {
         enabledDomains: ['bonds', 'bitcoin'],
         minimumAsOfBlock: 10,
       }),
-    ).rejects.toThrow('Bitcoin lock history failed at block 7: archive unavailable');
+    ).rejects.toThrow('Bitcoin lock history failed at block 9: archive unavailable');
 
-    expect(upsert).toHaveBeenCalledWith(
+    expect(upsert).toHaveBeenCalledTimes(3);
+    expect(upsert).toHaveBeenLastCalledWith(
       SyncStateKeys.FinancialHistory,
       expect.objectContaining({
-        domainCheckpoints: { bonds: { asOfBlock: 10, definitionVersion: 2, recoveryVersion: 1 } },
+        domainCheckpoints: {
+          bonds: { asOfBlock: 10, definitionVersion: 2, recoveryVersion: 1 },
+          bitcoin: {
+            asOfBlock: 8,
+            definitionVersion: 2,
+            recoveryVersion: 5,
+            partialRecovery: true,
+          },
+        },
       }),
     );
     expect(beginHistoryReplay).toHaveBeenCalledOnce();
-    expect(commitHistoryReplay).not.toHaveBeenCalled();
+    expect(commitHistoryReplay).toHaveBeenCalledWith(false);
     expect(cancelHistoryReplay).toHaveBeenCalledOnce();
     expect(beginHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(recoverBlock.mock.invocationCallOrder[0]);
     expect(recoverBlock.mock.invocationCallOrder[0]).toBeLessThan(cancelHistoryReplay.mock.invocationCallOrder[0]);
@@ -334,7 +362,7 @@ describe('FinancialHistoryImporter', () => {
             definitionVersion: 2,
             domains: ['bitcoin'],
             domainCheckpoints: {
-              bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 1 },
+              bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 4 },
             },
           })),
           upsert,
@@ -370,9 +398,9 @@ describe('FinancialHistoryImporter', () => {
       SyncStateKeys.FinancialHistory,
       expect.objectContaining({
         asOfBlock: 100,
-        recoveryVersions: { bitcoin: 3 },
+        recoveryVersions: { bitcoin: 5 },
         domainCheckpoints: {
-          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 3 },
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 5 },
         },
       }),
     );
@@ -383,7 +411,8 @@ describe('FinancialHistoryImporter', () => {
     expect(cancelHistoryReplay).not.toHaveBeenCalled();
     expect(beginHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(recoverBlock.mock.invocationCallOrder[0]);
     expect(recoverBlock.mock.invocationCallOrder[0]).toBeLessThan(commitHistoryReplay.mock.invocationCallOrder[0]);
-    expect(commitHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(upsert.mock.invocationCallOrder[0]);
+    expect(upsert.mock.invocationCallOrder[0]).toBeLessThan(commitHistoryReplay.mock.invocationCallOrder[0]);
+    expect(commitHistoryReplay.mock.invocationCallOrder[0]).toBeLessThan(upsert.mock.invocationCallOrder.at(-1)!);
   });
 
   it('does not let another account checkpoint hide missing active bond history', async () => {

--- a/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
+++ b/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
@@ -90,7 +90,7 @@ describe('financial history spec boundaries', () => {
       ],
     ]);
     const blockWatch = {
-      getHeader: vi.fn(async (blockNumber: number) => ({
+      getHeader: vi.fn(async ({ blockNumber }: { blockNumber: number }) => ({
         blockNumber,
         blockHash: `0x${blockNumber}`,
         blockTime: new Date('2026-01-01T00:00:00Z'),

--- a/src-vue/__test__/Financials.loading.test.ts
+++ b/src-vue/__test__/Financials.loading.test.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => {
       recovery: {},
       load: vi.fn<() => Promise<void>>(),
       getAllLocks: vi.fn((): object[] => []),
+      createLockSummary: vi.fn((_lock: object) => createBitcoinSummary(0n)),
       createLockSummaryAt: vi.fn(async (_lock: object, _api: object) => createBitcoinSummary(0n)),
       isLockedStatus: vi.fn(() => true),
       isReleaseStatus: vi.fn(() => false),
@@ -216,6 +217,8 @@ describe('financials store lifecycle', () => {
     mocks.bitcoinLocks.load.mockClear();
     mocks.bitcoinLocks.getAllLocks.mockReturnValue([]);
     mocks.bitcoinLocks.getAllLocks.mockClear();
+    mocks.bitcoinLocks.createLockSummary.mockImplementation(() => createBitcoinSummary(0n));
+    mocks.bitcoinLocks.createLockSummary.mockClear();
     mocks.bitcoinLocks.createLockSummaryAt.mockImplementation(async () => createBitcoinSummary(0n));
     mocks.bitcoinLocks.createLockSummaryAt.mockClear();
     mocks.bitcoinLocks.isLockedStatus.mockReturnValue(true);
@@ -551,7 +554,45 @@ describe('financials store lifecycle', () => {
       expect(financials.financialPositionAggregate.groupSummaries.liquid.state).toBe('ready');
     });
     await vi.waitFor(() => expect(mocks.needsFinancialHistoryRecovery).toHaveBeenCalled());
+    expect(financials.historyRecovery.state).toBe('ready');
     expect(mocks.restoreFinancialHistory).not.toHaveBeenCalled();
+  });
+
+  it('exposes persisted Bitcoin rows and settled performance before the complete financial snapshot is ready', () => {
+    const cachedSummary = createBitcoinSummary(0n);
+    const persistedSummary = {
+      ...cachedSummary,
+      status: 'Released',
+      receivedLiquidity: 30n,
+      historicalTotalFees: 20n,
+      record: {
+        ...cachedSummary.record,
+        status: 'Released',
+        removalReason: 'released',
+        removalBlockTime: new Date('2026-07-17T12:00:00Z'),
+        releaseRedemptionMicrogons: 40n,
+        releaseArgonTxFeeMicrogons: 3n,
+        releaseCompensationMicrogons: 0n,
+        btcPriceAtRemovalMicrogons: 1_200_000n,
+        isHistoryRecoveryPending: false,
+        fundingUtxoRecord: {
+          releaseBitcoinNetworkFee: 1_000n,
+        },
+      },
+    };
+    mocks.config.hasExtensionTreasury = true;
+    mocks.wallets.isLoadedPromise = new Promise(() => undefined);
+    mocks.bitcoinLocks.getAllLocks.mockReturnValue([persistedSummary.record]);
+    mocks.bitcoinLocks.createLockSummary.mockReturnValue(persistedSummary);
+
+    const financials = useFinancials();
+
+    expect(financials.bitcoinLockDisplayRecords).toEqual([persistedSummary]);
+    expect(financials.bitcoinLockPerformanceByUuid[persistedSummary.uuid]).toEqual({
+      profit: -30n,
+      percent: -30,
+    });
+    expect(financials.savingsIsLoaded).toBe(false);
   });
 
   it('requests recovery when live wallet tracking reports a history gap', async () => {

--- a/src-vue/__test__/Financials.test.ts
+++ b/src-vue/__test__/Financials.test.ts
@@ -21,7 +21,7 @@ import type { IWalletTransferRecord } from '../lib/db/WalletTransfersTable.ts';
 import { type IArgonAccountBalance, WalletsForArgon } from '../lib/WalletsForArgon.ts';
 import type { IMiningCohortFinancialRecord } from '../interfaces/db/ICohortFrameRecord.ts';
 import BitcoinLocks from '../lib/BitcoinLocks.ts';
-import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
+import { BitcoinFinancials, calculateBitcoinLockValuation } from '../lib/financials/BitcoinLocks.ts';
 import type { IBitcoinLockSummary } from '../interfaces/IBitcoinLockSummary.ts';
 import { ArgonBondsFinancials } from '../lib/financials/ArgonBonds.ts';
 import type { WalletForArgon } from '../lib/WalletForArgon.ts';
@@ -1101,12 +1101,12 @@ describe('financial position accounting', () => {
         pendingLiquidity: 10n,
         receivedLiquidity: 35n,
         valueBeyondLiquidity: 30n,
-        startingCapital: 100n,
-        endingCapital: 120n,
+        startingCapital: 45n,
+        endingCapital: 45n,
         securityFees: 10n,
         totalFees: 15n,
         unlockAmount: 60n,
-        totalReturn: 20,
+        totalReturn: 0,
       });
       expect(positions.map(position => position.id)).toEqual([
         `bitcoin-asset:${lock.uuid}`,
@@ -1117,17 +1117,113 @@ describe('financial position accounting', () => {
         ['bitcoin-liability', -60n],
       ]);
       expect(positions.every(position => position.lock.uuid === lock.uuid)).toBe(true);
-      expect(positions[0]).toMatchObject({ investedCost: 100n, paidIncome: 20n });
+      expect(positions[0]).toMatchObject({ investedCost: 45n, paidIncome: 20n });
       expect(bitcoin).toMatchObject({ grossAssets: 160n, grossLiabilities: 60n, currentValue: 100n });
       expect(bitcoin?.returnSummary.paidIncome).toBe(20n);
-      expect(bitcoin?.returnSummary.returnAmount).toBe(20n);
-      expect(bitcoin?.returnSummary.percent).toBe(20);
+      expect(bitcoin?.returnSummary.returnAmount).toBe(0n);
+      expect(bitcoin?.returnSummary.percent).toBe(0);
     } finally {
       redemption.mockRestore();
     }
   });
 
-  it('keeps total Bitcoin return at breakeven after a down-ratchet offsets the price loss', () => {
+  it('keeps Hodling Returns based on the BTC lock value', async () => {
+    const lock = {
+      uuid: 'lock-return-bases',
+      status: BitcoinLockStatus.LockedAndMinted,
+      ratchets: [{ lockedTargetPrice: 100n }],
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as IBitcoinLockRecord;
+    const summary = {
+      uuid: lock.uuid,
+      status: lock.status,
+      satoshis: 10_000n,
+      valueOfBtc: 90n,
+      startingCapital: 80n,
+      endingCapital: 88n,
+      pendingLiquidity: 0n,
+      receivedLiquidity: 80n,
+      totalFees: 0n,
+      unlockAmount: 72n,
+      record: lock,
+    } as IBitcoinLockSummary;
+    const financials = new BitcoinFinancials({
+      load: vi.fn(),
+      getAllLocks: () => [lock],
+      createLockSummaryAt: async () => summary,
+      isLockedStatus: () => true,
+    } as unknown as BitcoinLocks);
+
+    const snapshot = await financials.loadSnapshot({
+      clientAt: {} as never,
+      hasCurrentPrice: true,
+    });
+
+    expect(snapshot.positions[0]).toMatchObject({ investedCost: 80n });
+    expect(snapshot.hodlingInvestments[0]).toMatchObject({
+      startingCapital: 100n,
+      endingCapital: 90n,
+    });
+  });
+
+  it('keeps historical fees separate from the current Bitcoin value', () => {
+    const lock = {
+      satoshis: 10_000_000n,
+      lockedTargetPrice: 8_000n,
+      ratchets: [
+        {
+          mintAmount: 8_500n,
+          mintPending: 0n,
+          lockedTargetPrice: 9_000n,
+          securityFee: 10n,
+          txFee: 5n,
+          burned: 0n,
+        },
+        {
+          mintAmount: 0n,
+          mintPending: 0n,
+          lockedTargetPrice: 8_000n,
+          securityFee: 0n,
+          txFee: 0n,
+          burned: 0n,
+        },
+      ],
+      lockDetails: { couponFeesPaid: 0n },
+      releaseArgonTxFeeMicrogons: 3n,
+      btcPriceAtRemovalMicrogons: 60_000n,
+      fundingUtxoRecord: { releaseBitcoinNetworkFee: 100_000n },
+    } as unknown as IBitcoinLockRecord;
+    const currency = {
+      priceIndex: {},
+      convertSatToBtc: () => 0.1,
+      convertBtcToMicrogon: () => 7_000n,
+    } as unknown as Currency;
+    const redemption = vi.spyOn(BitcoinLock, 'calculateRedemptionAmountFromSatoshis').mockReturnValue(8_000n);
+
+    try {
+      const valuation = calculateBitcoinLockValuation({ lock, currency });
+
+      expect(valuation).toMatchObject({
+        valueOfBtc: 7_000n,
+        securityFees: 10n,
+        transactionFees: 5n,
+        totalFees: 15n,
+        historicalTransactionFees: 68n,
+        historicalTotalFees: 78n,
+      });
+
+      lock.fundingUtxoRecord = undefined;
+
+      expect(calculateBitcoinLockValuation({ lock, currency })).toMatchObject({
+        historicalTransactionFees: 8n,
+        historicalTotalFees: 18n,
+      });
+    } finally {
+      redemption.mockRestore();
+    }
+  });
+
+  it('reports retained down-ratchet liquidity as Bitcoin locking profit', () => {
     const lock = {
       uuid: 'down-ratchet',
       status: BitcoinLockStatus.LockedAndIsMinting,
@@ -1194,8 +1290,8 @@ describe('financial position accounting', () => {
         pendingLiquidity: 100n,
         receivedLiquidity: 20n,
         startingCapital: 120n,
-        endingCapital: 120n,
-        totalReturn: 0,
+        endingCapital: 140n,
+        totalReturn: 16.666666666666668,
       });
       expect(bitcoin).toMatchObject({
         grossAssets: 200n,
@@ -1205,8 +1301,8 @@ describe('financial position accounting', () => {
       expect(bitcoin.returnSummary).toMatchObject({
         investedCost: 120n,
         paidIncome: 20n,
-        returnAmount: 0n,
-        percent: 0,
+        returnAmount: 20n,
+        percent: 16.67,
       });
     } finally {
       redemption.mockRestore();
@@ -1274,6 +1370,7 @@ describe('financial position accounting', () => {
       pendingLiquidity: 10n,
       receivedLiquidity: 30n,
       totalFees: 5n,
+      historicalTotalFees: 20n,
       unlockAmount: 999n,
       endingCapital: 999n,
       record: lock,
@@ -1293,12 +1390,58 @@ describe('financial position accounting', () => {
         investedCost: 100n,
         paidIncome: 22n,
         settledPrincipalValue: 68n,
-        performanceEndingCapital: 100n,
+        performanceEndingCapital: 80n,
         endedAt: removedAt,
       }),
     ]);
     expect(bitcoin?.currentValue).toBe(10n);
-    expect(bitcoin?.returnSummary.returnAmount).toBe(0n);
+    expect(bitcoin?.returnSummary.returnAmount).toBe(-20n);
+  });
+
+  it('reports the liquidity retained after release as Bitcoin locking profit', () => {
+    const lock = {
+      uuid: 'lock-released-profit',
+      status: BitcoinLockStatus.Released,
+      satoshis: 13_146_391n,
+      lockedTargetPrice: 9_103_964_854n,
+      ratchets: [{ mintPending: 0n }],
+      releaseRedemptionMicrogons: 7_597_981_840n,
+      releaseArgonTxFeeMicrogons: 1_361n,
+      removalBlockTime: new Date('2026-07-02T20:51:01Z'),
+      removalReason: 'released',
+      btcPriceAtRemovalMicrogons: 58_105_590_350n,
+      fundingUtxoRecord: { releaseBitcoinNetworkFee: 847n },
+      createdAt: new Date('2026-06-11T00:00:00Z'),
+    } as unknown as IBitcoinLockRecord;
+    const summary = {
+      uuid: lock.uuid,
+      status: lock.status,
+      satoshis: lock.satoshis,
+      valueOfBtc: 7_638_788_100n,
+      startingCapital: 8_672_857_884n,
+      totalLiquidity: 8_672_857_884n,
+      pendingLiquidity: 0n,
+      receivedLiquidity: 8_672_857_884n,
+      totalFees: 56_794n,
+      historicalTotalFees: 550_309n,
+      unlockAmount: 7_597_981_840n,
+      endingCapital: 9_747_183_619n,
+      record: lock,
+    } as IBitcoinLockSummary;
+
+    const positions = bitcoinFinancials.createFinancialPositions({
+      summaries: [summary],
+      hasCurrentPrice: true,
+      hasConfirmedHistoryCoverage: true,
+    });
+    const bitcoin = reduceFinancialPositions(readySnapshots(positions)).groupSummaries.bitcoin;
+
+    expect(positions[0]).toMatchObject({
+      investedCost: 8_672_857_884n,
+      performanceEndingCapital: 9_747_183_619n,
+    });
+    expect(bitcoin?.returnSummary.returnAmount).toBe(1_074_325_735n);
+    expect(bitcoin?.returnSummary.percent).toBe(12.39);
   });
 
   it('keeps an incomplete released lock visible without inventing a settlement return', () => {

--- a/src-vue/components/Spinner.vue
+++ b/src-vue/components/Spinner.vue
@@ -15,6 +15,10 @@
   animation: rotation 1s linear infinite;
 }
 
+.Spinner.Inverse {
+  border-color: rgba(255, 255, 255, 0.25) rgba(255, 255, 255, 0.45) rgba(255, 255, 255, 0.65) rgba(255, 255, 255, 0.9);
+}
+
 @keyframes rotation {
   0% {
     transform: rotate(0deg);

--- a/src-vue/interfaces/IBitcoinLockSummary.ts
+++ b/src-vue/interfaces/IBitcoinLockSummary.ts
@@ -32,7 +32,10 @@ export interface IBitcoinLockSummary {
   ratchetPercent: number;
   totalReturn: number;
   securityFees: bigint;
+  transactionFees: bigint;
   totalFees: bigint;
+  historicalTransactionFees?: bigint;
+  historicalTotalFees?: bigint;
   unlockAmount: bigint;
   createdAt: Date;
   record: IBitcoinLockRecord;

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -18,6 +18,7 @@ import {
   type IBitcoinLockConfig,
   type SubmittableExtrinsic,
   TxResult,
+  TxSubmitter,
   type TxSigningAccount,
   u8aToHex,
   Vault,
@@ -1277,19 +1278,98 @@ export default class BitcoinLocks {
   }
 
   public async getRatchetPreview(lock: IBitcoinLockRecord): Promise<IBitcoinRatchetPreview> {
-    const { bitcoinLock, client, vault } = await this.getRatchetContext(lock);
-    const { burnAmount, ratchetingFee } = await bitcoinLock.calculateRatchetingCosts(
+    const context = await this.getRatchetContext(lock);
+    return await this.calculateRatchetPreview(lock, context);
+  }
+
+  private async getRatchetContext(lock: IBitcoinLockRecord) {
+    const client = await getMainchainClient(false);
+    const [vault, liveBitcoinLock] = await Promise.all([
+      Vault.get(client, lock.vaultId, NetworkConfig.tickMillis),
+      lock.utxoId === undefined ? undefined : BitcoinLock.get(client, lock.utxoId),
+    ]);
+    const bitcoinLock = new BitcoinLock(liveBitcoinLock ?? lock.lockDetails);
+
+    return { bitcoinLock, client, vault };
+  }
+
+  private async getLockSecuritizationRatio(client: ArgonClient, lock: IBitcoinLockRecord): Promise<bigint | undefined> {
+    if (lock.utxoId === undefined) return undefined;
+
+    const rawLock = await client.query.bitcoinLocks.locksByUtxoId(lock.utxoId);
+    if (!rawLock?.isSome) return undefined;
+
+    return rawLock.unwrap().securitizationRatio.toBigInt();
+  }
+
+  public async ratchet(lock: IBitcoinLockRecord, txSigner: TxSigningAccount, tip = 0n) {
+    return await this.runInQueueForUtxo(lock, 180e3, async () => {
+      const existingTxInfo = this.getPendingRatchetTxInfo(lock);
+      if (existingTxInfo) return existingTxInfo;
+
+      if (!this.isLockedStatus(lock)) {
+        throw new Error(`Lock with ID ${lock.utxoId} is not verified.`);
+      }
+
+      const context = await this.getRatchetContext(lock);
+      const { client } = context;
+      const preview = await this.calculateRatchetPreview(lock, context);
+      if (!preview.canRatchet) {
+        if (preview.shortfall > 0n) {
+          throw new Error(`Vault #${lock.vaultId} needs ${formatArgons(preview.shortfall)} more to ratchet this lock.`);
+        }
+        throw new Error('No ratcheting is available for this Bitcoin lock.');
+      }
+
+      // Use whatever is loaded into the price index at this time. NOTE: this could be old, but is likely what the user has seen
+      const microgonsAtTargetPerBtc = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
+
+      const tx = client.tx.bitcoinLocks.ratchet(lock.utxoId!, {
+        V1: { microgonsAtTargetPerBtc },
+      });
+      const txSubmitter = new TxSubmitter(client, tx, txSigner);
+      const requiredBalance = preview.burnAmount + preview.ratchetingFee;
+      const affordability = await txSubmitter.canAfford({
+        tip,
+        unavailableBalance: requiredBalance,
+      });
+      if (!affordability.canAfford) {
+        throw new Error(
+          `Insufficient funds to ratchet lock. Available: ${formatArgons(affordability.availableBalance)}, Required: ${formatArgons(requiredBalance)}`,
+        );
+      }
+      const txResult = await txSubmitter.submit({ tip, disableAutomaticTxTracking: true });
+
+      const txInfo = await this.#transactionTracker.trackTxResult<IBitcoinRatchetMetadata>({
+        txResult,
+        extrinsicType: ExtrinsicType.BitcoinRatchet,
+        metadata: { utxoId: lock.utxoId! },
+      });
+
+      void this.onRatchetFinalized(lock, txInfo).catch(error => {
+        console.error(`[BitcoinLocks] Error processing ratchet transaction #${txInfo.tx.id}`, error);
+      });
+      return txInfo;
+    });
+  }
+
+  private async calculateRatchetPreview(
+    lock: IBitcoinLockRecord,
+    { bitcoinLock, client, vault }: Awaited<ReturnType<BitcoinLocks['getRatchetContext']>>,
+  ): Promise<IBitcoinRatchetPreview> {
+    const microgonsAtTargetPerBtc = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
+    const { burnAmount, ratchetingFee: grossRatchetingFee } = await bitcoinLock.calculateRatchetingCosts(
       client,
       this.#currency.priceIndex,
       vault,
-      lock.lockedTargetPrice,
+      microgonsAtTargetPerBtc,
     );
+    const ratchetingFee = bitcoinLock.ownerAccount === vault.operatorAccountId ? 0n : grossRatchetingFee;
 
     const oldTargetPrice = bitcoinLock.lockedTargetPrice;
     const newTargetPrice = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(lock.satoshis);
     const lockSecuritizationRatio = await this.getLockSecuritizationRatio(client, lock);
     const availableVaultFunds = vault.availableSecuritization();
-
     const isUpRatchet = newTargetPrice > oldTargetPrice;
 
     let newLiquidityPromised: bigint;
@@ -1322,70 +1402,6 @@ export default class BitcoinLocks {
       shortfall,
       vaultId: lock.vaultId,
     };
-  }
-
-  private async getRatchetContext(lock: IBitcoinLockRecord) {
-    const client = await getMainchainClient(false);
-    const [vault, liveBitcoinLock] = await Promise.all([
-      Vault.get(client, lock.vaultId, NetworkConfig.tickMillis),
-      lock.utxoId === undefined ? undefined : BitcoinLock.get(client, lock.utxoId),
-    ]);
-    const bitcoinLock = new BitcoinLock(liveBitcoinLock ?? lock.lockDetails);
-
-    return { bitcoinLock, client, vault };
-  }
-
-  private async getLockSecuritizationRatio(client: ArgonClient, lock: IBitcoinLockRecord): Promise<bigint | undefined> {
-    if (lock.utxoId === undefined) return undefined;
-
-    const rawLock = await client.query.bitcoinLocks.locksByUtxoId(lock.utxoId);
-    if (!rawLock?.isSome) return undefined;
-
-    return rawLock.unwrap().securitizationRatio.toBigInt();
-  }
-
-  public async ratchet(lock: IBitcoinLockRecord, txSigner: TxSigningAccount, tip = 0n) {
-    return await this.runInQueueForUtxo(lock, 180e3, async () => {
-      const existingTxInfo = this.getPendingRatchetTxInfo(lock);
-      if (existingTxInfo) return existingTxInfo;
-
-      if (!this.isLockedStatus(lock)) {
-        throw new Error(`Lock with ID ${lock.utxoId} is not verified.`);
-      }
-
-      const { bitcoinLock, client, vault } = await this.getRatchetContext(lock);
-      const preview = await this.getRatchetPreview(lock);
-      if (!preview.canRatchet) {
-        if (preview.shortfall > 0n) {
-          throw new Error(`Vault #${lock.vaultId} needs ${formatArgons(preview.shortfall)} more to ratchet this lock.`);
-        }
-        throw new Error('No ratcheting is available for this Bitcoin lock.');
-      }
-
-      // Use whatever is loaded into the price index at this time. NOTE: this could be old, but is likely what the user has seen
-      const microgonsAtTargetPerBtc = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
-
-      const result = await bitcoinLock.ratchet({
-        client,
-        priceIndex: this.#currency.priceIndex,
-        microgonsAtTargetPerBtc,
-        txSigner,
-        tip,
-        vault,
-        disableAutomaticTxTracking: true,
-      });
-
-      const txInfo = await this.#transactionTracker.trackTxResult<IBitcoinRatchetMetadata>({
-        txResult: result.txResult,
-        extrinsicType: ExtrinsicType.BitcoinRatchet,
-        metadata: { utxoId: lock.utxoId! },
-      });
-
-      void this.onRatchetFinalized(lock, txInfo).catch(error => {
-        console.error(`[BitcoinLocks] Error processing ratchet transaction #${txInfo.tx.id}`, error);
-      });
-      return txInfo;
-    });
   }
 
   public getPendingRatchetTxInfo(
@@ -2916,8 +2932,20 @@ export default class BitcoinLocks {
 
       const promises = Object.values(this.data.locksByUtxoId)
         .map(lockRecord => {
-          if (this.isHistoryRecoveryPendingForLock(lockRecord) || this.isTerminalLock(lockRecord)) {
+          if (this.isHistoryRecoveryPendingForLock(lockRecord)) {
             return undefined;
+          }
+          if (this.isTerminalLock(lockRecord)) {
+            if (!lockRecord.ratchets.some(ratchet => ratchet.mintPending > 0n)) return undefined;
+
+            return this.runInQueueForUtxo(
+              lockRecord,
+              30e3,
+              () => this.syncMintPendingState(lockRecord, table, clientAt),
+              { waitForHistoryRecovery: true },
+            ).catch(err => {
+              console.warn(`[BitcoinLocks] Error syncing pending liquidity for utxo ${lockRecord.uuid}`, err);
+            });
           }
           if (lockRecord.status === BitcoinLockStatus.LockIsProcessingOnArgon) {
             // waiting for a utxo to be found
@@ -3061,8 +3089,8 @@ export default class BitcoinLocks {
     const utxoRef = await latestBitcoinLock.getFundingUtxoRef(apiClient);
     if (!utxoRef) return;
 
-    if (latestBitcoinLock.utxoSatoshis) {
-      lock.satoshis = latestBitcoinLock.satoshis;
+    if (latestBitcoinLock.utxoSatoshis !== undefined) {
+      lock.satoshis = latestBitcoinLock.utxoSatoshis;
     }
     this.applyLatestLockDetails(lock, latestBitcoinLock);
     lock.lockedTargetPrice = latestBitcoinLock.lockedTargetPrice;

--- a/src-vue/lib/BitcoinUtxoTracking.ts
+++ b/src-vue/lib/BitcoinUtxoTracking.ts
@@ -105,7 +105,9 @@ export default class BitcoinUtxoTracking {
     }
     if (!lock.utxoId) return undefined;
     const records = this.data.utxosByLockUtxoId[lock.utxoId] ?? [];
-    const record = records.find(x => x.status === BitcoinUtxoStatus.FundingUtxo);
+    const record =
+      records.find(x => x.status === BitcoinUtxoStatus.FundingUtxo) ??
+      records.find(x => this.isReleaseStatus(x.status) && x.satoshis === lock.satoshis);
     lock.fundingUtxoRecordId = record?.id ?? null;
     lock.fundingUtxoRecord = record;
     return record;

--- a/src-vue/lib/db/BitcoinLocksTable.ts
+++ b/src-vue/lib/db/BitcoinLocksTable.ts
@@ -253,10 +253,11 @@ export class BitcoinLocksTable extends BaseTable {
       lock.status = BitcoinLockStatus.LockedAndIsMinting;
     }
     await this.db.execute(
-      `UPDATE BitcoinLocks SET status = ?, fundingUtxoRecordId = ?, lockDetails = ?, lockedTargetPrice = ?, liquidityPromised = ?, ratchets = ?
+      `UPDATE BitcoinLocks SET status = ?, satoshis = ?, fundingUtxoRecordId = ?, lockDetails = ?, lockedTargetPrice = ?, liquidityPromised = ?, ratchets = ?
        WHERE uuid = ?`,
       toSqlParams([
         lock.status,
+        lock.satoshis,
         lock.fundingUtxoRecordId,
         lock.lockDetails,
         lock.lockedTargetPrice,

--- a/src-vue/lib/db/SyncStateTable.ts
+++ b/src-vue/lib/db/SyncStateTable.ts
@@ -41,6 +41,7 @@ export interface ISyncSchemas {
           asOfBlock: number;
           definitionVersion?: number;
           recoveryVersion?: number;
+          partialRecovery?: boolean;
         }
       >
     >;

--- a/src-vue/lib/financials/BitcoinLocks.ts
+++ b/src-vue/lib/financials/BitcoinLocks.ts
@@ -49,7 +49,8 @@ export class BitcoinFinancials {
       if ((this.locks.isLockedStatus(lock) || this.locks.isReleaseStatus(lock)) && lock.ratchets[0]) {
         hodlingInvestments.push({
           startingDate: lock.createdAt,
-          startingCapital: summary.startingCapital,
+          // Hodling compares BTC market movement; this is not the Bitcoin locking profit basis.
+          startingCapital: lock.ratchets[0].lockedTargetPrice,
           endingDate: new Date(),
           endingCapital: summary.valueOfBtc,
         });
@@ -89,6 +90,7 @@ function createBitcoinLockPositions(
     const bitcoinNetworkFeeValue = valueSatoshisAtRate(bitcoinNetworkFee, removalBtcPrice);
     const releaseRedemption = record.releaseRedemptionMicrogons ?? undefined;
     const releaseArgonTxFee = record.releaseArgonTxFeeMicrogons ?? undefined;
+    const historicalTotalFees = summary.historicalTotalFees;
     const releaseCompensation = hasConfirmedHistoryCoverage
       ? (record.releaseCompensationMicrogons ?? 0n)
       : (record.releaseCompensationMicrogons ?? undefined);
@@ -108,16 +110,17 @@ function createBitcoinLockPositions(
       releaseRedemption !== undefined &&
       releaseArgonTxFee !== undefined &&
       releaseCompensation !== undefined &&
-      bitcoinNetworkFeeValue !== undefined
+      bitcoinNetworkFeeValue !== undefined &&
+      historicalTotalFees !== undefined
     ) {
       hasCompleteReleaseHistory = true;
       settledPrincipalValue = removalBtcValue - releaseRedemption - bitcoinNetworkFeeValue;
       performanceEndingCapital = calculateBitcoinEndingCapital({
-        bitcoinValue: removalBtcValue,
+        bitcoinValue: summary.startingCapital,
         receivedLiquidity: summary.receivedLiquidity,
         pendingLiquidity: summary.pendingLiquidity,
         redemptionAmount: releaseRedemption,
-        fees: summary.totalFees + releaseArgonTxFee + bitcoinNetworkFeeValue,
+        fees: historicalTotalFees,
         compensation: releaseCompensation,
       });
     }
@@ -201,15 +204,26 @@ export function calculateBitcoinLockValuation({ lock, currency }: { lock: IBitco
   const securityFees = bigIntMax(grossSecurityFees - (lock.lockDetails?.couponFeesPaid ?? 0n), 0n);
   const transactionFees = lock.ratchets.reduce((total, ratchet) => total + ratchet.txFee, 0n);
   const totalFees = securityFees + transactionFees;
+  const releaseBitcoinNetworkFeeValue = valueSatoshisAtRate(
+    lock.fundingUtxoRecord?.releaseBitcoinNetworkFee,
+    lock.btcPriceAtRemovalMicrogons,
+  );
+  const hasHistoricalTransactionFees =
+    lock.releaseArgonTxFeeMicrogons !== undefined || releaseBitcoinNetworkFeeValue !== undefined;
+  const historicalTransactionFees = hasHistoricalTransactionFees
+    ? transactionFees + (lock.releaseArgonTxFeeMicrogons ?? 0n) + (releaseBitcoinNetworkFeeValue ?? 0n)
+    : undefined;
+  const historicalTotalFees =
+    historicalTransactionFees === undefined ? undefined : securityFees + historicalTransactionFees;
   const totalLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintAmount, 0n);
   const pendingLiquidity = lock.ratchets.reduce((total, ratchet) => total + ratchet.mintPending, 0n);
   const burnedLiquidity = lock.ratchets.reduce((total, ratchet) => total + (ratchet.burned ?? 0n), 0n);
   const receivedLiquidity = totalLiquidity - pendingLiquidity - burnedLiquidity;
-  const startingCapital = lock.ratchets[0]?.lockedTargetPrice ?? lock.lockedTargetPrice;
   const initialLiquidity = lock.ratchets[0]?.mintAmount ?? lock.liquidityPromised;
+  const startingCapital = lock.ratchets[0] ? receivedLiquidity + pendingLiquidity : initialLiquidity;
   const valueBeyondLiquidity = bigIntMax(valueOfBtc - lock.lockedTargetPrice, 0n);
   const currentEndingCapital = calculateBitcoinEndingCapital({
-    bitcoinValue: valueOfBtc,
+    bitcoinValue: startingCapital + valueBeyondLiquidity,
     receivedLiquidity,
     pendingLiquidity,
     redemptionAmount: unlockAmount,
@@ -226,7 +240,10 @@ export function calculateBitcoinLockValuation({ lock, currency }: { lock: IBitco
     startingCapital,
     endingCapital,
     securityFees,
+    transactionFees,
     totalFees,
+    historicalTransactionFees,
+    historicalTotalFees,
     unlockAmount,
     totalReturn: calculateBitcoinReturn(startingCapital, endingCapital),
   };

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -21,7 +21,12 @@ export class BitcoinLockRecovery {
   private readonly onHistoryRecoveryComplete: (locks: IBitcoinLockRecord[]) => void;
   private readonly utxoTracking: Pick<
     BitcoinUtxoTracking,
-    'getAcceptedFundingRecordForLock' | 'setAcceptedFundingRecordForLock' | 'setReleaseRequest' | 'upsertUtxoRecord'
+    | 'getAcceptedFundingRecordForLock'
+    | 'isReleaseCompleteStatus'
+    | 'isReleaseStatus'
+    | 'setAcceptedFundingRecordForLock'
+    | 'setReleaseRequest'
+    | 'upsertUtxoRecord'
   >;
   private historyReplayLocksByUtxoId?: Record<number, IBitcoinLockRecord>;
   private readonly historyRecoveryPendingUtxoIds = new Set<number>();
@@ -135,7 +140,8 @@ export class BitcoinLockRecovery {
     for (let eventIndex = 0; eventIndex < eventRecords.length; eventIndex += 1) {
       const { event } = eventRecords[eventIndex];
       const isBitcoinMint = event.section === 'mint' && event.method === 'BitcoinMint';
-      if (event.section !== 'bitcoinLocks' && !isBitcoinMint) continue;
+      const isBitcoinUtxoVerified = event.section === 'bitcoinUtxos' && event.method === 'UtxoVerified';
+      if (event.section !== 'bitcoinLocks' && !isBitcoinMint && !isBitcoinUtxoVerified) continue;
       if (event.section === 'bitcoinLocks' && !bitcoinRecoveryEventMethods.has(event.method)) {
         continue;
       }
@@ -195,25 +201,25 @@ export class BitcoinLockRecovery {
               ['lockedTargetPrice', 'lockedMarketRate', 'peggedPrice', 'lockPrice'],
               block,
             );
-            if (
-              creationRatchet.mintAmount !== creationLiquidity ||
-              creationRatchet.lockedTargetPrice !== creationTargetPrice
-            ) {
-              throw new Error(`Bitcoin lock ${utxoId} has invalid creation ratchet economics`);
-            }
-
             const extrinsicIndex = eventRecords[eventIndex].phase.isApplyExtrinsic
               ? eventRecords[eventIndex].phase.asApplyExtrinsic.toNumber()
               : undefined;
             if (
+              creationRatchet.mintAmount !== creationLiquidity ||
+              creationRatchet.lockedTargetPrice !== creationTargetPrice ||
               creationRatchet.mintPending !== creationRatchet.mintAmount ||
               creationRatchet.extrinsicIndex !== extrinsicIndex ||
               existing.createdAt.getTime() !== block.blockTime ||
               (existing.lockDetails?.couponFeesPaid ?? 0n) !== chainLock.couponFeesPaid
             ) {
               const recovered = this.createDetachedRecord(existing);
-              recovered.ratchets[creationRatchetIndex].mintPending = creationRatchet.mintAmount;
-              recovered.ratchets[creationRatchetIndex].extrinsicIndex = extrinsicIndex;
+              recovered.ratchets[creationRatchetIndex] = {
+                ...creationRatchet,
+                mintAmount: creationLiquidity,
+                mintPending: creationLiquidity,
+                lockedTargetPrice: creationTargetPrice,
+                extrinsicIndex,
+              };
               recovered.lockDetails = chainLock;
               await table.saveRecoveredHistory(recovered, new Date(block.blockTime));
               this.applyRecoveredRecord(recovered);
@@ -267,7 +273,44 @@ export class BitcoinLockRecovery {
         if (!isBitcoinMint && event.method !== 'BitcoinLockRatcheted') continue;
         throw new Error(`Bitcoin lock ${utxoId} history is missing its creation record`);
       }
-      if (event.method === 'BitcoinLockRatcheted') {
+      if (isBitcoinUtxoVerified) {
+        const chainLock = await BitcoinLock.get(api, utxoId);
+        if (!chainLock) throw new Error(`Bitcoin lock ${utxoId} is unavailable after funding verification`);
+
+        const recovered = this.createDetachedRecord(record);
+        const creationRatchet = recovered.ratchets[0];
+        if (!creationRatchet) throw new Error(`Bitcoin lock ${utxoId} is missing its creation ratchet`);
+
+        // Older UtxoVerified events did not include the received amount, so use the archived post-event state.
+        const verifiedSatoshis = chainLock.utxoSatoshis ?? chainLock.satoshis;
+        chainLock.couponFeesPaid = bigIntMax(chainLock.couponFeesPaid, recovered.lockDetails?.couponFeesPaid ?? 0n);
+        recovered.satoshis = verifiedSatoshis;
+        recovered.liquidityPromised = chainLock.liquidityPromised;
+        recovered.lockedTargetPrice = chainLock.lockedTargetPrice;
+        recovered.lockDetails = chainLock;
+        creationRatchet.mintAmount = chainLock.liquidityPromised;
+        creationRatchet.mintPending = chainLock.liquidityPromised;
+        creationRatchet.lockedTargetPrice = chainLock.lockedTargetPrice;
+        if (recovered.status === BitcoinLockStatus.LockPendingFunding) {
+          recovered.status = BitcoinLockStatus.LockedAndIsMinting;
+        }
+
+        const utxoRef = await chainLock.getFundingUtxoRef(api);
+        let fundingRecord;
+        if (utxoRef) {
+          fundingRecord = await this.utxoTracking.upsertUtxoRecord(
+            recovered,
+            { txid: utxoRef.txid, vout: utxoRef.vout, satoshis: verifiedSatoshis },
+            { markFundingUtxo: true },
+          );
+          await this.utxoTracking.setAcceptedFundingRecordForLock(recovered, fundingRecord);
+        }
+
+        this.assertSafePendingMint(recovered);
+        await table.saveRecoveredHistory(recovered);
+        if (fundingRecord) await table.setFundingUtxoRecordId(recovered, fundingRecord.id);
+        this.applyRecoveredRecord(recovered);
+      } else if (event.method === 'BitcoinLockRatcheted') {
         await this.importRatchet(record, block, eventRecords, eventIndex, api, table);
       } else if (isBitcoinMint) {
         await this.applyScopedMint(record, readRequiredEventBigInt(event, ['amount'], block), api, table);
@@ -293,7 +336,7 @@ export class BitcoinLockRecovery {
             await this.utxoTracking.setAcceptedFundingRecordForLock(recovered, fundingRecord);
           }
         }
-        if (fundingRecord) {
+        if (fundingRecord && !this.utxoTracking.isReleaseStatus(fundingRecord.status)) {
           await this.utxoTracking.setReleaseRequest(fundingRecord, {
             requestedReleaseAtTick: await api.query.ticks.currentTick().then(tick => tick.toNumber()),
             releaseToDestinationAddress: releaseRequest.toScriptPubkey,
@@ -302,7 +345,11 @@ export class BitcoinLockRecovery {
         }
         this.applyRecoveredRecord(recovered);
       } else if (event.method === 'BitcoinUtxoCosigned') {
-        if (record.status === BitcoinLockStatus.Released && !record.removalReason) {
+        const fundingRecord = this.utxoTracking.getAcceptedFundingRecordForLock(record);
+        const releaseIsComplete =
+          record.status === BitcoinLockStatus.Released ||
+          this.utxoTracking.isReleaseCompleteStatus(fundingRecord?.status);
+        if (releaseIsComplete && !record.removalReason) {
           const recovered = this.createDetachedRecord(record);
           const rates = await this.currency.fetchMainchainRatesAtBlock({ api, block });
           const phase = eventRecords[eventIndex].phase;
@@ -392,14 +439,16 @@ export class BitcoinLockRecovery {
   }
 
   public async findMissingActiveLockIds(api: ApiDecoration<'promise'>): Promise<number[]> {
-    const chainLocks = await api.query.bitcoinLocks.locksByUtxoId.entries();
+    const ownerKeys = await api.query.bitcoinLocks.utxoIdsByOwnerAccount.keys(this.walletKeys.defaultArgonAddress);
+    const utxoIds = ownerKeys.map(key => key.args[1].toNumber());
+    const chainLocks = await api.query.bitcoinLocks.locksByUtxoId.multi(utxoIds);
     const missing: number[] = [];
 
-    for (const [storageKey, lockOption] of chainLocks) {
-      if (lockOption.isNone || lockOption.unwrap().ownerAccount.toString() !== this.walletKeys.defaultArgonAddress)
-        continue;
+    for (let index = 0; index < utxoIds.length; index += 1) {
+      const lockOption = chainLocks[index];
+      if (!lockOption?.isSome) continue;
 
-      const utxoId = storageKey.args[0].toNumber();
+      const utxoId = utxoIds[index];
       const record = this.getRecoveryLock(utxoId);
       const chainLock = lockOption.unwrap();
       if (

--- a/src-vue/lib/recovery/MyVaultRecovery.ts
+++ b/src-vue/lib/recovery/MyVaultRecovery.ts
@@ -2,14 +2,16 @@ import { ITuple, Option, U8aFixed, u8aToHex, Vault } from '@argonprotocol/mainch
 import { IVaultingRules } from '../../interfaces/IVaultingRules.ts';
 import BigNumber from 'bignumber.js';
 import BitcoinLocks from '../BitcoinLocks.ts';
-import { MainchainClients, StorageFinder, TransactionEvents } from '@argonprotocol/apps-core';
+import { AccountActivityKind, MainchainClients, StorageFinder, TransactionEvents } from '@argonprotocol/apps-core';
 import { TICK_MILLIS } from '../Env.ts';
 import { Config } from '../Config.ts';
 import bs58check from 'bs58check';
 import { BitcoinNetwork } from '@argonprotocol/bitcoin';
+import { hexToU8a } from '@polkadot/util';
 import type { IBitcoinLockRecord } from '../db/BitcoinLocksTable.ts';
 import { DEFAULT_MASTER_XPUB_PATH } from '../MyVault.ts';
 import { WalletKeys } from '../WalletKeys.ts';
+import { findAddressActivity } from '../IndexerClient.ts';
 
 export class MyVaultRecovery {
   public static rebuildRules(args: {
@@ -84,31 +86,59 @@ export class MyVaultRecovery {
     });
     console.log('Recovered vault xpub path:', masterXpubPath);
 
-    const vaultCreateKey = client.query.vaults.vaultsById.key(vaultId);
-    const vaultStartBlock = await StorageFinder.binarySearchForStorageAddition(mainchainClients, vaultCreateKey).catch(
-      err => {
-        console.warn('Unable to find vault creation block:', err);
-        return undefined;
-      },
-    );
-    console.log('Look for vault create at block:', vaultStartBlock?.blockNumber ?? 'not found');
-    const vaultCreateBlockNumber = vaultStartBlock?.blockNumber ?? 0;
-    let vaultCreateFee = 0n;
-    if (vaultStartBlock) {
-      const result = await TransactionEvents.findFromFeePaidEvent({
+    const findVaultCreation = (blockHash: Uint8Array) => {
+      return TransactionEvents.findFromFeePaidEvent({
         client,
         accountAddress: vaultingAddress,
-        blockHash: vaultStartBlock.blockHash,
-        isMatchingEvent: ev => {
-          if (client.events.vaults.VaultCreated.is(ev)) {
-            const { vaultId: vaultIdRaw } = ev.data;
-            return vaultIdRaw.toNumber() === vaultId;
-          }
-          return false;
+        blockHash,
+        isMatchingEvent(event) {
+          if (!client.events.vaults.VaultCreated.is(event)) return false;
+          return event.data.vaultId.toNumber() === vaultId;
         },
       });
-      vaultCreateFee = result?.fee ?? 0n;
+    };
+
+    let vaultStartBlock: { blockNumber: number; blockHash: Uint8Array } | undefined;
+    let vaultCreateFee = 0n;
+    try {
+      const indexedActivity = await findAddressActivity(vaultingAddress, {
+        activityMask: AccountActivityKind.VaultPosition,
+      });
+      if (indexedActivity.coverage.gaps.length) {
+        throw new Error(indexedActivity.coverage.gaps[0].reason);
+      }
+
+      const indexedCreation = indexedActivity.blocks.at(0);
+      if (indexedCreation) {
+        const candidate = {
+          blockNumber: indexedCreation.blockNumber,
+          blockHash: hexToU8a(indexedCreation.blockHash),
+        };
+        const result = await findVaultCreation(candidate.blockHash);
+        if (result) {
+          vaultStartBlock = candidate;
+          vaultCreateFee = result.fee;
+        }
+      }
+    } catch (error) {
+      console.warn('Unable to find indexed vault creation block:', error);
     }
+
+    if (!vaultStartBlock) {
+      const vaultCreateKey = client.query.vaults.vaultsById.key(vaultId);
+      vaultStartBlock = await StorageFinder.binarySearchForStorageAddition(mainchainClients, vaultCreateKey).catch(
+        error => {
+          console.warn('Unable to find vault creation block:', error);
+          return undefined;
+        },
+      );
+      if (vaultStartBlock) {
+        vaultCreateFee = (await findVaultCreation(vaultStartBlock.blockHash))?.fee ?? 0n;
+      }
+    }
+
+    console.log('Look for vault create at block:', vaultStartBlock?.blockNumber ?? 'not found');
+    const vaultCreateBlockNumber = vaultStartBlock?.blockNumber ?? 0;
     return {
       masterXpubPath,
       createBlockNumber: vaultCreateBlockNumber,

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -37,7 +37,6 @@ export async function needsFinancialHistoryRecovery(args: {
   db: Db;
   accountId: string;
   enabledDomains: readonly IFinancialHistoryDomain[];
-  targetBlock: number;
   bitcoinLockRecovery?: Pick<BitcoinLockRecovery, 'hasPendingHistoryRecovery'>;
 }): Promise<boolean> {
   const savedState = await args.db.syncStateTable.get(SyncStateKeys.FinancialHistory);
@@ -50,7 +49,7 @@ export async function needsFinancialHistoryRecovery(args: {
     const recoveryVersion = historyRecoveryVersions[domain];
     return (
       !checkpoint ||
-      checkpoint.asOfBlock < args.targetBlock ||
+      checkpoint.partialRecovery ||
       (recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion)
     );
   });
@@ -59,6 +58,7 @@ export async function needsFinancialHistoryRecovery(args: {
 export type IFinancialHistoryImportResult = {
   importedBlockCount: number;
   domainErrors: Partial<Record<IFinancialHistoryDomain, string>>;
+  failedAtBlock?: number;
 };
 
 export type IFinancialHistoryRestoreResult = {
@@ -78,7 +78,7 @@ const earliestSupportedSpecVersions: Record<IFinancialHistoryDomain, number> = {
   vaulting: 116,
 };
 const historyRecoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {
-  bitcoin: 3,
+  bitcoin: 5,
   bonds: 1,
 };
 
@@ -120,6 +120,32 @@ export async function restoreFinancialHistory(args: {
 
   let importedBlockCount = 0;
   const recoveryErrors: string[] = [];
+  const saveDomainCheckpoint = async (
+    domain: IFinancialHistoryDomain,
+    checkpoint: IFinancialHistoryCheckpoint,
+  ): Promise<void> => {
+    domainCheckpoints[domain] = checkpoint;
+
+    const enabledCheckpoints = enabledDomains.map(enabledDomain => domainCheckpoints[enabledDomain]);
+    const aggregateAsOfBlock = Math.min(...enabledCheckpoints.map(saved => saved?.asOfBlock ?? 0));
+    const aggregateCheckpoint = enabledCheckpoints.find(saved => saved?.asOfBlock === aggregateAsOfBlock);
+    const recoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {};
+    for (const enabledDomain of enabledDomains) {
+      const recoveryVersion = domainCheckpoints[enabledDomain]?.recoveryVersion;
+      if (recoveryVersion !== undefined) recoveryVersions[enabledDomain] = recoveryVersion;
+    }
+
+    await db.syncStateTable.upsert(SyncStateKeys.FinancialHistory, {
+      accountId,
+      asOfBlock: aggregateAsOfBlock,
+      ...(aggregateCheckpoint?.definitionVersion !== undefined
+        ? { definitionVersion: aggregateCheckpoint.definitionVersion }
+        : {}),
+      ...(Object.keys(recoveryVersions).length ? { recoveryVersions } : {}),
+      domains: enabledDomains,
+      domainCheckpoints,
+    });
+  };
 
   args.onProgress?.(0);
   for (const domain of domainsToRestore) {
@@ -139,32 +165,15 @@ export async function restoreFinancialHistory(args: {
         force: args.force,
         targetBlock,
         onProgress: count => args.onProgress?.(importedBlockCount + count),
+        onCheckpoint: checkpoint => saveDomainCheckpoint(domain, checkpoint),
       });
       importedBlockCount += result.importedBlockCount;
-      domainCheckpoints[domain] = result.checkpoint;
-
-      const enabledCheckpoints = enabledDomains.map(enabledDomain => domainCheckpoints[enabledDomain]);
-      const aggregateAsOfBlock = Math.min(...enabledCheckpoints.map(saved => saved?.asOfBlock ?? 0));
-      const aggregateCheckpoint = enabledCheckpoints.find(saved => saved?.asOfBlock === aggregateAsOfBlock);
-      const recoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {};
-      for (const enabledDomain of enabledDomains) {
-        const recoveryVersion = domainCheckpoints[enabledDomain]?.recoveryVersion;
-        if (recoveryVersion !== undefined) recoveryVersions[enabledDomain] = recoveryVersion;
-      }
 
       if (isBitcoinReplay) {
-        await bitcoinLockRecovery.commitHistoryReplay(result.checkpoint.asOfBlock >= targetBlock);
+        await bitcoinLockRecovery.commitHistoryReplay(!result.error && result.checkpoint.asOfBlock >= targetBlock);
       }
-      await db.syncStateTable.upsert(SyncStateKeys.FinancialHistory, {
-        accountId,
-        asOfBlock: aggregateAsOfBlock,
-        ...(aggregateCheckpoint?.definitionVersion !== undefined
-          ? { definitionVersion: aggregateCheckpoint.definitionVersion }
-          : {}),
-        ...(Object.keys(recoveryVersions).length ? { recoveryVersions } : {}),
-        domains: enabledDomains,
-        domainCheckpoints,
-      });
+      await saveDomainCheckpoint(domain, result.checkpoint);
+      if (result.error) throw new Error(result.error);
     } catch (error) {
       if (isBitcoinReplay) bitcoinLockRecovery.cancelHistoryReplay();
       recoveryErrors.push(error instanceof Error ? error.message : `Unable to restore ${domain} history`);
@@ -206,7 +215,10 @@ export class FinancialHistoryImporter {
 
   public async importBlocks(
     indexedBlocks: readonly IIndexedActivityBlock[],
-    onProgress?: (importedBlockCount: number) => void,
+    options: {
+      onProgress?: (importedBlockCount: number) => void;
+      onCheckpoint?: (blockNumber: number) => Promise<void>;
+    } = {},
   ): Promise<IFinancialHistoryImportResult> {
     const activityMask = this.enabledDomains.reduce((mask, domain) => mask | domainActivityMasks[domain], 0);
     const blocksByNumber = new Map(
@@ -214,6 +226,7 @@ export class FinancialHistoryImporter {
     );
     const backlog = [...blocksByNumber.values()].sort((left, right) => left.blockNumber - right.blockNumber);
     const domainErrors: Partial<Record<IFinancialHistoryDomain, string>> = {};
+    let failedAtBlock: number | undefined;
     let importedBlockCount = 0;
 
     for (const indexedBlock of backlog) {
@@ -225,9 +238,14 @@ export class FinancialHistoryImporter {
         domainErrors[domain] ??=
           `Block ${indexedBlock.blockNumber.toLocaleString()} uses unsupported runtime spec ${indexedBlock.specVersion}; ` +
           `earliest supported for ${domain} is ${earliestSupportedSpecVersion}`;
+        if (this.enabledDomains.length === 1) {
+          failedAtBlock =
+            failedAtBlock === undefined ? indexedBlock.blockNumber : Math.min(failedAtBlock, indexedBlock.blockNumber);
+        }
       }
     }
     const supportedBacklog = backlog.filter(indexedBlock => {
+      if (failedAtBlock !== undefined && indexedBlock.blockNumber >= failedAtBlock) return false;
       return this.enabledDomains.some(domain => {
         return (
           (indexedBlock.activityMask & domainActivityMasks[domain]) !== 0 &&
@@ -237,21 +255,59 @@ export class FinancialHistoryImporter {
     });
 
     for (let start = 0; start < supportedBacklog.length; start += 8) {
-      const loadedBlocks = await Promise.all(
-        supportedBacklog.slice(start, start + 8).map(indexedBlock => this.loadBlock(indexedBlock)),
-      );
-      for (const loadedBlock of loadedBlocks) {
+      const batch = supportedBacklog.slice(start, start + 8);
+      const loadedBlocks = await Promise.allSettled(batch.map(indexedBlock => this.loadBlock(indexedBlock)));
+      let lastImportedBlockNumber: number | undefined;
+      for (let index = 0; index < loadedBlocks.length; index += 1) {
+        const loadedResult = loadedBlocks[index];
+        const indexedBlock = batch[index];
+        if (loadedResult.status === 'rejected') {
+          const detail =
+            loadedResult.reason instanceof Error ? loadedResult.reason.message : 'Unable to load historical block';
+          for (const domain of this.enabledDomains) {
+            if (!(indexedBlock.activityMask & domainActivityMasks[domain])) continue;
+
+            let label: 'bitcoin' | 'bond' | 'vault' = 'vault';
+            if (domain === 'bonds') label = 'bond';
+            if (domain === 'bitcoin') label = 'bitcoin';
+            domainErrors[domain] ??= describeDomainError(label, indexedBlock.blockNumber, detail);
+          }
+          return {
+            importedBlockCount,
+            domainErrors,
+            failedAtBlock: indexedBlock.blockNumber,
+          };
+        }
+
+        const loadedBlock = loadedResult.value;
+        const domainsWithErrors = new Set(Object.keys(domainErrors));
         await this.importBlock(loadedBlock, domainErrors);
+        const hasNewError = this.enabledDomains.some(domain => {
+          return !domainsWithErrors.has(domain) && domainErrors[domain] !== undefined;
+        });
+        if (hasNewError && this.enabledDomains.length === 1) {
+          return {
+            importedBlockCount,
+            domainErrors,
+            failedAtBlock: loadedBlock.indexedBlock.blockNumber,
+          };
+        }
         importedBlockCount += 1;
-        onProgress?.(importedBlockCount);
+        lastImportedBlockNumber = loadedBlock.indexedBlock.blockNumber;
+        options.onProgress?.(importedBlockCount);
       }
+      if (lastImportedBlockNumber !== undefined) await options.onCheckpoint?.(lastImportedBlockNumber);
     }
 
-    return { importedBlockCount, domainErrors };
+    return {
+      importedBlockCount,
+      domainErrors,
+      ...(failedAtBlock !== undefined ? { failedAtBlock } : {}),
+    };
   }
 
   private async loadBlock(indexedBlock: IIndexedActivityBlock) {
-    const block = await this.blockWatch.getHeader(indexedBlock.blockNumber);
+    const block = await this.blockWatch.getHeader(indexedBlock);
     if (block.blockHash.toLowerCase() !== indexedBlock.blockHash.toLowerCase()) {
       throw new Error(
         `Indexer hash mismatch at block ${indexedBlock.blockNumber.toLocaleString()}: expected ${indexedBlock.blockHash}, received ${block.blockHash}`,
@@ -321,13 +377,17 @@ async function restoreFinancialHistoryDomain(args: {
   force?: boolean;
   targetBlock: number;
   onProgress?: (importedBlockCount: number) => void;
-}): Promise<{ checkpoint: IFinancialHistoryCheckpoint; importedBlockCount: number }> {
+  onCheckpoint?: (checkpoint: IFinancialHistoryCheckpoint) => Promise<void>;
+}): Promise<{ checkpoint: IFinancialHistoryCheckpoint; importedBlockCount: number; error?: string }> {
   const { db, blockWatch, accountId, argonBonds, bitcoinLockRecovery, vaultHistory, domain, checkpoint } = args;
   const recoveryVersion = historyRecoveryVersions[domain];
   const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint?.recoveryVersion !== recoveryVersion;
   const hasIncompleteBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
+  const canResumeBitcoinRecovery = hasIncompleteBitcoinRecovery && checkpoint?.partialRecovery;
   let afterBlock =
-    args.force || !checkpoint || recoveryVersionChanged || hasIncompleteBitcoinRecovery ? 0 : checkpoint.asOfBlock;
+    args.force || !checkpoint || recoveryVersionChanged || (hasIncompleteBitcoinRecovery && !canResumeBitcoinRecovery)
+      ? 0
+      : checkpoint.asOfBlock;
   let indexedHistory = await findAddressActivity(accountId, {
     afterBlock,
     toBlock: args.targetBlock,
@@ -368,11 +428,32 @@ async function restoreFinancialHistoryDomain(args: {
       vaultHistory,
       enabledDomains: [domain],
       bitcoinLockRecovery,
-    }).importBlocks(backlog, args.onProgress);
+    }).importBlocks(backlog, {
+      onProgress: args.onProgress,
+      async onCheckpoint(blockNumber) {
+        await args.onCheckpoint?.({
+          asOfBlock: blockNumber,
+          definitionVersion: indexedHistory.definitionVersion,
+          ...(recoveryVersion !== undefined ? { recoveryVersion } : {}),
+          partialRecovery: true,
+        });
+      },
+    });
     importedBlockCount = result.importedBlockCount;
 
     const domainError = result.domainErrors[domain];
-    if (domainError) throw new Error(domainError);
+    if (domainError) {
+      return {
+        importedBlockCount,
+        error: domainError,
+        checkpoint: {
+          asOfBlock: Math.max(afterBlock, (result.failedAtBlock ?? afterBlock + 1) - 1),
+          definitionVersion: indexedHistory.definitionVersion,
+          ...(recoveryVersion !== undefined ? { recoveryVersion } : {}),
+          partialRecovery: true,
+        },
+      };
+    }
   }
 
   const recoveredThroughBlock = Math.min(indexedHistory.asOfBlock, args.targetBlock);
@@ -422,12 +503,15 @@ async function restoreFinancialHistoryDomain(args: {
       asOfBlock: recoveredThroughBlock,
       definitionVersion: indexedHistory.definitionVersion,
       ...(recoveryVersion !== undefined ? { recoveryVersion } : {}),
+      ...(recoveredThroughBlock < args.targetBlock ? { partialRecovery: true } : {}),
     },
   };
 }
 
 function describeDomainError(domain: 'bitcoin' | 'bond' | 'vault', blockNumber: number, error: unknown): string {
-  const detail = error instanceof Error ? error.message : `Unable to decode ${domain} history`;
+  let detail = `Unable to decode ${domain} history`;
+  if (error instanceof Error) detail = error.message;
+  if (typeof error === 'string') detail = error;
   let label = 'Vault';
   if (domain === 'bond') label = 'Bond';
   if (domain === 'bitcoin') label = 'Bitcoin lock';

--- a/src-vue/navigation/ProfitsMenu.vue
+++ b/src-vue/navigation/ProfitsMenu.vue
@@ -110,11 +110,7 @@
             </button>
           </li>
           <li
-            v-else-if="
-              historyRecovery.state === 'checking' ||
-              historyRecovery.state === 'restoring' ||
-              historyRecovery.state === 'waiting'
-            "
+            v-else-if="isHistoryRecoveryInProgress"
             class="mt-1 border-t border-slate-400/30 px-3 py-2 text-xs font-normal text-slate-500"
           >
             History catching up
@@ -144,7 +140,12 @@ defineExpose({
 
 const financials = useFinancials();
 const config = getConfig();
-const { financialPositionAggregate: aggregate, historyRecovery, bondSummariesByAsset } = storeToRefs(financials);
+const {
+  financialPositionAggregate: aggregate,
+  historyRecovery,
+  isHistoryRecoveryInProgress,
+  bondSummariesByAsset,
+} = storeToRefs(financials);
 const returnRows = Vue.computed(() => {
   if (!config.isLoaded) return [];
 

--- a/src-vue/overlays/BitcoinRatchetingOverlay.vue
+++ b/src-vue/overlays/BitcoinRatchetingOverlay.vue
@@ -52,7 +52,7 @@
         :disabled="isSubmitting || isLoadingPreview || !ratchetPreview?.canRatchet"
         class="bg-argon-600 inline-flex items-center px-5 py-1 text-white border border-argon-800 rounded disabled:opacity-50 cursor-pointer"
       >
-        <Spinner v-if="isSubmitting" class="mr-2 h-4 min-h-4 w-4 min-w-4" />
+        <Spinner v-if="isSubmitting" class="Inverse mr-2 h-4 min-h-4 w-4 min-w-4" />
         {{ isSubmitting ? 'Ratchet pending...' : 'Finish Ratchet' }}
       </button>
       <div v-if="errorMessage" class="mt-3 text-sm text-red-600">{{ errorMessage }}</div>

--- a/src-vue/overlays/BitcoinsReleasedOverlay.vue
+++ b/src-vue/overlays/BitcoinsReleasedOverlay.vue
@@ -1,42 +1,97 @@
 <template>
-  <div class="px-1 text-xs font-medium tracking-wide text-slate-400 uppercase">Released</div>
-  <div
+  <div class="px-1 text-xs font-medium tracking-wide text-slate-400">
+    {{ financials.liquidInvisibleRecords.length }} bitcoin transaction{{
+      financials.liquidInvisibleRecords.length === 1 ? '' : 's'
+    }}
+    {{ financials.liquidInvisibleRecords.length === 1 ? 'has' : 'have' }} been archived
+  </div>
+  <section
     v-for="lock in financials.liquidInvisibleRecords"
     :key="lock.uuid ?? lock.utxoId"
     @click="openDetail(lock)"
-    class="flex cursor-pointer flex-row items-center rounded border border-slate-200/50 bg-white/50 px-4 py-2 opacity-50 hover:opacity-70"
+    class="flex cursor-pointer flex-row items-center gap-2.5 rounded border border-slate-900/20 bg-slate-50 px-3.5 py-2 opacity-60 hover:opacity-80"
   >
-    <BitcoinIcon class="h-14 text-slate-400" />
-    <div class="grow">
-      <div class="font-mono text-sm font-semibold text-slate-700">
-        {{ satToBtcNm(lock.satoshis).format('0,0.[0000]') }} BTC
+    <BitcoinIcon class="text-argon-600/60 w-20" />
+    <div class="grow pl-2">
+      <div class="flex flex-row items-center gap-1 pt-3 pb-2 text-lg text-slate-800">
+        <span class="font-semibold">{{ satToBtcNm(lock.satoshis).format('0,0.[0000]') }} of BTC</span>
+        <span v-if="lock.record.removalBlockTime" class="font-light">
+          {{ removalDateLabel(lock.record) }}
+          {{ dayjs().diff(dayjs(lock.record.removalBlockTime), 'days') }} days ago
+        </span>
+        <span class="ml-auto font-semibold text-slate-500">Archived</span>
       </div>
-      <div class="text-xs text-slate-400">
-        {{ currency.symbol
-        }}{{ microgonToMoneyNm(bitcoinLocks.getDisplayLiquidityPromised(lock.record)).format('0,0.00') }}
-        liquidity Released
+      <div class="flex flex-row items-stretch border-t border-slate-400/30 pt-3 pb-3 whitespace-nowrap text-slate-500">
+        <span v-if="financials.bitcoinLockPerformanceByUuid[lock.uuid]">
+          {{ currency.symbol
+          }}{{ microgonToMoneyNm(financials.bitcoinLockPerformanceByUuid[lock.uuid]?.profit ?? 0n).format('0,0.[00]') }}
+          profit
+          <template v-if="lock.pendingLiquidity > 0n">
+            · {{ currency.symbol }}{{ microgonToMoneyNm(lock.pendingLiquidity).format('0,0.00') }} pending
+          </template>
+        </span>
+        <span v-else-if="isReturnLoading(lock)">Loading profit...</span>
+        <span v-else>Profit unavailable</span>
+        <div class="flex grow flex-row items-stretch justify-center">
+          <span class="h-full w-px bg-slate-400/50"></span>
+        </div>
+        <span>{{ currency.symbol }}{{ microgonToMoneyNm(lock.securityFees).format('0,0.00') }} vault fees</span>
+        <div class="flex grow flex-row items-stretch justify-center">
+          <span class="h-full w-px bg-slate-400/50"></span>
+        </div>
+        <span>
+          {{ currency.symbol
+          }}{{ microgonToMoneyNm(lock.historicalTransactionFees ?? lock.transactionFees).format('0,0.00') }}
+          {{ hasCompleteTransactionFees(lock.record) ? 'transaction fees' : 'known transaction fees' }}
+        </span>
+        <div class="flex grow flex-row items-stretch justify-center">
+          <span class="h-full w-px bg-slate-400/50"></span>
+        </div>
+        <span v-if="financials.bitcoinLockPerformanceByUuid[lock.uuid]" class="pr-1">
+          {{ numeral(financials.bitcoinLockPerformanceByUuid[lock.uuid]?.percent ?? 0).format('0,0.[00]') }}% return
+        </span>
+        <span v-else-if="isReturnLoading(lock)" class="pr-1">Loading return...</span>
+        <span v-else class="pr-1">Return unavailable</span>
       </div>
     </div>
-  </div>
+  </section>
 </template>
 <script setup lang="ts">
+import dayjs from 'dayjs';
 import BitcoinIcon from '../assets/wallets/bitcoin.svg?component';
-import { getBitcoinLocks } from '../stores/bitcoin.ts';
 import { getCurrency } from '../stores/currency.ts';
-import { createNumeralHelpers } from '../lib/numeral.ts';
+import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
 import type { IBitcoinLockSummary } from '../interfaces/IBitcoinLockSummary.ts';
+import type { IBitcoinLockRecord } from '../interfaces/IBitcoinLockRecord.ts';
 import { useFinancials } from '../stores/financials.ts';
 
 const emit = defineEmits<{
   (e: 'openDetail', lock: IBitcoinLockSummary): void;
 }>();
 
-const bitcoinLocks = getBitcoinLocks();
 const currency = getCurrency();
 const financials = useFinancials();
 const { microgonToMoneyNm, satToBtcNm } = createNumeralHelpers(currency);
 
 function openDetail(lock: IBitcoinLockSummary) {
   emit('openDetail', lock);
+}
+
+function isReturnLoading(lock: IBitcoinLockSummary) {
+  return lock.record.isHistoryRecoveryPending || financials.isHistoryRecoveryInProgress;
+}
+
+function removalDateLabel(lock: IBitcoinLockRecord) {
+  if (lock.removalReason === 'expired') return 'expired';
+  if (lock.removalReason === 'spent') return 'removed';
+  return 'released';
+}
+
+function hasCompleteTransactionFees(lock: IBitcoinLockRecord) {
+  return (
+    lock.releaseArgonTxFeeMicrogons !== undefined &&
+    lock.fundingUtxoRecord?.releaseBitcoinNetworkFee !== undefined &&
+    lock.btcPriceAtRemovalMicrogons !== undefined
+  );
 }
 </script>

--- a/src-vue/overlays/bitcoin-locking/LockDetail.vue
+++ b/src-vue/overlays/bitcoin-locking/LockDetail.vue
@@ -8,10 +8,35 @@
     <div class="grow">
       <div class="flex items-baseline gap-2">
         <span class="text-argon-600 font-mono text-2xl font-bold">{{ formattedBtc }} BTC</span>
-        <span class="text-sm text-slate-500">
+        <span v-if="isOwnLock && isReleased" class="text-sm text-slate-500">
+          <span>
+            {{ currency.symbol }}{{ microgonToMoneyNm(localLock!.liquidityPromised).format('0,0.[00]') }} liquidity
+          </span>
+          ·
+          <Tooltip :asChild="true" content="The Argons returned to unlock and release this bitcoin.">
+            <span class="cursor-help">
+              {{
+                localLock?.releaseRedemptionMicrogons === undefined
+                  ? 'release cost unavailable'
+                  : `${currency.symbol}${microgonToMoneyNm(localLock.releaseRedemptionMicrogons).format('0,0.[00]')} release cost`
+              }}
+            </span>
+          </Tooltip>
+          ·
+          <span class="font-medium text-slate-700">
+            <template v-if="settledPerformance">
+              {{ currency.symbol }}{{ microgonToMoneyNm(settledPerformance.profit).format('0,0.[00]') }} profit ({{
+                numeral(settledPerformance.percent).format('0,0.[00]')
+              }}%)
+            </template>
+            <template v-else-if="isReturnLoading">return loading...</template>
+            <template v-else>return unavailable</template>
+          </span>
+        </span>
+        <span v-else class="text-sm text-slate-500">
           <Tooltip :asChild="true" content="The current market value of this bitcoin based on the latest oracle price.">
             <span class="cursor-help">
-              {{ currency.symbol }}{{ satToMoneyNm(fundingSatoshis).format('0,0.[00]') }} market
+              {{ currency.symbol }}{{ satToMoneyNm(fundingSatoshis).format('0,0.[00]') }} current market
             </span>
           </Tooltip>
           ·
@@ -35,7 +60,63 @@
         </a>
       </div>
 
-      <div class="mt-4 flex flex-row items-start gap-6">
+      <div v-if="isOwnLock && isReleased" class="mt-4 flex items-stretch border-t border-slate-200 pt-3 text-sm">
+        <div v-if="localSummary?.pendingLiquidity" class="w-32 shrink-0 text-center">
+          <div class="text-xs font-semibold tracking-wide text-slate-400 uppercase">Pending</div>
+          <div class="mt-0.5 font-medium text-slate-700">
+            {{ currency.symbol }}{{ microgonToMoneyNm(localSummary.pendingLiquidity).format('0,0.[00]') }}
+          </div>
+        </div>
+        <div
+          class="min-w-0 grow px-3 text-center"
+          :class="{ 'border-l border-slate-200': localSummary?.pendingLiquidity }"
+        >
+          <Tooltip :asChild="true" content="The fee charged by the vault operator for securing this bitcoin lock.">
+            <div class="cursor-help">
+              <div class="text-xs font-semibold tracking-wide text-slate-400 uppercase">Vault fees</div>
+              <div class="mt-0.5 font-medium text-slate-700">
+                {{ currency.symbol }}{{ microgonToMoneyNm(vaultFees).format('0,0.[00]') }}
+              </div>
+            </div>
+          </Tooltip>
+        </div>
+        <div class="min-w-0 grow border-l border-slate-200 px-3 text-center">
+          <Tooltip
+            :asChild="true"
+            content="The Bitcoin network fee deducted from the bitcoin returned to your wallet, valued at its release price."
+          >
+            <div class="cursor-help">
+              <div class="text-xs font-semibold tracking-wide text-slate-400 uppercase">BTC unlock fee</div>
+              <div class="mt-0.5 font-medium text-slate-700">
+                {{
+                  bitcoinUnlockCost === undefined
+                    ? 'Unavailable'
+                    : `${currency.symbol}${microgonToMoneyNm(bitcoinUnlockCost).format('0,0.[00]')}`
+                }}
+              </div>
+            </div>
+          </Tooltip>
+        </div>
+        <div class="min-w-0 grow border-l border-slate-200 px-3 text-center">
+          <Tooltip
+            :asChild="true"
+            content="Argon transaction fees paid to initialize, ratchet, and release this bitcoin lock."
+          >
+            <div class="cursor-help">
+              <div class="text-xs font-semibold tracking-wide text-slate-400 uppercase">Argon transaction fees</div>
+              <div class="mt-0.5 font-medium text-slate-700">
+                {{
+                  argonTransactionCost === undefined
+                    ? 'Unavailable'
+                    : `${currency.symbol}${microgonToMoneyNm(argonTransactionCost).format('0,0.[00]')}`
+                }}
+              </div>
+            </div>
+          </Tooltip>
+        </div>
+      </div>
+
+      <div v-else class="mt-4 flex flex-row items-start gap-6">
         <div class="space-y-1.5 text-sm text-slate-600">
           <div v-if="!isPendingFunding && isOwnLock && unlockPrice > 0n">
             <Tooltip
@@ -53,7 +134,20 @@
           <div v-if="vaultFees > 0n" class="text-slate-500">
             <Tooltip :asChild="true" content="The fee charged by the vault operator for securing this bitcoin lock.">
               <span class="cursor-help">
-                Vault fee: {{ currency.symbol }}{{ microgonToMoneyNm(vaultFees).format('0,0.[00]') }}
+                Vault fees
+                <span class="font-semibold">
+                  {{ currency.symbol }}{{ microgonToMoneyNm(vaultFees).format('0,0.[00]') }}
+                </span>
+              </span>
+            </Tooltip>
+          </div>
+          <div v-if="transactionFees > 0n" class="text-slate-500">
+            <Tooltip :asChild="true" content="Argon transaction fees paid to initialize and ratchet this bitcoin lock.">
+              <span class="cursor-help">
+                Argon transaction fees
+                <span class="font-semibold">
+                  {{ currency.symbol }}{{ microgonToMoneyNm(transactionFees).format('0,0.[000000]') }}
+                </span>
               </span>
             </Tooltip>
           </div>
@@ -128,6 +222,7 @@ import { getConfig } from '../../stores/config.ts';
 import { getMiningFrames } from '../../stores/mainchain.ts';
 import { getVaults } from '../../stores/vaults.ts';
 import { getWalletKeys } from '../../stores/wallets.ts';
+import { useFinancials } from '../../stores/financials.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/outline';
 import BitcoinMempool from '../../lib/BitcoinMempool.ts';
@@ -137,6 +232,7 @@ import VaultIcon from '../../assets/wallets/vault.svg?component';
 import Tooltip from '../../components/Tooltip.vue';
 import CountdownClock from '../../components/CountdownClock.vue';
 import type { IExternalBitcoinLock } from '../../lib/MyVault.ts';
+import { valueSatoshisAtRate } from '../../lib/financials/BitcoinLocks.ts';
 
 dayjs.extend(utc);
 
@@ -145,6 +241,7 @@ const bitcoinLocks = getBitcoinLocks();
 const config = getConfig();
 const miningFrames = getMiningFrames();
 const vaults = getVaults();
+const financials = useFinancials();
 const { microgonToMoneyNm, satToMoneyNm } = createNumeralHelpers(currency);
 
 const props = defineProps<{
@@ -183,6 +280,21 @@ const isReleased = Vue.computed(() => {
   return !!props.isReleased;
 });
 
+const settledPerformance = Vue.computed(() => {
+  const uuid = localLock.value?.uuid;
+  if (!uuid) return;
+  return financials.bitcoinLockPerformanceByUuid[uuid];
+});
+
+const isReturnLoading = Vue.computed(() => {
+  return !!localLock.value?.isHistoryRecoveryPending || financials.isHistoryRecoveryInProgress;
+});
+
+const localSummary = Vue.computed(() => {
+  if (!localLock.value) return;
+  return bitcoinLocks.createLockSummary(localLock.value);
+});
+
 const vaultLabel = Vue.computed(() => {
   const upstreamOperator = config.upstreamOperator;
   if (config.hasExtensionTreasury && upstreamOperator) {
@@ -197,7 +309,13 @@ const vaultLabel = Vue.computed(() => {
 const statusMessage = Vue.computed(() => {
   if (isReleased.value) {
     if (isOwnLock.value) {
-      return 'Your bitcoin has been unlocked and returned to your wallet.';
+      const releasedOn = localLock.value?.removalBlockTime
+        ? ` on ${dayjs(localLock.value.removalBlockTime).format('MMM D, YYYY')}`
+        : '';
+      if (localSummary.value?.pendingLiquidity) {
+        return `Your bitcoin was unlocked and returned to your wallet${releasedOn}. The remaining argons will continue minting to your wallet.`;
+      }
+      return `Your bitcoin was unlocked and returned to your wallet${releasedOn}.`;
     }
     return 'This bitcoin has been unlocked and returned to the owner.';
   }
@@ -241,8 +359,30 @@ const mintedPct = Vue.computed(() => {
 });
 
 const vaultFees = Vue.computed(() => {
-  if (localLock.value) return bitcoinLocks.createLockSummary(localLock.value).securityFees;
+  if (localSummary.value) return localSummary.value.securityFees;
   return props.lock.lockDetails?.securityFees ?? 0n;
+});
+
+const transactionFees = Vue.computed(() => {
+  const summary = localSummary.value;
+  if (!summary) return 0n;
+  return summary.transactionFees;
+});
+
+const bitcoinUnlockCost = Vue.computed(() => {
+  const lock = localLock.value;
+  if (!lock) return;
+
+  return valueSatoshisAtRate(
+    lock.fundingUtxoRecord?.releaseBitcoinNetworkFee,
+    lock.btcPriceAtRemovalMicrogons ?? undefined,
+  );
+});
+
+const argonTransactionCost = Vue.computed(() => {
+  const lock = localLock.value;
+  if (!lock || lock.releaseArgonTxFeeMicrogons === undefined) return;
+  return transactionFees.value + lock.releaseArgonTxFeeMicrogons;
 });
 
 const timerLabel = Vue.computed(() => {

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -1,9 +1,14 @@
 <template>
   <div DashBox data-testid="BitcoinLocksScreen" class="flex h-full min-h-0 grow flex-col">
-    <div v-if="!isLoaded" class="flex grow items-center justify-center text-slate-500">Loading...</div>
+    <div
+      v-if="!pageSourcesAreLoaded && !hasBitcoinRecords"
+      class="flex grow items-center justify-center text-slate-500"
+    >
+      Loading...
+    </div>
 
     <!-- Blank state -->
-    <div v-else-if="!financials.bitcoinLockDisplayRecords.length" class="flex grow flex-col">
+    <div v-else-if="!hasBitcoinRecords" class="flex grow flex-col">
       <div class="flex grow flex-col items-center justify-center">
         <div class="flex w-8/12 max-w-200 flex-col items-center py-10">
           <header class="text-argon-600 pb-3 text-xl font-bold">
@@ -157,6 +162,7 @@
               @ratchet="openRatchetingOverlay"
               @unlock="openUnlockingOverlay"
             />
+            <BitcoinsReleasedOverlay v-if="financials.liquidInvisibleRecords.length" @open-detail="openDetail" />
           </section>
           <div class="relative px-0.5 pb-0.5">
             <img src="/treasury-footers/bitcoin-locks.png" class="w-full opacity-50" />
@@ -218,6 +224,7 @@ import type { IBitcoinLockSummary } from '../interfaces/IBitcoinLockSummary.ts';
 import { useFinancials } from '../stores/financials.ts';
 import { getMyVault, getVaults } from '../stores/vaults.ts';
 import BitcoinRecord from './treasury-screens/components/BitcoinRecord.vue';
+import BitcoinsReleasedOverlay from '../overlays/BitcoinsReleasedOverlay.vue';
 import ArrowCalloutButton from '../components/ArrowCalloutButton.vue';
 import { OperationalStepId, useCertificationController } from '../stores/certificationController.ts';
 
@@ -233,13 +240,16 @@ const vaults = getVaults();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 const currentTick = Vue.ref(0);
-const isLoaded = Vue.ref(false);
+const pageSourcesAreLoaded = Vue.ref(false);
 const showLockingOverlay = Vue.ref(false);
 const showDetailOverlay = Vue.ref(false);
 const showUnlockingOverlay = Vue.ref(false);
 const showRatchetingOverlay = Vue.ref(false);
 const selectedLock = Vue.ref<IBitcoinLockSummary>();
 const couponProviderLabel = config.upstreamOperator?.name || 'The vault operator';
+const hasBitcoinRecords = Vue.computed(() => {
+  return financials.bitcoinLockDisplayRecords.length > 0 || financials.liquidInvisibleRecords.length > 0;
+});
 const defaultVault = Vue.computed(() => {
   const vaultId = myVault.vaultId;
   if (vaultId) {
@@ -304,14 +314,17 @@ function openArgonWallet() {
 }
 
 Vue.onMounted(async () => {
-  await Promise.all([currency.isLoadedPromise, bitcoinLockCoupons.refresh(), bitcoinLocks.load(), miningFrames.load()]);
+  void bitcoinLockCoupons.refresh().catch(error => {
+    console.error('Unable to refresh Bitcoin lock coupons', error);
+  });
+  await Promise.all([currency.isLoadedPromise, bitcoinLocks.load(), miningFrames.load()]);
 
   currentTick.value = miningFrames.currentTick;
   unsubMiningFrames = miningFrames.onTick(() => {
     currentTick.value = miningFrames.currentTick;
   }).unsubscribe;
 
-  isLoaded.value = true;
+  pageSourcesAreLoaded.value = true;
 });
 
 Vue.onUnmounted(() => {

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -171,7 +171,7 @@
               class="inline-flex cursor-pointer items-center rounded-md border px-2"
             >
               <template v-if="isRatchetPending">
-                <Spinner class="mr-1.5 h-3 min-h-3 w-3 min-w-3" />
+                <Spinner class="Inverse mr-1.5 h-3 min-h-3 w-3 min-w-3" />
                 Ratcheting...
               </template>
               <span v-else-if="lockSummary.ratchetPercent">

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -93,7 +93,14 @@ export const useFinancials = defineStore('financials', () => {
     state: 'checking' | 'restoring' | 'waiting' | 'ready' | 'error';
     recoveredBlockCount: number;
     message?: string;
-  }>({ state: 'checking', recoveredBlockCount: 0 });
+  }>({ state: 'ready', recoveredBlockCount: 0 });
+  const isHistoryRecoveryInProgress = Vue.computed(() => {
+    return (
+      historyRecovery.value.state === 'checking' ||
+      historyRecovery.value.state === 'restoring' ||
+      historyRecovery.value.state === 'waiting'
+    );
+  });
   let hasConfirmedFinancialHistoryCoverage = false;
   let queuedAccountHeader: IBlockHeaderInfo | undefined;
   let queuedAccountReconciliation = false;
@@ -601,25 +608,70 @@ export const useFinancials = defineStore('financials', () => {
 
   const liquidAllRecords = Vue.ref<IBitcoinLockSummary[]>([]);
 
+  const bitcoinLockSummaries = Vue.computed<IBitcoinLockSummary[]>(() => {
+    const summariesByUuid = new Map(liquidAllRecords.value.map(summary => [summary.uuid, summary]));
+    for (const lock of bitcoinLocks.getAllLocks({ includeHistoryRecoveryPending: true })) {
+      if (!summariesByUuid.has(lock.uuid)) {
+        summariesByUuid.set(lock.uuid, bitcoinLocks.createLockSummary(lock));
+      }
+    }
+    return [...summariesByUuid.values()];
+  });
+
   const liquidInvisibleRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
-    return liquidAllRecords.value.filter(l => bitcoinLocks.isInactiveForVaultDisplay(l.record));
+    return bitcoinLockSummaries.value.filter(lock => bitcoinLocks.isInactiveForVaultDisplay(lock.record));
   });
 
   const liquidVisibleRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
-    return liquidAllRecords.value.filter(
+    return bitcoinLockSummaries.value.filter(
       lock => !lock.record.isHistoryRecoveryPending && !bitcoinLocks.isInactiveForVaultDisplay(lock.record),
     );
   });
 
   const bitcoinLockDisplayRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
-    const recoveringRecords = bitcoinLocks
-      .getAllLocks({ includeHistoryRecoveryPending: true })
-      .filter(lock => lock.isHistoryRecoveryPending && !bitcoinLocks.isInactiveForVaultDisplay(lock))
-      .map(lock => bitcoinLocks.createLockSummary(lock));
+    return bitcoinLockSummaries.value
+      .filter(lock => !bitcoinLocks.isInactiveForVaultDisplay(lock.record))
+      .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+  });
 
-    return [...liquidVisibleRecords.value, ...recoveringRecords].sort(
-      (left, right) => right.createdAt.getTime() - left.createdAt.getTime(),
-    );
+  const bitcoinLockPerformanceByUuid = Vue.computed(() => {
+    const performanceByUuid: Record<string, { profit: bigint; percent: number }> = {};
+    for (const position of financialPositionAggregate.value.groupSummaries.bitcoin.positions) {
+      if (position.kind !== 'bitcoin-asset') continue;
+
+      const performance = calculatePositionReturn([position]);
+      if (performance.returnAmount === undefined || performance.percent === undefined) continue;
+
+      performanceByUuid[position.lock.uuid] = {
+        profit: performance.returnAmount,
+        percent: performance.percent,
+      };
+    }
+
+    const persistedPositions = bitcoinFinancials.createFinancialPositions({
+      summaries: bitcoinLockSummaries.value.filter(summary => {
+        return (
+          !performanceByUuid[summary.uuid] &&
+          summary.record.removalReason === 'released' &&
+          summary.record.isHistoryRecoveryPending === false
+        );
+      }),
+      hasCurrentPrice: false,
+      hasConfirmedHistoryCoverage: true,
+    });
+    for (const position of persistedPositions) {
+      if (position.kind !== 'bitcoin-asset') continue;
+
+      const performance = calculatePositionReturn([position]);
+      if (performance.returnAmount === undefined || performance.percent === undefined) continue;
+
+      performanceByUuid[position.lock.uuid] = {
+        profit: performance.returnAmount,
+        percent: performance.percent,
+      };
+    }
+
+    return performanceByUuid;
   });
 
   const liquidLockedRecords = Vue.computed(() => {
@@ -831,7 +883,9 @@ export const useFinancials = defineStore('financials', () => {
         accountSnapshot.value = undefined;
         await queueAccountRefresh({ force: true });
         if (config.walletAccountsHadPreviousLife && (config.hasExtensionTreasury || config.hasExtensionOperations)) {
-          void initializeFinancialHistoryRecovery().catch(() => undefined);
+          void initializeFinancialHistoryRecovery().catch(error => {
+            console.error('[FinancialHistory] Unable to initialize recovery', error);
+          });
         }
       } catch (error) {
         console.error('Unable to activate financial positions', error);
@@ -912,7 +966,9 @@ export const useFinancials = defineStore('financials', () => {
 
     isLoaded.value = true;
     if (config.walletAccountsHadPreviousLife && (config.hasExtensionTreasury || config.hasExtensionOperations)) {
-      void initializeFinancialHistoryRecovery().catch(() => undefined);
+      void initializeFinancialHistoryRecovery().catch(error => {
+        console.error('[FinancialHistory] Unable to initialize recovery', error);
+      });
     }
   }
 
@@ -929,7 +985,6 @@ export const useFinancials = defineStore('financials', () => {
       db,
       accountId: wallets.defaultArgonWallet.address,
       enabledDomains,
-      targetBlock,
       bitcoinLockRecovery: bitcoinLocks.recovery,
     });
     if (needsRecovery) {
@@ -1041,6 +1096,7 @@ export const useFinancials = defineStore('financials', () => {
 
     liquidAllRecords,
     bitcoinLockDisplayRecords,
+    bitcoinLockPerformanceByUuid,
     liquidVisibleRecords,
     liquidInvisibleRecords,
     liquidLockedRecords,
@@ -1055,6 +1111,7 @@ export const useFinancials = defineStore('financials', () => {
     financialPositionAggregate,
     liquidNativeBalances,
     historyRecovery,
+    isHistoryRecoveryInProgress,
     restoreFinancialHistory,
   };
 });


### PR DESCRIPTION
## Summary

Bitcoin accounts with legacy or partially recovered records no longer remain stuck because older history lacks fields that exist in current records or because the lock is no longer available from live chain state. Recovery now uses indexed archive history, preserves partial progress across refreshes, repairs verified UTXO amounts and funding links, and continues tracking undelivered liquidity after Bitcoin has been released.

The Bitcoin Locks page now renders persisted records before the live financial snapshot finishes. Archived locks show their release date, liquidity, release cost, settled profit and return, plus separate Vault, Bitcoin unlock, and Argon transaction fees. Profit is based on liquidity the user retained after redemption and complete recorded costs, rather than the Bitcoin market value at lock.

Ratchets against the user's own vault now apply the vault-owner fee exemption consistently during preview and affordability checks.

## Validation

- The focused recovery, UTXO, financial-history, accounting, and loading suites pass: 130 tests.
- The final archived-performance tests pass: 55 tests.
- Typecheck and formatting checks pass.
- Local refresh logs confirmed persisted Bitcoin rows load immediately from SQLite while unrelated wallet/indexer catch-up can continue in the background.
