### PR TITLE
Responsive fixes

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
         "alwaysOnTop": false,
         "center": true,
         "maximized": false,
-        "minWidth": 1000,
+        "minWidth": 1200,
         "minHeight": 800,
         "shadow": true,
         "transparent": true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,8 +23,8 @@
         "alwaysOnTop": false,
         "center": true,
         "maximized": false,
-        "minWidth": 1200,
-        "minHeight": 800,
+        "minWidth": 1100,
+        "minHeight": 700,
         "shadow": true,
         "transparent": true
       }

--- a/src-tauri/tauri.desktop.local.docknet.conf.json
+++ b/src-tauri/tauri.desktop.local.docknet.conf.json
@@ -24,7 +24,7 @@
         "backgroundThrottling": "disabled",
         "center": true,
         "maximized": false,
-        "minWidth": 1000,
+        "minWidth": 1200,
         "minHeight": 800,
         "shadow": true,
         "transparent": true

--- a/src-tauri/tauri.desktop.local.docknet.conf.json
+++ b/src-tauri/tauri.desktop.local.docknet.conf.json
@@ -24,8 +24,8 @@
         "backgroundThrottling": "disabled",
         "center": true,
         "maximized": false,
-        "minWidth": 1200,
-        "minHeight": 800,
+        "minWidth": 1100,
+        "minHeight": 700,
         "shadow": true,
         "transparent": true
       }

--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -15,7 +15,6 @@
           :class="
             controller.selectedTab === TopTab.ArgonBonds ||
             controller.selectedTab === TopTab.BitcoinLocks ||
-            controller.selectedTab === TopTab.BitcoinLoans ||
             controller.selectedTab === TopTab.StableSwaps
               ? 'rounded border-[1px] border-slate-400/40 bg-white shadow-md'
               : ''
@@ -27,7 +26,6 @@
           <ArgonBonds v-else-if="controller.selectedTab === TopTab.ArgonBonds" />
           <ArgonotStakes v-else-if="controller.selectedTab === TopTab.ArgonotStaking" />
           <BitcoinLocks v-else-if="controller.selectedTab === TopTab.BitcoinLocks" />
-          <OldBitcoinLoans v-else-if="controller.selectedTab === TopTab.BitcoinLoans" />
           <StableSwaps v-else-if="controller.selectedTab === TopTab.StableSwaps" />
 
           <Mining v-else-if="controller.selectedTab === TopTab.Mining" />
@@ -133,7 +131,6 @@ import ArgonBonds from './screens/ArgonBonds.vue';
 import BitcoinLocks from './screens/BitcoinLocks.vue';
 import LeftBar from './navigation/LeftBar.vue';
 import StableSwaps from './screens/StableSwaps.vue';
-import OldBitcoinLoans from './screens/OldBitcoinLoans.vue';
 import Home from './screens/Home.vue';
 import WelcomeToTreasuryOverlay from './overlays/WelcomeToTreasuryOverlay.vue';
 import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';

--- a/src-vue/components/AlertCalloutButton.vue
+++ b/src-vue/components/AlertCalloutButton.vue
@@ -41,11 +41,11 @@
             >
               Quit Task
             </button>
-<!--            <button-->
-<!--              class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
-<!--            >-->
-<!--              View Documentation-->
-<!--            </button>-->
+            <!--            <button-->
+            <!--              class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
+            <!--            >-->
+            <!--              View Documentation-->
+            <!--            </button>-->
           </div>
         </div>
         <HoverCardArrow

--- a/src-vue/components/AlertCalloutButton.vue
+++ b/src-vue/components/AlertCalloutButton.vue
@@ -41,11 +41,11 @@
             >
               Quit Task
             </button>
-            <button
-              class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"
-            >
-              View Documentation
-            </button>
+<!--            <button-->
+<!--              class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
+<!--            >-->
+<!--              View Documentation-->
+<!--            </button>-->
           </div>
         </div>
         <HoverCardArrow

--- a/src-vue/components/ArrowCalloutButton.vue
+++ b/src-vue/components/ArrowCalloutButton.vue
@@ -62,11 +62,11 @@
               >
                 Cancel Task
               </button>
-<!--              <button-->
-<!--                class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
-<!--              >-->
-<!--                View Documentation-->
-<!--              </button>-->
+              <!--              <button-->
+              <!--                class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
+              <!--              >-->
+              <!--                View Documentation-->
+              <!--              </button>-->
             </div>
           </div>
           <HoverCardArrow

--- a/src-vue/components/ArrowCalloutButton.vue
+++ b/src-vue/components/ArrowCalloutButton.vue
@@ -62,11 +62,11 @@
               >
                 Cancel Task
               </button>
-              <button
-                class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"
-              >
-                View Documentation
-              </button>
+<!--              <button-->
+<!--                class="border-argon-600/60 text-argon-600 hover:bg-argon-600/5 grow cursor-pointer rounded border px-5 py-1"-->
+<!--              >-->
+<!--                View Documentation-->
+<!--              </button>-->
             </div>
           </div>
           <HoverCardArrow

--- a/src-vue/interfaces/IConfig.ts
+++ b/src-vue/interfaces/IConfig.ts
@@ -25,7 +25,6 @@ export enum TopTab {
   ArgonBonds = 'ArgonBonds',
   ArgonotStaking = 'ArgonotStaking',
   BitcoinLocks = 'BitcoinLocks',
-  BitcoinLoans = 'BitcoinLoans',
   StableSwaps = 'StableSwaps',
 
   Mining = 'Mining',

--- a/src-vue/navigation/CertificationMenu.vue
+++ b/src-vue/navigation/CertificationMenu.vue
@@ -175,9 +175,9 @@
         @focus="onMenuEnter"
       >
         <div class="relative flex flex-row items-center whitespace-nowrap pl-2.5 pr-3 pt-px">
-          <CheckBadgeIcon v-if="!isUnlockTrack" class="relative top-px h-[17px] w-[17px]" aria-hidden="true" />
-          <CertificationIcon v-else class="relative w-[24px] top-1.5 -left-px pointer-events-none" />
-          <span class="ml-0.5">{{ isUnlockTrack ? 'Treasury' : 'Operator' }} Certification</span>
+          <CertificationIcon class="relative w-[24px] top-1.5 -left-px pointer-events-none" />
+          <span class="TopBarOptionalLabel ml-1">{{ isUnlockTrack ? 'Treasury' : 'Operator' }}</span>
+          <span class="ml-1">Certification</span>
           <span class="font-mono ml-1">({{ completedStepCount }}/{{ currentStepIds.length }})</span>
         </div>
       </NavigationMenuTrigger>
@@ -247,7 +247,7 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import { NavigationMenuContent, NavigationMenuItem, NavigationMenuTrigger } from 'reka-ui';
-import { XMarkIcon, CheckBadgeIcon } from '@heroicons/vue/24/outline';
+import { XMarkIcon } from '@heroicons/vue/24/outline';
 import { MICROGONS_PER_ARGON, NetworkConfig } from '@argonprotocol/apps-core';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import { TopTab } from '../interfaces/IConfig.ts';
@@ -354,7 +354,7 @@ const checklistDescription = Vue.computed(() => {
     return 'Complete the following steps to unlock the next level features of this app.';
   }
 
-  const withUpstream = controller.chainProgress.hasUpstreamAccount ? ' (along with your upstream operator)' : '';
+  const withUpstream = controller.chainProgress.hasUpstreamAccount ? ' (along with your sponsor)' : '';
   return `Complete the following operations steps, and you'll earn${withUpstream} a ${operationalActivationRewardLabel.value} bonus from the Argon Treasury.`;
 });
 

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -381,7 +381,10 @@
           </a>
         </div>
       </div>
-      <div v-else class="relative flex grow flex-col items-center justify-center text-center text-slate-700/30">
+      <div
+        v-else
+        class="ExploreLinks relative flex grow flex-col items-center justify-center text-center text-slate-700/30"
+      >
         <div class="relative flex flex-row items-center text-center whitespace-nowrap">Explore</div>
         <div class="relative mt-px">
           <a
@@ -807,6 +810,12 @@ ul li {
     .wallet-summary-detail {
       @apply text-xs;
     }
+  }
+}
+
+@media (max-height: 750px) {
+  .LeftBar.OperationsEnabled .ExploreLinks {
+    @apply hidden;
   }
 }
 </style>

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="Navigation LeftBar z-10 flex h-full max-w-76 min-w-76 flex-col gap-y-1.5 select-none">
+  <div
+    class="Navigation LeftBar z-10 flex h-full max-w-76 min-w-76 flex-col gap-y-1.5 select-none"
+    :class="{ OperationsEnabled: config.isLoaded && config.hasExtensionOperations }"
+  >
     <section DashBox class="w-full px-1">
-      <div class="mt-3">
+      <div>
         <header>Basic Nav</header>
         <ul>
           <li
@@ -33,7 +36,7 @@
     </section>
 
     <section DashBox v-if="config.isLoaded && config.hasExtensionTreasury" class="w-full px-1">
-      <div class="mt-3">
+      <div>
         <header class="relative flex flex-row items-center">
           <div class="grow">Treasury</div>
           <div class="relative flex">
@@ -134,7 +137,7 @@
     </section>
 
     <section DashBox v-if="config.isLoaded && config.hasExtensionOperations" class="w-full px-1">
-      <div class="mt-3">
+      <div>
         <header class="relative flex flex-row items-center">
           <div class="grow">Operations</div>
           <div class="relative flex">
@@ -407,7 +410,7 @@
         <div class="bg-argon-100/15 h-full w-full" style="text-shadow: 1px 1px 0 white">
           <div class="absolute top-0 left-0 h-full w-5 rounded-bl-lg bg-linear-to-r from-slate-600/10 to-transparent" />
           <div class="flex flex-col justify-center pt-1 pr-3 pl-3">
-            <header class="flex w-full flex-row items-center border-b border-slate-500/20 pb-1.5!">
+            <header class="flex w-full flex-row items-center border-b border-slate-500/20 pt-1! pb-1.5!">
               <WalletSelector
                 :selectedWallet="selectedWallet"
                 :walletSelections="walletSelections"
@@ -440,7 +443,7 @@
               </div>
               <div
                 v-if="selectedWalletBalanceIsLoaded && selectedWallet.walletType === WalletType.defaultArgon"
-                class="mx-auto mt-2 w-fit border-t border-slate-500/30 pt-2 text-center opacity-50"
+                class="wallet-summary-detail mx-auto mt-2 w-fit border-t border-slate-500/30 pt-2 text-center opacity-50"
               >
                 {{ currency.symbol
                 }}{{ microgonToMoneyNm(selectedWalletBalance - financials.savingsTotalPending).format('0,0.00') }} is
@@ -448,7 +451,7 @@
               </div>
               <div
                 v-else-if="selectedWalletBalanceIsLoaded && isEthereumWalletSelection(selectedWallet)"
-                class="mx-auto mt-2 flex w-fit gap-x-2 border-t border-slate-500/30 pt-2 text-center opacity-50"
+                class="wallet-summary-detail mx-auto mt-2 flex w-fit gap-x-2 border-t border-slate-500/30 pt-2 text-center opacity-50"
               >
                 {{ currency.symbol }}{{ microgonToMoneyNm(selectedOtherTokenValue).format('0,0.00') }} is in eth or
                 other tokens
@@ -672,7 +675,7 @@ Vue.onBeforeUnmount(() => {
 @reference "../main.css";
 
 header {
-  @apply px-2 pt-1 pb-3 font-bold text-slate-700/40 uppercase;
+  @apply px-2 pt-4 pb-3 font-bold text-slate-700/40 uppercase;
 }
 
 .wallet-summary:hover {
@@ -749,6 +752,60 @@ ul li {
       &:after {
         @apply rounded-bl-lg;
       }
+    }
+  }
+}
+
+@media (max-height: 1000px) {
+  .LeftBar.OperationsEnabled {
+    @apply gap-y-1;
+
+    > section > div > header {
+      @apply pt-2 pb-2;
+    }
+
+    ul li {
+      @apply py-0;
+
+      article {
+        @apply py-1.5;
+      }
+    }
+
+    .wallet-summary {
+      @apply my-1 py-3;
+    }
+
+    .wallet-summary-total {
+      @apply text-[40px];
+    }
+
+    .wallet-summary-detail {
+      @apply mt-1 pt-1 text-sm;
+    }
+  }
+}
+
+@media (max-height: 850px) {
+  .LeftBar.OperationsEnabled {
+    > section > div > header {
+      @apply py-1.5;
+    }
+
+    ul li article {
+      @apply py-1;
+    }
+
+    .wallet-summary {
+      @apply py-2;
+    }
+
+    .wallet-summary-total {
+      @apply text-3xl;
+    }
+
+    .wallet-summary-detail {
+      @apply text-xs;
     }
   }
 }

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -79,7 +79,7 @@
                 <ArgonBondIcon class="w-5.5 opacity-70" />
               </div>
               <div class="grow">Argon Bonds</div>
-              <div class="opacity-60">{{ currency.symbol }}{{ formatFinancialGroupValue('bonds') }}</div>
+              <div class="opacity-60">{{ currency.symbol }}{{ formatBondValue('ARGN') }}</div>
               <ArrowCalloutButton
                 v-if="
                   controller.activeGuideId === OperationalStepId.AcquireArgonBonds &&
@@ -100,7 +100,7 @@
                 <ArgonotBondIcon class="w-5.5 opacity-70" />
               </div>
               <div class="grow">Argonot Stakes</div>
-              <div class="opacity-60">{{ currency.symbol }}{{ formatFinancialGroupValue('bonds') }}</div>
+              <div class="opacity-60">{{ currency.symbol }}{{ formatBondValue('ARGNOT') }}</div>
               <!--              <ArrowCalloutButton-->
               <!--                v-if="-->
               <!--                  controller.activeGuideId === OperationalStepId.AcquireArgonotStakes &&-->
@@ -600,6 +600,14 @@ function formatFinancialGroupValue(group: FinancialGroup): string {
   const summary = financials.financialPositionAggregate.groupSummaries[group];
   if (summary.state !== 'ready' && !(summary.state === 'stale' && summary.positions.length)) return '--';
   return microgonToMoneyNm(summary.currentValue).format('0,0.00');
+}
+
+function formatBondValue(asset: 'ARGN' | 'ARGNOT'): string {
+  if (!currency.isLoaded) return '--';
+
+  const summary = financials.financialPositionAggregate.groupSummaries.bonds;
+  if (summary.state !== 'ready' && !(summary.state === 'stale' && summary.positions.length)) return '--';
+  return microgonToMoneyNm(financials.bondSummariesByAsset[asset].currentValue).format('0,0.00');
 }
 
 function openDefaultArgonWallet() {

--- a/src-vue/navigation/PortfolioDetailsMenu.vue
+++ b/src-vue/navigation/PortfolioDetailsMenu.vue
@@ -284,7 +284,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import { UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { MICROGONS_PER_ARGON, MICRONOTS_PER_ARGONOT, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import { storeToRefs } from 'pinia';
 import { NavigationMenuContent, NavigationMenuItem, NavigationMenuTrigger } from 'reka-ui';
 import { InformationCircleIcon, MinusIcon, PlusIcon } from '@heroicons/vue/20/solid';
@@ -328,6 +328,8 @@ const {
 const bondAssetRows = Vue.computed(() => {
   const bondPositions = aggregate.value.groupSummaries.bonds.positions.filter(position => position.kind === 'bond');
   const positions = bondPositions.filter(position => position.lifecycle !== 'completed');
+  const argonPositions = positions.filter(position => position.nativeAsset === 'ARGN');
+  const argonotPositions = positions.filter(position => position.nativeAsset === 'ARGNOT');
 
   return [
     {
@@ -336,7 +338,9 @@ const bondAssetRows = Vue.computed(() => {
       singularLabel: 'bond',
       pluralLabel: 'bonds',
       currentValue: bondSummariesByAsset.value.ARGN.currentValue,
-      count: positions.filter(position => position.nativeAsset === 'ARGN').length,
+      count: Number(
+        argonPositions.reduce((total, position) => total + position.nativePrincipal, 0n) / BigInt(MICROGONS_PER_ARGON),
+      ),
       expanded: argonBondsAreExpanded,
     },
     {
@@ -345,7 +349,10 @@ const bondAssetRows = Vue.computed(() => {
       singularLabel: 'stake',
       pluralLabel: 'stakes',
       currentValue: bondSummariesByAsset.value.ARGNOT.currentValue,
-      count: positions.filter(position => position.nativeAsset === 'ARGNOT').length,
+      count: Number(
+        argonotPositions.reduce((total, position) => total + position.nativePrincipal, 0n) /
+          BigInt(MICRONOTS_PER_ARGONOT),
+      ),
       expanded: argonotStakesAreExpanded,
     },
   ];

--- a/src-vue/navigation/ServerMenu.vue
+++ b/src-vue/navigation/ServerMenu.vue
@@ -8,7 +8,7 @@
       >
         <div v-if="!config.isServerAdded" class="relative flex flex-row items-center pl-2.5 pr-3 pt-px whitespace-nowrap" style="word-spacing: -6px">
           <PluginSmallIcon class="h-3.5 relative mr-1.5" />
-          Add Node
+          <span class="TopBarOptionalLabel">Add </span>Node
         </div>
         <div v-else-if="config.isServerInstalling" class="relative -top-px flex flex-row pl-2.5 pr-3 pt-1">
           {{ serverInstallStatusLabel }}

--- a/src-vue/navigation/SponsorMenu.vue
+++ b/src-vue/navigation/SponsorMenu.vue
@@ -9,8 +9,8 @@
         <div
           class="group pointer-events-auto flex h-[30px] cursor-pointer flex-row items-center rounded-md border border-slate-400/50 px-3 font-semibold hover:border-slate-400/50 hover:bg-slate-400/10 focus:outline-none"
         >
-          <div v-if="config.upstreamOperator" class="text-argon-600/70">
-            Sponsored by {{ upstreamOperatorName }}
+          <div v-if="config.upstreamOperator" class="text-argon-600/70 whitespace-nowrap">
+            Sponsored<span class="TopBarOptionalLabel"> by {{ upstreamOperatorName }}</span>
           </div>
           <div v-else class="group-hover:text-argon-600 text-slate-900/70">Connect a Vault</div>
         </div>

--- a/src-vue/navigation/TopBar.vue
+++ b/src-vue/navigation/TopBar.vue
@@ -1,7 +1,7 @@
 <!-- prettier-ignore -->
 <template>
   <div
-    class="bg-white/95 relative flex min-h-14 w-full flex-row items-center select-none"
+    class="TopBar bg-white/95 relative flex min-h-14 w-full flex-row items-center select-none"
     style="border-radius: 10px 10px 0 0; box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2)"
     data-tauri-drag-region
   >
@@ -10,7 +10,7 @@
     />
     <div class="absolute right-2 -bottom-px h-px w-full bg-slate-400/30" />
 
-    <div class="flex flex-row items-center w-1/3 pointer-events-none relative top-px">
+    <div class="flex flex-row items-center pointer-events-none relative top-px">
       <WindowControls />
       <div class="relative top-px text-[19px] font-bold whitespace-nowrap flex flex-row items-center">
         Argon Desktop
@@ -44,7 +44,7 @@
 
     <NavigationMenuRoot
       v-if="controller.isLoaded && !controller.isImporting"
-      class="relative mr-3 flex w-1/3 grow flex-row items-center justify-end pointer-events-none"
+      class="relative mr-3 flex flex-row grow items-center justify-end pointer-events-none"
       :model-value="navigationMenuValue"
       :delay-duration="0"
       :skip-delay-duration="0"
@@ -220,3 +220,11 @@ Vue.onBeforeUnmount(() => {
   basicEmitter.off('openCertificationMenu', openCertificationMenu);
 });
 </script>
+
+<style scoped>
+@media (max-width: 1300px) {
+  .TopBar :deep(.TopBarOptionalLabel) {
+    display: none;
+  }
+}
+</style>

--- a/src-vue/screens/mining-screen/Dashboard.vue
+++ b/src-vue/screens/mining-screen/Dashboard.vue
@@ -6,17 +6,7 @@
 
       <section class="flex flex-row gap-x-2 h-[14%]">
         <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
-            <span>{{ myMiningSeats.global.seatsTotal || 0 }}</span>
-            <label>Total Mining Seat{{ myMiningSeats.global.seatsTotal === 1 ? '' : 's' }}</label>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" :sideOffset="-10" align="start" :collisionPadding="9" class="bg-white border border-gray-800/20 rounded-md shadow-2xl z-50 p-4 w-xs text-slate-900/60">
-            The number of mining seats you've controlled over the previous year.
-            <TooltipArrow :width="27" :height="15" class="fill-white stroke-[0.5px] stroke-gray-800/20 -mt-px" />
-          </TooltipContent>
-        </TooltipRoot>
-        <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
+          <TooltipTrigger as="div" box stat-box class="flex flex-col w-[20%] !py-4 group">
             <span>{{ numeral(myMiningSeats.global.framesCompleted).format('0,0.[00]') }}</span>
             <label>Frame{{ myMiningSeats.global.framesCompleted === 1 ? '' : 's' }} Completed</label>
           </TooltipTrigger>
@@ -26,7 +16,7 @@
           </TooltipContent>
         </TooltipRoot>
         <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
+          <TooltipTrigger as="div" box stat-box class="flex flex-col w-[20%] !py-4 group">
             <span>{{ numeral(myMiningSeats.global.framesRemaining).format('0,0.[00]') }}</span>
             <label>Frame{{ myMiningSeats.global.framesRemaining === 1 ? '' : 's' }} Remaining</label>
           </TooltipTrigger>
@@ -36,7 +26,7 @@
           </TooltipContent>
         </TooltipRoot>
         <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
+          <TooltipTrigger as="div" box stat-box class="flex flex-col w-[20%] !py-4 group">
             <span>
               {{ currency.symbol
               }}{{ microgonToMoneyNm(miningReturnSummary.investedCost).formatIfElse('< 100', '0.00', '0,0') }}
@@ -49,7 +39,7 @@
           </TooltipContent>
         </TooltipRoot>
         <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
+          <TooltipTrigger as="div" box stat-box class="flex flex-col w-[20%] !py-4 group">
             <span>
               {{ currency.symbol
               }}{{ microgonToMoneyNm(miningReturnSummary.returnAmount ?? 0n).formatIfElse('< 100', '0.00', '0,0') }}
@@ -62,7 +52,7 @@
           </TooltipContent>
         </TooltipRoot>
         <TooltipRoot>
-          <TooltipTrigger as="div" box stat-box class="flex flex-col w-2/12 !py-4 group">
+          <TooltipTrigger as="div" box stat-box class="flex flex-col w-[20%] !py-4 group">
             <span v-if="miningReturnSummary.percent !== undefined">
               {{ numeral(miningReturnSummary.percent).formatIfElseCapped('< 100', '0.[00]', '0,0', 9_999) }}%
             </span>
@@ -171,7 +161,6 @@
                         </template>
                       </div>
                     </CountdownClock>
-                    <div class="titleize">{{ auctionTimingLabel }}</div>
                   </div>
                 </div>
               </div>
@@ -368,24 +357,6 @@ const avgMicronotsPerWinningBid = Vue.computed<bigint | null>(() => {
   if (!auctionBids.value.length) return null;
   const total = auctionBids.value.reduce((sum, bid) => sum + (bid.micronotsStakedPerSeat ?? 0n), 0n);
   return total / BigInt(auctionBids.value.length);
-});
-
-const auctionTimingLabel = Vue.computed(() => {
-  const auctionCloseTick = currentFrameDetail.value?.auctionCloseTick ?? null;
-  if (isSelectedLiveFrame.value) {
-    if (auctionCloseTick) {
-      const auctionClosedAt = dayjs.utc(auctionCloseTick * TICK_MILLIS).local();
-      return `Auction Closed ${auctionClosedAt.format('h:mm A')}`;
-    }
-
-    return 'Auction Closing Pending';
-  }
-
-  if (!auctionCloseTick) return 'Auction Closed -----';
-
-  const auctionClosedAt = dayjs.utc(auctionCloseTick * TICK_MILLIS).local();
-
-  return `Auction Closed ${auctionClosedAt.format('h:mm A')}`;
 });
 
 const countdownNextBidAt = Vue.computed(() => {


### PR DESCRIPTION
- Make the Operations sidebar vertically responsive with compact navigation and wallet layouts at reduced window heights
- Shorten TopBar labels on narrow windows to prevent controls from clipping
- Increase the minimum desktop window width from 1000px to 1100px
- Decreased the minimum desktop window height from 800px to 700px
- Display separate Argon Bond and Argonot Stake values in the sidebar
- Calculate portfolio bond and stake counts from their native principal amounts
- Remove obsolete Bitcoin Loans tab wiring
- Standardize certification visuals and sponsor terminology

## Responsive behavior

- Compact LeftBar layout at 1000px and 850px viewport heights when Operations is enabled
- Compact TopBar labels below 1300px:
  - `Operator/Treasury Certification` → `Certification`
  - `Sponsored by <name>` → `Sponsored`
  - `Add Node` → `Node`