### PR TITLE
fix: harden local client recovery

### DIFF
--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NetworkConfig } from '@argonprotocol/apps-core';
+import { minimumVaultDelegateBalance, NetworkConfig } from '@argonprotocol/apps-core';
 
 type IMockTx = { id: string };
 type IMockSignedTx = {
@@ -97,10 +97,23 @@ import {
 const syncKeypair = { address: 'sync-account' } as any;
 
 describe('EthereumBeaconSyncService', () => {
-  const createClient = (startingNonce = 4, hasEthereumChainConfig = true): ArgonClient =>
+  const createClient = ({
+    startingNonce = 4,
+    hasEthereumChainConfig = true,
+    getDelegateBalance = () => minimumVaultDelegateBalance,
+  }: {
+    startingNonce?: number;
+    hasEthereumChainConfig?: boolean;
+    getDelegateBalance?: () => bigint;
+  } = {}): ArgonClient =>
     ({
       isConnected: true,
       query: {
+        system: {
+          account: vi.fn(async () => ({
+            data: { free: { toBigInt: getDelegateBalance } },
+          })),
+        },
         crosschainTransfer: {
           chainConfigBySourceChain: vi.fn(async () =>
             hasEthereumChainConfig
@@ -178,7 +191,7 @@ describe('EthereumBeaconSyncService', () => {
   });
 
   it('stays idle until the Ethereum transfer gateway is configured on-chain', async () => {
-    const service = new EthereumBeaconSyncService(createClient(4, false), {
+    const service = new EthereumBeaconSyncService(createClient({ hasEthereumChainConfig: false }), {
       beaconApiUrl: 'https://beacon.example',
       submitLane: createSubmitLane(createClient()),
     });
@@ -193,13 +206,70 @@ describe('EthereumBeaconSyncService', () => {
     });
   });
 
+  it('checks the delegate balance before generating work and again after waiting for the submission lane', async () => {
+    let delegateBalance = minimumVaultDelegateBalance - 1n;
+    const client = createClient({
+      getDelegateBalance: () => delegateBalance,
+    });
+    const submitLane = createSubmitLane(client);
+    const service = new EthereumBeaconSyncService(client, {
+      beaconApiUrl: 'https://beacon.example',
+      submitLane,
+    });
+
+    await service.runOnce();
+
+    expect(mainchainMock.getNextEthereumBeaconSyncTxs).not.toHaveBeenCalled();
+    expect(service.state()).toMatchObject({
+      mode: 'idle',
+      lastError: 'Vault delegate needs more funds before Ethereum beacon sync can run.',
+    });
+
+    delegateBalance = minimumVaultDelegateBalance;
+    const laneEntered = vi.fn();
+    let releaseLane!: () => void;
+    const laneGate = new Promise<void>(resolve => {
+      releaseLane = resolve;
+    });
+    void submitLane.runExclusive(async () => {
+      laneEntered();
+      await laneGate;
+    });
+
+    mainchainMock.getEthereumBeaconSyncState.mockResolvedValue({
+      isBootstrapped: true,
+      hasNextSyncCommittee: true,
+      latestFinalizedBlockRoot: '0xabc',
+      latestFinalizedSlot: 800n,
+      nextRecommendedFinalizedSlot: 832n,
+      latestSyncCommitteeUpdatePeriod: 12n,
+      headerInterval: 32n,
+    });
+    mainchainMock.getNextEthereumBeaconSyncTxs.mockResolvedValue([{ id: 'tx-1' }]);
+
+    await vi.waitFor(() => expect(laneEntered).toHaveBeenCalledOnce());
+    const runOncePromise = service.runOnce();
+    await vi.waitFor(() => expect(mainchainMock.getNextEthereumBeaconSyncTxs).toHaveBeenCalledOnce());
+
+    delegateBalance = minimumVaultDelegateBalance - 1n;
+    releaseLane();
+    await runOncePromise;
+
+    expect(client.query.system.account).toHaveBeenCalledTimes(3);
+    expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
+    expect(service.state()).toMatchObject({
+      mode: 'idle',
+      lastError: 'Vault delegate needs more funds before Ethereum beacon sync can run.',
+    });
+  });
+
   it('submits returned transactions in order and refreshes sync state', async () => {
     let resolveFirstInBlock!: () => void;
     const firstInBlock = new Promise<void>(resolve => {
       resolveFirstInBlock = resolve;
     });
     const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
-    const client = createClient(12);
+    const client = createClient({ startingNonce: 12 });
 
     mainchainMock.getEthereumBeaconSyncState
       .mockResolvedValueOnce({
@@ -281,7 +351,11 @@ describe('EthereumBeaconSyncService', () => {
     vi.useFakeTimers();
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const txs: IMockTx[] = [{ id: 'tx-1' }];
-    const client = createClient(12);
+    let delegateBalance = minimumVaultDelegateBalance;
+    const client = createClient({
+      startingNonce: 12,
+      getDelegateBalance: () => delegateBalance,
+    });
 
     (client.rpc.author.pendingExtrinsics as any) = vi
       .fn()
@@ -295,15 +369,6 @@ describe('EthereumBeaconSyncService', () => {
       .mockResolvedValueOnce([]);
 
     mainchainMock.getEthereumBeaconSyncState
-      .mockResolvedValueOnce({
-        isBootstrapped: true,
-        hasNextSyncCommittee: true,
-        latestFinalizedBlockRoot: '0xabc',
-        latestFinalizedSlot: 800n,
-        nextRecommendedFinalizedSlot: 832n,
-        latestSyncCommitteeUpdatePeriod: 12n,
-        headerInterval: 32n,
-      })
       .mockResolvedValueOnce({
         isBootstrapped: true,
         hasNextSyncCommittee: true,
@@ -365,17 +430,16 @@ describe('EthereumBeaconSyncService', () => {
       mode: 'submitting',
     });
 
+    delegateBalance = minimumVaultDelegateBalance - 1n;
     await service.runOnce();
 
-    expect(mainchainMock.getNextEthereumBeaconSyncTxs).toHaveBeenCalledTimes(1);
     expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(1);
     expect(service.state()).toMatchObject({
       lastSubmittedTxHash: 'tx-1-hash',
-      latestFinalizedSlot: 800n,
-      latestSyncCommitteeUpdatePeriod: 12n,
       mode: 'submitting',
     });
 
+    delegateBalance = minimumVaultDelegateBalance;
     await service.runOnce();
 
     expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenNthCalledWith(
@@ -512,7 +576,7 @@ describe('EthereumBeaconSyncService', () => {
 
   it('waits for the next sweep when an equal-priority transaction is already pending', async () => {
     const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
-    const client = createClient(12);
+    const client = createClient({ startingNonce: 12 });
 
     mainchainMock.getEthereumBeaconSyncState.mockResolvedValue({
       isBootstrapped: true,
@@ -552,7 +616,7 @@ describe('EthereumBeaconSyncService', () => {
       TxSubmissionErrorCode.Dropped,
       'Transaction was dropped before it was included in a block.',
     );
-    const client = createClient(12);
+    const client = createClient({ startingNonce: 12 });
 
     mainchainMock.getEthereumBeaconSyncState
       .mockResolvedValueOnce({
@@ -617,7 +681,7 @@ describe('EthereumBeaconSyncService', () => {
   });
 
   it('treats ExpectedFinalizedHeaderNotStored as idle so the next pass can retry', async () => {
-    const client = createClient(12);
+    const client = createClient({ startingNonce: 12 });
 
     mainchainMock.getEthereumBeaconSyncState.mockResolvedValue({
       isBootstrapped: true,

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -1,5 +1,11 @@
 import { setTimeout as sleep } from 'node:timers/promises';
-import { NetworkConfig, raceWithTimeout, SingleFileQueue, type IEthereumSyncStatus } from '@argonprotocol/apps-core';
+import {
+  minimumVaultDelegateBalance,
+  NetworkConfig,
+  raceWithTimeout,
+  SingleFileQueue,
+  type IEthereumSyncStatus,
+} from '@argonprotocol/apps-core';
 import {
   type ArgonClient,
   ExtrinsicError,
@@ -111,20 +117,6 @@ export class EthereumBeaconSyncService {
       return;
     }
 
-    const syncState = await getEthereumBeaconSyncState(this.client);
-
-    this.stateData.latestSyncCommitteeUpdatePeriod = syncState.latestSyncCommitteeUpdatePeriod;
-    delete this.stateData.lastError;
-
-    if (!syncState.isBootstrapped) {
-      this.stateData.mode = 'needsBootstrap';
-      delete this.stateData.latestFinalizedSlot;
-      return;
-    }
-
-    this.stateData.latestFinalizedSlot = syncState.latestFinalizedSlot;
-    await this.updateExecutionLag();
-
     if (this.stateData.mode === 'submitting' && this.stateData.lastSubmittedTxHash) {
       const pendingExtrinsics = await this.client.rpc.author.pendingExtrinsics();
       const isSubmittedTxStillPending = pendingExtrinsics.some(
@@ -143,6 +135,29 @@ export class EthereumBeaconSyncService {
       this.stateData.mode = 'idle';
       delete this.stateData.lastSubmittedTxHash;
     }
+
+    const delegateBalance = await this.client.query.system
+      .account(submitLane.address)
+      .then(x => x.data.free.toBigInt());
+    if (delegateBalance < minimumVaultDelegateBalance) {
+      this.stateData.mode = 'idle';
+      this.stateData.lastError = 'Vault delegate needs more funds before Ethereum beacon sync can run.';
+      return;
+    }
+
+    const syncState = await getEthereumBeaconSyncState(this.client);
+
+    this.stateData.latestSyncCommitteeUpdatePeriod = syncState.latestSyncCommitteeUpdatePeriod;
+    delete this.stateData.lastError;
+
+    if (!syncState.isBootstrapped) {
+      this.stateData.mode = 'needsBootstrap';
+      delete this.stateData.latestFinalizedSlot;
+      return;
+    }
+
+    this.stateData.latestFinalizedSlot = syncState.latestFinalizedSlot;
+    await this.updateExecutionLag();
 
     let txs;
     try {
@@ -166,6 +181,15 @@ export class EthereumBeaconSyncService {
 
       try {
         const result = await submitLane.runExclusive(async (client, getNonce) => {
+          const currentDelegateBalance = await client.query.system
+            .account(submitLane.address)
+            .then(x => x.data.free.toBigInt());
+          if (currentDelegateBalance < minimumVaultDelegateBalance) {
+            this.stateData.mode = 'idle';
+            this.stateData.lastError = 'Vault delegate needs more funds before Ethereum beacon sync can run.';
+            return;
+          }
+
           try {
             return await new TxSubmitter(client, tx, submitLane.keypair).submit({
               nonce: await getNonce(),

--- a/core/__test__/BlockWatch.test.ts
+++ b/core/__test__/BlockWatch.test.ts
@@ -469,6 +469,31 @@ describe('BlockWatch archive recovery', () => {
     expect(blockWatch.finalizedBlockHeader.blockNumber).toBe(101);
   });
 
+  it('keeps restarted headers when stale finalized recovery completes', async () => {
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+
+    const oldFinalizedHeader = createHeaderInfo(100, '0x100', '0x099');
+    const staleFinalizedHeader = createHeaderInfo(101, '0x101', '0x100');
+    const restartedHeaders = [createHeaderInfo(200, '0x200', '0x199'), createHeaderInfo(201, '0x201', '0x200')];
+    const staleBestHeader = createDeferredPromise<unknown>();
+    const getHeader = vi.fn(() => staleBestHeader.promise);
+    const archiveClient = { rpc: { chain: { getHeader } } };
+    const blockWatch = new BlockWatch(createClients({}, archiveClient) as any);
+    const blockWatchInternal = getInternalBlockWatch(blockWatch);
+    blockWatch.latestHeaders = [oldFinalizedHeader];
+    blockWatchInternal.subscriptionGeneration = 1;
+
+    const staleUpdate = blockWatchInternal.setFinalizedHeader(createHeader(staleFinalizedHeader), 1);
+    await vi.waitFor(() => expect(getHeader).toHaveBeenCalledOnce());
+
+    blockWatchInternal.subscriptionGeneration = 2;
+    blockWatch.latestHeaders = restartedHeaders;
+    staleBestHeader.resolve({ __info: staleFinalizedHeader });
+    await staleUpdate;
+
+    expect(blockWatch.latestHeaders).toEqual(restartedHeaders);
+  });
+
   it('starts on archive when the pruned client fails during startup', async () => {
     vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
 
@@ -490,6 +515,51 @@ describe('BlockWatch archive recovery', () => {
     expect(archiveClient.rpc.chain.subscribeNewHeads).toHaveBeenCalledOnce();
     expect(getInternalBlockWatch(blockWatch).activeSource).toBe('archive');
     expect(blockWatch.finalizedBlockHeader).toBe(finalizedHeader);
+  });
+
+  it('moves forced pruned subscriptions to archive on degradation and restores them after promotion', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(BlockWatch, 'readHeader').mockImplementation(readMockHeader);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const finalizedHeader = createHeaderInfo(100, '0x100', '0x099');
+      const prunedClient = createSubscriptionClient(finalizedHeader);
+      const archiveClient = createSubscriptionClient(finalizedHeader);
+      const archiveFinalizedHead = createDeferredPromise<string>();
+      archiveClient.rpc.chain.getFinalizedHead.mockImplementation(() => archiveFinalizedHead.promise);
+      let onDegraded!: (error: Error | undefined, clientType: 'archive' | 'pruned') => void;
+      let onPrunedClient!: () => void;
+      const clients = {
+        prunedClientPromise: Promise.resolve(prunedClient) as Promise<typeof prunedClient> | undefined,
+        archiveClientPromise: Promise.resolve(archiveClient),
+        events: {
+          on: vi.fn((event: string, callback: (...args: any[]) => void) => {
+            if (event === 'degraded') onDegraded = callback;
+            if (event === 'on-pruned-client') onPrunedClient = callback;
+            return () => undefined;
+          }),
+        },
+      };
+      const blockWatch = new BlockWatch(clients as any, true);
+
+      await blockWatch.start();
+      expect(blockWatch.subscriptionClient).toBe(prunedClient);
+
+      clients.prunedClientPromise = undefined;
+      onDegraded(undefined, 'pruned');
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(archiveClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce());
+
+      clients.prunedClientPromise = Promise.resolve(prunedClient);
+      onPrunedClient();
+      archiveFinalizedHead.resolve(finalizedHeader.blockHash);
+      await vi.waitFor(() => expect(archiveClient.rpc.chain.subscribeNewHeads).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(prunedClient.rpc.chain.subscribeNewHeads).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('keeps concurrent startup callers attached when the pruned client connects', async () => {
@@ -628,35 +698,6 @@ describe('BlockWatch archive recovery', () => {
     expect(secondPrunedClient.at).toHaveBeenCalledOnce();
   });
 
-  it('queues a follow-up restart requested during an active restart', async () => {
-    vi.useFakeTimers();
-
-    try {
-      const blockWatch = new BlockWatch(createClients({}, {}) as any);
-      const blockWatchInternal = getInternalBlockWatch(blockWatch);
-      const firstRestart = createDeferredPromise<void>();
-
-      blockWatchInternal.unsubscribe = vi.fn();
-      const startMock = vi.spyOn(blockWatch, 'start').mockImplementation(async source => {
-        blockWatchInternal.unsubscribe = vi.fn();
-        if (source === 'archive') {
-          await firstRestart.promise;
-        }
-      });
-
-      const restartPromise = blockWatchInternal.restart('archive', 'Initial restart');
-      blockWatchInternal.scheduleRestart('pruned', 'Promote recovered pruned client');
-      firstRestart.resolve();
-
-      await restartPromise;
-      await vi.runAllTimersAsync();
-
-      expect(startMock.mock.calls.map(([source]) => source)).toEqual(['archive', 'pruned']);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it('retries a failed restart until subscriptions recover', async () => {
     vi.useFakeTimers();
 
@@ -756,8 +797,8 @@ function getInternalBlockWatch(blockWatch: BlockWatch) {
   return blockWatch as unknown as {
     activeSource: 'archive' | 'pruned';
     restart(source: 'archive' | 'pruned', reason: string): Promise<void>;
-    scheduleRestart(source: 'archive' | 'pruned', reason: string, delayMs?: number): void;
-    setFinalizedHeader(header: ReturnType<typeof createHeader>): Promise<void>;
+    setFinalizedHeader(header: ReturnType<typeof createHeader>, generation?: number): Promise<void>;
+    subscriptionGeneration: number;
     unsubscribe?: () => void;
   };
 }

--- a/core/__test__/MainchainClients.test.ts
+++ b/core/__test__/MainchainClients.test.ts
@@ -1,43 +1,185 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MainchainClients } from '../src/MainchainClients.ts';
 
+const getClient = vi.hoisted(() => vi.fn());
+
+vi.mock('@argonprotocol/mainchain', async importOriginal => ({
+  ...(await importOriginal<typeof import('@argonprotocol/mainchain')>()),
+  getClient,
+}));
+
 describe('MainchainClients', () => {
+  let clients: MainchainClients;
+  let prunedClient: ReturnType<typeof createClient>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    prunedClient = createClient('pruned');
+    getClient.mockImplementation(async () => prunedClient);
+    clients = new MainchainClients('ws://archive', () => false, createClient('archive') as any);
+  });
+
+  afterEach(async () => {
+    await clients.disconnect();
+    getClient.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('selects a connected candidate only after its state probe succeeds', async () => {
+    let finishProbe!: (blockNumber: number) => void;
+    const stateProbe = new Promise<number>(resolve => {
+      finishProbe = resolve;
+    });
+    prunedClient = createClient('pruned', {
+      finalizedStateNumber: vi.fn(() => stateProbe),
+    });
+
+    const prunedReady = clients.setPrunedClient('ws://pruned');
+    let didResolvePrunedReady = false;
+    void prunedReady.then(() => {
+      didResolvePrunedReady = true;
+    });
+    await vi.waitFor(() => expect(prunedClient.finalizedStateNumber).toHaveBeenCalledOnce());
+
+    await expect(clients.prunedClientOrArchivePromise).resolves.toMatchObject({ name: 'archive' });
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'archive', clientType: 'archive' });
+    expect(didResolvePrunedReady).toBe(false);
+    finishProbe(100);
+    await expect(prunedReady).resolves.toMatchObject({ name: 'pruned' });
+
+    expect(prunedClient.rpc.chain.getFinalizedHead).toHaveBeenCalledOnce();
+    expect(prunedClient.at).toHaveBeenCalledWith('0xfinalized');
+    expect(prunedClient.finalizedStateNumber).toHaveBeenCalledOnce();
+    await expect(clients.prunedClientOrArchivePromise).resolves.toMatchObject({ name: 'pruned' });
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'pruned', clientType: 'pruned' });
+    await expect(clients.get(true)).resolves.toMatchObject({ name: 'archive', clientType: 'archive' });
+  });
+
+  it('keeps a preferred candidate when its state probe succeeds and demotes it when the next probe fails', async () => {
+    prunedClient = createClient('pruned', {
+      currentStateNumber: vi.fn().mockRejectedValue(new Error('4003: State already discarded')),
+      finalizedStateNumber: vi
+        .fn()
+        .mockResolvedValueOnce(100)
+        .mockResolvedValueOnce(100)
+        .mockRejectedValueOnce(new Error('4003: State already discarded')),
+    });
+
+    await clients.setPrunedClient('ws://pruned');
+    await vi.waitFor(() => expect(clients.prunedClientPromise).toBeDefined());
+    const selectedClient = await clients.get(false);
+
+    await expect(selectedClient.query.system.number()).rejects.toThrow('State already discarded');
+
+    await vi.waitFor(() => expect(prunedClient.finalizedStateNumber).toHaveBeenCalledTimes(2));
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'pruned', clientType: 'pruned' });
+
+    await expect(selectedClient.query.system.number()).rejects.toThrow('State already discarded');
+    await vi.waitFor(() => expect(clients.prunedClientPromise).toBeUndefined());
+
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'archive', clientType: 'archive' });
+  });
+
+  it('restores a disconnected candidate only after its current-state probe succeeds', async () => {
+    await clients.setPrunedClient('ws://pruned');
+    await vi.waitFor(() => expect(clients.prunedClientPromise).toBeDefined());
+
+    prunedClient.emit('disconnected');
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'archive', clientType: 'archive' });
+
+    prunedClient.emit('connected');
+    await vi.waitFor(() => expect(prunedClient.finalizedStateNumber).toHaveBeenCalledTimes(2));
+    await expect(clients.get(false)).resolves.toMatchObject({ name: 'pruned', clientType: 'pruned' });
+  });
+
+  it('deduplicates state probes and retries one that stalls', async () => {
+    vi.useFakeTimers();
+    prunedClient = createClient('pruned', {
+      currentStateNumber: vi.fn(() => Promise.reject(new Error('4003: State already discarded'))),
+      finalizedStateNumber: vi
+        .fn()
+        .mockResolvedValueOnce(100)
+        .mockImplementationOnce(() => new Promise<number>(() => undefined))
+        .mockResolvedValue(100),
+    });
+
+    try {
+      await clients.setPrunedClient('ws://pruned');
+      await vi.waitFor(() => expect(clients.prunedClientPromise).toBeDefined());
+      const selectedClient = await clients.get(false);
+
+      await Promise.allSettled([selectedClient.query.system.number(), selectedClient.query.system.number()]);
+      await vi.waitFor(() => expect(prunedClient.finalizedStateNumber).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(65_000);
+      await vi.waitFor(() => expect(prunedClient.finalizedStateNumber).toHaveBeenCalledTimes(3));
+
+      await expect(clients.get(false)).resolves.toMatchObject({ name: 'pruned' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('emits a degraded event when clearing an active pruned client', async () => {
-    const archiveClient = createClient();
-    const prunedClient = createClient();
-    const clients = new MainchainClients('ws://archive', () => false, archiveClient as any);
-    const internalClients = clients as unknown as {
-      connectionStateByClient: { pruned: 'connected' | 'disconnected' };
-      currentClientByType: { pruned?: ReturnType<typeof createClient> };
-      prunedClientPromise?: Promise<ReturnType<typeof createClient>>;
-      prunedUrl?: string;
-    };
     const degraded = vi.fn();
 
     clients.events.on('degraded', degraded);
-
-    internalClients.connectionStateByClient.pruned = 'connected';
-    internalClients.currentClientByType.pruned = prunedClient;
-    internalClients.prunedClientPromise = Promise.resolve(prunedClient);
-    internalClients.prunedUrl = 'ws://pruned';
+    await clients.setPrunedClient('ws://pruned');
+    await vi.waitFor(() => expect(clients.prunedClientPromise).toBeDefined());
 
     clients.clearPrunedClient();
-    await Promise.resolve();
+    await vi.waitFor(() => expect(prunedClient.disconnect).toHaveBeenCalledOnce());
 
     expect(degraded).toHaveBeenCalledOnce();
     expect(degraded).toHaveBeenCalledWith(undefined, 'pruned');
-    expect(prunedClient.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects the previous candidate when its replacement fails to connect', async () => {
+    const previousClient = createClient('previous');
+    getClient.mockResolvedValueOnce(previousClient).mockRejectedValueOnce(new Error('Replacement failed'));
+
+    await clients.setPrunedClient('ws://previous');
+
+    await expect(clients.setPrunedClient('ws://replacement')).rejects.toThrow('Replacement failed');
+    await vi.waitFor(() => expect(previousClient.disconnect).toHaveBeenCalledOnce());
   });
 });
 
-function createClient() {
+function createClient(
+  name: string,
+  options: {
+    currentStateNumber?: ReturnType<typeof vi.fn>;
+    finalizedStateNumber?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
   const listeners: Record<string, Array<() => void>> = {};
+  const currentStateNumber = options.currentStateNumber ?? vi.fn().mockResolvedValue(100);
+  const finalizedStateNumber = options.finalizedStateNumber ?? vi.fn().mockResolvedValue(100);
+  const finalizedApi = {
+    query: { system: { number: finalizedStateNumber } },
+    tx: {},
+  };
 
   return {
+    name,
+    tx: {},
+    query: { system: { number: currentStateNumber } },
+    rpc: {
+      chain: {
+        getFinalizedHead: vi.fn().mockResolvedValue('0xfinalized'),
+      },
+    },
+    at: vi.fn().mockResolvedValue(finalizedApi),
+    finalizedStateNumber,
     on: vi.fn((event: string, listener: () => void) => {
       listeners[event] ??= [];
       listeners[event].push(listener);
     }),
+    emit: (event: string) => {
+      for (const listener of listeners[event] ?? []) {
+        listener();
+      }
+    },
     disconnect: vi.fn(async () => {
       for (const listener of listeners.disconnected ?? []) {
         listener();

--- a/core/src/BlockWatch.ts
+++ b/core/src/BlockWatch.ts
@@ -102,12 +102,7 @@ export class BlockWatch {
       }),
 
       this.clients.events.on('on-pruned-client', () => {
-        if (
-          !this.isLoaded.isSettled ||
-          this.isRestarting ||
-          this.forcePrunedClientSubscriptions ||
-          this.activeSource === 'pruned'
-        ) {
+        if (!this.isRestarting && (!this.isLoaded.isSettled || this.activeSource === 'pruned')) {
           return;
         }
         this.scheduleRestart('pruned', 'Switched to pruned client');
@@ -177,6 +172,9 @@ export class BlockWatch {
           try {
             gap = await this.fillNewHeadGap(this.finalizedBlockHeader, announcedHeader);
           } catch (error) {
+            if (generation !== this.subscriptionGeneration) {
+              return;
+            }
             if (!isUnreadableBlockError(error)) {
               throw error;
             }
@@ -192,6 +190,9 @@ export class BlockWatch {
               announcedParentHash: announcedHeader.parentHash,
               error: String(error),
             });
+            return;
+          }
+          if (generation !== this.subscriptionGeneration) {
             return;
           }
           const newBlocks = gap.filter(x => !this.latestHeaders.some(y => y.blockHash === x.blockHash));
@@ -213,7 +214,7 @@ export class BlockWatch {
           if (generation !== this.subscriptionGeneration) {
             return;
           }
-          await this.setFinalizedHeader(header);
+          await this.setFinalizedHeader(header, generation);
         });
       });
 
@@ -453,7 +454,10 @@ export class BlockWatch {
     }
   }
 
-  private async setFinalizedHeader(header: Header): Promise<void> {
+  private async setFinalizedHeader(header: Header, generation = this.subscriptionGeneration): Promise<void> {
+    if (generation !== this.subscriptionGeneration) {
+      return;
+    }
     const finalizedHash = header.hash.toHex();
     const finalizedNumber = header.number.toNumber();
     const bestKnown = this.bestBlockHeader.blockNumber;
@@ -478,10 +482,17 @@ export class BlockWatch {
           selectedClient => selectedClient.rpc.chain.getHeader(),
           { blockNumber: finalizedNumber, finalizedNumber },
         );
+        if (generation !== this.subscriptionGeneration) {
+          return;
+        }
         // presume our old finalized is still valid, fill in the gap to the new best
-        const bestTail = await this.fillNewHeadGap(this.finalizedBlockHeader, bestHeader);
+        const finalizedHeader = this.finalizedBlockHeader;
+        const bestTail = await this.fillNewHeadGap(finalizedHeader, bestHeader);
+        if (generation !== this.subscriptionGeneration) {
+          return;
+        }
         // New canonical window: [latest finalized ... best]
-        this.latestHeaders = [this.finalizedBlockHeader, ...bestTail];
+        this.latestHeaders = [finalizedHeader, ...bestTail];
 
         if (this.bestBlockHeader.blockNumber <= bestKnown) {
           this.finalizedAheadRecoveryFailures += 1;
@@ -500,6 +511,9 @@ export class BlockWatch {
           this.events.emit('best-blocks', bestTail as [...any, IBlockHeaderInfo]);
         }
       } catch (error) {
+        if (generation !== this.subscriptionGeneration) {
+          return;
+        }
         this.finalizedAheadRecoveryFailures += 1;
         if (this.finalizedAheadRecoveryFailures >= 3) {
           this.scheduleRestart(this.getRecoverySource(), `Failed to recover finalized gap at block ${finalizedNumber}`);
@@ -666,7 +680,7 @@ export class BlockWatch {
   }
 
   private getRecoverySource(): ISubscriptionSource {
-    if (this.activeSource === 'pruned' && !this.forcePrunedClientSubscriptions) {
+    if (this.activeSource === 'pruned') {
       return 'archive';
     }
     return this.getPreferredSubscriptionSource();

--- a/core/src/MainchainClients.ts
+++ b/core/src/MainchainClients.ts
@@ -1,6 +1,7 @@
 import { type ApiDecoration, type ArgonClient, getClient } from '@argonprotocol/mainchain';
 import { wrapApi } from './ClientWrapper.js';
-import { createTypedEventEmitter } from './utils.js';
+import { createDeferred, type IDeferred } from './Deferred.js';
+import { createTypedEventEmitter, raceWithTimeout } from './utils.js';
 
 export type ArgonQueryClient = ArgonClient | ApiDecoration<'promise'>;
 const stringifyApiLogValue = (_key: string, value: unknown) => (typeof value === 'bigint' ? value.toString() : value);
@@ -15,10 +16,19 @@ interface IDisconnectLogInfo {
   time: number;
 }
 
+interface IPrunedCandidate {
+  url: string;
+  connection: Promise<ArgonClient>;
+  ready: IDeferred<ArgonClient>;
+}
+
 type IClientType = 'archive' | 'pruned';
 type IClientConnectionState = 'connected' | 'disconnected';
 
 export class MainchainClients {
+  private static readonly prunedStateProbeTimeoutMs = 60e3;
+  private static readonly prunedStateProbeRetryMs = 5e3;
+
   public events = createTypedEventEmitter<{
     'connection-state-changed': (hasConnectedClient: boolean) => void;
     degraded: (error: Error | undefined, clientType: 'archive' | 'pruned') => void;
@@ -28,11 +38,13 @@ export class MainchainClients {
   public get prunedClientOrArchivePromise(): Promise<ArgonClient> {
     return this.prunedClientPromise ?? this.archiveClientPromise;
   }
+  public get prunedUrl(): string | undefined {
+    return this.prunedCandidate?.url;
+  }
 
   archiveUrl: string;
   archiveClientPromise: Promise<ArgonClient>;
 
-  prunedUrl?: string;
   prunedClientPromise?: Promise<ArgonClient>;
   lastErrorByClient: { archive: ILastErrorInfo; pruned: ILastErrorInfo } = {
     archive: { errors: [], lastErrorTime: 0 },
@@ -47,6 +59,9 @@ export class MainchainClients {
     archive: { message: '', time: 0 },
     pruned: { message: '', time: 0 },
   };
+  private prunedCandidate?: IPrunedCandidate;
+  private prunedStateProbePromise?: Promise<void>;
+  private prunedStateProbeTimer?: ReturnType<typeof setTimeout>;
   private isShuttingDown = false;
 
   constructor(
@@ -77,34 +92,66 @@ export class MainchainClients {
     return connectedClient;
   }
 
-  public async setPrunedClient(url: string): Promise<ArgonClient> {
-    if (this.prunedUrl === url && this.prunedClientPromise) {
-      return this.prunedClientPromise;
+  public setPrunedClient(url: string): Promise<ArgonClient> {
+    const previousCandidate = this.prunedCandidate;
+    if (previousCandidate?.url === url && !previousCandidate.ready.isRejected) {
+      return previousCandidate.ready.promise;
     }
 
-    const previousClientPromise = this.prunedClientPromise;
-    this.prunedUrl = url;
-    this.prunedClientPromise = getMainchainClientOrThrow(url).then(client => this.wrapClient(client, 'pruned'));
-    const client = await this.prunedClientPromise;
-    this.events.emit('on-pruned-client', client, url);
-    void previousClientPromise?.then(previousClient => previousClient.disconnect()).catch(() => undefined);
-    return this.prunedClientPromise;
+    const wasPreferred = !!this.prunedClientPromise;
+    this.prunedClientPromise = undefined;
+    this.currentClientByType.pruned = undefined;
+    this.setConnectionState('pruned', 'disconnected');
+    this.stopPrunedStateProbe();
+    const ready = createDeferred<ArgonClient>(false);
+    void ready.promise.catch(() => undefined);
+    const connection = getMainchainClientOrThrow(url).then(async client => {
+      if (this.prunedCandidate?.ready !== ready) {
+        await client.disconnect();
+        throw new Error('Pruned client was replaced before it connected');
+      }
+      return this.wrapClient(client, 'pruned');
+    });
+    const candidate = { url, connection, ready };
+    this.prunedCandidate = candidate;
+    void previousCandidate?.connection.then(previousClient => previousClient.disconnect()).catch(() => undefined);
+    previousCandidate?.ready.reject(new Error('Pruned client was replaced'));
+
+    if (wasPreferred) {
+      this.events.emit('degraded', undefined, 'pruned');
+    }
+
+    void candidate.connection
+      .then(client => {
+        this.schedulePrunedStateProbe(client);
+      })
+      .catch(error => {
+        if (this.prunedCandidate !== candidate) {
+          return;
+        }
+        this.currentClientByType.pruned = undefined;
+        this.setConnectionState('pruned', 'disconnected');
+        candidate.ready.reject(error);
+      });
+
+    return candidate.ready.promise;
   }
 
   public clearPrunedClient(): void {
-    const previousClientPromise = this.prunedClientPromise;
-    if (!previousClientPromise) return;
+    const previousCandidate = this.prunedCandidate;
+    if (!previousCandidate) return;
 
-    const shouldNotifyDegraded =
-      this.connectionStateByClient.pruned === 'connected' && !!this.currentClientByType.pruned;
+    const shouldNotifyDegraded = !!this.prunedClientPromise;
+    this.prunedCandidate = undefined;
     this.prunedClientPromise = undefined;
-    this.prunedUrl = undefined;
+    previousCandidate.ready.reject(new Error('Pruned client was cleared'));
     this.currentClientByType.pruned = undefined;
+    this.stopPrunedStateProbe();
     this.setConnectionState('pruned', 'disconnected');
     if (shouldNotifyDegraded) {
       this.events.emit('degraded', undefined, 'pruned');
     }
-    void previousClientPromise.then(previousClient => previousClient.disconnect()).catch(() => undefined);
+    void previousCandidate.connection.then(previousClient => previousClient.disconnect()).catch(() => undefined);
   }
 
   public async get(needsHistoricalBlocks: boolean): Promise<ArgonClient & { clientType: 'archive' | 'pruned' }> {
@@ -121,9 +168,11 @@ export class MainchainClients {
 
   public async disconnect() {
     this.isShuttingDown = true;
+    this.prunedCandidate?.ready.reject(new Error('Mainchain clients disconnected'));
+    this.stopPrunedStateProbe();
     await Promise.allSettled([
       this.archiveClientPromise.then(client => client.disconnect()),
-      this.prunedClientPromise?.then(client => client.disconnect()),
+      this.prunedCandidate?.connection.then(client => client.disconnect()),
     ]);
   }
 
@@ -152,8 +201,18 @@ export class MainchainClients {
         apiError = error;
         const errorTracker = this.lastErrorByClient[clientType];
         errorTracker.errors.push(error);
+        if (errorTracker.errors.length > 6) {
+          errorTracker.errors.shift();
+        }
         errorTracker.lastErrorTime = Date.now();
-        if (errorTracker.errors.length > 5) {
+        const isStateDiscarded = String(error).toLowerCase().includes('state already discarded');
+        if (clientType === 'pruned' && isStateDiscarded) {
+          this.schedulePrunedStateProbe(api);
+        } else if (errorTracker.errors.length > 5 && clientType === 'pruned') {
+          if (this.demotePrunedClient(api, error)) {
+            this.schedulePrunedStateProbe(api, MainchainClients.prunedStateProbeRetryMs);
+          }
+        } else if (errorTracker.errors.length > 5) {
           this.events.emit('degraded', error, clientType);
         }
 
@@ -187,7 +246,12 @@ export class MainchainClients {
       }
 
       this.setConnectionState(clientType, 'disconnected');
-      this.events.emit('degraded', undefined, clientType);
+      if (clientType === 'pruned') {
+        this.stopPrunedStateProbe();
+        this.demotePrunedClient(api);
+      } else {
+        this.events.emit('degraded', undefined, clientType);
+      }
       if (this.isShuttingDown) {
         return;
       }
@@ -205,9 +269,115 @@ export class MainchainClients {
         return;
       }
       this.setConnectionState(clientType, 'connected');
+      if (clientType === 'pruned') {
+        this.schedulePrunedStateProbe(api);
+      }
       if (!apiError) this.events.emit('working', '', clientType);
     });
     return api;
+  }
+
+  private schedulePrunedStateProbe(client: ArgonClient, delayMs = 0): void {
+    if (
+      this.isShuttingDown ||
+      this.currentClientByType.pruned !== client ||
+      this.connectionStateByClient.pruned !== 'connected' ||
+      this.prunedStateProbePromise ||
+      this.prunedStateProbeTimer
+    ) {
+      return;
+    }
+
+    if (delayMs > 0) {
+      this.prunedStateProbeTimer = setTimeout(() => {
+        this.prunedStateProbeTimer = undefined;
+        this.schedulePrunedStateProbe(client);
+      }, delayMs);
+      return;
+    }
+
+    const probePromise = raceWithTimeout(
+      (async () => {
+        const finalizedHash = await client.rpc.chain.getFinalizedHead();
+        const finalizedClient = await client.at(finalizedHash);
+        await finalizedClient.query.system.number();
+      })(),
+      MainchainClients.prunedStateProbeTimeoutMs,
+      () => {
+        throw new Error('Pruned client state probe timed out');
+      },
+    );
+    this.prunedStateProbePromise = probePromise;
+    let shouldRetry = false;
+
+    void probePromise
+      .then(() => {
+        if (
+          this.prunedStateProbePromise !== probePromise ||
+          this.currentClientByType.pruned !== client ||
+          this.connectionStateByClient.pruned !== 'connected' ||
+          this.prunedClientPromise
+        ) {
+          return;
+        }
+
+        const hadConnectedClient = this.hasConnectedClient();
+        this.prunedClientPromise = Promise.resolve(client);
+        this.prunedCandidate?.ready.resolve(client);
+        const hasConnectedClient = this.hasConnectedClient();
+        if (hadConnectedClient !== hasConnectedClient) {
+          this.events.emit('connection-state-changed', hasConnectedClient);
+        }
+        this.events.emit('on-pruned-client', client, this.prunedUrl!);
+      })
+      .catch(error => {
+        if (
+          this.prunedStateProbePromise !== probePromise ||
+          this.isShuttingDown ||
+          this.currentClientByType.pruned !== client
+        ) {
+          return;
+        }
+        this.demotePrunedClient(client, error as Error);
+        shouldRetry = this.connectionStateByClient.pruned === 'connected';
+      })
+      .finally(() => {
+        if (this.prunedStateProbePromise !== probePromise) {
+          return;
+        }
+
+        this.prunedStateProbePromise = undefined;
+        if (shouldRetry) {
+          this.schedulePrunedStateProbe(client, MainchainClients.prunedStateProbeRetryMs);
+        }
+      });
+  }
+
+  private stopPrunedStateProbe(): void {
+    if (this.prunedStateProbeTimer) {
+      clearTimeout(this.prunedStateProbeTimer);
+      this.prunedStateProbeTimer = undefined;
+    }
+    this.prunedStateProbePromise = undefined;
+  }
+
+  private demotePrunedClient(client: ArgonClient, error?: Error): boolean {
+    const candidate = this.prunedCandidate;
+    if (this.currentClientByType.pruned !== client || !this.prunedClientPromise || !candidate) {
+      return false;
+    }
+
+    const hadConnectedClient = this.hasConnectedClient();
+    this.prunedClientPromise = undefined;
+    const readiness = createDeferred<ArgonClient>(false);
+    void readiness.promise.catch(() => undefined);
+    candidate.ready = readiness;
+    const hasConnectedClient = this.hasConnectedClient();
+    if (hadConnectedClient !== hasConnectedClient) {
+      this.events.emit('connection-state-changed', hasConnectedClient);
+    }
+    this.events.emit('degraded', error, 'pruned');
+    return true;
   }
 
   private setConnectionState(clientType: IClientType, connectionState: IClientConnectionState): void {

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -313,7 +313,7 @@ export async function readComposePortWithRetry(args: {
       }
 
       const matchedPort = endpoint.match(/:(\d+)\s*$/)?.[1];
-      if (!matchedPort) {
+      if (!matchedPort || matchedPort === '0') {
         throw new Error(`Could not parse mapped port from "${endpoint}" for ${args.service}:${args.port}`);
       }
 

--- a/src-vue/stores/mainchain.ts
+++ b/src-vue/stores/mainchain.ts
@@ -212,6 +212,7 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
   }
 
   const serverApiClient = getServerApiClient();
+  let prunedUrl: string;
   if (config.isServerInstalled && config.serverDetails.ipAddress) {
     if (!(await serverApiClient.isGatewayReady())) {
       console.warn('[Mainchain] Configured server gateway is not ready for pruned RPC');
@@ -221,7 +222,7 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
 
     try {
       const sessionId = await serverApiClient.getAdminOperatorSessionId({ forceVerify: true });
-      await mainchainClients.setPrunedClient(serverApiClient.getGatewayWebsocketUrl('/substrate', sessionId));
+      prunedUrl = serverApiClient.getGatewayWebsocketUrl('/substrate', sessionId);
     } catch (error) {
       console.warn(
         `[Mainchain] Failed to connect configured pruned client after ${Date.now() - connectStartedAt}ms`,
@@ -230,19 +231,24 @@ async function connectPrunedClientToConfiguredServer(): Promise<void> {
       mainchainClients.clearPrunedClient();
       throw error;
     }
-
-    return;
-  }
-
-  const upstreamOperatorClient = getUpstreamOperatorClient();
-  if (upstreamOperatorClient.operatorHost && config.upstreamOperator) {
+  } else {
+    const upstreamOperatorClient = getUpstreamOperatorClient();
+    if (!upstreamOperatorClient.operatorHost || !config.upstreamOperator) {
+      mainchainClients.clearPrunedClient();
+      return;
+    }
     const sessionId = await upstreamOperatorClient.getMemberSessionId({
       forceVerify: true,
     });
-
-    await mainchainClients.setPrunedClient(upstreamOperatorClient.getWebsocketUrl('/substrate', sessionId));
-    return;
+    prunedUrl = upstreamOperatorClient.getWebsocketUrl('/substrate', sessionId);
   }
 
-  mainchainClients.clearPrunedClient();
+  void mainchainClients.setPrunedClient(prunedUrl).catch(error => {
+    if (mainchainClients.prunedUrl === prunedUrl) {
+      console.warn(
+        `[Mainchain] Failed to connect configured pruned client after ${Date.now() - connectStartedAt}ms`,
+        error,
+      );
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Pruned RPC failures no longer stall startup or expose a connected-but-unusable local client to application queries. A configured client becomes preferred only after a finalized-state query succeeds, falls back to archive when its state is proven unhealthy or its transport disconnects, and is promoted again after a throttled recovery probe.

BlockWatch follows that same lifecycle and ignores stale subscription work after a restart, preventing an older finalized-head task from clearing newly installed headers. Beacon sync also rechecks delegate funding inside its serialized submission lane so it does not enqueue transactions that can no longer pay fees. The local dev launcher retries the transient Docker port value of `0` observed during recovery testing.

## Validation

- 42 focused tests passed across MainchainClients, BlockWatch, and EthereumBeaconSyncService.
- In dev Docker, stopping the local Argon node produced the expected gateway failures while the Bot continued processing through archive RPC. After the node restarted and caught up, gateway errors stopped and the Bot recovered without restarting.
