### PR TITLE
Fix empty vault display after database restore

### DIFF
--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -13,6 +13,7 @@ import {
   VaultingSetupStatus,
 } from '../interfaces/IConfig.ts';
 import { JsonExt } from '@argonprotocol/apps-core';
+import type PluginSql from '@tauri-apps/plugin-sql';
 
 beforeAll(() => {
   WalletKeys.prototype.didWalletHavePreviousLife = vi.fn().mockResolvedValue(false);
@@ -216,8 +217,8 @@ it('keeps mining setup active while the final server install step is still runni
   expect(config.miningSetupStatus).toBe(MiningSetupStatus.Installing);
 });
 
-it.each([VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
-  'finishes interrupted vault setup from %s when vaulting rules and a vault were already saved',
+it.each([VaultingSetupStatus.None, VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
+  'recovers completed vault setup from %s when vaulting rules and an open vault were saved',
   async vaultingSetupStatus => {
     const dbPromise = createMockedDbPromise({
       vaultingSetupStatus: `"${vaultingSetupStatus}"`,
@@ -245,6 +246,20 @@ it.each([VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
     );
   },
 );
+
+it('preserves completed vaulting setup when recreating the local database', async () => {
+  const dbPromise = createMockedDbPromise({
+    vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"`,
+  });
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  await config.restoreToConnection({} as PluginSql);
+
+  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
+});
 
 it('keeps interrupted setup active without durable evidence that creation finished', async () => {
   const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -138,6 +138,7 @@ export class Config implements IConfig {
       'serverDetails',
       'biddingRules',
       'vaultingRules',
+      'vaultingSetupStatus',
       'oldestFrameIdToSync',
       'defaultCurrencyKey',
       'requiresPassword',
@@ -284,11 +285,7 @@ export class Config implements IConfig {
         rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
       }
 
-      if (
-        (loadedData.vaultingSetupStatus === VaultingSetupStatus.Checklist ||
-          loadedData.vaultingSetupStatus === VaultingSetupStatus.Installing) &&
-        rawData[dbFields.vaultingRules]
-      ) {
+      if (loadedData.vaultingSetupStatus !== VaultingSetupStatus.Finished && rawData[dbFields.vaultingRules]) {
         const savedVault = await db.vaultsTable.get();
         if (savedVault && !savedVault.isClosed) {
           loadedData.vaultingSetupStatus = VaultingSetupStatus.Finished;


### PR DESCRIPTION
## Summary

Preserve completed vault setup state when recreating the local database and recover it from an existing open vault if older restore data reset that state.

## Why

Database restore preserved the vault rules and records but dropped `vaultingSetupStatus`. The app then treated an already-created vault as incomplete, leaving the vault display empty after recovery.

## Impact

Operators rebuilding or restoring their local database will see their existing open vault again without repeating vault setup.

## Validation

- Config tests
- TypeScript typecheck
- ESLint and Prettier