### PR TITLE
Move to external

### DIFF
--- a/src-vue/__test__/WalletOverlayState.test.ts
+++ b/src-vue/__test__/WalletOverlayState.test.ts
@@ -11,6 +11,7 @@ import {
   selectPrimaryWallet,
   selectTransferWallet,
   showAddWalletOnTransferSide,
+  showCustomArgonAddressOnTransferSide,
   shouldLoadEthereumWalletSelection,
   toggleWalletTransferDirection,
   type IWalletOverlayState,
@@ -131,6 +132,13 @@ describe('wallet overlay state', () => {
       primaryWallet,
       transferIn: { addWalletStep: 'external' },
       transferOut: { wallet: transferWallet },
+    });
+  });
+
+  it('opens a custom Argon address on an active transfer side', () => {
+    expect(showCustomArgonAddressOnTransferSide({ primaryWallet, transferOut: {} }, 'out')).toEqual({
+      primaryWallet,
+      transferOut: { customArgonAddress: true },
     });
   });
 

--- a/src-vue/overlays/MoveCapitalButton.vue
+++ b/src-vue/overlays/MoveCapitalButton.vue
@@ -28,7 +28,9 @@
           :moveFrom="moveFrom"
           :moveTo="moveTo"
           :moveToken="moveToken"
+          :externalAddress="externalAddress"
           @close="close"
+          @transactionPending="emit('transactionPending', $event)"
         />
         <PopoverArrow :width="26" :height="12" class="stroke-argon-600/15 -mt-px fill-white" />
       </PopoverContent>
@@ -50,6 +52,7 @@ const props = withDefaults(
     moveFrom?: MoveFrom;
     moveTo?: MoveTo;
     moveToken?: MoveToken;
+    externalAddress?: string;
     side?: 'top' | 'right' | 'bottom' | 'left';
   }>(),
   {
@@ -59,6 +62,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'updatedOpen', value: boolean): void;
+  (e: 'transactionPending', value: boolean): void;
 }>();
 
 const isOpen = Vue.ref(false);

--- a/src-vue/overlays/move-capital/MoveCapitalCore.vue
+++ b/src-vue/overlays/move-capital/MoveCapitalCore.vue
@@ -65,7 +65,7 @@
         </button>
       </div>
 
-      <template v-if="moveTo === MoveTo.External">
+      <template v-if="moveTo === MoveTo.External && !isExternalAddressPinned">
         <input
           v-model="externalAddress"
           :disabled="pendingTxInfo !== null"
@@ -114,6 +114,7 @@
       <button @click="close" class="cursor-pointer rounded-md border border-slate-600/60 px-7 py-1.5">Cancel</button>
       <button
         v-if="canSubmit"
+        type="button"
         @click="submitTransfer"
         :class="[
           !canAfford || !hasTokensToMove
@@ -185,6 +186,7 @@ const props = withDefaults(
     walletType?: WalletType.defaultArgon;
     moveFrom?: MoveFrom;
     showInputMenus?: boolean;
+    externalAddress?: string;
     moveTo?: MoveTo;
     maxAmount?: bigint;
     moveToken?: MoveToken;
@@ -198,6 +200,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'close'): void;
+  (e: 'transactionPending', value: boolean): void;
 }>();
 
 const myVault = getMyVault();
@@ -220,7 +223,8 @@ const isMoveToPinned = Vue.ref(false);
 const switchRotation = Vue.ref(90);
 const switchRotationDelta = Vue.ref(180);
 
-const externalAddress = Vue.ref('');
+const externalAddress = Vue.ref(props.externalAddress ?? '');
+const isExternalAddressPinned = Vue.computed(() => props.externalAddress !== undefined);
 const canChangeDestination = Vue.computed(() => !pendingTxInfo.value && !props.moveTo);
 const txFee = Vue.ref(0n);
 
@@ -502,12 +506,14 @@ async function submitTransfer() {
     };
     const txInfo = await moveCapital.move(moveFrom.value, moveTo.value, assetsToMove, fromWallet, toAddress);
 
+    emit('transactionPending', true);
     trackTxInfo(txInfo);
     pendingTxInfo.value = txInfo;
   } catch (err) {
     console.error('Error during transfer: %o', err);
     transactionError.value = 'This transfer failed, please try again';
     isProcessing.value = false;
+    emit('transactionPending', false);
   }
 }
 
@@ -520,6 +526,9 @@ function trackTxInfo(txInfo: TransactionInfo) {
       pendingTxInfo.value = null;
       transactionError.value = error.message;
       console.error('Error during transfer: %o', error);
+    }
+    if (args.progressPct === 100) {
+      emit('transactionPending', false);
     }
   });
 }
@@ -550,6 +559,7 @@ Vue.watch(
       isLoaded.value = false;
       isMoveToPinned.value = false;
       moveFrom.value = props.moveFrom || MoveFrom.DefaultArgon;
+      externalAddress.value = props.externalAddress ?? '';
       moveTo.value = props.moveTo ?? moveToOptions.value[0].value;
       if (!moveToOptions.value.some(option => option.value === moveTo.value)) {
         moveTo.value = moveToOptions.value[0].value;
@@ -593,6 +603,7 @@ Vue.onMounted(async () => {
     ) {
       const metdata = txInfo.tx.metadataJson as ITransactionMoveMetadata;
       pendingTxInfo.value = txInfo;
+      emit('transactionPending', true);
       isProcessing.value = true;
       amountToMove.value = metdata.assetsToMove[MoveToken.ARGN] ?? metdata.assetsToMove[MoveToken.ARGNOT] ?? 0n;
       moveTo.value = normalizeMoveTo(metdata.moveTo);

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -39,6 +39,7 @@
               :transferDirection="transferInConfig?.crosschainDirection"
               :moveFrom="transferInConfig?.moveFrom"
               :moveTo="transferInConfig?.moveTo"
+              :customArgonAddress="props.transferIn.customArgonAddress"
               class="relative mt-7 -mr-px mb-7"
               @select="emit('selectTransferWallet', 'in', $event)"
               @closeWallet="emit('returnToTransferWalletChooser', 'in')"
@@ -47,6 +48,7 @@
               @minimize="emit('toggleTransferDirection', 'in')"
               @addNewWallet="emit('addNewWallet', 'in')"
               @addExternalEthereum="emit('addExternalEthereum', 'in')"
+              @selectCustomArgonAddress="emit('selectCustomArgonAddress', 'in')"
               @openTransferOverlay="
                 props.transferIn.wallet &&
                 props.primaryWallet &&
@@ -115,11 +117,15 @@
                 v-if="props.primaryWallet"
                 :selection="props.primaryWallet"
                 :wallet="getWallet(props.primaryWallet)"
-                :mode="props.transferOut?.wallet ? 'transfer' : 'chooser'"
+                :mode="props.transferOut?.wallet || props.transferOut?.customArgonAddress ? 'transfer' : 'chooser'"
+                :moveFrom="customTransferMoveFrom"
+                :moveTo="props.transferOut?.customArgonAddress ? MoveTo.External : undefined"
+                :externalAddress="customArgonAddress"
+                @customTransferStarted="customArgonAddressLocked = true"
                 :showGuidance="props.showGuidance"
                 :guidanceContext="props.guidanceContext"
                 :indentTokensLeft="!!props.transferIn?.wallet"
-                :indentTokensRight="!!props.transferOut?.wallet"
+                :indentTokensRight="!!props.transferOut?.wallet || !!props.transferOut?.customArgonAddress"
                 class="grow"
               />
               <EthereumWalletSetup
@@ -142,8 +148,10 @@
               :availableWallets="props.availableWallets"
               :isSource="false"
               :transferDirection="transferOutConfig?.crosschainDirection"
-              :moveFrom="transferOutConfig?.moveFrom"
               :moveTo="transferOutConfig?.moveTo"
+              :moveFrom="transferOutMoveFrom"
+              :customArgonAddress="props.transferOut.customArgonAddress"
+              :customArgonAddressLocked="customArgonAddressLocked"
               class="relative mt-7 mb-7 -ml-px"
               @select="emit('selectTransferWallet', 'out', $event)"
               @closeWallet="emit('returnToTransferWalletChooser', 'out')"
@@ -152,6 +160,8 @@
               @minimize="emit('toggleTransferDirection', 'out')"
               @addNewWallet="emit('addNewWallet', 'out')"
               @addExternalEthereum="emit('addExternalEthereum', 'out')"
+              @selectCustomArgonAddress="emit('selectCustomArgonAddress', 'out')"
+              @updateCustomArgonAddress="customArgonAddress = $event"
               @openTransferOverlay="
                 props.transferOut.wallet &&
                 props.primaryWallet &&
@@ -214,6 +224,7 @@ const emit = defineEmits<{
   (event: 'returnToTransferWalletChooser', direction: IWalletTransferDirection): void;
   (event: 'addNewWallet', direction: IWalletTransferDirection): void;
   (event: 'addExternalEthereum', direction: IWalletTransferDirection): void;
+  (event: 'selectCustomArgonAddress', direction: IWalletTransferDirection): void;
   (event: 'completeAddWallet', target: 'primary' | IWalletTransferDirection, walletRecord: IWalletRecord): void;
   (event: 'close'): void;
 }>();
@@ -228,6 +239,8 @@ const activeTransferOverlay = Vue.ref<{
   networkName: string;
   feeTokenSymbol: string;
 }>();
+const customArgonAddress = Vue.ref('');
+const customArgonAddressLocked = Vue.ref(false);
 
 const transferInConfig = Vue.computed(() =>
   props.transferIn?.wallet && props.primaryWallet
@@ -238,6 +251,14 @@ const transferOutConfig = Vue.computed(() =>
   props.transferOut?.wallet && props.primaryWallet
     ? getTransferConfig(props.primaryWallet, props.transferOut.wallet)
     : undefined,
+);
+const transferOutMoveFrom = Vue.computed(() => {
+  if (transferOutConfig.value?.moveFrom) return transferOutConfig.value.moveFrom;
+  if (!props.primaryWallet || isEthereumWalletSelection(props.primaryWallet)) return;
+  return props.primaryWallet.walletType === WalletType.miningBot ? MoveFrom.MiningBot : MoveFrom.DefaultArgon;
+});
+const customTransferMoveFrom = Vue.computed(() =>
+  props.transferOut?.customArgonAddress ? transferOutMoveFrom.value : undefined,
 );
 
 function getTransferConfig(source: IWalletSelection, recipient: IWalletSelection) {
@@ -297,9 +318,12 @@ Vue.watch(
     props.primaryWallet ? getWalletSelectionKey(props.primaryWallet) : undefined,
     props.transferIn?.wallet ? getWalletSelectionKey(props.transferIn.wallet) : undefined,
     props.transferOut?.wallet ? getWalletSelectionKey(props.transferOut.wallet) : undefined,
+    props.transferOut?.customArgonAddress,
   ],
   () => {
     activeTransferOverlay.value = undefined;
+    customArgonAddress.value = '';
+    customArgonAddressLocked.value = false;
   },
 );
 </script>

--- a/src-vue/wallets/WalletDialogs.vue
+++ b/src-vue/wallets/WalletDialogs.vue
@@ -17,6 +17,7 @@
     @returnToTransferWalletChooser="returnToTransferWalletChooser"
     @addNewWallet="addNewWallet"
     @addExternalEthereum="addExternalEthereum"
+    @selectCustomArgonAddress="selectCustomArgonAddress"
     @completeAddWallet="completeAddWallet"
     @close="closeOverlay"
   />
@@ -48,6 +49,7 @@ import {
   selectPrimaryWallet,
   selectTransferWallet,
   showAddWalletOnTransferSide,
+  showCustomArgonAddressOnTransferSide,
   shouldLoadEthereumWalletSelection,
   toggleWalletTransferDirection,
   type IWalletOverlayState,
@@ -119,6 +121,12 @@ function addExternalEthereum(direction: IWalletTransferDirection) {
 
 function addNewWallet(direction: IWalletTransferDirection) {
   showSidecarAddWallet(direction, 'external');
+}
+
+function selectCustomArgonAddress(direction: IWalletTransferDirection) {
+  if (!openWallet.value || direction !== 'out') return;
+  const nextState = showCustomArgonAddressOnTransferSide(openWallet.value, direction);
+  openWallet.value.transferOut = nextState.transferOut;
 }
 
 function showSidecarAddWallet(direction: IWalletTransferDirection, initialStep: 'choice' | 'external') {

--- a/src-vue/wallets/components/ArgonTokens.vue
+++ b/src-vue/wallets/components/ArgonTokens.vue
@@ -22,23 +22,16 @@
         :moveFrom="props.moveFrom"
         :moveTo="props.moveTo"
         :moveToken="MoveToken.ARGN"
+        :externalAddress="props.externalAddress"
         side="top"
+        @transactionPending="updateTransferPending(MoveToken.ARGN, $event)"
       >
-        <button
-          type="button"
-          :disabled="!moveMicrogons"
-          :title="!moveMicrogons ? 'No ARGN available to move' : 'Move ARGN'"
-          class="absolute top-1/2 z-40 h-[45.6px] -translate-x-1/2 -translate-y-1/2 cursor-pointer disabled:cursor-default"
-          :class="props.movePlacement === 'left' ? '-left-1' : 'left-[calc(100%+4px)]'"
-        >
-          <div
-            :class="!moveMicrogons ? 'text-slate-500 opacity-30' : 'text-argon-600'"
-            class="absolute inset-0 flex items-center justify-center text-sm font-bold"
-          >
-            <span class="relative right-1.5">MOVE</span>
-          </div>
-          <MoveArrow class="pointer-events-none h-full" />
-        </button>
+        <MoveArrowButton
+          :disabled="!moveMicrogons || !canMoveToDestination"
+          :pending="argonTransferPending"
+          :placement="props.movePlacement"
+          :title="argonMoveTitle"
+        />
       </MoveCapitalButton>
     </li>
     <li
@@ -63,23 +56,16 @@
         :moveFrom="props.moveFrom"
         :moveTo="props.moveTo"
         :moveToken="MoveToken.ARGNOT"
+        :externalAddress="props.externalAddress"
         side="top"
+        @transactionPending="updateTransferPending(MoveToken.ARGNOT, $event)"
       >
-        <button
-          type="button"
-          :disabled="!moveMicronots"
-          :title="!moveMicronots ? 'No ARGNOT available to move' : 'Move ARGNOT'"
-          class="absolute top-1/2 z-40 h-[45.6px] -translate-x-1/2 -translate-y-1/2 cursor-pointer disabled:cursor-default"
-          :class="props.movePlacement === 'left' ? '-left-1' : 'left-[calc(100%+4px)]'"
-        >
-          <div
-            :class="!moveMicronots ? 'text-slate-500 opacity-30' : 'text-argon-600'"
-            class="absolute inset-0 flex items-center justify-center text-sm font-bold"
-          >
-            <span class="relative right-1.5">MOVE</span>
-          </div>
-          <MoveArrow class="pointer-events-none h-full" />
-        </button>
+        <MoveArrowButton
+          :disabled="!moveMicronots || !canMoveToDestination"
+          :pending="argonotTransferPending"
+          :placement="props.movePlacement"
+          :title="argonotMoveTitle"
+        />
       </MoveCapitalButton>
     </li>
     <li v-if="props.microgonsToMint" class="relative flex flex-row gap-x-2 border-y border-slate-400/50 py-2">
@@ -90,16 +76,15 @@
   </ul>
 </template>
 <script setup lang="ts">
-import { computed } from 'vue';
-import { MoveToken } from '@argonprotocol/apps-core';
-import type { MoveFrom, MoveTo } from '@argonprotocol/apps-core';
+import { computed, ref } from 'vue';
+import { isValidArgonAccountAddress, MoveTo, MoveToken, type MoveFrom } from '@argonprotocol/apps-core';
 import ArgonotIcon from '../../assets/resources/argonot.svg';
 import ArgonIcon from '../../assets/resources/argon.svg';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import CrosschainMoveButton from './CrosschainMoveButton.vue';
 import MoveCapitalButton from '../../overlays/MoveCapitalButton.vue';
-import MoveArrow from '../../assets/move-arrow.svg';
+import MoveArrowButton from './MoveArrowButton.vue';
 
 const currency = getCurrency();
 
@@ -118,6 +103,7 @@ const props = withDefaults(
     moveDirection?: 'transferToArgon' | 'transferOutOfArgon';
     moveFrom?: MoveFrom;
     moveTo?: MoveTo;
+    externalAddress?: string;
     networkName?: string;
     feeTokenSymbol?: string;
   }>(),
@@ -133,6 +119,25 @@ const props = withDefaults(
 
 const moveMicrogons = computed(() => props.moveMicrogons ?? props.microgons);
 const moveMicronots = computed(() => props.moveMicronots ?? props.micronots);
+const argonTransferPending = ref(false);
+const argonotTransferPending = ref(false);
+const canMoveToDestination = computed(
+  () => props.moveTo !== MoveTo.External || isValidArgonAccountAddress(props.externalAddress?.trim() ?? ''),
+);
+const argonMoveTitle = computed(() =>
+  !moveMicrogons.value
+    ? 'No ARGN available to move'
+    : canMoveToDestination.value
+      ? 'Move ARGN'
+      : 'Enter a valid Argon address',
+);
+const argonotMoveTitle = computed(() =>
+  !moveMicronots.value
+    ? 'No ARGNOT available to move'
+    : canMoveToDestination.value
+      ? 'Move ARGNOT'
+      : 'Enter a valid Argon address',
+);
 
 const emit = defineEmits<{
   (
@@ -142,7 +147,19 @@ const emit = defineEmits<{
       availableAmount: bigint;
     },
   ): void;
+  (e: 'customTransferStarted'): void;
 }>();
+
+function updateTransferPending(moveToken: MoveToken, isPending: boolean) {
+  if (moveToken === MoveToken.ARGN) {
+    argonTransferPending.value = isPending;
+  } else {
+    argonotTransferPending.value = isPending;
+  }
+  if (isPending && props.moveTo === MoveTo.External) {
+    emit('customTransferStarted');
+  }
+}
 
 function openTransferOverlay(moveToken: MoveToken.ARGN | MoveToken.ARGNOT, availableAmount: bigint) {
   if (!props.moveDirection) {

--- a/src-vue/wallets/components/CrosschainMoveButton.vue
+++ b/src-vue/wallets/components/CrosschainMoveButton.vue
@@ -1,45 +1,23 @@
 <template>
   <HoverCardRoot :open="isHovered && !!activeTransfer" :openDelay="0">
-    <div
-      class="absolute top-1/2 z-40 -translate-x-1/2 -translate-y-1/2"
-      :class="props.placement === 'left' ? '-left-1' : 'left-[calc(100%+4px)]'"
-    >
-      <div class="absolute top-1 left-0 z-10 h-[calc(100%-8px)] w-[15%] bg-linear-to-r from-white to-transparent" />
-      <div class="relative h-[45.6px]">
-        <HoverCardTrigger :asChild="true">
-          <button
-            :data-testid="getMoveButtonTestId()"
-            type="button"
-            :aria-disabled="isMoveDisabled"
-            :title="isMoveDisabled ? `No ${props.moveToken} available to move` : `Move ${props.moveToken}`"
-            class="h-full"
-            :class="isMoveDisabled ? 'cursor-default' : 'cursor-pointer'"
-            @mouseenter="isHovered = true"
-            @mouseleave="isHovered = false"
-            @click="openTransferOverlay"
-          >
-            <div
-              v-if="hasPendingTransfer"
-              spinner
-              class="absolute top-1/2 right-4 z-20 h-5 w-5 -translate-y-1/2 border-3"
-            />
-            <div
-              v-else
-              class="absolute inset-0 flex items-center justify-center text-sm font-bold"
-              :class="isMoveDisabled ? 'text-slate-500 opacity-30' : 'text-argon-600'"
-            >
-              <span class="relative right-1.5 z-20">{{ WALLET_MOVE_LABEL }}</span>
-            </div>
-            <MoveArrow class="pointer-events-none h-full" />
-          </button>
-        </HoverCardTrigger>
+    <HoverCardTrigger :asChild="true">
+      <MoveArrowButton
+        :disabled="isMoveDisabled"
+        :pending="hasPendingTransfer"
+        :placement="props.placement"
+        :testId="getMoveButtonTestId()"
+        :title="isMoveDisabled ? `No ${props.moveToken} available to move` : `Move ${props.moveToken}`"
+        @mouseenter="isHovered = true"
+        @mouseleave="isHovered = false"
+        @click="openTransferOverlay"
+      >
         <ArrowCalloutButton
           v-if="showInboundArgonGuide"
           guidance="Click MOVE to transfer your Uniswap ARGN into this Argon wallet."
           class="absolute top-1/2 left-full z-50 ml-3 -translate-y-1/2"
         />
-      </div>
-    </div>
+      </MoveArrowButton>
+    </HoverCardTrigger>
 
     <HoverCardPortal>
       <HoverCardContent
@@ -146,7 +124,6 @@ import ProgressBar from '../../components/ProgressBar.vue';
 import type { IArgonWalletType, IEthereumMoveToken } from '../../interfaces/IEthereumInboundTransferTracker.ts';
 import type { IEthereumInboundActiveTransfer } from '../../lib/EthereumInboundTransferTracker.ts';
 import { useFloatingZIndex } from '../../overlays/helpers/OverlayZIndex.ts';
-import MoveArrow from '../../assets/move-arrow.svg';
 import { formatEvmNativeFeeWei } from '../../lib/Utils.ts';
 import { createNumeralHelpers } from '../../lib/numeral.ts';
 import numeral from '../../lib/numeral.ts';
@@ -155,7 +132,6 @@ import { getCurrency } from '../../stores/currency.ts';
 import { getEthereumMoveTracker } from '../../stores/moveFromEthereum.ts';
 import { getEthereumOutboundTransferTracker } from '../../stores/moveToEthereum.ts';
 import { loadEthereumChainConfig } from '../../lib/EthereumClient.ts';
-import { WALLET_MOVE_LABEL } from '../walletOverlayState.ts';
 import {
   getCrosschainTransferProgressView,
   isCrosschainTransferVisible,
@@ -164,6 +140,7 @@ import {
 } from './crosschainTransferView.ts';
 import ArrowCalloutButton from '../../components/ArrowCalloutButton.vue';
 import { useCertificationController } from '../../stores/certificationController.ts';
+import MoveArrowButton from './MoveArrowButton.vue';
 
 const props = defineProps<{
   moveToken: IEthereumMoveToken;
@@ -321,22 +298,3 @@ function getArgonWalletLabel(walletType?: IArgonWalletType) {
   }
 }
 </script>
-
-<style>
-[spinner] {
-  border-radius: 50%;
-  display: block;
-  border-style: solid;
-  border-color: rgba(166, 0, 212, 0.15) rgba(166, 0, 212, 0.25) rgba(166, 0, 212, 0.35) rgba(166, 0, 212, 0.5);
-  animation: rotation 1s linear infinite;
-}
-
-@keyframes rotation {
-  0% {
-    transform: translateY(-50%) rotate(0deg);
-  }
-  100% {
-    transform: translateY(-50%) rotate(360deg);
-  }
-}
-</style>

--- a/src-vue/wallets/components/CustomArgonAddressSidecar.vue
+++ b/src-vue/wallets/components/CustomArgonAddressSidecar.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="px-5 py-5">
+    <div class="mb-4 border-b border-slate-600/20 px-7 pt-6 pb-7 text-base opacity-60">
+      Insert any Argon address here in the field below.
+    </div>
+    <div class="px-7">
+      <label
+        for="custom-argon-address"
+        class="mb-1 block text-sm font-medium text-slate-600/80"
+        :class="props.disabled ? 'opacity-30' : ''"
+      >
+        Address of Account
+      </label>
+      <input
+        id="custom-argon-address"
+        v-model="address"
+        data-testid="WalletOverlay.customArgonAddress"
+        type="text"
+        :disabled="props.disabled"
+        class="w-full rounded-md border border-slate-900/40 px-2 py-1.5 font-mono disabled:opacity-30"
+        placeholder="Address of Account"
+        @input="emitAddress"
+      />
+      <div v-if="addressWarning" class="mt-3 w-full rounded-md border p-2 text-sm text-yellow-600">
+        {{ addressWarning }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { isValidArgonAccountAddress } from '@argonprotocol/apps-core';
+
+const props = defineProps<{
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'updateAddress', address: string): void;
+}>();
+
+const address = ref('');
+const addressWarning = computed(() => {
+  const trimmedAddress = address.value.trim();
+  if (!trimmedAddress || isValidArgonAccountAddress(trimmedAddress)) return '';
+  return 'The address entered is not a valid Argon address.';
+});
+
+function emitAddress() {
+  emit('updateAddress', address.value.trim());
+}
+</script>

--- a/src-vue/wallets/components/MoveArrowButton.vue
+++ b/src-vue/wallets/components/MoveArrowButton.vue
@@ -1,0 +1,70 @@
+<template>
+  <div
+    class="absolute top-1/2 z-40 -translate-x-1/2 -translate-y-1/2"
+    :class="props.placement === 'left' ? '-left-1' : 'left-[calc(100%+4px)]'"
+  >
+    <div class="absolute top-1 left-0 z-10 h-[calc(100%-8px)] w-[15%] bg-linear-to-r from-white to-transparent" />
+    <div class="relative h-[45.6px]">
+      <button
+        :data-testid="props.testId"
+        type="button"
+        :disabled="props.disabled"
+        :aria-disabled="props.disabled"
+        :title="props.title"
+        class="h-full"
+        :class="props.disabled ? 'cursor-default' : 'cursor-pointer'"
+        @click="emit('click', $event)"
+      >
+        <div v-if="props.pending" spinner class="absolute inset-y-0 right-4 z-20 my-auto h-5 w-5 border-3" />
+        <div
+          v-else
+          class="absolute inset-0 flex items-center justify-center text-sm font-bold"
+          :class="props.disabled ? 'text-slate-500 opacity-30' : 'text-argon-600'"
+        >
+          <span class="relative right-1.5 z-20">{{ WALLET_MOVE_LABEL }}</span>
+        </div>
+        <MoveArrow class="pointer-events-none h-full" />
+      </button>
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useForwardExpose } from 'reka-ui';
+import MoveArrow from '../../assets/move-arrow.svg';
+import { WALLET_MOVE_LABEL } from '../walletOverlayState.ts';
+
+useForwardExpose();
+
+const props = defineProps<{
+  disabled: boolean;
+  pending?: boolean;
+  placement?: 'left' | 'right';
+  title?: string;
+  testId?: string;
+}>();
+
+const emit = defineEmits<{
+  (event: 'click', mouseEvent: MouseEvent): void;
+}>();
+</script>
+
+<style scoped>
+[spinner] {
+  border-radius: 50%;
+  display: block;
+  border-style: solid;
+  border-color: rgba(166, 0, 212, 0.15) rgba(166, 0, 212, 0.25) rgba(166, 0, 212, 0.35) rgba(166, 0, 212, 0.5);
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src-vue/wallets/components/WalletChooser.vue
+++ b/src-vue/wallets/components/WalletChooser.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="flex h-full flex-col text-left" :class="props.compact ? 'px-5 pb-5' : 'px-4 pt-3 pb-5'">
     <div class="mt-3 flex max-h-80 flex-col gap-2 overflow-y-auto pr-1">
+      <button
+        v-if="props.showCustomArgonAddress"
+        data-testid="WalletOverlay.chooseCustomArgonAddress()"
+        type="button"
+        class="relative flex min-h-14 w-full cursor-pointer items-center border-b border-black/20 px-3 py-2 text-left text-black/70 hover:bg-white/10"
+        @click="emit('selectCustomArgonAddress')"
+      >
+        <ArgonLogo class="h-8 w-8 shrink-0" />
+        <span class="ml-3 min-w-0">
+          <strong class="block truncate text-sm text-black/70">Custom Argon Address</strong>
+          <span class="block truncate text-xs text-black/50">Send to any Argon address</span>
+        </span>
+      </button>
       <div v-for="wallet in props.availableWallets" :key="getWalletSelectionKey(wallet)" class="relative">
         <button
           :data-wallet-key="getWalletSelectionKey(wallet)"
@@ -99,12 +112,14 @@ const props = defineProps<{
   availableWallets: IWalletSelection[];
   compact?: boolean;
   dark?: boolean;
+  showCustomArgonAddress?: boolean;
 }>();
 
 const emit = defineEmits<{
   (event: 'select', wallet: IWalletSelection): void;
   (event: 'addNewWallet'): void;
   (event: 'addExternalEthereum'): void;
+  (event: 'selectCustomArgonAddress'): void;
 }>();
 
 const wallets = useWallets();

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -34,11 +34,13 @@
           :moveDirection="props.transferDirection"
           :moveFrom="props.moveFrom"
           :moveTo="props.moveTo"
+          :externalAddress="props.externalAddress"
           :networkName="props.transferDirection ? 'Ethereum' : ''"
           :feeTokenSymbol="props.transferDirection ? 'ETH' : ''"
           :indentLeft="props.indentTokensLeft"
           :indentRight="props.indentTokensRight"
           @openTransferOverlay="emit('openTransferOverlay', $event)"
+          @customTransferStarted="emit('customTransferStarted')"
         />
       </div>
     </div>
@@ -78,6 +80,7 @@ const props = defineProps<{
   transferDirection?: 'transferToArgon' | 'transferOutOfArgon';
   moveFrom?: MoveFrom;
   moveTo?: MoveTo;
+  externalAddress?: string;
   indentTokensLeft?: boolean;
   indentTokensRight?: boolean;
   showGuidance?: boolean;
@@ -86,6 +89,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (event: 'openTransferOverlay', transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint }): void;
+  (event: 'customTransferStarted'): void;
 }>();
 
 const financials = useFinancials();

--- a/src-vue/wallets/components/WalletTransferSidecar.vue
+++ b/src-vue/wallets/components/WalletTransferSidecar.vue
@@ -3,24 +3,26 @@
     class="flex h-auto w-90 shrink-0 flex-col overflow-visible border border-black/40 shadow-2xl transition-colors duration-150"
     :class="[
       props.direction === 'in' ? 'rounded-l-lg' : 'rounded-r-lg',
-      props.wallet || props.addWalletStep ? 'bg-white' : 'bg-gray-300/80 text-black/60',
+      props.wallet || props.addWalletStep || props.customArgonAddress ? 'bg-white' : 'bg-gray-200/80 text-black/60',
     ]"
     :data-testid="`WalletOverlay.transfer${capitalizedDirection}Panel`"
   >
     <header
       class="mx-1 flex h-14 shrink-0 items-center gap-x-2.5 border-b px-3"
-      :class="props.wallet || props.addWalletStep ? 'border-slate-300' : 'border-black/25'"
+      :class="props.wallet || props.addWalletStep || props.customArgonAddress ? 'border-slate-300' : 'border-black/25'"
     >
       <div class="min-w-0 grow" :class="props.direction === 'in' ? 'order-3 text-right' : 'order-1 text-left'">
         <div
           class="truncate text-xl font-bold"
-          :class="props.wallet || props.addWalletStep ? 'text-slate-800/70' : 'text-black/60'"
+          :class="
+            props.wallet || props.addWalletStep || props.customArgonAddress ? 'text-slate-800/70' : 'text-black/60'
+          "
         >
           {{ headerTitle }}
         </div>
       </div>
       <CopyToClipboard
-        v-if="props.wallet"
+        v-if="props.wallet && !props.customArgonAddress"
         :content="props.wallet.address"
         :data-testid="`WalletOverlay.transfer${capitalizedDirection}WalletAddress`"
         class="order-2 flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-slate-500/60 hover:border-slate-500/60 hover:bg-[#f1f3f7]"
@@ -33,17 +35,33 @@
         :data-testid="`WalletOverlay.transfer${capitalizedDirection}Minimize()`"
         type="button"
         :title="
-          props.wallet ? 'Close wallet' : props.addWalletStep ? 'Cancel adding wallet' : 'Minimize transfer panel'
+          props.wallet || props.customArgonAddress
+            ? 'Close wallet'
+            : props.addWalletStep
+              ? 'Cancel adding wallet'
+              : 'Minimize transfer panel'
         "
-        class="hover:bg-argon-300/10 relative z-10 flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-md border border-slate-400/60 text-sm/6 font-semibold hover:border-slate-500/60 focus:outline-none"
+        class="hover:bg-argon-300/10 relative z-10 flex h-[34px] w-[34px] shrink-0 cursor-pointer items-center justify-center rounded-md border border-slate-500/60 text-sm/6 font-semibold hover:border-slate-500/60 focus:outline-none"
         :class="props.direction === 'in' ? 'order-1' : 'order-3'"
-        @click="props.wallet ? emit('closeWallet') : props.addWalletStep ? emit('cancelAddWallet') : emit('minimize')"
+        @click="
+          props.wallet || props.customArgonAddress
+            ? emit('closeWallet')
+            : props.addWalletStep
+              ? emit('cancelAddWallet')
+              : emit('minimize')
+        "
       >
-        <XMarkIcon class="pointer-events-none h-5 w-5 stroke-2 text-slate-400/80" />
+        <XMarkIcon class="pointer-events-none h-5 w-5 stroke-2 text-slate-600/80" />
       </button>
     </header>
 
-    <template v-if="props.wallet">
+    <CustomArgonAddressSidecar
+      v-if="props.customArgonAddress"
+      :disabled="props.customArgonAddressLocked"
+      class="min-h-0 grow"
+      @updateAddress="emit('updateCustomArgonAddress', $event)"
+    />
+    <template v-else-if="props.wallet">
       <div class="flex h-[120px] shrink-0 flex-col items-center justify-center">
         <div class="text-argon-700/70 text-5xl font-bold">
           <span>{{ currency.symbol }}</span>
@@ -109,10 +127,12 @@
       :availableWallets="props.availableWallets"
       :compact="true"
       :dark="true"
+      :showCustomArgonAddress="props.direction === 'out' && props.moveFrom !== undefined"
       class="min-h-0 grow"
       @select="emit('select', $event)"
       @addNewWallet="emit('addNewWallet')"
       @addExternalEthereum="emit('addExternalEthereum')"
+      @selectCustomArgonAddress="emit('selectCustomArgonAddress')"
     />
   </section>
 </template>
@@ -140,6 +160,7 @@ import ArgonTokens from './ArgonTokens.vue';
 import WalletChooser from './WalletChooser.vue';
 import EthereumBottom from './EthereumBottom.vue';
 import EthereumWalletSetup from '../EthereumWalletImportOverlay.vue';
+import CustomArgonAddressSidecar from './CustomArgonAddressSidecar.vue';
 
 const props = defineProps<{
   direction: IWalletTransferDirection;
@@ -152,6 +173,8 @@ const props = defineProps<{
   transferDirection?: 'transferToArgon' | 'transferOutOfArgon';
   moveFrom?: MoveFrom;
   moveTo?: MoveTo;
+  customArgonAddress?: boolean;
+  customArgonAddressLocked?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -163,6 +186,8 @@ const emit = defineEmits<{
   (event: 'addNewWallet'): void;
   (event: 'addExternalEthereum'): void;
   (event: 'openTransferOverlay', transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint }): void;
+  (event: 'selectCustomArgonAddress'): void;
+  (event: 'updateCustomArgonAddress', address: string): void;
 }>();
 
 const capitalizedDirection = computed(() => (props.direction === 'in' ? 'In' : 'Out'));
@@ -182,11 +207,13 @@ const nonNativeTokenValue = computed(
   () => props.wallet?.otherTokens.reduce((total, token) => total + currency.convertOtherToMicrogon(token), 0n) ?? 0n,
 );
 const headerTitle = computed(() =>
-  props.addWalletStep
-    ? 'Add Wallet'
-    : props.walletSelection
-      ? getName(props.walletSelection)
-      : `TRANSFER ${props.direction.toUpperCase()}`,
+  props.customArgonAddress
+    ? 'Custom Argon Address'
+    : props.addWalletStep
+      ? 'Add Wallet'
+      : props.walletSelection
+        ? getName(props.walletSelection)
+        : `TRANSFER ${props.direction.toUpperCase()}`,
 );
 
 function getName(selection: IWalletSelection) {

--- a/src-vue/wallets/walletOverlayState.ts
+++ b/src-vue/wallets/walletOverlayState.ts
@@ -12,6 +12,7 @@ export type IWalletSetupStep = 'choice' | 'external';
 export type IWalletTransferSideState = {
   wallet?: IWalletSelection;
   addWalletStep?: IWalletSetupStep;
+  customArgonAddress?: boolean;
 };
 
 export type IWalletOverlayState = {
@@ -93,6 +94,14 @@ export function showAddWalletOnTransferSide(
 ): IWalletOverlayState {
   const key = direction === 'in' ? 'transferIn' : 'transferOut';
   return state[key] ? { ...state, [key]: { addWalletStep: initialStep } } : state;
+}
+
+export function showCustomArgonAddressOnTransferSide(
+  state: IWalletOverlayState,
+  direction: IWalletTransferDirection,
+): IWalletOverlayState {
+  const key = direction === 'in' ? 'transferIn' : 'transferOut';
+  return state[key] ? { ...state, [key]: { customArgonAddress: true } } : state;
 }
 
 export function getWalletSelectionKey(wallet: IWalletSelection): string {


### PR DESCRIPTION
- Adds “Custom Argon Address” as the first outbound destination.
- Adds an address-only sidecar with validation.
- Supports sending ARGN or ARGNOT through the existing Move arrows.
- Locks the address after transaction submission and resets it when the sidecar opens or closes.
- Shares Move-arrow styling, fade, spinner, and pending states with Ethereum transfers.
- Keeps transfer popovers correctly anchored across repeated moves.