### PR TITLE
feat(ethereum): add RPC failover

### DIFF
--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -516,6 +516,29 @@ describe('EthereumBeaconSyncService', () => {
     ).rejects.toThrow(/Beacon API request timed out after \d+ms for \/eth\/v1\/beacon\/headers\/finalized/);
   });
 
+  it('preserves path-authenticated beacon API URLs', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { root: '0xroot', header: { message: { slot: '1' } } } })),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: { message: { body: { execution_payload: { block_number: '1' } } } },
+          }),
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+    await waitForFinalizedBeaconExecutionAtOrAbove('https://beacon.example/v2/test-key', 1n);
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://beacon.example/v2/test-key/eth/v1/beacon/headers/finalized',
+      'https://beacon.example/v2/test-key/eth/v2/beacon/blocks/0xroot',
+    ]);
+  });
+
   it('treats finality update not ready as idle instead of error', async () => {
     mainchainMock.getEthereumBeaconSyncState.mockResolvedValue({
       isBootstrapped: true,

--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -119,11 +119,12 @@ describe('EthereumGatewayProverService', () => {
     vi.clearAllMocks();
     viemMock.createPublicClient.mockReturnValue({
       readContract: viemMock.readContract,
+      transport: { onResponse: vi.fn() },
     });
     NetworkConfig.setNetwork('dev-docker');
     NetworkConfig.setRuntimeOverride('dev-docker', {
       ethereumNetwork: {
-        executionRpcUrl: 'http://ethereum.test',
+        executionRpcUrls: ['http://ethereum.test'],
       },
     });
   });
@@ -804,7 +805,7 @@ describe('EthereumGatewayProverService', () => {
     NetworkConfig.setNetwork('mainnet');
     NetworkConfig.setRuntimeOverride('mainnet', {
       ethereumNetwork: {
-        executionRpcUrl: 'http://ethereum.test',
+        executionRpcUrls: ['http://ethereum.test'],
       },
     });
 
@@ -859,7 +860,7 @@ describe('EthereumGatewayProverService', () => {
     NetworkConfig.setNetwork('mainnet');
     NetworkConfig.setRuntimeOverride('mainnet', {
       ethereumNetwork: {
-        executionRpcUrl: 'http://ethereum.test',
+        executionRpcUrls: ['http://ethereum.test'],
       },
     });
 

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import {
+  getEthereumExecutionRpcUrls,
   minimumVaultDelegateBalance,
   NetworkConfig,
   raceWithTimeout,
@@ -16,8 +17,8 @@ import {
   isTxSubmissionError,
   TxSubmitter,
 } from '@argonprotocol/mainchain';
-import { createPublicClient, http } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
+import { createEthereumExecutionClient } from './EthereumExecutionClient.ts';
 
 type IEthereumBeaconSyncServiceOptions = {
   beaconApiUrl?: string;
@@ -275,15 +276,13 @@ export class EthereumBeaconSyncService {
       const latestExecutionAnchor = await getLatestArgonFinalizedExecutionHeader(this.client);
       this.stateData.latestExecutionAnchorBlockNumber = latestExecutionAnchor.blockNumber;
 
-      const executionRpcUrl = NetworkConfig.get().ethereumNetwork.executionRpcUrl.trim();
-      if (!executionRpcUrl) {
+      const executionRpcUrls = getEthereumExecutionRpcUrls();
+      if (!executionRpcUrls.length) {
         return;
       }
 
       try {
-        const latestEthereumBlockNumber = await createPublicClient({
-          transport: http(executionRpcUrl),
-        }).getBlockNumber();
+        const latestEthereumBlockNumber = await createEthereumExecutionClient(executionRpcUrls).getBlockNumber();
         this.stateData.latestEthereumBlockNumber = latestEthereumBlockNumber;
       } catch {
         delete this.stateData.latestEthereumBlockNumber;
@@ -399,7 +398,8 @@ async function getBeaconJson<T>(
 ): Promise<T> {
   let response: Response;
   try {
-    response = await fetch(new URL(path, beaconApiUrl), {
+    const normalizedBaseUrl = beaconApiUrl.endsWith('/') ? beaconApiUrl : `${beaconApiUrl}/`;
+    response = await fetch(new URL(path.replace(/^\//, ''), normalizedBaseUrl), {
       headers: { accept: 'application/json' },
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/bot/src/EthereumExecutionClient.ts
+++ b/bot/src/EthereumExecutionClient.ts
@@ -1,0 +1,32 @@
+import { ETHEREUM_EXECUTION_RPC_TRANSPORT, logEthereumExecutionRpcFallback } from '@argonprotocol/apps-core';
+import { createPublicClient, fallback, http, shouldThrow } from 'viem';
+
+export function createEthereumExecutionClient(executionRpcUrls: string[]) {
+  const transports = executionRpcUrls.map(url =>
+    http(url, {
+      retryCount: ETHEREUM_EXECUTION_RPC_TRANSPORT.requestRetryCount,
+      timeout: ETHEREUM_EXECUTION_RPC_TRANSPORT.timeoutMs,
+    }),
+  );
+  if (!transports.length) {
+    throw new Error('Ethereum execution RPC is not configured on this network.');
+  }
+
+  const fallbackTransport = fallback(transports, {
+    retryCount: ETHEREUM_EXECUTION_RPC_TRANSPORT.fallbackRetryCount,
+  });
+  const client = createPublicClient({ transport: fallbackTransport });
+  client.transport.onResponse(({ error, method, status, transport }) => {
+    if (status !== 'error' || shouldThrow(error)) {
+      return;
+    }
+
+    logEthereumExecutionRpcFallback({
+      executionRpcUrls,
+      failedRpcUrl: transport.value?.url,
+      method,
+    });
+  });
+
+  return client;
+}

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -1,4 +1,6 @@
 import {
+  getEthereumExecutionRpcUrls,
+  logEthereumExecutionRpcFallback,
   minimumVaultDelegateBalance,
   NetworkConfig,
   raceWithTimeout,
@@ -19,8 +21,9 @@ import {
 } from '@argonprotocol/mainchain';
 import process from 'node:process';
 import { createHash } from 'node:crypto';
-import { createPublicClient, http, type Hex } from 'viem';
+import { type Hex } from 'viem';
 import { DelegateSubmitLane } from './DelegateSubmitLane.ts';
+import { createEthereumExecutionClient } from './EthereumExecutionClient.ts';
 import { HttpError } from './HttpError.ts';
 
 export class EthereumGatewayProverService {
@@ -91,7 +94,7 @@ export class EthereumGatewayProverService {
   public async getRelayStatus(): Promise<IEthereumGatewayRelayStatus> {
     try {
       const client = this.requireClient();
-      this.requireExecutionRpcUrl();
+      this.requireExecutionRpcUrls();
       await this.loadGatewayAddress();
       const gatewaySyncPause = await client.query.crosschainTransfer.gatewaySyncPauseBySourceChain('Ethereum');
       if (!gatewaySyncPause.isNone) {
@@ -193,14 +196,9 @@ export class EthereumGatewayProverService {
         this.lastStallSweepWindowIndex = undefined;
       }
 
-      const executionRpcUrl = this.requireExecutionRpcUrl();
+      const executionRpcUrls = this.requireExecutionRpcUrls();
       const gatewayAddress = await this.loadGatewayAddress();
-      const executionClient = createPublicClient({
-        transport: http(executionRpcUrl, {
-          retryCount: 1,
-          timeout: 15_000,
-        }),
-      });
+      const executionClient = createEthereumExecutionClient(executionRpcUrls);
       const latestLocatorIndex = await executionClient.readContract({
         abi: EvmContracts.mintingGatewayAbi,
         address: gatewayAddress,
@@ -232,8 +230,7 @@ export class EthereumGatewayProverService {
         return;
       }
       const latestExecutionHeader = await getLatestArgonFinalizedExecutionHeader(client);
-      const proofPayload = await buildGatewayActivityProofPayload(client, {
-        executionRpcUrl,
+      const proofPayload = await buildGatewayActivityProofPayloadWithFallback(client, executionRpcUrls, {
         gatewayAddress,
         throughExecutionBlockNumber: latestExecutionHeader.blockNumber,
       });
@@ -370,12 +367,12 @@ export class EthereumGatewayProverService {
           continue;
         }
 
-        const executionRpcUrl = this.requireExecutionRpcUrl();
+        const executionRpcUrls = this.requireExecutionRpcUrls();
         const gatewayAddress = await this.loadGatewayAddress();
         latestResponse = await this.runToCheckpointWithContext(
           throughGatewayActivityNonce,
           client,
-          executionRpcUrl,
+          executionRpcUrls,
           gatewayAddress,
           preparedProofPayload,
         );
@@ -398,7 +395,7 @@ export class EthereumGatewayProverService {
   private async runToCheckpointWithContext(
     throughGatewayActivityNonce: bigint,
     client: ReturnType<EthereumGatewayProverService['requireClient']>,
-    executionRpcUrl: string,
+    executionRpcUrls: string[],
     gatewayAddress: Hex,
     preparedProofPayload?: EthereumGatewayActivityProofPayload,
   ): Promise<IEthereumGatewayCatchUpResponse> {
@@ -434,8 +431,7 @@ export class EthereumGatewayProverService {
       }
       if (!proofPayload) {
         const latestExecutionHeader = await getLatestArgonFinalizedExecutionHeader(client);
-        proofPayload = await buildGatewayActivityProofPayload(client, {
-          executionRpcUrl,
+        proofPayload = await buildGatewayActivityProofPayloadWithFallback(client, executionRpcUrls, {
           gatewayAddress,
           throughExecutionBlockNumber: latestExecutionHeader.blockNumber,
         });
@@ -598,13 +594,13 @@ export class EthereumGatewayProverService {
     return client;
   }
 
-  private requireExecutionRpcUrl(): string {
-    const executionRpcUrl = NetworkConfig.get().ethereumNetwork.executionRpcUrl.trim() || undefined;
-    if (!executionRpcUrl) {
+  private requireExecutionRpcUrls(): string[] {
+    const executionRpcUrls = getEthereumExecutionRpcUrls();
+    if (!executionRpcUrls.length) {
       throw new HttpError('Ethereum execution RPC is not configured on this network.', 503);
     }
 
-    return executionRpcUrl;
+    return executionRpcUrls;
   }
 
   private async loadCurrentRuntimeGatewayActivityNonce(
@@ -716,6 +712,54 @@ export class EthereumGatewayProverService {
       }
     }
   }
+}
+
+async function buildGatewayActivityProofPayloadWithFallback(
+  client: Parameters<typeof buildGatewayActivityProofPayload>[0],
+  executionRpcUrls: string[],
+  args: Omit<Parameters<typeof buildGatewayActivityProofPayload>[1], 'executionRpcUrl'>,
+): ReturnType<typeof buildGatewayActivityProofPayload> {
+  let lastError: unknown;
+  let hadNullPayload = false;
+
+  for (const executionRpcUrl of executionRpcUrls) {
+    try {
+      const payload = await buildGatewayActivityProofPayload(client, {
+        ...args,
+        executionRpcUrl,
+      });
+      if (payload !== null) {
+        return payload;
+      }
+      hadNullPayload = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // These errors come from Argon runtime bounds, so another execution RPC cannot resolve them.
+      if (
+        message.startsWith('Gateway proof requires ') ||
+        message === 'Oldest uncovered gateway activity exceeds the Argon finalized execution-header window'
+      ) {
+        throw error;
+      }
+
+      lastError = error;
+      logEthereumExecutionRpcFallback({
+        executionRpcUrls,
+        failedRpcUrl: executionRpcUrl,
+        method: 'buildGatewayActivityProofPayload',
+      });
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  if (hadNullPayload) {
+    return null;
+  }
+
+  throw new Error(lastError ? String(lastError) : 'Ethereum execution RPC is not configured on this network.');
 }
 
 function isRedundantCatchUpError(reason: string): boolean {

--- a/bot/src/configureNetwork.ts
+++ b/bot/src/configureNetwork.ts
@@ -44,7 +44,11 @@ function readRuntimeOverride(networkName: keyof typeof NetworkConfigSettings): I
       ? {
           ethereumNetwork: {
             ...baseOverride.ethereumNetwork,
-            executionRpcUrl: envExecutionRpcUrl,
+            executionRpcUrls: [
+              envExecutionRpcUrl,
+              ...(baseOverride.ethereumNetwork?.executionRpcUrls ??
+                NetworkConfigSettings[networkName].ethereumNetwork.executionRpcUrls),
+            ],
           },
         }
       : {}),

--- a/core/network.config.json
+++ b/core/network.config.json
@@ -8,7 +8,7 @@
     "websiteHost": "http://localhost:5173",
     "ethereumNetwork": {
       "beaconApiUrl": "",
-      "executionRpcUrl": "",
+      "executionRpcUrls": [],
       "finalityBlocks": 16,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },
@@ -31,7 +31,7 @@
     "websiteHost": "http://localhost:5173",
     "ethereumNetwork": {
       "beaconApiUrl": "",
-      "executionRpcUrl": "",
+      "executionRpcUrls": [],
       "finalityBlocks": 16,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },
@@ -54,7 +54,11 @@
     "websiteHost": "https://staging.argon.network",
     "ethereumNetwork": {
       "beaconApiUrl": "https://ethereum-sepolia-beacon-api.publicnode.com",
-      "executionRpcUrl": "https://ethereum-sepolia-rpc.publicnode.com",
+      "executionRpcUrls": [
+        "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://11155111.rpc.thirdweb.com",
+        "https://public.1rpc.io/sepolia"
+      ],
       "finalityBlocks": 32,
       "usdcTokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
@@ -77,7 +81,7 @@
     "websiteHost": "https://argon.network",
     "ethereumNetwork": {
       "beaconApiUrl": "https://ethereum-beacon-api.publicnode.com",
-      "executionRpcUrl": "https://ethereum-rpc.publicnode.com",
+      "executionRpcUrls": ["https://ethereum-rpc.publicnode.com", "https://eth.drpc.org", "https://public.1rpc.io/eth"],
       "finalityBlocks": 32,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },

--- a/core/src/NetworkConfig.ts
+++ b/core/src/NetworkConfig.ts
@@ -144,7 +144,7 @@ export interface INetworkConfig {
 
 export interface IEthereumNetworkConfig {
   beaconApiUrl: string;
-  executionRpcUrl: string;
+  executionRpcUrls: string[];
   finalityBlocks: number;
   usdcTokenAddress: string;
 }
@@ -153,4 +153,57 @@ export interface IBaseNetworkConfig {
   chainId: number;
   rpcUrl: string;
   usdcTokenAddress: string;
+}
+
+export const ETHEREUM_EXECUTION_RPC_TRANSPORT = {
+  requestRetryCount: 0,
+  fallbackRetryCount: 1,
+  timeoutMs: 15_000,
+} as const;
+
+export function getEthereumExecutionRpcUrls(configuredExecutionRpcUrl?: string): string[] {
+  const ethereumNetwork = NetworkConfig.get().ethereumNetwork;
+  return Array.from(
+    new Set(
+      [configuredExecutionRpcUrl, ...ethereumNetwork.executionRpcUrls]
+        .map(url => url?.trim())
+        .filter((url): url is string => Boolean(url)),
+    ),
+  );
+}
+
+export function logEthereumExecutionRpcFallback(args: {
+  executionRpcUrls: string[];
+  failedRpcUrl?: string;
+  method: string;
+}): void {
+  const { executionRpcUrls, failedRpcUrl, method } = args;
+  if (!failedRpcUrl) {
+    return;
+  }
+
+  const failedRpcIndex = executionRpcUrls.indexOf(failedRpcUrl);
+  if (failedRpcIndex < 0) {
+    return;
+  }
+
+  const fallbackRpcUrl = executionRpcUrls[failedRpcIndex + 1];
+  if (!fallbackRpcUrl) {
+    return;
+  }
+
+  console.warn(
+    `[Ethereum RPC] ${method} failed on ${formatEthereumRpcUrlForLog(failedRpcUrl)}; ` +
+      `falling back to ${formatEthereumRpcUrlForLog(fallbackRpcUrl)}.`,
+  );
+}
+
+function formatEthereumRpcUrlForLog(rpcUrl: string): string {
+  try {
+    return new URL(rpcUrl).origin;
+  } catch {
+    const schemeSeparatorIndex = rpcUrl.indexOf('://');
+    const authority = schemeSeparatorIndex >= 0 ? rpcUrl.slice(schemeSeparatorIndex + 3) : rpcUrl;
+    return authority.split(/[/?]/)[0];
+  }
 }

--- a/e2e/helpers/startDevEthereumMintingAuthority.ts
+++ b/e2e/helpers/startDevEthereumMintingAuthority.ts
@@ -37,7 +37,7 @@ export async function startDevEthereumMintingAuthority(args: {
   NetworkConfig.setNetwork('dev-docker');
   NetworkConfig.setRuntimeOverride('dev-docker', {
     ethereumNetwork: {
-      executionRpcUrl,
+      executionRpcUrls: [executionRpcUrl],
       finalityBlocks: 16,
     },
   });
@@ -131,7 +131,7 @@ async function activateDevEthereumMintingAuthority(args: {
 
   NetworkConfig.setRuntimeOverride('dev-docker', {
     ethereumNetwork: {
-      executionRpcUrl,
+      executionRpcUrls: [executionRpcUrl],
       finalityBlocks: 16,
     },
   });

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -171,7 +171,7 @@ export async function startDevUpstreamServer(args: {
   const argonNetworkConfigOverride = args.devEthereum
     ? JSON.stringify({
         ethereumNetwork: {
-          executionRpcUrl: args.devEthereum.serverExecutionRpcUrl,
+          executionRpcUrls: [args.devEthereum.serverExecutionRpcUrl],
           finalityBlocks: args.devEthereumConfig?.finalityBlocks,
           usdcTokenAddress: args.devEthereum.usdcTokenAddress,
         },

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -118,7 +118,7 @@ async function main(): Promise<void> {
     if (resolvedOverride) {
       tauriEnv.ARGON_NETWORK_CONFIG_OVERRIDE = JSON.stringify(resolvedOverride);
       console.log(
-        `[tauri-dev] Runtime override archive=${resolvedOverride.archiveUrl} esplora=${resolvedOverride.esploraHost}${resolvedOverride.indexerHost ? ` indexer=${resolvedOverride.indexerHost}` : ''}${resolvedOverride.ethereumNetwork?.executionRpcUrl ? ` ethereumExecution=${resolvedOverride.ethereumNetwork.executionRpcUrl}` : ''}${resolvedOverride.ethereumNetwork?.usdcTokenAddress ? ` usdc=${resolvedOverride.ethereumNetwork.usdcTokenAddress}` : ''}`,
+        `[tauri-dev] Runtime override archive=${resolvedOverride.archiveUrl} esplora=${resolvedOverride.esploraHost}${resolvedOverride.indexerHost ? ` indexer=${resolvedOverride.indexerHost}` : ''}${resolvedOverride.ethereumNetwork?.executionRpcUrls?.[0] ? ` ethereumExecution=${resolvedOverride.ethereumNetwork.executionRpcUrls[0]}` : ''}${resolvedOverride.ethereumNetwork?.usdcTokenAddress ? ` usdc=${resolvedOverride.ethereumNetwork.usdcTokenAddress}` : ''}`,
       );
     } else {
       delete tauriEnv.ARGON_NETWORK_CONFIG_OVERRIDE;
@@ -478,7 +478,7 @@ async function resolveDevDockerNetworkConfigOverride(
   };
   if (ethereumExecutionRpcUrl) {
     override.ethereumNetwork = {
-      executionRpcUrl: ethereumExecutionRpcUrl,
+      executionRpcUrls: [ethereumExecutionRpcUrl],
       ...(usdcTokenAddress ? { usdcTokenAddress } : {}),
     };
   }
@@ -492,7 +492,7 @@ async function resolveRuntimeEthereumExecutionRpcUrl(
   devEthereum?: IStartDevEthereumResult,
   inheritedOverride?: RuntimeNetworkConfigOverride,
 ): Promise<string | undefined> {
-  const inheritedExecutionRpcUrl = readNonEmpty(inheritedOverride?.ethereumNetwork?.executionRpcUrl);
+  const inheritedExecutionRpcUrl = readNonEmpty(inheritedOverride?.ethereumNetwork?.executionRpcUrls?.[0]);
   if (inheritedExecutionRpcUrl) {
     return inheritedExecutionRpcUrl;
   }

--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -15,7 +15,7 @@ describe('EthereumClient', () => {
     setFetchImplementation();
     NetworkConfig.setRuntimeOverride('dev-docker', {
       ethereumNetwork: {
-        executionRpcUrl: 'https://ethereum.test',
+        executionRpcUrls: ['https://ethereum.test'],
       },
     });
   });
@@ -121,5 +121,30 @@ describe('EthereumClient', () => {
     const requestBody = JSON.parse(String(runtimeFetchMock.mock.calls[0][1]?.body));
     expect(requestBody.method).toBe('eth_getBalance');
     expect(requestBody.params).toEqual(['0x0000000000000000000000000000000000000001', 'latest']);
+  });
+
+  it('uses the configured RPC before the built-in fallbacks', async () => {
+    NetworkConfig.setRuntimeOverride('dev-docker', {
+      ethereumNetwork: {
+        executionRpcUrls: ['https://ethereum-fallback.test'],
+      },
+    });
+    runtimeFetchMock.mockResolvedValueOnce(new Response('unavailable', { status: 503 })).mockResolvedValueOnce(
+      new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x2a' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+    setFetchImplementation(runtimeFetchMock as unknown as FetchImplementation);
+
+    const publicClient = createEthereumPublicClient(undefined, 'https://ethereum-configured.test');
+
+    await expect(publicClient.getBalance({ address: '0x0000000000000000000000000000000000000001' })).resolves.toBe(42n);
+    expect(runtimeFetchMock.mock.calls.map(call => String(call[0]))).toEqual([
+      'https://ethereum-configured.test/',
+      'https://ethereum-fallback.test/',
+    ]);
   });
 });

--- a/src-vue/__test__/EthereumCrosschain.integration.test.ts
+++ b/src-vue/__test__/EthereumCrosschain.integration.test.ts
@@ -184,7 +184,7 @@ describe.skipIf(skipE2E || !TestEthereum.isInstalled())('EthereumCrosschain inte
     argonotTokenAddress = fixture.argonotTokenAddress;
     NetworkConfig.setRuntimeOverride('dev-docker', {
       ethereumNetwork: {
-        executionRpcUrl: endpoints.executionRpcUrl,
+        executionRpcUrls: [endpoints.executionRpcUrl],
         finalityBlocks: 16,
       },
     });

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -1,7 +1,10 @@
 import {
+  ETHEREUM_EXECUTION_RPC_TRANSPORT,
   fetch,
+  getEthereumExecutionRpcUrls,
   getErrorDiagnostics,
   getObjectStringProperty,
+  logEthereumExecutionRpcFallback,
   MoveToken,
   NetworkConfig,
 } from '@argonprotocol/apps-core';
@@ -22,6 +25,7 @@ import {
   createPublicClient,
   defineChain,
   encodeFunctionData,
+  fallback,
   getAddress,
   keccak256,
   hexToBytes,
@@ -32,6 +36,7 @@ import {
   type PublicClient,
   RpcRequestError,
   serializeTransaction,
+  shouldThrow,
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
   WaitForTransactionReceiptTimeoutError,
@@ -812,14 +817,43 @@ function createEthereumPublicClientForRpc(
   executionRpcUrl: string,
   chain?: Parameters<typeof createPublicClient>[0]['chain'],
 ): PublicClient {
-  return createPublicClient({
-    ...(chain ? { chain } : {}),
-    transport: http(executionRpcUrl, {
-      retryCount: 1,
-      timeout: 15_000,
+  const executionRpcUrls = getEthereumExecutionRpcUrls(executionRpcUrl).map(url => {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.hostname !== 'host.docker.internal') {
+      return url;
+    }
+
+    parsedUrl.hostname = '127.0.0.1';
+    return parsedUrl.toString();
+  });
+  const transports = executionRpcUrls.map(url =>
+    http(url, {
+      retryCount: ETHEREUM_EXECUTION_RPC_TRANSPORT.requestRetryCount,
+      timeout: ETHEREUM_EXECUTION_RPC_TRANSPORT.timeoutMs,
       fetchFn: fetch,
     }),
+  );
+
+  const fallbackTransport = fallback(transports, {
+    retryCount: ETHEREUM_EXECUTION_RPC_TRANSPORT.fallbackRetryCount,
   });
+  const client = createPublicClient({
+    ...(chain ? { chain } : {}),
+    transport: fallbackTransport,
+  });
+  client.transport.onResponse(({ error, method, status, transport }) => {
+    if (status !== 'error' || shouldThrow(error)) {
+      return;
+    }
+
+    logEthereumExecutionRpcFallback({
+      executionRpcUrls,
+      failedRpcUrl: transport.value?.url,
+      method,
+    });
+  });
+
+  return client;
 }
 
 function convertEthereumBaseUnitsToRuntimeAmount(amountBaseUnits: bigint): bigint {
@@ -831,7 +865,7 @@ function convertEthereumBaseUnitsToRuntimeAmount(amountBaseUnits: bigint): bigin
 }
 
 export function getDefaultEthereumExecutionRpcUrl(): string | undefined {
-  return NetworkConfig.get().ethereumNetwork.executionRpcUrl.trim() || undefined;
+  return getEthereumExecutionRpcUrls()[0];
 }
 
 export function getEthereumExecutionRpcUrl(configuredExecutionRpcUrl?: string): string | undefined {

--- a/src-vue/lib/StableSwapPublicClient.ts
+++ b/src-vue/lib/StableSwapPublicClient.ts
@@ -2,11 +2,11 @@ import type { PublicClient } from 'viem';
 import { createEthereumPublicClient } from './EthereumClient.ts';
 import { NETWORK_NAME } from './Env.ts';
 
-export async function createStableSwapPublicClient(): Promise<PublicClient> {
-  if (NETWORK_NAME === 'dev-docker') {
+export async function createStableSwapPublicClient(executionRpcUrl?: string): Promise<PublicClient> {
+  if (NETWORK_NAME === 'dev-docker' && !executionRpcUrl?.trim()) {
     const { createStableSwapFixturePublicClient } = await import('./StableSwapFixturePublicClient.ts');
     return createStableSwapFixturePublicClient();
   }
 
-  return createEthereumPublicClient();
+  return createEthereumPublicClient(undefined, executionRpcUrl);
 }

--- a/src-vue/lib/StableSwaps.ts
+++ b/src-vue/lib/StableSwaps.ts
@@ -61,6 +61,7 @@ type StableSwapsOptions = {
   argonTokenAddress?: Address;
   argonotTokenAddress?: Address;
   chainId?: number;
+  executionRpcUrl?: string;
 };
 
 export class StableSwaps {
@@ -395,13 +396,13 @@ export class StableSwaps {
   public static async buildStableSwapUniswapUrl(
     argonAmountMicrogons: bigint,
     inputCurrency?: string,
-    options: Pick<StableSwapsOptions, 'argonTokenAddress'> & { chainId?: number } = {},
+    options: Pick<StableSwapsOptions, 'argonTokenAddress' | 'chainId' | 'executionRpcUrl'> = {},
   ): Promise<string | null> {
     if (argonAmountMicrogons <= 0n) {
       return null;
     }
 
-    const chainConfig = options.argonTokenAddress ? undefined : await loadEthereumChainConfig();
+    const chainConfig = options.argonTokenAddress ? undefined : await loadEthereumChainConfig(options.executionRpcUrl);
     const argonTokenAddress = options.argonTokenAddress ?? chainConfig?.argonTokenAddress;
     if (!argonTokenAddress) {
       return null;
@@ -418,9 +419,9 @@ export class StableSwaps {
 
   public static async getInputCurrency(
     inputToken: IStableSwapInputTokenSymbol,
-    options: { argonotTokenAddress?: Address } = {},
+    options: Pick<StableSwapsOptions, 'argonotTokenAddress' | 'executionRpcUrl'> = {},
   ): Promise<string | undefined> {
-    const chainConfig = await loadEthereumChainConfig();
+    const chainConfig = await loadEthereumChainConfig(options.executionRpcUrl);
     const chainId = chainConfig?.chainId ?? ChainId.MAINNET;
     const stableSwapChain = getStableSwapChainConfig(chainId);
 
@@ -551,7 +552,8 @@ export class StableSwaps {
   private async getArgonotToken(chainId: number): Promise<Token | null> {
     try {
       const argonotTokenAddress =
-        this.options.argonotTokenAddress ?? (await loadEthereumChainConfig())?.argonotTokenAddress;
+        this.options.argonotTokenAddress ??
+        (await loadEthereumChainConfig(this.options.executionRpcUrl))?.argonotTokenAddress;
       return argonotTokenAddress ? getStableSwapArgonotToken(argonotTokenAddress, chainId) : null;
     } catch {
       return null;
@@ -563,7 +565,8 @@ export class StableSwaps {
       this.argonTokenPromise ??
       (async () => {
         const argonTokenAddress =
-          this.options.argonTokenAddress ?? (await loadEthereumChainConfig())?.argonTokenAddress;
+          this.options.argonTokenAddress ??
+          (await loadEthereumChainConfig(this.options.executionRpcUrl))?.argonTokenAddress;
         if (!argonTokenAddress) {
           throw new Error('Ethereum gateway chain config is not available on this Argon network.');
         }
@@ -659,7 +662,9 @@ export class StableSwaps {
     if (!this.chainIdPromise && this.options.chainId) {
       this.chainIdPromise = Promise.resolve(this.options.chainId);
     }
-    this.chainIdPromise ??= loadEthereumChainConfig().then(x => x?.chainId ?? ChainId.MAINNET);
+    this.chainIdPromise ??= loadEthereumChainConfig(this.options.executionRpcUrl).then(
+      x => x?.chainId ?? ChainId.MAINNET,
+    );
 
     const chainIdPromise = this.chainIdPromise;
     try {

--- a/src-vue/overlays/ServerSettingsOverlay.vue
+++ b/src-vue/overlays/ServerSettingsOverlay.vue
@@ -27,7 +27,17 @@
           </div>
         </div>
 
-        <div class="text-gray-500">Beacon API URL</div>
+        <div class="flex items-center gap-1 text-gray-500">
+          Beacon API URL
+          <Tooltip
+            as-child
+            :content="`Argon requires these standard Beacon REST API routes: ${ETHEREUM_BEACON_API_REQUIRED_PATHS.join(', ')}. A custom URL is tested before it is saved.`"
+          >
+            <span class="cursor-help text-slate-400 hover:text-slate-600">
+              <InformationCircleIcon class="size-4" />
+            </span>
+          </Tooltip>
+        </div>
         <div>
           <input
             v-model="beaconApiUrlInput"
@@ -104,8 +114,12 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import dayjs from 'dayjs';
+import { InformationCircleIcon } from '@heroicons/vue/20/solid';
+import { fetch } from '@argonprotocol/apps-core';
+import type { EthereumBeaconConfigSpecResponse, EthereumVersionedLightClientUpdate } from '@argonprotocol/mainchain';
 import OverlayBase from './OverlayBase.vue';
 import CountupClock from '../components/CountupClock.vue';
+import Tooltip from '../components/Tooltip.vue';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import {
   getDefaultEthereumBeaconApiUrl,
@@ -117,6 +131,14 @@ import { getBot } from '../stores/bot.ts';
 import { getConfig } from '../stores/config.ts';
 import { getInstaller } from '../stores/installer.ts';
 import { SERVER_ENV_VARS } from '../lib/Env.ts';
+
+const ETHEREUM_BEACON_API_REQUIRED_PATHS = [
+  '/eth/v1/config/spec',
+  '/eth/v1/beacon/light_client/finality_update',
+  '/eth/v1/beacon/light_client/updates',
+] as const;
+
+const REQUEST_TIMEOUT_MS = 10_000;
 
 const bot = getBot();
 const config = getConfig();
@@ -179,6 +201,36 @@ async function saveServerSettings(args: { disableBeaconSync?: boolean } = {}) {
       throw new Error('A beacon API URL is required to activate syncing.');
     }
 
+    if (savedBeaconApiUrl) {
+      settingsActionMessage.value = 'Testing beacon API compatibility…';
+      const [spec, finalityUpdate] = await Promise.all([
+        getBeaconJson<EthereumBeaconConfigSpecResponse>(savedBeaconApiUrl, ETHEREUM_BEACON_API_REQUIRED_PATHS[0]),
+        getBeaconJson<EthereumVersionedLightClientUpdate>(savedBeaconApiUrl, ETHEREUM_BEACON_API_REQUIRED_PATHS[1]),
+      ]);
+      const slotsPerEpoch = readBeaconBigInt(spec?.data?.SLOTS_PER_EPOCH, 'SLOTS_PER_EPOCH');
+      const epochsPerSyncCommitteePeriod = readBeaconBigInt(
+        spec?.data?.EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
+        'EPOCHS_PER_SYNC_COMMITTEE_PERIOD',
+      );
+      readBeaconBigInt(spec?.data?.SLOTS_PER_HISTORICAL_ROOT, 'SLOTS_PER_HISTORICAL_ROOT');
+      const finalizedSlot = readBeaconBigInt(
+        finalityUpdate?.data?.finalized_header?.beacon?.slot,
+        'finalized light-client slot',
+        0n,
+      );
+      const currentPeriod = finalizedSlot / slotsPerEpoch / epochsPerSyncCommitteePeriod;
+      const updatesPath = `${ETHEREUM_BEACON_API_REQUIRED_PATHS[2]}?start_period=${currentPeriod}&count=1`;
+      const updates = await getBeaconJson<unknown>(savedBeaconApiUrl, updatesPath);
+
+      if (!Array.isArray(updates)) {
+        throw new Error(
+          `Beacon API compatibility check failed: ${ETHEREUM_BEACON_API_REQUIRED_PATHS[2]} returned invalid data.`,
+        );
+      }
+
+      settingsActionMessage.value = '';
+    }
+
     const previousBeaconApiUrl = config.ethereumBeaconApiUrl;
     const previousExecutionRpcUrl = config.ethereumExecutionRpcUrl;
     const shouldBeEnabled = !!getEthereumBeaconApiUrl(savedBeaconApiUrl);
@@ -231,6 +283,47 @@ async function waitForBeaconSyncState(shouldBeEnabled: boolean) {
 
     await new Promise(resolve => window.setTimeout(resolve, 1_000));
   }
+}
+
+async function getBeaconJson<T>(beaconApiUrl: string, path: string): Promise<T> {
+  let response: Response;
+  try {
+    const normalizedBaseUrl = beaconApiUrl.endsWith('/') ? beaconApiUrl : `${beaconApiUrl}/`;
+    response = await fetch(new URL(path.replace(/^\//, ''), normalizedBaseUrl), {
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Beacon API compatibility check failed for ${path}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Beacon API compatibility check failed: ${path} returned HTTP ${response.status}.`);
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new Error(`Beacon API compatibility check failed: ${path} did not return JSON.`);
+  }
+}
+
+function readBeaconBigInt(value: string | undefined, label: string, minimum = 1n): bigint {
+  if (value === undefined) {
+    throw new Error(`Beacon API compatibility check failed: ${label} is missing or invalid.`);
+  }
+
+  try {
+    const result = BigInt(value);
+    if (result >= minimum) {
+      return result;
+    }
+  } catch {
+    // The compatibility error below identifies the invalid Beacon API field.
+  }
+
+  throw new Error(`Beacon API compatibility check failed: ${label} is missing or invalid.`);
 }
 
 function validateOptionalUrl(label: string, value?: string) {

--- a/src-vue/screens/treasury-screens/components/SwapRecord.vue
+++ b/src-vue/screens/treasury-screens/components/SwapRecord.vue
@@ -79,10 +79,12 @@ import { useWallets } from '../../../stores/wallets.ts';
 import { bigIntMin, bigNumberToBigInt, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import BigNumber from 'bignumber.js';
 import { StableSwaps } from '../../../lib/StableSwaps.ts';
+import { getConfig } from '../../../stores/config.ts';
 
 dayjs.extend(utc);
 
 const currency = getCurrency();
+const config = getConfig();
 const wallets = useWallets();
 
 const { microgonToArgonNm, microgonToNm } = createNumeralHelpers(currency);
@@ -119,10 +121,13 @@ const walletOutputAmount = Vue.computed(() => {
 });
 
 async function openCurrentTrade() {
-  const inputCurrency = await StableSwaps.getInputCurrency(props.swap.inputToken);
+  const executionRpcUrl = config.ethereumExecutionRpcUrl;
+  const inputCurrency = await StableSwaps.getInputCurrency(props.swap.inputToken, { executionRpcUrl });
   if (!inputCurrency && props.swap.inputToken !== UnitOfMeasurement.ETH) return;
 
-  const swapUrl = await StableSwaps.buildStableSwapUniswapUrl(walletOutputAmount.value, inputCurrency);
+  const swapUrl = await StableSwaps.buildStableSwapUniswapUrl(walletOutputAmount.value, inputCurrency, {
+    executionRpcUrl,
+  });
   if (!swapUrl) return;
 
   await tauriOpenUrl(swapUrl);

--- a/src-vue/stores/stableSwaps.ts
+++ b/src-vue/stores/stableSwaps.ts
@@ -28,9 +28,17 @@ export const useStableSwaps = defineStore('stableSwaps', () => {
 
   let loadPromise: Promise<void> | undefined;
   let stableSwapsPromise: Promise<StableSwaps> | undefined;
+  let stableSwapsExecutionRpcUrl: string | undefined;
 
   async function getStableSwaps(): Promise<StableSwaps> {
-    stableSwapsPromise ??= createStableSwapPublicClient().then(publicClient => new StableSwaps(publicClient));
+    const executionRpcUrl = config.ethereumExecutionRpcUrl;
+    if (!stableSwapsPromise || stableSwapsExecutionRpcUrl !== executionRpcUrl) {
+      stableSwapsExecutionRpcUrl = executionRpcUrl;
+      stableSwapsPromise = createStableSwapPublicClient(executionRpcUrl).then(
+        publicClient => new StableSwaps(publicClient, { executionRpcUrl }),
+      );
+    }
+
     return await stableSwapsPromise;
   }
 


### PR DESCRIPTION
## Summary

Ethereum reads now continue through an ordered provider list when the configured or primary RPC is unavailable, with sanitized warnings showing each real endpoint transition. The same network selection drives StableSwaps and bot execution reads, while gateway proofs retain per-provider construction so stale results can advance to another endpoint without masking known Argon proof-bound failures.

Custom Beacon endpoints are checked for the REST routes and network constants required by sync before they are saved. App-side Beacon requests also preserve path-based authentication prefixes such as Alchemy's `/v2/<key>` URLs.

## Validation

- Configured execution RPC failure fell through to the next provider and returned the expected Ethereum result.
- Path-authenticated Beacon URLs retained their base prefix across finalized-header and block requests.
- 39 focused Ethereum tests passed, with bot and Vue typechecks plus repository lint checks clean.

## Follow-up

The corresponding base-path fix in `@argonprotocol/mainchain` is being handled separately before the Apps runtime pin so Alchemy works through the dependency's core sync requests as well.
