### PR TITLE
fix(vaulting): report one collect transaction while preparing

### DIFF
--- a/src-vue/overlays/VaultCollectOverlay.vue
+++ b/src-vue/overlays/VaultCollectOverlay.vue
@@ -91,8 +91,8 @@
         <div v-if="showCollectProgress" class="rounded-md border border-slate-200 bg-slate-50 px-4 py-4">
           <div class="mb-3 text-sm font-semibold text-slate-700">
             {{
-              activeCollectTransactionCount === 1
-                ? 'Submitting...'
+              activeCollectTransactionCount <= 1
+                ? 'Submitting 1 transaction...'
                 : `Submitting ${activeCollectTransactionCount} transactions...`
             }}
           </div>


### PR DESCRIPTION
Vault revenue collection no longer shows “Submitting 0 transactions…” while its single submission is being prepared. The initial progress state now accurately reports one transaction, while plural counts remain available for multiple tracked submissions.

Automated UI validation was not run because this worktree has no Yarn install state.
