### PR TITLE
fix(server): check disk space before custom install

### DIFF
--- a/src-vue/lib/MiningMachine.ts
+++ b/src-vue/lib/MiningMachine.ts
@@ -17,6 +17,8 @@ export class MiningMachineError extends Error {
 
 // DigitalOcean API response types
 const DEFAULT_DIGITALOCEAN_IMAGE = 'ubuntu-24-04-x64';
+const BYTES_PER_GB = 1e9;
+export const MINIMUM_INSTALL_DISK_GB = 100;
 
 type IDropletActionLink = { id: number; rel: string; href: string };
 type ICreateDropletResponse = {
@@ -398,6 +400,10 @@ export class MiningMachine {
         throw new MiningMachineError('A SSH connection could not be established to your server.');
       }
     })();
+
+    if (!hasRunningBot && !serverMeta.walletAddress) {
+      this.ensureInstallationDiskSpace(serverMeta.availableDiskBytes);
+    }
     progressFn?.(100);
 
     if (serverMeta.walletAddress && serverMeta.walletAddress !== miningBotAccountAddress) {
@@ -405,6 +411,16 @@ export class MiningMachine {
     }
 
     return newServerDetails;
+  }
+
+  public static ensureInstallationDiskSpace(availableDiskBytes?: number): void {
+    if (availableDiskBytes === undefined) return;
+    if (availableDiskBytes >= MINIMUM_INSTALL_DISK_GB * BYTES_PER_GB) return;
+
+    const availableDiskGb = Math.floor(availableDiskBytes / BYTES_PER_GB);
+    throw new MiningMachineError(
+      `Argon requires at least ${MINIMUM_INSTALL_DISK_GB} GB of available disk space (${availableDiskGb} GB found)`,
+    );
   }
 }
 

--- a/src-vue/lib/SSH.ts
+++ b/src-vue/lib/SSH.ts
@@ -11,6 +11,7 @@ export interface ITryServerData {
   oldestFrameIdToSync: number | undefined;
   ethereumBeaconApiUrl: string | undefined;
   ethereumExecutionRpcUrl: string | undefined;
+  availableDiskBytes?: number;
 }
 
 export class SSH {
@@ -55,14 +56,18 @@ export class SSH {
     }
     this.connection = connection; // save the working connection
 
-    if (!walletAddress)
+    if (!walletAddress) {
+      const availableDiskBytes = await server.getAvailableDiskBytes().catch(() => undefined);
+
       return {
         walletAddress: undefined,
         biddingRules: undefined,
         oldestFrameIdToSync: undefined,
         ethereumBeaconApiUrl: undefined,
         ethereumExecutionRpcUrl: undefined,
+        availableDiskBytes,
       };
+    }
 
     const { biddingRules, oldestFrameIdToSync, ethereumBeaconApiUrl, ethereumExecutionRpcUrl } =
       await server.downloadConfigState();

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -69,6 +69,20 @@ export class ServerAdmin {
     return !!output;
   }
 
+  public async getAvailableDiskBytes(): Promise<number> {
+    const [output, code] = await this.connection.runCommandWithTimeout(
+      `df -Pk "$HOME" | awk 'NR == 2 { print $4; found=1 } END { if (!found) exit 1 }'`,
+      10e3,
+    );
+    const availableKilobytesText = output.trim();
+    const availableKilobytes = Number(availableKilobytesText);
+    if (code !== 0 || !availableKilobytesText || !Number.isSafeInteger(availableKilobytes) || availableKilobytes < 0) {
+      throw new Error('Could not determine available server disk space');
+    }
+
+    return availableKilobytes * 1024;
+  }
+
   public async createWorkdir(): Promise<void> {
     const username = this.connection.username;
     await this.connection.runCommandWithTimeout(

--- a/src-vue/panels/server-connect/CustomServer.vue
+++ b/src-vue/panels/server-connect/CustomServer.vue
@@ -31,7 +31,9 @@
           <td class="border-b border-slate-400/40 py-2 pl-4 font-sans font-bold">4+ vCPUs</td>
           <td></td>
           <td class="border-b border-slate-400/40 py-2 pr-4">Hard Drive</td>
-          <td class="border-b border-slate-400/40 py-2 pl-4 font-sans font-bold">100GB or more</td>
+          <td class="border-b border-slate-400/40 py-2 pl-4 font-sans font-bold">
+            {{ MINIMUM_INSTALL_DISK_GB }}GB or more available
+          </td>
         </tr>
         <tr>
           <td class="border-b border-slate-400/40 py-2 pr-4">Internet</td>
@@ -163,6 +165,7 @@ import { IServerConnectChildExposed } from '../ServerConnectPanel.vue';
 import { IConfigServerAddCustomServer, ServerType } from '../../interfaces/IConfig.ts';
 import { SERVER_ENV_VARS } from '../../lib/Env.ts';
 import { getWalletKeys } from '../../stores/wallets.ts';
+import { MINIMUM_INSTALL_DISK_GB, MiningMachine } from '../../lib/MiningMachine.ts';
 
 const emit = defineEmits(['ready']);
 
@@ -240,6 +243,10 @@ async function connect(): Promise<IConfigServerAddCustomServer> {
 
   if (serverMeta.walletAddress && serverMeta.walletAddress !== walletKeys.miningBotAddress) {
     throw new Error('The server has a different wallet address than your mining account.');
+  }
+
+  if (!serverMeta.walletAddress) {
+    MiningMachine.ensureInstallationDiskSpace(serverMeta.availableDiskBytes);
   }
 
   if (serverMeta.biddingRules) {


### PR DESCRIPTION
## Summary

Fresh custom-server installs now stop before provisioning when less than 100 GB is available, giving operators a clear capacity error while the disk can still be resized instead of failing later during image and chain-data downloads.

DigitalOcean provisioning remains unchanged because all supported 4-vCPU/8-GB plan variants (`s-4vcpu-8gb`, `s-4vcpu-8gb-amd`, and `s-4vcpu-8gb-intel`) already include 160 GB disks. Existing and running installations also remain exempt from the fresh-install capacity requirement.

## Validation

- Repository pre-commit typecheck, lint, ESLint, and Rust formatting checks passed.
- The full Vue suite passed with 451 tests across 70 files.
