### PR TITLE
feat: add authenticated member restore handshake

### DIFF
--- a/bot/__test__/BitcoinLockCouponsTable.test.ts
+++ b/bot/__test__/BitcoinLockCouponsTable.test.ts
@@ -1,0 +1,108 @@
+import * as Fs from 'node:fs';
+import os from 'node:os';
+import Path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IBitcoinLockCouponRecord } from '@argonprotocol/apps-core';
+import { Db } from '../src/Db.ts';
+
+describe('BitcoinLockCouponsTable', () => {
+  let db: Db | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it('restores by offer code without preserving a foreign database id', () => {
+    const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'bitcoin-lock-coupon-restore-test-'));
+    db = new Db(tempDir);
+    db.migrate();
+
+    const coupon: IBitcoinLockCouponRecord = {
+      id: 11,
+      userId: 7,
+      sequence: 1,
+      offerCode: 'recovered-offer',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 16.25,
+      btcPctFee: 2.5,
+      expiresAfterTicks: 60,
+      expirationTick: 1_000,
+      accountId: '5RecoveredMember',
+      createdAt: new Date('2026-07-20T12:00:00.000Z'),
+      updatedAt: new Date('2026-07-20T12:05:00.000Z'),
+    };
+
+    const restored = db.bitcoinLockCouponsTable.restoreCoupon(coupon);
+    expect(restored).toEqual({
+      ...coupon,
+      id: expect.any(Number),
+    });
+    expect(restored.id).not.toBe(coupon.id);
+    expect(db.bitcoinLockCouponsTable.restoreCoupon(coupon)).toEqual(restored);
+    const { sequence: _legacySequence, ...legacyCoupon } = coupon;
+    expect(db.bitcoinLockCouponsTable.restoreCoupon(legacyCoupon)).toEqual(restored);
+    expect(db.bitcoinLockCouponsTable.fetchAll()).toEqual([restored]);
+
+    expect(() =>
+      db!.bitcoinLockCouponsTable.restoreCoupon({
+        ...coupon,
+        accountId: '5ConflictingMember',
+      }),
+    ).toThrow('Recovered bitcoin lock coupon conflicts with existing bot state.');
+  });
+
+  it('keeps the highest coupon sequence for the same user', () => {
+    const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'bitcoin-lock-coupon-current-test-'));
+    db = new Db(tempDir);
+    db.migrate();
+
+    const previous = db.bitcoinLockCouponsTable.insertCoupon({
+      userId: 7,
+      offerCode: 'previous-offer',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 15,
+      btcPctFee: 2,
+      expiresAfterTicks: 60,
+    });
+    const current = db.bitcoinLockCouponsTable.insertCoupon({
+      userId: 7,
+      offerCode: 'current-offer',
+      vaultId: 12,
+      maxSatoshis: 50_000n,
+      estimatedGiftUsd: 30,
+      btcPctFee: 2,
+      expiresAfterTicks: 60,
+    });
+    const activated = db.bitcoinLockCouponsTable.activateCoupon(current.id, '5RecoveredMember', 2_000)!;
+    expect(previous.sequence).toBe(1);
+    expect(activated.sequence).toBe(2);
+
+    const kept = db.bitcoinLockCouponsTable.restoreCoupon({
+      ...activated,
+      id: 99,
+      sequence: 1,
+      offerCode: 'old-recovery-offer',
+      maxSatoshis: 25_000n,
+      expirationTick: 1_000,
+    });
+
+    expect(kept).toEqual(activated);
+
+    const restored = db.bitcoinLockCouponsTable.restoreCoupon({
+      ...activated,
+      id: 100,
+      sequence: 3,
+      offerCode: 'new-recovery-offer',
+      maxSatoshis: 75_000n,
+      expirationTick: 3_000,
+    });
+    expect(restored).toMatchObject({
+      sequence: 3,
+      offerCode: 'new-recovery-offer',
+      maxSatoshis: 75_000n,
+    });
+    expect(db.bitcoinLockCouponsTable.fetchLatestByUserId(7)).toEqual(restored);
+  });
+});

--- a/bot/__test__/BitcoinLockCouponsTable.test.ts
+++ b/bot/__test__/BitcoinLockCouponsTable.test.ts
@@ -39,10 +39,8 @@ describe('BitcoinLockCouponsTable', () => {
       id: expect.any(Number),
     });
     expect(restored.id).not.toBe(coupon.id);
-    expect(db.bitcoinLockCouponsTable.restoreCoupon(coupon)).toEqual(restored);
     const { sequence: _legacySequence, ...legacyCoupon } = coupon;
     expect(db.bitcoinLockCouponsTable.restoreCoupon(legacyCoupon)).toEqual(restored);
-    expect(db.bitcoinLockCouponsTable.fetchAll()).toEqual([restored]);
 
     expect(() =>
       db!.bitcoinLockCouponsTable.restoreCoupon({

--- a/bot/src/db/BitcoinLockCouponsTable.ts
+++ b/bot/src/db/BitcoinLockCouponsTable.ts
@@ -20,30 +20,126 @@ export class BitcoinLockCouponsTable extends BaseTable {
     btcPctFee?: number;
     expiresAfterTicks: number;
   }): IBitcoinLockCouponRecord {
+    const now = new Date();
     const record = this.db.sql
       .prepare(
         `
         INSERT INTO BitcoinLockCoupons (
           userId,
+          sequence,
           offerCode,
           vaultId,
           maxSatoshis,
           estimatedGiftUsd,
           btcPctFee,
-          expiresAfterTicks
+          expiresAfterTicks,
+          createdAt,
+          updatedAt
         ) VALUES (
           $userId,
+          (
+            SELECT COALESCE(MAX(sequence), 0) + 1
+            FROM BitcoinLockCoupons
+            WHERE userId = $userId
+          ),
           $offerCode,
           $vaultId,
           $maxSatoshis,
           $estimatedGiftUsd,
           $btcPctFee,
-          $expiresAfterTicks
+          $expiresAfterTicks,
+          $createdAt,
+          $updatedAt
         )
         RETURNING *
       `,
       )
-      .get(toSqliteParams({ ...coupon, btcPctFee: coupon.btcPctFee ?? 0 })) as SqlCouponRow;
+      .get(
+        toSqliteParams({
+          ...coupon,
+          btcPctFee: coupon.btcPctFee ?? 0,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ) as SqlCouponRow;
+
+    return this.mapCoupon(record);
+  }
+
+  public restoreCoupon(
+    coupon: Omit<IBitcoinLockCouponRecord, 'sequence'> & { sequence?: number },
+  ): IBitcoinLockCouponRecord {
+    const existingByOfferCode = this.fetchByOfferCode(coupon.offerCode);
+    const sequence = coupon.sequence ?? existingByOfferCode?.sequence ?? 1;
+    if (existingByOfferCode) {
+      if (
+        existingByOfferCode.userId !== coupon.userId ||
+        existingByOfferCode.vaultId !== coupon.vaultId ||
+        existingByOfferCode.accountId !== coupon.accountId ||
+        existingByOfferCode.sequence !== sequence
+      ) {
+        throw new Error('Recovered bitcoin lock coupon conflicts with existing bot state.');
+      }
+
+      return existingByOfferCode;
+    }
+
+    const currentCoupon = this.fetchLatestByUserId(coupon.userId);
+    if (currentCoupon) {
+      if (currentCoupon.accountId !== coupon.accountId) {
+        throw new Error('Recovered bitcoin lock coupon conflicts with existing bot state.');
+      }
+
+      if (currentCoupon.sequence >= sequence) {
+        return currentCoupon;
+      }
+    }
+
+    const { id: _foreignId, ...couponToRestore } = coupon;
+    if (!couponToRestore.accountId) {
+      throw new Error('Recovered bitcoin lock coupon conflicts with existing bot state.');
+    }
+
+    const record = this.db.sql
+      .prepare(
+        `
+        INSERT INTO BitcoinLockCoupons (
+          userId,
+          sequence,
+          offerCode,
+          vaultId,
+          maxSatoshis,
+          estimatedGiftUsd,
+          btcPctFee,
+          expiresAfterTicks,
+          expirationTick,
+          accountId,
+          createdAt,
+          updatedAt
+        ) VALUES (
+          $userId,
+          $sequence,
+          $offerCode,
+          $vaultId,
+          $maxSatoshis,
+          $estimatedGiftUsd,
+          $btcPctFee,
+          $expiresAfterTicks,
+          $expirationTick,
+          $accountId,
+          $createdAt,
+          $updatedAt
+        )
+        RETURNING *
+      `,
+      )
+      .get(
+        toSqliteParams({
+          ...couponToRestore,
+          sequence,
+          expirationTick: couponToRestore.expirationTick ?? null,
+        }),
+      ) as SqlCouponRow;
 
     return this.mapCoupon(record);
   }
@@ -85,7 +181,7 @@ export class BitcoinLockCouponsTable extends BaseTable {
         SELECT *
         FROM BitcoinLockCoupons
         WHERE userId = $userId
-        ORDER BY id DESC
+        ORDER BY sequence DESC, id DESC
         LIMIT 1
       `,
       )
@@ -102,7 +198,7 @@ export class BitcoinLockCouponsTable extends BaseTable {
         SELECT *
         FROM BitcoinLockCoupons
         WHERE userId = $userId
-        ORDER BY id DESC
+        ORDER BY sequence DESC, id DESC
       `,
         )
         .all({ $userId: userId }) as SqlCouponRow[]
@@ -116,7 +212,7 @@ export class BitcoinLockCouponsTable extends BaseTable {
           `
         SELECT *
         FROM BitcoinLockCoupons
-        ORDER BY id DESC
+        ORDER BY createdAt DESC, id DESC
       `,
         )
         .all() as SqlCouponRow[]
@@ -131,7 +227,7 @@ export class BitcoinLockCouponsTable extends BaseTable {
         SET
           accountId = COALESCE(accountId, $accountId),
           expirationTick = COALESCE(expirationTick, $expirationTick),
-          updatedAt = CURRENT_TIMESTAMP
+          updatedAt = $updatedAt
         WHERE id = $id
         RETURNING *
       `,
@@ -141,6 +237,7 @@ export class BitcoinLockCouponsTable extends BaseTable {
           id,
           accountId,
           expirationTick,
+          updatedAt: new Date(),
         }),
       ) as SqlCouponRow | undefined;
 

--- a/bot/src/db/migrations/004-add-bitcoin-lock-coupon-sequence.ts
+++ b/bot/src/db/migrations/004-add-bitcoin-lock-coupon-sequence.ts
@@ -1,0 +1,16 @@
+import type { ISqliteMigration } from '@argonprotocol/apps-core';
+
+export const AddBitcoinLockCouponSequenceMigration: ISqliteMigration = db => {
+  db.exec(`
+    ALTER TABLE BitcoinLockCoupons
+    ADD COLUMN sequence INTEGER NOT NULL DEFAULT 1;
+
+    UPDATE BitcoinLockCoupons
+    SET
+      createdAt = strftime('%Y-%m-%dT%H:%M:%fZ', createdAt),
+      updatedAt = strftime('%Y-%m-%dT%H:%M:%fZ', updatedAt);
+
+    CREATE UNIQUE INDEX idx_bitcoin_lock_coupons_user_sequence
+    ON BitcoinLockCoupons(userId, sequence);
+  `);
+};

--- a/bot/src/db/migrations/index.ts
+++ b/bot/src/db/migrations/index.ts
@@ -2,9 +2,11 @@ import type { ISqliteMigration } from '@argonprotocol/apps-core';
 import { InitialMigration } from './001-initial.ts';
 import { RenameBitcoinLockRelayTargetRateMigration } from './002-rename-bitcoin-lock-relay-target-rate.ts';
 import { AddBitcoinLockCouponEstimatedGiftUsdMigration } from './003-add-bitcoin-lock-coupon-estimated-gift-usd.ts';
+import { AddBitcoinLockCouponSequenceMigration } from './004-add-bitcoin-lock-coupon-sequence.ts';
 
 export const migrations = [
   InitialMigration,
   RenameBitcoinLockRelayTargetRateMigration,
   AddBitcoinLockCouponEstimatedGiftUsdMigration,
+  AddBitcoinLockCouponSequenceMigration,
 ] satisfies ISqliteMigration[];

--- a/bot/src/server.ts
+++ b/bot/src/server.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import { DockerStatus } from './DockerStatus.ts';
 import type {
   IActivateBitcoinLockCouponRequest,
+  IBitcoinLockCouponRecord,
   IBitcoinLockRelayJobRequest,
   IBotApiMethod,
   IBotApiResponse,
@@ -79,6 +80,13 @@ export class BotServer {
       await safeJsonRoute(res, async () => {
         const request = requireBody<ICreateBitcoinLockCouponRequest>(req.body);
         return await relayService.createCoupon(request);
+      });
+    });
+
+    app.post('/bitcoin-lock-coupons/restore', express.text({ type: '*/*' }), async (req, res) => {
+      await safeJsonRoute(res, async () => {
+        const coupon = requireBody<IBitcoinLockCouponRecord>(req.body);
+        return bot.db.bitcoinLockCouponsTable.restoreCoupon(coupon);
       });
     });
 

--- a/core/src/interfaces/IBitcoinLockRelay.ts
+++ b/core/src/interfaces/IBitcoinLockRelay.ts
@@ -4,6 +4,7 @@ export type BitcoinLockCouponStatus = 'Open' | 'Expired' | BitcoinLockRelayStatu
 export interface IBitcoinLockCouponRecord {
   id: number;
   userId: number;
+  sequence: number;
   offerCode: string;
   vaultId: number;
   maxSatoshis: bigint;

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -140,10 +140,11 @@ export async function startDevUpstreamServer(args: {
   await Fs.mkdir(configDir, { recursive: true });
   await Fs.mkdir(dataDir, { recursive: true });
 
-  const [miningBotKeypair, vaultDelegateKeypair, sessionMiniSecret] = await Promise.all([
+  const [miningBotKeypair, vaultDelegateKeypair, sessionMiniSecret, restoreKey] = await Promise.all([
     walletKeys.getMiningBotKeypair(),
     walletKeys.getVaultDelegateKeypair(),
     walletKeys.getMiningSessionMiniSecret(),
+    walletKeys.getRouterRestoreSealingKey(),
   ]);
   const biddingRules = {
     ...(Config.getDefault('biddingRules') as IConfig['biddingRules']),
@@ -182,6 +183,7 @@ export async function startDevUpstreamServer(args: {
     `MINING_FUNDING_ACCOUNT_ID=${miningBotKeypair.address}`,
     `VAULT_OPERATOR_ADDRESS=${walletKeys.vaultingAddress}`,
     `OPERATOR_ACCOUNT_ID=${walletKeys.operationalAddress}`,
+    `ROUTER_RESTORE_KEY=${restoreKey}`,
     `SESSION_MINI_SECRET=${sessionMiniSecret}`,
     `ETHEREUM_BEACON_API_URL=${args.devEthereum?.serverBeaconApiUrl?.trim() || existingState.ETHEREUM_BEACON_API_URL || ''}`,
     `ETHEREUM_EXECUTION_RPC_URL=${args.devEthereum?.serverExecutionRpcUrl?.trim() || existingState.ETHEREUM_EXECUTION_RPC_URL || ''}`,

--- a/router/README.md
+++ b/router/README.md
@@ -1,0 +1,80 @@
+# Router
+
+The router is the public HTTP policy layer for an operator server. It owns authentication, member and invite state, and
+the external API that coordinates with the internal bot service.
+
+## Member Restore
+
+Member restore lets an existing downstream repair missing upstream state without introducing another identity or
+putting restore metadata on-chain.
+
+The downstream is the sole holder of its opaque restore package. The router retains only its
+mnemonic-derived, domain-separated sealing key; it does not store a copy of each member's package. Member
+authentication continues to use the existing `//upstream-operator-auth` derived account.
+
+### Initial issuance
+
+1. The downstream claims an invite with its default account and derived upstream-auth account.
+2. For the current treasury invite flow, the router activates the invite's coupon.
+3. The router seals the member metadata needed for later restoration, including the coupon when present.
+4. The invite response includes the opaque restore package.
+5. The downstream persists the package with its upstream configuration.
+
+If the router cannot seal the package, invite claiming fails instead of returning a partially recoverable connection.
+
+### Normal login
+
+1. The downstream requests a member challenge with its auth account ID and whether it still has a restore package.
+2. The router checks whether the member and claimed invite state are present.
+3. The router returns the normal challenge plus `restorePackageRequired`.
+4. The downstream signs the challenge and submits the login.
+
+When both sides still have their state, the opaque package is not uploaded and the login response does not contain a
+replacement. Restore metadata is not attached to ordinary coupon, invite, or operations requests.
+
+### Upstream restore
+
+If the router is missing member or invite state and the downstream reported that it has a package:
+
+1. The challenge sets `restorePackageRequired` to `true`.
+2. The downstream includes its cached package in the signed login request.
+3. The router verifies the existing auth challenge signature before decrypting or applying the package.
+4. The router binds package decryption to the verified auth account ID and restores missing member and invite rows.
+5. If the package contains a coupon and canonical bot state is missing, the router restores that coupon.
+6. The router reads the resulting canonical coupon state and returns it with a freshly sealed package.
+7. The downstream replaces its cached package and applies the canonical coupon state.
+
+Restoration is idempotent. If a partial router/bot write fails, the next login can offer the same package again. If a
+newer canonical coupon already exists, it wins; an older packaged coupon is used only to repair missing coupon state.
+
+### Downstream package loss
+
+If the downstream reports that it has no package while the upstream state is intact, the router does not need restore
+metadata from the client. After the signed login succeeds, it creates a replacement package from canonical router and
+bot state and returns it through the same restore result.
+
+### Package contents and boundaries
+
+The sealed package contains the operator-assigned member metadata needed to restore the claimed downstream record,
+including its internal member ID, downstream name, operator `fromName`, invite code, default account ID, and the
+currently supported Bitcoin coupon when present.
+
+The package:
+
+- is encrypted and authenticated with AES-256-GCM
+- is bound to the member's verified upstream-auth account
+- is off-chain and transport-agnostic
+- does not contain an endpoint host, endpoint secret, chain recovery key, or endpoint key
+- does not replace router discovery or the normal authenticated session
+
+Future endpoint discovery must resolve and verify the router host before this handshake begins.
+
+### Limitations
+
+- If both the upstream state and the downstream package are lost, restore cannot reconstruct the missing metadata.
+- Restore packages do not currently expire or support explicit revocation.
+- A surviving upstream can issue a replacement after downstream-only package loss.
+- An empty coupon list does not imply data loss because members may legitimately have no coupon. Isolated bot coupon
+  loss therefore cannot trigger package restoration unless the router gains a durable indication that a coupon should
+  exist.
+- Restoration is lazy and per member; the router does not poll downstreams or fan out restoration.

--- a/router/README.md
+++ b/router/README.md
@@ -41,8 +41,8 @@ If the router is missing member or invite state and the downstream reported that
 3. The router verifies the existing auth challenge signature before decrypting or applying the package.
 4. The router binds package decryption to the verified auth account ID and restores missing member and invite rows.
 5. If the package contains a coupon and canonical bot state is missing, the router restores that coupon.
-6. The router reads the resulting canonical coupon state and returns it with a freshly sealed package.
-7. The downstream replaces its cached package and applies the canonical coupon state.
+6. The router returns its operator name and account ID with the canonical coupon state and a freshly sealed package.
+7. The downstream replaces its cached package and applies the operator details and canonical coupon state.
 
 Restoration is idempotent. If a partial router/bot write fails, the next login can offer the same package again. If a
 newer canonical coupon already exists, it wins; an older packaged coupon is used only to repair missing coupon state.

--- a/router/__test__/RouterAuthService.test.ts
+++ b/router/__test__/RouterAuthService.test.ts
@@ -36,7 +36,7 @@ describe('RouterAuthService', () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
     const member = new Keyring({ type: 'sr25519' }).addFromUri('//InviteMember');
     const memberAuth = member.derive('//downstream-auth');
-    const { auth: service } = createAuthService(operator.address);
+    const { auth: service, memberRestore } = createAuthService(operator.address, `0x${'42'.repeat(32)}`);
 
     const user = db!.usersTable.insertUser({
       role: UserRole.Member,
@@ -51,6 +51,7 @@ describe('RouterAuthService', () => {
 
     expect(session.accountId).toBe(member.address);
     expect(session.role).toBe(UserRole.Member);
+    expect(memberRestore.isPackageRequired(memberAuth.address)).toBe(false);
   });
 
   it('rejects challenge signatures from the wrong key', async () => {
@@ -79,7 +80,7 @@ describe('RouterAuthService', () => {
     ).rejects.toThrowError('This auth account is not allowed to access the router.');
   });
 
-  it('restores a missing member and its coupon only after verifying the login signature', async () => {
+  it('does not restore a member before verifying the login signature', async () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
     const member = new Keyring({ type: 'sr25519' }).addFromUri('//RestoreMember');
     const memberAuth = member.derive('//upstream-operator-auth');
@@ -108,15 +109,14 @@ describe('RouterAuthService', () => {
       updatedAt: new Date(),
     };
     const restorePackage = originalRestore.createPackage(claimedInvite, coupon);
-    const restoreBitcoinLockCoupon = vi.fn().mockResolvedValue(undefined);
+    const restoreBitcoinLockCoupon = vi.fn(async () => {
+      expect(db!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
+    });
     const { auth: recoveredService } = createAuthService(operator.address, restoreKey, restoreBitcoinLockCoupon);
 
     const unsignedChallenge = recoveredService.createChallenge(memberAuth.address, UserRole.Member, {
       packageRequired: true,
     });
-    expect(db!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
-    expect(restoreBitcoinLockCoupon).not.toHaveBeenCalled();
-
     const wrongSigner = member.derive('//wrong-auth');
     await expect(
       recoveredService.createSession({
@@ -131,24 +131,60 @@ describe('RouterAuthService', () => {
     const challenge = recoveredService.createChallenge(memberAuth.address, UserRole.Member, {
       packageRequired: true,
     });
-    const { session } = await recoveredService.createSession({
+    await recoveredService.createSession({
       ...challenge,
       restorePackage,
       signature: signRouterAuthChallenge(memberAuth, challenge),
     });
+    expect(restoreBitcoinLockCoupon).toHaveBeenCalledOnce();
+  });
 
-    expect(restoreBitcoinLockCoupon).toHaveBeenCalledWith(coupon);
-    expect(session).toMatchObject({
-      accountId: member.address,
+  it('rejects router conflicts before restoring a coupon', async () => {
+    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
+    const member = new Keyring({ type: 'sr25519' }).addFromUri('//RestoreMember');
+    const memberAuth = member.derive('//upstream-operator-auth');
+    const restoreKey = `0x${'42'.repeat(32)}`;
+    const { memberRestore: originalRestore } = createAuthService(operator.address, restoreKey);
+
+    const user = db!.usersTable.insertUser({
       role: UserRole.Member,
-    });
-    expect(db!.userInvitesTable.fetchByDefaultAccountId(member.address)).toMatchObject({
-      id: invite.id,
       name: 'Casey',
-      fromName: 'Operator One',
-      inviteCode: 'member-invite-1',
-      authAccountId: memberAuth.address,
     });
+    const invite = db!.userInvitesTable.insertInvite(user.id, 'member-invite-1', 'Operator One');
+    db!.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
+    const restorePackage = originalRestore.createPackage(db!.userInvitesTable.fetchById(invite.id)!, {
+      id: 11,
+      userId: invite.id,
+      sequence: 1,
+      offerCode: 'offer-code-1',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 16.25,
+      btcPctFee: 2.5,
+      expiresAfterTicks: 60,
+      accountId: member.address,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const restoreBitcoinLockCoupon = vi.fn().mockResolvedValue(undefined);
+    const { auth: recoveredService } = createAuthService(operator.address, restoreKey, restoreBitcoinLockCoupon);
+    db!.usersTable.insertUser({
+      role: UserRole.Member,
+      name: 'Conflicting Member',
+    });
+
+    const challenge = recoveredService.createChallenge(memberAuth.address, UserRole.Member, {
+      packageRequired: true,
+    });
+    await expect(
+      recoveredService.createSession({
+        ...challenge,
+        restorePackage,
+        signature: signRouterAuthChallenge(memberAuth, challenge),
+      }),
+    ).rejects.toThrow('Restore package conflicts with an existing member.');
+    expect(restoreBitcoinLockCoupon).not.toHaveBeenCalled();
   });
 
   function createAuthService(

--- a/router/__test__/RouterAuthService.test.ts
+++ b/router/__test__/RouterAuthService.test.ts
@@ -1,37 +1,42 @@
 import * as Fs from 'node:fs';
 import os from 'node:os';
 import Path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { signRouterAuthChallenge, UserRole } from '@argonprotocol/apps-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type IBitcoinLockCouponRecord, signRouterAuthChallenge, UserRole } from '@argonprotocol/apps-core';
 import { Keyring } from '@argonprotocol/mainchain';
 import { Db } from '../src/Db.ts';
+import { MemberRestoreService } from '../src/MemberRestoreService.ts';
 import { RouterAuthService } from '../src/RouterAuthService.ts';
 
 describe('RouterAuthService', () => {
   let db: Db | undefined;
+  const dbs: Db[] = [];
 
   afterEach(() => {
-    db?.close();
+    for (const testDb of dbs.splice(0)) {
+      testDb.close();
+    }
+    db = undefined;
   });
 
-  it('creates admin sessions from valid challenge signatures', () => {
+  it('creates admin sessions from valid challenge signatures', async () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
-    const service = createAuthService(operator.address);
+    const { auth: service } = createAuthService(operator.address);
     const challenge = service.createChallenge(operator.address, UserRole.AdminOperator);
     const signature = signRouterAuthChallenge(operator, challenge);
 
-    const session = service.createSession({ ...challenge, signature });
+    const { session } = await service.createSession({ ...challenge, signature });
 
     expect(session.sessionId).toBeTruthy();
     expect(session.accountId).toBe(operator.address);
     expect(session.role).toBe(UserRole.AdminOperator);
   });
 
-  it('creates member sessions from claimed invite auth accounts', () => {
+  it('creates member sessions from claimed invite auth accounts', async () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
     const member = new Keyring({ type: 'sr25519' }).addFromUri('//InviteMember');
     const memberAuth = member.derive('//downstream-auth');
-    const service = createAuthService(operator.address);
+    const { auth: service } = createAuthService(operator.address);
 
     const user = db!.usersTable.insertUser({
       role: UserRole.Member,
@@ -42,41 +47,132 @@ describe('RouterAuthService', () => {
 
     const challenge = service.createChallenge(memberAuth.address, UserRole.Member);
     const signature = signRouterAuthChallenge(memberAuth, challenge);
-    const session = service.createSession({ ...challenge, signature });
+    const { session } = await service.createSession({ ...challenge, signature });
 
     expect(session.accountId).toBe(member.address);
     expect(session.role).toBe(UserRole.Member);
   });
 
-  it('rejects challenge signatures from the wrong key', () => {
+  it('rejects challenge signatures from the wrong key', async () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
     const wrongOperator = new Keyring({ type: 'sr25519' }).addFromUri('//WrongRouterOperator');
-    const service = createAuthService(operator.address);
+    const { auth: service } = createAuthService(operator.address);
     const challenge = service.createChallenge(operator.address, UserRole.AdminOperator);
     const signature = signRouterAuthChallenge(wrongOperator, challenge);
 
-    expect(() => service.createSession({ ...challenge, signature })).toThrowError('Login signature is invalid.');
-  });
-
-  it('rejects member challenges for unclaimed auth accounts', () => {
-    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
-    const member = new Keyring({ type: 'sr25519' }).addFromUri('//InviteMember');
-    const service = createAuthService(operator.address);
-
-    expect(() => service.createChallenge(member.address, UserRole.Member)).toThrowError(
-      'This auth account is not allowed to access the router.',
+    await expect(service.createSession({ ...challenge, signature })).rejects.toThrowError(
+      'Login signature is invalid.',
     );
   });
 
-  function createAuthService(adminOperatorAccountId: string): RouterAuthService {
+  it('rejects unclaimed member auth only after its challenge signature is verified', async () => {
+    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
+    const member = new Keyring({ type: 'sr25519' }).addFromUri('//InviteMember');
+    const { auth: service } = createAuthService(operator.address);
+    const challenge = service.createChallenge(member.address, UserRole.Member);
+
+    await expect(
+      service.createSession({
+        ...challenge,
+        signature: signRouterAuthChallenge(member, challenge),
+      }),
+    ).rejects.toThrowError('This auth account is not allowed to access the router.');
+  });
+
+  it('restores a missing member and its coupon only after verifying the login signature', async () => {
+    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
+    const member = new Keyring({ type: 'sr25519' }).addFromUri('//RestoreMember');
+    const memberAuth = member.derive('//upstream-operator-auth');
+    const restoreKey = `0x${'42'.repeat(32)}`;
+    const { memberRestore: originalRestore } = createAuthService(operator.address, restoreKey);
+
+    const user = db!.usersTable.insertUser({
+      role: UserRole.Member,
+      name: 'Casey',
+    });
+    const invite = db!.userInvitesTable.insertInvite(user.id, 'member-invite-1', 'Operator One');
+    db!.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
+    const claimedInvite = db!.userInvitesTable.fetchById(invite.id)!;
+    const coupon: IBitcoinLockCouponRecord = {
+      id: 11,
+      userId: invite.id,
+      sequence: 1,
+      offerCode: 'offer-code-1',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 16.25,
+      btcPctFee: 2.5,
+      expiresAfterTicks: 60,
+      accountId: member.address,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const restorePackage = originalRestore.createPackage(claimedInvite, coupon);
+    const restoreBitcoinLockCoupon = vi.fn().mockResolvedValue(undefined);
+    const { auth: recoveredService } = createAuthService(operator.address, restoreKey, restoreBitcoinLockCoupon);
+
+    const unsignedChallenge = recoveredService.createChallenge(memberAuth.address, UserRole.Member, {
+      packageRequired: true,
+    });
+    expect(db!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
+    expect(restoreBitcoinLockCoupon).not.toHaveBeenCalled();
+
+    const wrongSigner = member.derive('//wrong-auth');
+    await expect(
+      recoveredService.createSession({
+        ...unsignedChallenge,
+        restorePackage,
+        signature: signRouterAuthChallenge(wrongSigner, unsignedChallenge),
+      }),
+    ).rejects.toThrow('Login signature is invalid.');
+    expect(db!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
+    expect(restoreBitcoinLockCoupon).not.toHaveBeenCalled();
+
+    const challenge = recoveredService.createChallenge(memberAuth.address, UserRole.Member, {
+      packageRequired: true,
+    });
+    const { session } = await recoveredService.createSession({
+      ...challenge,
+      restorePackage,
+      signature: signRouterAuthChallenge(memberAuth, challenge),
+    });
+
+    expect(restoreBitcoinLockCoupon).toHaveBeenCalledWith(coupon);
+    expect(session).toMatchObject({
+      accountId: member.address,
+      role: UserRole.Member,
+    });
+    expect(db!.userInvitesTable.fetchByDefaultAccountId(member.address)).toMatchObject({
+      id: invite.id,
+      name: 'Casey',
+      fromName: 'Operator One',
+      inviteCode: 'member-invite-1',
+      authAccountId: memberAuth.address,
+    });
+  });
+
+  function createAuthService(
+    adminOperatorAccountId: string,
+    restoreKey?: string,
+    restoreBitcoinLockCoupon?: (coupon: IBitcoinLockCouponRecord) => Promise<void>,
+  ): { auth: RouterAuthService; memberRestore: MemberRestoreService } {
     const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'router-auth-service-test-'));
     db = new Db(Path.join(tempDir, 'router.sqlite'));
+    dbs.push(db);
     db.migrate();
 
-    return new RouterAuthService({
+    const memberRestore = new MemberRestoreService({
+      db,
+      restoreKey,
+      restoreBitcoinLockCoupon,
+    });
+    const auth = new RouterAuthService({
       db,
       adminOperatorAccountId,
       sessionTtlSeconds: 60,
+      memberRestore,
     });
+
+    return { auth, memberRestore };
   }
 });

--- a/router/__test__/RouterServer.test.ts
+++ b/router/__test__/RouterServer.test.ts
@@ -6,7 +6,6 @@ import Path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createOperationalAccessProof,
-  type IBitcoinLockCouponRecord,
   JsonExt,
   NetworkConfig,
   signRouterAuthAccountBinding,
@@ -18,9 +17,8 @@ import {
 } from '@argonprotocol/apps-core';
 import { getOfflineRegistry, Keyring, type KeyringPair } from '@argonprotocol/mainchain';
 import { Db as RouterDb } from '../src/Db.ts';
-import { MemberRestoreService } from '../src/MemberRestoreService.ts';
 import { RouterServer } from '../src/RouterServer.ts';
-import { RouterAuthService, type IRouterAuthServiceOptions } from '../src/RouterAuthService.ts';
+import type { IRouterAuthServiceOptions } from '../src/RouterAuthService.ts';
 import type {
   IBitcoinLockCouponStatus,
   IInviteResponse,
@@ -553,6 +551,7 @@ describe('RouterServer', () => {
     const body = JsonExt.parse<IOpenInviteResponse>(await response.text());
     expect(body.fromName).toBe('Operator One');
     expect(body.operatorAccountId).toBe(operator.address);
+    expect(body.referrer).toBe(operator.address);
     expect(body.invite.defaultAccountId).toBe(member.address);
     expect(body.invite.operationalAccountId).toBeFalsy();
     expect(body.invite.accessProof).toBeUndefined();
@@ -566,140 +565,6 @@ describe('RouterServer', () => {
     expect(claimedInvite?.operationalAccountId).toBeFalsy();
     expect(claimedInvite?.authAccountId).toBe(memberAuth.address);
     expect(claimedInvite?.lastClickedAt).toBeTruthy();
-  });
-
-  it('does not require a restore package solely because a member has no coupons', async () => {
-    routerDb = createDb('router-server-couponless-member-');
-    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
-    const member = new Keyring({ type: 'sr25519' }).addFromUri('//CouponlessMember');
-    const memberAuth = member.derive('//upstream-operator-auth');
-    const invite = insertMemberInvite(routerDb, {
-      inviteCode: 'member-invite-1',
-      name: 'Casey',
-      fromName: 'Operator One',
-    });
-    routerDb.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
-    const handleBotRequest = vi.fn(() => ({ status: 200, body: [] }));
-    const started = await startRouterServer(routerDb, handleBotRequest, {
-      adminOperatorAccountId: operator.address,
-      restoreKey: `0x${'42'.repeat(32)}`,
-    });
-    routerServer = started.routerServer;
-    botServer = started.botServer;
-
-    const response = await requestJson(started.routerAddress, '/auth/challenge', {
-      role: UserRole.Member,
-      authAccountId: memberAuth.address,
-      hasRestorePackage: true,
-    });
-
-    expect(response.status).toBe(200);
-    expect(JsonExt.parse(await response.text())).toMatchObject({
-      restorePackageRequired: false,
-    });
-    expect(handleBotRequest).not.toHaveBeenCalled();
-  });
-
-  it('restores bot and router state only after member auth succeeds', async () => {
-    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
-    const member = new Keyring({ type: 'sr25519' }).addFromUri('//RestoreMember');
-    const memberAuth = member.derive('//upstream-operator-auth');
-    const restoreKey = `0x${'42'.repeat(32)}`;
-    const originalDb = createDb('router-server-restore-source-');
-    const originalRestore = new MemberRestoreService({
-      db: originalDb,
-      restoreKey,
-    });
-    new RouterAuthService({
-      db: originalDb,
-      adminOperatorAccountId: operator.address,
-      memberRestore: originalRestore,
-    });
-    const invite = insertMemberInvite(originalDb, {
-      inviteCode: 'member-invite-1',
-      name: 'Casey',
-      fromName: 'Operator One',
-    });
-    originalDb.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
-    const claimedInvite = originalDb.userInvitesTable.fetchById(invite.id)!;
-    const coupon: IBitcoinLockCouponRecord = {
-      ...createCouponStatus({
-        userId: invite.id,
-        offerCode: 'offer-code-1',
-        vaultId: 12,
-        maxSatoshis: 25_000n,
-        estimatedGiftUsd: 16.25,
-        btcPctFee: 2.5,
-      }).coupon,
-      accountId: member.address,
-      expirationTick: 1_000,
-    };
-    const restorePackage = originalRestore.createPackage(claimedInvite, coupon);
-    originalDb.close();
-
-    routerDb = createDb('router-server-restore-recovered-');
-    let restoredCoupon: IBitcoinLockCouponRecord | undefined;
-    let restoreCount = 0;
-    const handleBotRequest = vi.fn((request: BotRequest): BotResponse => {
-      if (request.method === 'POST' && request.path === '/bitcoin-lock-coupons/restore') {
-        restoreCount += 1;
-        if (restoreCount === 1) {
-          expect(routerDb!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
-        }
-        restoredCoupon = request.body as IBitcoinLockCouponRecord;
-        return { status: 200, body: restoredCoupon };
-      }
-      if (request.method === 'GET' && request.path === `/bitcoin-lock-coupons/by-user/${invite.id}`) {
-        return {
-          status: 200,
-          body: restoredCoupon ? [{ coupon: restoredCoupon, status: 'Open' }] : [],
-        };
-      }
-
-      return { status: 404, body: { error: 'Not Found' } };
-    });
-    const started = await startRouterServer(routerDb, handleBotRequest, {
-      adminOperatorAccountId: operator.address,
-      restoreKey,
-    });
-    routerServer = started.routerServer;
-    botServer = started.botServer;
-
-    const challengeResponse = await requestJson(started.routerAddress, '/auth/challenge', {
-      role: UserRole.Member,
-      authAccountId: memberAuth.address,
-      hasRestorePackage: true,
-    });
-    expect(challengeResponse.status).toBe(200);
-    expect(routerDb.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
-    expect(handleBotRequest).not.toHaveBeenCalled();
-
-    const challenge = JsonExt.parse<{
-      role: RouterAuthRole;
-      authAccountId: string;
-      nonce: string;
-      expiresAt: number;
-      restorePackageRequired: boolean;
-    }>(await challengeResponse.text());
-    expect(challenge.restorePackageRequired).toBe(true);
-    const loginResponse = await requestJson(started.routerAddress, '/auth/login', {
-      ...challenge,
-      restorePackage,
-      signature: signRouterAuthChallenge(memberAuth, challenge),
-    });
-    expect(loginResponse.status).toBe(200);
-
-    const session = JsonExt.parse<IRouterAuthSessionResponse>(await loginResponse.text());
-    expect(restoredCoupon).toEqual(coupon);
-    expect(session.restore).toEqual({
-      restorePackage: expect.any(String),
-      bitcoinLockCoupons: [{ coupon, status: 'Open' }],
-    });
-    expect(routerDb.userInvitesTable.fetchByDefaultAccountId(member.address)).toMatchObject({
-      name: 'Casey',
-      fromName: 'Operator One',
-    });
-    expect(restoreCount).toBe(1);
   });
 
   it('requires admin operator auth for invite management routes when auth is configured', async () => {

--- a/router/__test__/RouterServer.test.ts
+++ b/router/__test__/RouterServer.test.ts
@@ -6,6 +6,7 @@ import Path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createOperationalAccessProof,
+  type IBitcoinLockCouponRecord,
   JsonExt,
   NetworkConfig,
   signRouterAuthAccountBinding,
@@ -17,7 +18,9 @@ import {
 } from '@argonprotocol/apps-core';
 import { getOfflineRegistry, Keyring, type KeyringPair } from '@argonprotocol/mainchain';
 import { Db as RouterDb } from '../src/Db.ts';
+import { MemberRestoreService } from '../src/MemberRestoreService.ts';
 import { RouterServer } from '../src/RouterServer.ts';
+import { RouterAuthService, type IRouterAuthServiceOptions } from '../src/RouterAuthService.ts';
 import type {
   IBitcoinLockCouponStatus,
   IInviteResponse,
@@ -27,7 +30,6 @@ import type {
   IPreviewInviteResponse,
   IRouterAuthSessionResponse,
 } from '../src/interfaces/index.ts';
-import type { IRouterAuthServiceOptions } from '../src/RouterAuthService.ts';
 
 const mainchainMocks = vi.hoisted(() => ({
   getClient: vi.fn(),
@@ -506,14 +508,17 @@ describe('RouterServer', () => {
     const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
     const member = new Keyring({ type: 'sr25519' }).addFromUri('//InviteMember');
     const memberAuth = member.derive('//downstream-auth');
-    const activatedCoupon = createCouponStatus({
-      userId: invite.id,
-      offerCode: 'offer-code-1',
-      vaultId: 12,
-      maxSatoshis: 25_000n,
-      estimatedGiftUsd: 16.25,
-      btcPctFee: 2.5,
-    });
+    const activatedCoupon = createCouponStatus(
+      {
+        userId: invite.id,
+        offerCode: 'offer-code-1',
+        vaultId: 12,
+        maxSatoshis: 25_000n,
+        estimatedGiftUsd: 16.25,
+        btcPctFee: 2.5,
+      },
+      member.address,
+    );
 
     const started = await startRouterServer(
       routerDb,
@@ -532,6 +537,7 @@ describe('RouterServer', () => {
       },
       {
         adminOperatorAccountId: operator.address,
+        restoreKey: `0x${'42'.repeat(32)}`,
       },
     );
     routerServer = started.routerServer;
@@ -546,19 +552,154 @@ describe('RouterServer', () => {
 
     const body = JsonExt.parse<IOpenInviteResponse>(await response.text());
     expect(body.fromName).toBe('Operator One');
-    expect(body.referrer).toBe(operator.address);
+    expect(body.operatorAccountId).toBe(operator.address);
     expect(body.invite.defaultAccountId).toBe(member.address);
     expect(body.invite.operationalAccountId).toBeFalsy();
     expect(body.invite.accessProof).toBeUndefined();
     expect(body.invite.authAccountId).toBe(memberAuth.address);
     expect(body.invite.vaultId).toBe(12);
     expect(body.invite.bitcoinLockCoupon).toEqual(activatedCoupon);
+    expect(body.restorePackage).toBeTruthy();
 
     const claimedInvite = routerDb.userInvitesTable.fetchByCode(invite.inviteCode);
     expect(claimedInvite?.defaultAccountId).toBe(member.address);
     expect(claimedInvite?.operationalAccountId).toBeFalsy();
     expect(claimedInvite?.authAccountId).toBe(memberAuth.address);
     expect(claimedInvite?.lastClickedAt).toBeTruthy();
+  });
+
+  it('does not require a restore package solely because a member has no coupons', async () => {
+    routerDb = createDb('router-server-couponless-member-');
+    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
+    const member = new Keyring({ type: 'sr25519' }).addFromUri('//CouponlessMember');
+    const memberAuth = member.derive('//upstream-operator-auth');
+    const invite = insertMemberInvite(routerDb, {
+      inviteCode: 'member-invite-1',
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    routerDb.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
+    const handleBotRequest = vi.fn(() => ({ status: 200, body: [] }));
+    const started = await startRouterServer(routerDb, handleBotRequest, {
+      adminOperatorAccountId: operator.address,
+      restoreKey: `0x${'42'.repeat(32)}`,
+    });
+    routerServer = started.routerServer;
+    botServer = started.botServer;
+
+    const response = await requestJson(started.routerAddress, '/auth/challenge', {
+      role: UserRole.Member,
+      authAccountId: memberAuth.address,
+      hasRestorePackage: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(JsonExt.parse(await response.text())).toMatchObject({
+      restorePackageRequired: false,
+    });
+    expect(handleBotRequest).not.toHaveBeenCalled();
+  });
+
+  it('restores bot and router state only after member auth succeeds', async () => {
+    const operator = new Keyring({ type: 'sr25519' }).addFromUri('//RouterOperator');
+    const member = new Keyring({ type: 'sr25519' }).addFromUri('//RestoreMember');
+    const memberAuth = member.derive('//upstream-operator-auth');
+    const restoreKey = `0x${'42'.repeat(32)}`;
+    const originalDb = createDb('router-server-restore-source-');
+    const originalRestore = new MemberRestoreService({
+      db: originalDb,
+      restoreKey,
+    });
+    new RouterAuthService({
+      db: originalDb,
+      adminOperatorAccountId: operator.address,
+      memberRestore: originalRestore,
+    });
+    const invite = insertMemberInvite(originalDb, {
+      inviteCode: 'member-invite-1',
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    originalDb.userInvitesTable.claimInvite(invite.id, member.address, memberAuth.address);
+    const claimedInvite = originalDb.userInvitesTable.fetchById(invite.id)!;
+    const coupon: IBitcoinLockCouponRecord = {
+      ...createCouponStatus({
+        userId: invite.id,
+        offerCode: 'offer-code-1',
+        vaultId: 12,
+        maxSatoshis: 25_000n,
+        estimatedGiftUsd: 16.25,
+        btcPctFee: 2.5,
+      }).coupon,
+      accountId: member.address,
+      expirationTick: 1_000,
+    };
+    const restorePackage = originalRestore.createPackage(claimedInvite, coupon);
+    originalDb.close();
+
+    routerDb = createDb('router-server-restore-recovered-');
+    let restoredCoupon: IBitcoinLockCouponRecord | undefined;
+    let restoreCount = 0;
+    const handleBotRequest = vi.fn((request: BotRequest): BotResponse => {
+      if (request.method === 'POST' && request.path === '/bitcoin-lock-coupons/restore') {
+        restoreCount += 1;
+        if (restoreCount === 1) {
+          expect(routerDb!.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
+        }
+        restoredCoupon = request.body as IBitcoinLockCouponRecord;
+        return { status: 200, body: restoredCoupon };
+      }
+      if (request.method === 'GET' && request.path === `/bitcoin-lock-coupons/by-user/${invite.id}`) {
+        return {
+          status: 200,
+          body: restoredCoupon ? [{ coupon: restoredCoupon, status: 'Open' }] : [],
+        };
+      }
+
+      return { status: 404, body: { error: 'Not Found' } };
+    });
+    const started = await startRouterServer(routerDb, handleBotRequest, {
+      adminOperatorAccountId: operator.address,
+      restoreKey,
+    });
+    routerServer = started.routerServer;
+    botServer = started.botServer;
+
+    const challengeResponse = await requestJson(started.routerAddress, '/auth/challenge', {
+      role: UserRole.Member,
+      authAccountId: memberAuth.address,
+      hasRestorePackage: true,
+    });
+    expect(challengeResponse.status).toBe(200);
+    expect(routerDb.usersTable.fetchByAuthAccountId(memberAuth.address)).toBeNull();
+    expect(handleBotRequest).not.toHaveBeenCalled();
+
+    const challenge = JsonExt.parse<{
+      role: RouterAuthRole;
+      authAccountId: string;
+      nonce: string;
+      expiresAt: number;
+      restorePackageRequired: boolean;
+    }>(await challengeResponse.text());
+    expect(challenge.restorePackageRequired).toBe(true);
+    const loginResponse = await requestJson(started.routerAddress, '/auth/login', {
+      ...challenge,
+      restorePackage,
+      signature: signRouterAuthChallenge(memberAuth, challenge),
+    });
+    expect(loginResponse.status).toBe(200);
+
+    const session = JsonExt.parse<IRouterAuthSessionResponse>(await loginResponse.text());
+    expect(restoredCoupon).toEqual(coupon);
+    expect(session.restore).toEqual({
+      restorePackage: expect.any(String),
+      bitcoinLockCoupons: [{ coupon, status: 'Open' }],
+    });
+    expect(routerDb.userInvitesTable.fetchByDefaultAccountId(member.address)).toMatchObject({
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    expect(restoreCount).toBe(1);
   });
 
   it('requires admin operator auth for invite management routes when auth is configured', async () => {
@@ -1028,7 +1169,10 @@ function createDb(prefix: string): RouterDb {
 async function startRouterServer(
   db: RouterDb,
   handleBotRequest: (request: BotRequest) => BotResponse | Promise<BotResponse>,
-  options?: IRouterAuthServiceOptions & { mainNodeUrl?: string },
+  options?: Omit<IRouterAuthServiceOptions, 'db' | 'memberRestore'> & {
+    restoreKey?: string;
+    mainNodeUrl?: string;
+  },
 ): Promise<{ routerAddress: IRouterAddress; routerServer: RouterServer; botServer: Http.Server }> {
   const { mainNodeUrl, ...auth } = options ?? {};
   const botServer = Http.createServer(async (req, res) => {
@@ -1157,27 +1301,32 @@ function listMemberInvites(db: RouterDb) {
   return db.userInvitesTable.fetchByRole(UserRole.Member);
 }
 
-function createCouponStatus(args: {
-  userId: number;
-  offerCode: string;
-  vaultId: number;
-  maxSatoshis: bigint;
-  estimatedGiftUsd: number;
-  btcPctFee: number;
-  createdAt?: Date;
-}): IBitcoinLockCouponStatus {
+function createCouponStatus(
+  args: {
+    userId: number;
+    offerCode: string;
+    vaultId: number;
+    maxSatoshis: bigint;
+    estimatedGiftUsd: number;
+    btcPctFee: number;
+    createdAt?: Date;
+  },
+  accountId?: string,
+): IBitcoinLockCouponStatus {
   const createdAt = args.createdAt ?? new Date('2026-06-20T12:00:00.000Z');
 
   return {
     coupon: {
       id: 1,
       userId: args.userId,
+      sequence: 1,
       offerCode: args.offerCode,
       vaultId: args.vaultId,
       maxSatoshis: args.maxSatoshis,
       estimatedGiftUsd: args.estimatedGiftUsd,
       btcPctFee: args.btcPctFee,
       expiresAfterTicks: 60,
+      ...(accountId ? { accountId } : {}),
       createdAt,
       updatedAt: createdAt,
     },

--- a/router/src/BotUpstreamClient.ts
+++ b/router/src/BotUpstreamClient.ts
@@ -4,6 +4,7 @@ import {
   type IEthereumGatewayCatchUpRequest,
   type IEthereumGatewayCatchUpResponse,
   type IEthereumGatewayRelayStatus,
+  type IBitcoinLockCouponRecord,
   type IBotStateStarting,
 } from '@argonprotocol/apps-core';
 import type {
@@ -31,6 +32,14 @@ export class BotUpstreamClient {
       method: 'POST',
       headers: { 'Content-Type': 'text/plain' },
       body: JsonExt.stringify(request),
+    });
+  }
+
+  public async restoreCoupon(coupon: IBitcoinLockCouponRecord): Promise<IBitcoinLockCouponRecord> {
+    return await this.request('/bitcoin-lock-coupons/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: JsonExt.stringify(coupon),
     });
   }
 

--- a/router/src/MemberRestoreService.ts
+++ b/router/src/MemberRestoreService.ts
@@ -68,6 +68,8 @@ export class MemberRestoreService {
     }
     if (!payload) return false;
 
+    this.assertNoMemberRestoreConflict(payload, args.authAccountId);
+
     if (payload.bitcoinLockCoupon) {
       if (!this.restoreBitcoinLockCoupon) {
         throw new RouterError('Bitcoin lock coupon restoration is not configured.', 503);
@@ -136,7 +138,7 @@ export class MemberRestoreService {
     return payload;
   }
 
-  private restoreMember(payload: IRestorePackagePayload, authAccountId: string): void {
+  private assertNoMemberRestoreConflict(payload: IRestorePackagePayload, authAccountId: string): void {
     const member = payload.member;
     const existingUser = this.db.usersTable.fetchByAuthAccountId(authAccountId, UserRole.Member);
     if (existingUser) {
@@ -151,11 +153,6 @@ export class MemberRestoreService {
         throw new RouterError('Restore package conflicts with an existing member.', 409);
       }
 
-      this.db.userInvitesTable.restoreClaimedInvite({
-        userId: member.id,
-        inviteCode: member.inviteCode,
-        fromName: member.fromName,
-      });
       return;
     }
 
@@ -165,6 +162,25 @@ export class MemberRestoreService {
       this.db.userInvitesTable.fetchByCode(member.inviteCode)
     ) {
       throw new RouterError('Restore package conflicts with an existing member.', 409);
+    }
+  }
+
+  private restoreMember(payload: IRestorePackagePayload, authAccountId: string): void {
+    this.assertNoMemberRestoreConflict(payload, authAccountId);
+
+    const member = payload.member;
+    const existingUser = this.db.usersTable.fetchByAuthAccountId(authAccountId, UserRole.Member);
+    if (existingUser) {
+      if (this.db.userInvitesTable.fetchById(existingUser.id)) {
+        return;
+      }
+
+      this.db.userInvitesTable.restoreClaimedInvite({
+        userId: member.id,
+        inviteCode: member.inviteCode,
+        fromName: member.fromName,
+      });
+      return;
     }
 
     this.db.usersTable.restoreClaimedUser({

--- a/router/src/MemberRestoreService.ts
+++ b/router/src/MemberRestoreService.ts
@@ -1,0 +1,229 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { type IBitcoinLockCouponRecord, JsonExt, UserRole } from '@argonprotocol/apps-core';
+import type { Db } from './Db.ts';
+import { RouterError } from './RouterError.ts';
+import type { IUserInviteRecord } from './db/UserInvitesTable.ts';
+
+const RESTORE_PACKAGE_AAD = Buffer.from('argon-router-restore-v1');
+const RESTORE_PACKAGE_NONCE_BYTES = 12;
+const RESTORE_PACKAGE_TAG_BYTES = 16;
+
+type IRestorePackagePayload = {
+  version: 1;
+  member: Pick<IUserInviteRecord, 'id' | 'name' | 'fromName' | 'inviteCode'> & {
+    defaultAccountId: string;
+  };
+  bitcoinLockCoupon?: IBitcoinLockCouponRecord;
+};
+
+export class MemberRestoreService {
+  private readonly db: Db;
+  private readonly restoreKey?: Buffer;
+  private readonly restoreBitcoinLockCoupon?: (coupon: IBitcoinLockCouponRecord) => Promise<void>;
+
+  constructor(options: {
+    db: Db;
+    restoreKey?: string;
+    restoreBitcoinLockCoupon?: (coupon: IBitcoinLockCouponRecord) => Promise<void>;
+  }) {
+    this.db = options.db;
+    this.restoreKey = decodeRestoreKey(options.restoreKey);
+    this.restoreBitcoinLockCoupon = options.restoreBitcoinLockCoupon;
+  }
+
+  public get isEnabled(): boolean {
+    return !!this.restoreKey;
+  }
+
+  public isPackageRequired(authAccountId: string): boolean {
+    if (!this.isEnabled) return false;
+
+    const user = this.db.usersTable.fetchByAuthAccountId(authAccountId, UserRole.Member);
+    return !user || !this.db.userInvitesTable.fetchById(user.id);
+  }
+
+  public async restoreAuthenticatedMember(args: {
+    authAccountId: string;
+    restorePackage?: string;
+    packageRequired: boolean;
+  }): Promise<boolean> {
+    const existingUser = this.db.usersTable.fetchByAuthAccountId(args.authAccountId, UserRole.Member) ?? undefined;
+    const existingInvite = existingUser
+      ? (this.db.userInvitesTable.fetchById(existingUser.id) ?? undefined)
+      : undefined;
+    if (args.packageRequired && !args.restorePackage) {
+      throw new RouterError('The router no longer recognizes this member and requires its restore package.', 403);
+    }
+
+    const payload = args.restorePackage ? this.validatePackage(args.restorePackage, args.authAccountId) : undefined;
+    if (
+      payload &&
+      existingUser &&
+      (payload.member.id !== existingUser.id || payload.member.defaultAccountId !== existingUser.accountId)
+    ) {
+      throw new RouterError('Restore package does not match the current member.', 403);
+    }
+    if ((!existingUser || !existingInvite) && !payload) {
+      throw new RouterError('This auth account is not allowed to access the router.', 403);
+    }
+    if (!payload) return false;
+
+    if (payload.bitcoinLockCoupon) {
+      if (!this.restoreBitcoinLockCoupon) {
+        throw new RouterError('Bitcoin lock coupon restoration is not configured.', 503);
+      }
+
+      await this.restoreBitcoinLockCoupon(payload.bitcoinLockCoupon);
+    }
+    this.db.transaction(() => this.restoreMember(payload, args.authAccountId));
+    return true;
+  }
+
+  public createPackage(invite: IUserInviteRecord, bitcoinLockCoupon?: IBitcoinLockCouponRecord): string {
+    if (!this.restoreKey || !invite.defaultAccountId || !invite.authAccountId) {
+      throw new RouterError('Router member restore is not configured for this member.', 503);
+    }
+    if (
+      bitcoinLockCoupon &&
+      (bitcoinLockCoupon.userId !== invite.id || bitcoinLockCoupon.accountId !== invite.defaultAccountId)
+    ) {
+      throw new RouterError('Bitcoin lock coupon does not match this member.', 409);
+    }
+
+    return sealPackage(
+      {
+        version: 1,
+        member: {
+          id: invite.id,
+          name: invite.name,
+          fromName: invite.fromName,
+          inviteCode: invite.inviteCode,
+          defaultAccountId: invite.defaultAccountId,
+        },
+        ...(bitcoinLockCoupon ? { bitcoinLockCoupon } : {}),
+      },
+      this.restoreKey,
+      invite.authAccountId,
+    );
+  }
+
+  private validatePackage(restorePackage: string, authAccountId: string): IRestorePackagePayload {
+    if (!this.restoreKey) {
+      throw new RouterError('Router member restore is not configured.', 503);
+    }
+
+    const payload = unsealPackage(restorePackage, this.restoreKey, authAccountId);
+    const member = payload.member;
+    if (
+      payload.version !== 1 ||
+      !member ||
+      !member.id ||
+      !member.name ||
+      !member.fromName ||
+      !member.inviteCode ||
+      !member.defaultAccountId
+    ) {
+      throw new RouterError('Restore package does not match this member.', 403);
+    }
+    if (
+      payload.bitcoinLockCoupon &&
+      (payload.bitcoinLockCoupon.userId !== member.id ||
+        payload.bitcoinLockCoupon.accountId !== member.defaultAccountId)
+    ) {
+      throw new RouterError('Restore package contains inconsistent coupon details.', 403);
+    }
+
+    return payload;
+  }
+
+  private restoreMember(payload: IRestorePackagePayload, authAccountId: string): void {
+    const member = payload.member;
+    const existingUser = this.db.usersTable.fetchByAuthAccountId(authAccountId, UserRole.Member);
+    if (existingUser) {
+      if (existingUser.id !== member.id || existingUser.accountId !== member.defaultAccountId) {
+        throw new RouterError('Restore package conflicts with an existing member.', 409);
+      }
+      const existingInvite = this.db.userInvitesTable.fetchById(existingUser.id);
+      if (existingInvite) {
+        return;
+      }
+      if (this.db.userInvitesTable.fetchByCode(member.inviteCode)) {
+        throw new RouterError('Restore package conflicts with an existing member.', 409);
+      }
+
+      this.db.userInvitesTable.restoreClaimedInvite({
+        userId: member.id,
+        inviteCode: member.inviteCode,
+        fromName: member.fromName,
+      });
+      return;
+    }
+
+    if (
+      this.db.usersTable.fetchById(member.id) ||
+      this.db.usersTable.fetchByAccountId(member.defaultAccountId) ||
+      this.db.userInvitesTable.fetchByCode(member.inviteCode)
+    ) {
+      throw new RouterError('Restore package conflicts with an existing member.', 409);
+    }
+
+    this.db.usersTable.restoreClaimedUser({
+      id: member.id,
+      role: UserRole.Member,
+      name: member.name,
+      accountId: member.defaultAccountId,
+      authAccountId,
+    });
+    this.db.userInvitesTable.restoreClaimedInvite({
+      userId: member.id,
+      inviteCode: member.inviteCode,
+      fromName: member.fromName,
+    });
+  }
+}
+
+function decodeRestoreKey(value?: string): Buffer | undefined {
+  if (!value) return;
+
+  const normalized = value.trim().replace(/^0x/, '');
+  if (!/^[0-9a-f]{64}$/i.test(normalized)) {
+    throw new Error('ROUTER_RESTORE_KEY must be a 32-byte hex value.');
+  }
+
+  return Buffer.from(normalized, 'hex');
+}
+
+function sealPackage(payload: IRestorePackagePayload, key: Buffer, authAccountId: string): string {
+  const nonce = randomBytes(RESTORE_PACKAGE_NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  cipher.setAAD(getPackageAad(authAccountId));
+
+  const ciphertext = Buffer.concat([cipher.update(JsonExt.stringify(payload), 'utf8'), cipher.final()]);
+
+  return Buffer.concat([nonce, ciphertext, cipher.getAuthTag()]).toString('base64url');
+}
+
+function unsealPackage(restorePackage: string, key: Buffer, authAccountId: string): IRestorePackagePayload {
+  try {
+    const encrypted = Buffer.from(restorePackage, 'base64url');
+    if (encrypted.length <= RESTORE_PACKAGE_NONCE_BYTES + RESTORE_PACKAGE_TAG_BYTES) {
+      throw new Error('Restore package is too short.');
+    }
+
+    const nonce = encrypted.subarray(0, RESTORE_PACKAGE_NONCE_BYTES);
+    const tag = encrypted.subarray(encrypted.length - RESTORE_PACKAGE_TAG_BYTES);
+    const ciphertext = encrypted.subarray(RESTORE_PACKAGE_NONCE_BYTES, encrypted.length - RESTORE_PACKAGE_TAG_BYTES);
+    const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+    decipher.setAAD(getPackageAad(authAccountId));
+    decipher.setAuthTag(tag);
+
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    return JsonExt.parse<IRestorePackagePayload>(plaintext);
+  } catch {
+    throw new RouterError('Restore package is invalid.', 403);
+  }
+}
+
+function getPackageAad(authAccountId: string): Buffer {
+  return Buffer.concat([RESTORE_PACKAGE_AAD, Buffer.from([0]), Buffer.from(authAccountId)]);
+}

--- a/router/src/RouterAuthService.ts
+++ b/router/src/RouterAuthService.ts
@@ -7,15 +7,21 @@ import {
   verifyRouterAuthChallenge,
 } from '@argonprotocol/apps-core';
 import type { Db } from './Db.ts';
+import type { MemberRestoreService } from './MemberRestoreService.ts';
 import type { IUserRecord } from './db/UsersTable.ts';
 import { RouterError } from './RouterError.ts';
-import type { IRouterAuthSessionRequest, IRouterAuthSessionResponse } from './interfaces/index.ts';
+import type {
+  IRouterAuthChallengeResponse,
+  IRouterAuthSessionRequest,
+  IRouterAuthSessionResponse,
+} from './interfaces/index.ts';
 
 export interface IRouterAuthServiceOptions {
   db?: Db;
   adminOperatorAccountId?: string;
   sessionTtlSeconds?: number;
   challengeTtlMs?: number;
+  memberRestore?: MemberRestoreService;
 }
 
 export interface IAuthenticatedRouterSession {
@@ -27,17 +33,26 @@ const DEFAULT_CHALLENGE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_SECONDS = 12 * 60 * 60;
 
 export class RouterAuthService {
-  private readonly challengesByNonce = new Map<string, IRouterAuthChallenge>();
+  private readonly challengesByNonce = new Map<
+    string,
+    {
+      challenge: IRouterAuthChallenge;
+      restorePackageRequired: boolean;
+      restorePackageRequested: boolean;
+    }
+  >();
   private readonly db?: Db;
   private readonly adminOperatorAccountId?: string;
   private readonly sessionTtlSeconds: number;
   private readonly challengeTtlMs: number;
+  private readonly memberRestore?: MemberRestoreService;
 
   constructor(options: IRouterAuthServiceOptions = {}) {
     this.db = options.db;
     this.adminOperatorAccountId = options.adminOperatorAccountId?.trim() || undefined;
     this.sessionTtlSeconds = options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS;
     this.challengeTtlMs = options.challengeTtlMs ?? DEFAULT_CHALLENGE_TTL_MS;
+    this.memberRestore = options.memberRestore;
     this.ensureAdminOperatorUser();
   }
 
@@ -49,12 +64,24 @@ export class RouterAuthService {
     this.db?.sessionsTable.deleteInactiveSessions();
   }
 
-  public createChallenge(authAccountId: string, role: RouterAuthRole = UserRole.AdminOperator): IRouterAuthChallenge {
+  public createChallenge(
+    authAccountId: string,
+    role: RouterAuthRole = UserRole.AdminOperator,
+    restore: {
+      packageRequired?: boolean;
+      packageRequested?: boolean;
+    } = {},
+  ): IRouterAuthChallengeResponse {
     this.assertEnabled();
 
     const normalizedRole = normalizeRole(role);
     const trimmedAuthAccountId = authAccountId.trim();
-    this.getUserForAuth(trimmedAuthAccountId, normalizedRole);
+    if (!trimmedAuthAccountId) {
+      throw new RouterError('An auth account id is required.', 400);
+    }
+    if (normalizedRole === UserRole.AdminOperator) {
+      this.getUserForAuth(trimmedAuthAccountId, normalizedRole);
+    }
     this.pruneExpiredChallenges();
 
     const challenge = {
@@ -64,15 +91,26 @@ export class RouterAuthService {
       expiresAt: Date.now() + this.challengeTtlMs,
     };
 
-    this.challengesByNonce.set(challenge.nonce, challenge);
-    return challenge;
+    this.challengesByNonce.set(challenge.nonce, {
+      challenge,
+      restorePackageRequired: normalizedRole === UserRole.Member && !!restore.packageRequired,
+      restorePackageRequested: normalizedRole === UserRole.Member && !!restore.packageRequested,
+    });
+    return {
+      ...challenge,
+      restorePackageRequired: normalizedRole === UserRole.Member && !!restore.packageRequired,
+    };
   }
 
-  public createSession(request: IRouterAuthSessionRequest): IRouterAuthSessionResponse {
+  public async createSession(request: IRouterAuthSessionRequest): Promise<{
+    session: IRouterAuthSessionResponse;
+    refreshRestorePackage: boolean;
+  }> {
     this.assertEnabled();
 
-    const challenge = this.challengesByNonce.get(request.nonce);
+    const pendingChallenge = this.challengesByNonce.get(request.nonce);
     this.challengesByNonce.delete(request.nonce);
+    const challenge = pendingChallenge?.challenge;
 
     if (!challenge || challenge.expiresAt <= Date.now()) {
       throw new RouterError('Login challenge expired. Please try again.', 401);
@@ -87,21 +125,37 @@ export class RouterAuthService {
       throw new RouterError('Login signature is invalid.', 403);
     }
 
-    const user = this.getUserForAuth(challenge.authAccountId, challenge.role);
-    const sessionId = nanoid();
-    this.db!.sessionsTable.deleteInactiveSessions();
+    let restorePackageApplied = false;
+    if (challenge.role === UserRole.Member) {
+      restorePackageApplied =
+        (await this.memberRestore?.restoreAuthenticatedMember({
+          authAccountId: challenge.authAccountId,
+          restorePackage: request.restorePackage,
+          packageRequired: pendingChallenge.restorePackageRequired,
+        })) ?? false;
+    }
 
-    const session = this.db!.sessionsTable.insertSession({
-      sessionId,
-      userId: user.id,
-      expiresAt: new Date(Date.now() + this.sessionTtlSeconds * 1000),
+    const sessionId = nanoid();
+    const session = this.db!.transaction(() => {
+      const user = this.getUserForAuth(challenge.authAccountId, challenge.role);
+      this.db!.sessionsTable.deleteInactiveSessions();
+      const session = this.db!.sessionsTable.insertSession({
+        sessionId,
+        userId: user.id,
+        expiresAt: new Date(Date.now() + this.sessionTtlSeconds * 1000),
+      });
+
+      return {
+        sessionId,
+        expiresAt: session.expiresAt.toISOString(),
+        accountId: user.accountId!,
+        role: normalizeRole(user.role),
+      };
     });
 
     return {
-      sessionId,
-      expiresAt: session.expiresAt.toISOString(),
-      accountId: user.accountId!,
-      role: normalizeRole(user.role),
+      session,
+      refreshRestorePackage: pendingChallenge.restorePackageRequested || restorePackageApplied,
     };
   }
 
@@ -128,14 +182,10 @@ export class RouterAuthService {
   }
 
   public requireMemberSession(req: Request, accountId?: string): IAuthenticatedRouterSession {
-    return this.requireUserSession(req, [UserRole.Member], accountId);
+    return this.requireSession(req, [UserRole.Member], accountId);
   }
 
-  public requireSession(req: Request, allowedRoles: readonly RouterAuthRole[], accountId?: string): IAuthenticatedRouterSession {
-    return this.requireUserSession(req, allowedRoles, accountId);
-  }
-
-  public requireUserSession(
+  public requireSession(
     req: Request,
     allowedRoles: readonly RouterAuthRole[],
     accountId?: string,
@@ -269,7 +319,7 @@ export class RouterAuthService {
 
   private pruneExpiredChallenges(): void {
     const now = Date.now();
-    for (const [nonce, challenge] of this.challengesByNonce) {
+    for (const [nonce, { challenge }] of this.challengesByNonce) {
       if (challenge.expiresAt <= now) {
         this.challengesByNonce.delete(nonce);
       }

--- a/router/src/RouterServer.ts
+++ b/router/src/RouterServer.ts
@@ -16,8 +16,15 @@ import { getClient } from '@argonprotocol/mainchain';
 import { ArgonApis } from './ArgonApis.ts';
 import { BitcoinApis } from './BitcoinApis.ts';
 import { BotUpstreamClient } from './BotUpstreamClient.ts';
-import { ADMIN_OPERATOR_ACCOUNT_ID, BITCOIN_CONFIG, ROUTER_AUTH_SESSION_TTL_SECONDS, SERVER_ROOT } from './env.ts';
+import {
+  ADMIN_OPERATOR_ACCOUNT_ID,
+  BITCOIN_CONFIG,
+  ROUTER_AUTH_SESSION_TTL_SECONDS,
+  ROUTER_RESTORE_KEY,
+  SERVER_ROOT,
+} from './env.ts';
 import type { Db } from './Db.ts';
+import { MemberRestoreService } from './MemberRestoreService.ts';
 import { RouterError } from './RouterError.ts';
 import { RouterAuthService, type IRouterAuthServiceOptions } from './RouterAuthService.ts';
 import { UserInviteService } from './UserInviteService.ts';
@@ -41,13 +48,17 @@ import type {
   IRouterAuthSessionResponse,
 } from './interfaces/index.ts';
 
+type IRouterServerAuthOptions = Omit<IRouterAuthServiceOptions, 'db' | 'memberRestore'> & {
+  restoreKey?: string;
+};
+
 interface IRouterServerOptions {
   db: Db;
   botInternalUrl: string;
   port?: number | string;
   localNodeUrl?: string;
   mainNodeUrl?: string;
-  auth?: IRouterAuthServiceOptions;
+  auth?: IRouterServerAuthOptions;
 }
 
 export class RouterServer {
@@ -72,6 +83,7 @@ export class RouterServer {
     const inviteProgressNodeUrl = this.options.mainNodeUrl ?? this.options.localNodeUrl;
     const adminOperatorAccountId =
       this.options.auth?.adminOperatorAccountId?.trim() || ADMIN_OPERATOR_ACCOUNT_ID?.trim();
+    const { restoreKey = ROUTER_RESTORE_KEY, ...authOptions } = this.options.auth ?? {};
     const getInviteProgressClient = async () => {
       if (!inviteProgressNodeUrl) {
         throw new RouterError('A mainchain node is required to approve operations access.', 503);
@@ -80,11 +92,19 @@ export class RouterServer {
       this.inviteProgressClientPromise ??= getClient(inviteProgressNodeUrl, { throwOnConnect: true });
       return await this.inviteProgressClientPromise;
     };
+    const memberRestore = new MemberRestoreService({
+      db,
+      restoreKey,
+      restoreBitcoinLockCoupon: async coupon => {
+        await botClient.restoreCoupon(coupon);
+      },
+    });
     const routerAuth = new RouterAuthService({
       db,
       sessionTtlSeconds: ROUTER_AUTH_SESSION_TTL_SECONDS ? Number(ROUTER_AUTH_SESSION_TTL_SECONDS) : undefined,
-      ...this.options.auth,
+      ...authOptions,
       adminOperatorAccountId,
+      memberRestore,
     });
     routerAuth.pruneInactiveSessions();
 
@@ -132,17 +152,43 @@ export class RouterServer {
       '/auth/challenge',
       express.text({ type: '*/*' }),
       safeJsonRoute(async req => {
-        const { authAccountId, role } = requireBody<IRouterAuthChallengeRequest>(req);
-        return routerAuth.createChallenge(authAccountId, role);
+        const { authAccountId, role, hasRestorePackage } = requireBody<IRouterAuthChallengeRequest>(req);
+        const restorePackageRequired = role === UserRole.Member && memberRestore.isPackageRequired(authAccountId);
+
+        return routerAuth.createChallenge(authAccountId, role, {
+          packageRequired: restorePackageRequired,
+          packageRequested: role === UserRole.Member && hasRestorePackage === false,
+        });
       }),
     );
 
     app.post(
       '/auth/login',
       express.text({ type: '*/*' }),
-      safeJsonRoute<IRouterAuthSessionResponse>(async req =>
-        routerAuth.createSession(requireBody<IRouterAuthSessionRequest>(req)),
-      ),
+      safeJsonRoute<IRouterAuthSessionResponse>(async req => {
+        const { session, refreshRestorePackage } = await routerAuth.createSession(
+          requireBody<IRouterAuthSessionRequest>(req),
+        );
+        if (session.role !== UserRole.Member || !memberRestore.isEnabled || !refreshRestorePackage) {
+          return session;
+        }
+
+        const invite = db.userInvitesTable.fetchByDefaultAccountId(session.accountId, UserRole.Member);
+        if (!invite) {
+          throw new RouterError('Invite not found', 404);
+        }
+
+        const bitcoinLockCoupons = await botClient.listCouponsByUserId(invite.id);
+        const bitcoinLockCoupon = bitcoinLockCoupons[0];
+        const restorePackage = memberRestore.createPackage(invite, bitcoinLockCoupon?.coupon);
+
+        session.restore = {
+          restorePackage,
+          bitcoinLockCoupons,
+        };
+
+        return session;
+      }),
     );
 
     app.get('/auth/verify/admin', (req, res) => {
@@ -345,10 +391,12 @@ export class RouterServer {
           userId: invite.id,
           accountId: defaultAccountId,
         });
+        const restorePackage = memberRestore.createPackage(invite, bitcoinLockCoupon.coupon);
 
         return {
           fromName: invite.fromName,
-          referrer: adminOperatorAccountId,
+          operatorAccountId: adminOperatorAccountId,
+          restorePackage,
           invite: {
             ...toTreasuryUserInvite(invite),
             vaultId: bitcoinLockCoupon.coupon.vaultId,
@@ -624,7 +672,6 @@ export class RouterServer {
             }
             throw error;
           });
-
         return { bitcoinLock };
       }),
     );

--- a/router/src/RouterServer.ts
+++ b/router/src/RouterServer.ts
@@ -183,6 +183,8 @@ export class RouterServer {
         const restorePackage = memberRestore.createPackage(invite, bitcoinLockCoupon?.coupon);
 
         session.restore = {
+          fromName: invite.fromName,
+          operatorAccountId: adminOperatorAccountId!,
           restorePackage,
           bitcoinLockCoupons,
         };
@@ -396,6 +398,7 @@ export class RouterServer {
         return {
           fromName: invite.fromName,
           operatorAccountId: adminOperatorAccountId,
+          referrer: adminOperatorAccountId,
           restorePackage,
           invite: {
             ...toTreasuryUserInvite(invite),

--- a/router/src/db/UserInvitesTable.ts
+++ b/router/src/db/UserInvitesTable.ts
@@ -198,6 +198,35 @@ export class UserInvitesTable extends BaseTable {
     return this.fetchById(id);
   }
 
+  public restoreClaimedInvite(args: { userId: number; inviteCode: string; fromName: string }): IUserInviteRecord {
+    this.db.sql
+      .prepare(
+        `
+        INSERT INTO UserInvites (
+          userId,
+          inviteCode,
+          fromName,
+          firstClickedAt,
+          lastClickedAt
+        ) VALUES (
+          $userId,
+          $inviteCode,
+          $fromName,
+          CURRENT_TIMESTAMP,
+          CURRENT_TIMESTAMP
+        )
+      `,
+      )
+      .run(toSqliteParams(args));
+
+    const invite = this.fetchById(args.userId);
+    if (!invite) {
+      throw new Error(`Invite ${args.userId} not found after member restore.`);
+    }
+
+    return invite;
+  }
+
   public deleteByUserId(userId: number): void {
     this.db.sql
       .prepare(

--- a/router/src/db/UsersTable.ts
+++ b/router/src/db/UsersTable.ts
@@ -51,6 +51,40 @@ export class UsersTable extends BaseTable {
     return this.mapUser(record);
   }
 
+  public restoreClaimedUser(
+    user: Pick<IUserRecord, 'id' | 'role' | 'name' | 'accountId' | 'authAccountId' | 'operationalAccountId'>,
+  ): IUserRecord {
+    const record = this.db.sql
+      .prepare(
+        `
+        INSERT INTO Users (
+          id,
+          role,
+          name,
+          accountId,
+          authAccountId,
+          operationalAccountId
+        ) VALUES (
+          $id,
+          $role,
+          $name,
+          $accountId,
+          $authAccountId,
+          $operationalAccountId
+        )
+        RETURNING *
+      `,
+      )
+      .get(
+        toSqliteParams({
+          ...user,
+          operationalAccountId: user.operationalAccountId ?? null,
+        }),
+      ) as SqlUserRow;
+
+    return this.mapUser(record);
+  }
+
   public fetchById(id: number): IUserRecord | null {
     const record = this.db.sql
       .prepare(
@@ -106,11 +140,22 @@ export class UsersTable extends BaseTable {
     return record ? this.mapUser(record) : null;
   }
 
-  public claimAccount(
-    id: number,
-    accountId: string,
-    authAccountId: string,
-  ): IUserRecord | null {
+  public fetchByOperationalAccountId(operationalAccountId: string): IUserRecord | null {
+    const record = this.db.sql
+      .prepare(
+        `
+        SELECT *
+        FROM Users
+        WHERE operationalAccountId = $operationalAccountId
+        LIMIT 1
+      `,
+      )
+      .get({ $operationalAccountId: operationalAccountId }) as SqlUserRow | undefined;
+
+    return record ? this.mapUser(record) : null;
+  }
+
+  public claimAccount(id: number, accountId: string, authAccountId: string): IUserRecord | null {
     const record = this.db.sql
       .prepare(
         `

--- a/router/src/env.ts
+++ b/router/src/env.ts
@@ -4,6 +4,7 @@ export const VAULT_OPERATOR_ADDRESS = process.env.VAULT_OPERATOR_ADDRESS;
 export const ADMIN_OPERATOR_ACCOUNT_ID = process.env.OPERATOR_ACCOUNT_ID;
 export const BOT_INTERNAL_URL = process.env.BOT_INTERNAL_URL || 'http://bot:8080';
 export const ROUTER_AUTH_SESSION_TTL_SECONDS = process.env.ROUTER_AUTH_SESSION_TTL_SECONDS;
+export const ROUTER_RESTORE_KEY = process.env.ROUTER_RESTORE_KEY;
 export const PORT = process.env.PORT || 8080;
 
 export const ARGON_CHAIN = process.env.ARGON_CHAIN;

--- a/router/src/interfaces/IRouterApi.ts
+++ b/router/src/interfaces/IRouterApi.ts
@@ -1,4 +1,4 @@
-import type { IRouterAuthChallenge, RouterAuthRole, UserRole, IOperationalAccessProof  } from '@argonprotocol/apps-core';
+import type { IRouterAuthChallenge, RouterAuthRole, UserRole, IOperationalAccessProof } from '@argonprotocol/apps-core';
 import type { IBitcoinLockCouponStatus, IBitcoinLockRelayRequest } from './IBitcoinLockRelay.js';
 import type { ITreasuryUserInvite } from './ITreasuryUserInvite.js';
 
@@ -41,10 +41,16 @@ export interface IMarkOperationsUpgradedRequest {
 export interface IRouterAuthChallengeRequest {
   authAccountId: string;
   role?: RouterAuthRole;
+  hasRestorePackage?: boolean;
 }
+
+export type IRouterAuthChallengeResponse = IRouterAuthChallenge & {
+  restorePackageRequired: boolean;
+};
 
 export interface IRouterAuthSessionRequest extends IRouterAuthChallenge {
   signature: string;
+  restorePackage?: string;
 }
 
 export interface IRouterAuthSessionResponse {
@@ -52,6 +58,7 @@ export interface IRouterAuthSessionResponse {
   expiresAt: string;
   accountId: string;
   role: RouterAuthRole;
+  restore?: IListBitcoinLockCouponsResponse & { restorePackage: string };
 }
 
 export interface IRouterErrorResponse {
@@ -81,8 +88,9 @@ export interface IListBitcoinLockCouponsResponse {
 
 export interface IOpenInviteResponse {
   fromName: string;
-  referrer: string;
+  operatorAccountId: string;
   invite: ITreasuryUserInvite;
+  restorePackage: string;
 }
 
 export interface IBitcoinLockStatusResponse {

--- a/router/src/interfaces/IRouterApi.ts
+++ b/router/src/interfaces/IRouterApi.ts
@@ -58,7 +58,11 @@ export interface IRouterAuthSessionResponse {
   expiresAt: string;
   accountId: string;
   role: RouterAuthRole;
-  restore?: IListBitcoinLockCouponsResponse & { restorePackage: string };
+  restore?: IListBitcoinLockCouponsResponse & {
+    fromName: string;
+    operatorAccountId: string;
+    restorePackage: string;
+  };
 }
 
 export interface IRouterErrorResponse {
@@ -89,6 +93,8 @@ export interface IListBitcoinLockCouponsResponse {
 export interface IOpenInviteResponse {
   fromName: string;
   operatorAccountId: string;
+  /** @deprecated Use operatorAccountId. */
+  referrer: string;
   invite: ITreasuryUserInvite;
   restorePackage: string;
 }

--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -299,6 +299,26 @@ if ! (already_ran "DockerInstall"); then
       run_command "sudo docker rm -f $status_container_ids"
     fi
     run_compose "sudo docker network inspect ${network_name} >/dev/null 2>&1 || sudo docker network create ${network_name}"
+
+    router_db="$HOME_DIR/data/argon/router.sqlite"
+    bot_db="$HOME_DIR/data/argon/vault.sqlite"
+    if [[ ! -f "$router_db" && ! -f "$bot_db" ]]; then
+      latest_database_backup=""
+      for database_backup in "$HOME_DIR"/backups/argon-server-databases-*.tar.gz; do
+        if [[ ! -f "$database_backup" ]]; then
+          continue
+        fi
+        if [[ -z "$latest_database_backup" || "$database_backup" -nt "$latest_database_backup" ]]; then
+          latest_database_backup="$database_backup"
+        fi
+      done
+
+      if [[ -n "$latest_database_backup" ]]; then
+        echo "Restoring server databases from $latest_database_backup"
+        run_command "tar -xzf $latest_database_backup -C $HOME_DIR"
+      fi
+    fi
+
     run_compose "sudo docker compose up router -d --build"
 
     echo "-----------------------------------------------------------------"

--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -315,7 +315,7 @@ if ! (already_ran "DockerInstall"); then
 
       if [[ -n "$latest_database_backup" ]]; then
         echo "Restoring server databases from $latest_database_backup"
-        run_command "tar -xzf $latest_database_backup -C $HOME_DIR"
+        run_command "tar -xzf \"$latest_database_backup\" -C \"$HOME_DIR\""
       fi
     fi
 

--- a/server/scripts/wipe_server.sh
+++ b/server/scripts/wipe_server.sh
@@ -1,12 +1,40 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIRNAME="$(dirname "$0")"
-HOME_DIR="$DIRNAME/../.."
-pkill -f "$HOME_DIR/server/scripts/installer.sh"
+HOME_DIR="$(realpath "$DIRNAME/../..")"
+DATA_DIR="$HOME_DIR/data/argon"
+BACKUP_DIR="$HOME_DIR/backups"
+pkill -f "$HOME_DIR/server/scripts/installer.sh" || true
 
 cd "$HOME_DIR/server"
 
 docker compose --profile=all down --rmi all --volumes
+
+DATABASES=()
+for database in router.sqlite vault.sqlite; do
+  if [[ -f "$DATA_DIR/$database" ]]; then
+    DATABASES+=("data/argon/$database")
+  fi
+done
+
+if (( ${#DATABASES[@]} )); then
+  # Do not delete server data unless its database backup completed successfully.
+  set -e
+  mkdir -p "$BACKUP_DIR"
+  chown --reference="$HOME_DIR" "$BACKUP_DIR"
+  STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+  TEMP_ARCHIVE="$(mktemp --tmpdir="$BACKUP_DIR" --suffix=.tar.gz.tmp "argon-server-databases-$STAMP-XXXXXXXX")"
+  ARCHIVE="${TEMP_ARCHIVE%.tmp}"
+  tar -C "$HOME_DIR" -czf "$TEMP_ARCHIVE" "${DATABASES[@]}"
+  chown --reference="$HOME_DIR" "$TEMP_ARCHIVE"
+  chmod 0600 "$TEMP_ARCHIVE"
+  mv "$TEMP_ARCHIVE" "$ARCHIVE"
+  set +e
+  echo "Database backup ready: $ARCHIVE"
+else
+  echo "No server databases found"
+fi
+
 docker system prune -af --volumes
 
 rm -rf "$HOME_DIR"/account

--- a/src-vue/__test__/MemberRestore.integration.test.ts
+++ b/src-vue/__test__/MemberRestore.integration.test.ts
@@ -1,14 +1,14 @@
 import * as Fs from 'node:fs';
 import os from 'node:os';
 import Path from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   type IActivateBitcoinLockCouponRequest,
   type IBitcoinLockCouponRecord,
   type IBitcoinLockCouponStatus,
   UserRole,
 } from '@argonprotocol/apps-core';
-import { BotServer, Db as BotDb, type Bot } from '@argonprotocol/apps-bot';
+import { type BotServer, Db as BotDb, startServer as startBotServer, type Bot } from '@argonprotocol/apps-bot';
 import type { IRouterAuthSessionResponse } from '@argonprotocol/apps-router';
 import { Db as RouterDb } from '../../router/src/Db.ts';
 import { RouterServer } from '../../router/src/RouterServer.ts';
@@ -61,21 +61,17 @@ describe('member restore handshake integration', () => {
     });
     let restorePackage: string | undefined = claimed.restorePackage;
     let downstreamCoupons: IBitcoinLockCouponStatus[] = [];
-    const applyRestoreResult = vi.fn((restore: NonNullable<IRouterAuthSessionResponse['restore']>) => {
+    let downstreamRestore: IRouterAuthSessionResponse['restore'];
+    const applyRestoreResult = (restore: NonNullable<IRouterAuthSessionResponse['restore']>) => {
+      downstreamRestore = restore;
       restorePackage = restore.restorePackage;
       downstreamCoupons = restore.bitcoinLockCoupons;
-    });
+    };
     let serverAuthClient = new ServerAuthClient(() => memberWalletKeys, {
       getRestorePackage: () => restorePackage,
       applyRestoreResult,
     });
     let upstreamOperatorClient = new UpstreamOperatorClient(serverAuthClient, () => operatorHost);
-
-    await expect(upstreamOperatorClient.getMemberInvite()).resolves.toMatchObject({
-      name: 'Casey',
-      fromName: 'Operator One',
-    });
-    expect(applyRestoreResult).not.toHaveBeenCalled();
 
     await source.routerServer.close();
     routerServers.splice(routerServers.indexOf(source.routerServer), 1);
@@ -93,8 +89,11 @@ describe('member restore handshake integration', () => {
       name: 'Casey',
       fromName: 'Operator One',
     });
-    expect(applyRestoreResult).toHaveBeenCalledOnce();
     expect(downstreamCoupons).toHaveLength(1);
+    expect(downstreamRestore).toMatchObject({
+      fromName: 'Operator One',
+      operatorAccountId: operatorWalletKeys.operationalAddress,
+    });
     expect(recovered.routerDb.userInvitesTable.fetchByDefaultAccountId(claimed.invite.defaultAccountId!)).toMatchObject(
       {
         name: 'Casey',
@@ -105,7 +104,7 @@ describe('member restore handshake integration', () => {
 
     restorePackage = undefined;
     downstreamCoupons = [];
-    applyRestoreResult.mockClear();
+    downstreamRestore = undefined;
     serverAuthClient = new ServerAuthClient(() => memberWalletKeys, {
       getRestorePackage: () => restorePackage,
       applyRestoreResult,
@@ -116,7 +115,6 @@ describe('member restore handshake integration', () => {
       name: 'Casey',
       fromName: 'Operator One',
     });
-    expect(applyRestoreResult).toHaveBeenCalledOnce();
     expect(restorePackage).toBeTruthy();
     expect(downstreamCoupons).toHaveLength(1);
   });
@@ -149,7 +147,7 @@ describe('member restore handshake integration', () => {
         return botDb.bitcoinLockCouponsTable.fetchByUserId(userId).map(toCouponStatus);
       },
     };
-    const botServer = new BotServer(
+    const botServer = startBotServer(
       {
         db: botDb,
         relayService,
@@ -164,7 +162,6 @@ describe('member restore handshake integration', () => {
       } as unknown as Bot,
       0,
     );
-    botServer.start();
     await botServer.waitForListening();
     botServers.push(botServer);
 

--- a/src-vue/__test__/MemberRestore.integration.test.ts
+++ b/src-vue/__test__/MemberRestore.integration.test.ts
@@ -1,0 +1,204 @@
+import * as Fs from 'node:fs';
+import os from 'node:os';
+import Path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type IActivateBitcoinLockCouponRequest,
+  type IBitcoinLockCouponRecord,
+  type IBitcoinLockCouponStatus,
+  UserRole,
+} from '@argonprotocol/apps-core';
+import { BotServer, Db as BotDb, type Bot } from '@argonprotocol/apps-bot';
+import type { IRouterAuthSessionResponse } from '@argonprotocol/apps-router';
+import { Db as RouterDb } from '../../router/src/Db.ts';
+import { RouterServer } from '../../router/src/RouterServer.ts';
+import { ServerAuthClient } from '../lib/ServerAuthClient.ts';
+import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
+import { createMockWalletKeys } from './helpers/wallet.ts';
+
+describe('member restore handshake integration', () => {
+  const tempDirs: string[] = [];
+  const botServers: BotServer[] = [];
+  const botDbs: BotDb[] = [];
+  const routerServers: RouterServer[] = [];
+  const routerDbs: RouterDb[] = [];
+
+  afterEach(async () => {
+    await Promise.all(routerServers.splice(0).map(server => server.close().catch(() => undefined)));
+    await Promise.all(botServers.splice(0).map(server => server.close().catch(() => undefined)));
+    routerDbs.splice(0).forEach(db => db.close());
+    botDbs.splice(0).forEach(db => db.close());
+    await Promise.all(tempDirs.splice(0).map(dir => Fs.promises.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('negotiates upstream and downstream restoration through the signed member login', async () => {
+    const operatorWalletKeys = createMockWalletKeys('//RestoreOperator');
+    const memberWalletKeys = createMockWalletKeys('//RestoreMember');
+    const restoreKey = `0x${'42'.repeat(32)}`;
+    const source = await startUpstream('source', operatorWalletKeys.operationalAddress, restoreKey);
+    let operatorHost = source.operatorHost;
+
+    const member = source.routerDb.usersTable.insertUser({
+      role: UserRole.Member,
+      name: 'Casey',
+    });
+    const invite = source.routerDb.userInvitesTable.insertInvite(member.id, 'member-invite-1', 'Operator One');
+    source.botDb.bitcoinLockCouponsTable.insertCoupon({
+      userId: invite.id,
+      offerCode: 'offer-code-1',
+      vaultId: 12,
+      maxSatoshis: 25_000n,
+      estimatedGiftUsd: 16.25,
+      btcPctFee: 2.5,
+      expiresAfterTicks: 60,
+    });
+
+    const claimed = await UpstreamOperatorClient.claimInvite({
+      operatorHost,
+      inviteCode: invite.inviteCode,
+      defaultAccountKeypair: await memberWalletKeys.getLiquidLockingKeypair(),
+      authKeypair: await memberWalletKeys.getUpstreamOperatorAuthKeypair(),
+    });
+    let restorePackage: string | undefined = claimed.restorePackage;
+    let downstreamCoupons: IBitcoinLockCouponStatus[] = [];
+    const applyRestoreResult = vi.fn((restore: NonNullable<IRouterAuthSessionResponse['restore']>) => {
+      restorePackage = restore.restorePackage;
+      downstreamCoupons = restore.bitcoinLockCoupons;
+    });
+    let serverAuthClient = new ServerAuthClient(() => memberWalletKeys, {
+      getRestorePackage: () => restorePackage,
+      applyRestoreResult,
+    });
+    let upstreamOperatorClient = new UpstreamOperatorClient(serverAuthClient, () => operatorHost);
+
+    await expect(upstreamOperatorClient.getMemberInvite()).resolves.toMatchObject({
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    expect(applyRestoreResult).not.toHaveBeenCalled();
+
+    await source.routerServer.close();
+    routerServers.splice(routerServers.indexOf(source.routerServer), 1);
+    source.routerDb.close();
+    routerDbs.splice(routerDbs.indexOf(source.routerDb), 1);
+    await source.botServer.close();
+    botServers.splice(botServers.indexOf(source.botServer), 1);
+    source.botDb.close();
+    botDbs.splice(botDbs.indexOf(source.botDb), 1);
+
+    const recovered = await startUpstream('recovered', operatorWalletKeys.operationalAddress, restoreKey);
+    operatorHost = recovered.operatorHost;
+
+    await expect(upstreamOperatorClient.getMemberInvite()).resolves.toMatchObject({
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    expect(applyRestoreResult).toHaveBeenCalledOnce();
+    expect(downstreamCoupons).toHaveLength(1);
+    expect(recovered.routerDb.userInvitesTable.fetchByDefaultAccountId(claimed.invite.defaultAccountId!)).toMatchObject(
+      {
+        name: 'Casey',
+        fromName: 'Operator One',
+      },
+    );
+    expect(recovered.botDb.bitcoinLockCouponsTable.fetchAll()).toHaveLength(1);
+
+    restorePackage = undefined;
+    downstreamCoupons = [];
+    applyRestoreResult.mockClear();
+    serverAuthClient = new ServerAuthClient(() => memberWalletKeys, {
+      getRestorePackage: () => restorePackage,
+      applyRestoreResult,
+    });
+    upstreamOperatorClient = new UpstreamOperatorClient(serverAuthClient, () => operatorHost);
+
+    await expect(upstreamOperatorClient.getMemberInvite()).resolves.toMatchObject({
+      name: 'Casey',
+      fromName: 'Operator One',
+    });
+    expect(applyRestoreResult).toHaveBeenCalledOnce();
+    expect(restorePackage).toBeTruthy();
+    expect(downstreamCoupons).toHaveLength(1);
+  });
+
+  async function startUpstream(
+    name: string,
+    adminOperatorAccountId: string,
+    restoreKey: string,
+  ): Promise<{
+    botDb: BotDb;
+    botServer: BotServer;
+    routerDb: RouterDb;
+    routerServer: RouterServer;
+    operatorHost: string;
+  }> {
+    const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), `restore-handshake-${name}-`));
+    tempDirs.push(tempDir);
+
+    const botDb = new BotDb(Path.join(tempDir, 'bot'));
+    botDb.migrate();
+    botDbs.push(botDb);
+    const relayService = {
+      activateLatestCoupon: async (request: IActivateBitcoinLockCouponRequest) => {
+        const coupon = botDb.bitcoinLockCouponsTable.fetchLatestByUserId(request.userId);
+        if (!coupon) throw new Error('Bitcoin lock coupon not found.');
+
+        return toCouponStatus(botDb.bitcoinLockCouponsTable.activateCoupon(coupon.id, request.accountId, 1_000)!);
+      },
+      getBitcoinLockCouponsByUserId: async (userId: number) => {
+        return botDb.bitcoinLockCouponsTable.fetchByUserId(userId).map(toCouponStatus);
+      },
+    };
+    const botServer = new BotServer(
+      {
+        db: botDb,
+        relayService,
+        ethereumGatewayProverService: {},
+        state: async () => ({}),
+        getHistoryForFrame: async () => ({}),
+        getMiningFrameDetail: async () => ({}),
+        storage: {
+          bidsFile: () => ({ get: async () => ({}) }),
+          earningsFile: () => ({ get: async () => ({}) }),
+        },
+      } as unknown as Bot,
+      0,
+    );
+    botServer.start();
+    await botServer.waitForListening();
+    botServers.push(botServer);
+
+    const routerDb = new RouterDb(Path.join(tempDir, 'router.sqlite'));
+    routerDb.migrate();
+    routerDbs.push(routerDb);
+    const botAddress = botServer.getAddress();
+    const routerServer = new RouterServer({
+      db: routerDb,
+      botInternalUrl: `http://${botAddress.host}:${botAddress.port}`,
+      port: 0,
+      auth: {
+        adminOperatorAccountId,
+        restoreKey,
+      },
+    });
+    routerServer.start();
+    await routerServer.waitForListening();
+    routerServers.push(routerServer);
+
+    const routerAddress = routerServer.getAddress();
+    return {
+      botDb,
+      botServer,
+      routerDb,
+      routerServer,
+      operatorHost: `http://${routerAddress.host}:${routerAddress.port}`,
+    };
+  }
+});
+
+function toCouponStatus(coupon: IBitcoinLockCouponRecord): IBitcoinLockCouponStatus {
+  return {
+    coupon,
+    status: 'Open',
+  };
+}

--- a/src-vue/__test__/ServerAuthClient.test.ts
+++ b/src-vue/__test__/ServerAuthClient.test.ts
@@ -145,6 +145,59 @@ describe('ServerAuthClient', () => {
     expect(walletMock.upstreamOperatorAuthSigner.sign).toHaveBeenCalledTimes(1);
   });
 
+  it('sends a cached package only when the member challenge requests it', async () => {
+    const baseUrl = 'https://restore-session.example';
+    const restoreStore = {
+      getRestorePackage: vi.fn(() => 'cached-restore-package'),
+      applyRestoreResult: vi.fn(),
+    };
+    serverAuthClient = new ServerAuthClient(
+      () => ({
+        operationalAddress: 'admin-account',
+        getOperationalKeypair: walletMock.getOperationalKeypair,
+        getUpstreamOperatorAuthKeypair: walletMock.getUpstreamOperatorAuthKeypair,
+      }),
+      restoreStore,
+    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ...createChallenge('nonce-1', UserRole.Member),
+          restorePackageRequired: true,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ...createSession(UserRole.Member),
+          restore: {
+            restorePackage: 'replacement-restore-package',
+            bitcoinLockCoupons: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(emptyResponse(204));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await serverAuthClient.getMemberSessionId(baseUrl);
+
+    expect(fetchPaths(fetchMock)).toEqual(['/auth/challenge', '/auth/login', '/auth/verify/member']);
+    expect(fetchPayloads(fetchMock)[0]).toMatchObject({
+      role: UserRole.Member,
+      authAccountId: 'upstream-operator-auth-account',
+      hasRestorePackage: true,
+    });
+    expect(fetchPayloads(fetchMock)[0]).not.toHaveProperty('restorePackage');
+    expect(fetchPayloads(fetchMock)[1]).toMatchObject({
+      restorePackage: 'cached-restore-package',
+    });
+    expect(restoreStore.getRestorePackage).toHaveBeenCalledOnce();
+    expect(restoreStore.applyRestoreResult).toHaveBeenCalledWith({
+      restorePackage: 'replacement-restore-package',
+      bitcoinLockCoupons: [],
+    });
+  });
+
   it('does not cache transport failures as auth failures', async () => {
     const baseUrl = 'https://transport-failure.example';
     const fetchMock = vi

--- a/src-vue/__test__/ServerAuthClient.test.ts
+++ b/src-vue/__test__/ServerAuthClient.test.ts
@@ -147,17 +147,16 @@ describe('ServerAuthClient', () => {
 
   it('sends a cached package only when the member challenge requests it', async () => {
     const baseUrl = 'https://restore-session.example';
-    const restoreStore = {
-      getRestorePackage: vi.fn(() => 'cached-restore-package'),
-      applyRestoreResult: vi.fn(),
-    };
     serverAuthClient = new ServerAuthClient(
       () => ({
         operationalAddress: 'admin-account',
         getOperationalKeypair: walletMock.getOperationalKeypair,
         getUpstreamOperatorAuthKeypair: walletMock.getUpstreamOperatorAuthKeypair,
       }),
-      restoreStore,
+      {
+        getRestorePackage: () => 'cached-restore-package',
+        applyRestoreResult: () => undefined,
+      },
     );
     const fetchMock = vi
       .fn()
@@ -167,15 +166,7 @@ describe('ServerAuthClient', () => {
           restorePackageRequired: true,
         }),
       )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          ...createSession(UserRole.Member),
-          restore: {
-            restorePackage: 'replacement-restore-package',
-            bitcoinLockCoupons: [],
-          },
-        }),
-      )
+      .mockResolvedValueOnce(jsonResponse(createSession(UserRole.Member)))
       .mockResolvedValueOnce(emptyResponse(204));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -190,11 +181,6 @@ describe('ServerAuthClient', () => {
     expect(fetchPayloads(fetchMock)[0]).not.toHaveProperty('restorePackage');
     expect(fetchPayloads(fetchMock)[1]).toMatchObject({
       restorePackage: 'cached-restore-package',
-    });
-    expect(restoreStore.getRestorePackage).toHaveBeenCalledOnce();
-    expect(restoreStore.applyRestoreResult).toHaveBeenCalledWith({
-      restorePackage: 'replacement-restore-package',
-      bitcoinLockCoupons: [],
     });
   });
 

--- a/src-vue/__test__/TreasuryAppInvite.integration.test.ts
+++ b/src-vue/__test__/TreasuryAppInvite.integration.test.ts
@@ -191,6 +191,7 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
         mainNodeUrl: network.archiveUrl,
         auth: {
           adminOperatorAccountId: operatorHarness.walletKeys.operationalAddress,
+          restoreKey: await operatorHarness.walletKeys.getRouterRestoreSealingKey(),
         },
       });
       routerServer.start();

--- a/src-vue/__test__/TreasuryAppInvite.integration.test.ts
+++ b/src-vue/__test__/TreasuryAppInvite.integration.test.ts
@@ -231,7 +231,7 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       });
       const coupon = claimedInvite.invite.bitcoinLockCoupon!;
       expect(claimedInvite.fromName).toBe(expectedFromName);
-      expect(claimedInvite.referrer).toBe(operatorHarness.walletKeys.operationalAddress);
+      expect(claimedInvite.operatorAccountId).toBe(operatorHarness.walletKeys.operationalAddress);
       expect(coupon.coupon.expirationTick).toBeGreaterThan(0);
       expect(claimedInvite.invite.defaultAccountId).toBe(defaultAccountId);
       expect(claimedInvite.invite.authAccountId).toBe(

--- a/src-vue/interfaces/IConfig.ts
+++ b/src-vue/interfaces/IConfig.ts
@@ -150,6 +150,7 @@ export const UpstreamOperatorSchema = z.object({
   name: z.string(),
   vaultId: z.number().optional(),
   accountId: z.string().optional(),
+  restorePackage: z.string().optional(),
 });
 
 export const ConfigSyncDetailsSchema = z.object({

--- a/src-vue/lib/Installer.ts
+++ b/src-vue/lib/Installer.ts
@@ -812,6 +812,7 @@ export default class Installer {
       miningFundingAccountId: this.walletKeys.miningBotAddress,
       vaultOperatorAddress: this.walletKeys.vaultingAddress,
       operatorAccountId: this.walletKeys.operationalAddress,
+      routerRestoreKey: await this.walletKeys.getRouterRestoreSealingKey(),
       ethereumBeaconApiUrl,
       ethereumExecutionRpcUrl,
     });

--- a/src-vue/lib/MemoryWalletKeys.ts
+++ b/src-vue/lib/MemoryWalletKeys.ts
@@ -70,7 +70,7 @@ export class MemoryWalletKeys extends WalletKeys {
     this.vaultingAccount = vaultingAccount;
     this.operationalAccount = operationalAccount;
     this.vaultDelegateAccount = vaultingAccount.derive('//delegate');
-    this.upstreamOperatorAuthAccount = operationalAccount.derive('//upstream-operator-auth');
+    this.upstreamOperatorAuthAccount = rootAccount.derive('//upstream-operator-auth');
   }
 
   public async exposeMasterMnemonic(): Promise<string> {
@@ -91,6 +91,10 @@ export class MemoryWalletKeys extends WalletKeys {
 
   public async getMiningSessionMiniSecret(): Promise<string> {
     return miniSecretFromUri(`${this.substrateSuri}//mining//session`);
+  }
+
+  public async getRouterRestoreSealingKey(): Promise<string> {
+    return miniSecretFromUri(`${this.substrateSuri}//router-restore-sealing`);
   }
 
   public async getDefaultArgonKeypair(): Promise<KeyringPair> {

--- a/src-vue/lib/ServerAdmin.ts
+++ b/src-vue/lib/ServerAdmin.ts
@@ -179,6 +179,7 @@ export class ServerAdmin {
     miningFundingAccountId: string;
     vaultOperatorAddress: string;
     operatorAccountId: string;
+    routerRestoreKey: string;
     ethereumBeaconApiUrl?: string;
     ethereumExecutionRpcUrl?: string;
   }): Promise<void> {
@@ -187,6 +188,7 @@ export class ServerAdmin {
       `MINING_FUNDING_ACCOUNT_ID=${envState.miningFundingAccountId}`,
       `VAULT_OPERATOR_ADDRESS=${envState.vaultOperatorAddress}`,
       `OPERATOR_ACCOUNT_ID=${envState.operatorAccountId}`,
+      `ROUTER_RESTORE_KEY=${envState.routerRestoreKey}`,
     ];
     const ethereumBeaconApiUrl = envState.ethereumBeaconApiUrl?.trim();
     const ethereumExecutionRpcUrl = envState.ethereumExecutionRpcUrl?.trim();
@@ -549,13 +551,18 @@ export class ServerAdmin {
   }
 
   public async completelyWipeEverything(): Promise<void> {
-    const shellCommand = `sudo ${this.workDir}/server/scripts/wipe_server.sh `;
-
     try {
-      await this.connection.runCommandWithTimeout(shellCommand, 60e3);
+      const [output, status] = await this.connection.runCommandWithTimeout(
+        `sudo ${this.workDir}/server/scripts/wipe_server.sh`,
+        60e3,
+      );
+      if (status !== 0) {
+        console.error('Error wiping server:', output.trim());
+      }
     } catch (error) {
       console.error('Error wiping server:', error);
     }
+
     if (this.connection.isDockerHostProxy) {
       await LocalMachine.remove();
     }

--- a/src-vue/lib/ServerAuthClient.ts
+++ b/src-vue/lib/ServerAuthClient.ts
@@ -1,17 +1,24 @@
 import {
   fetch,
-  type IRouterAuthChallenge as IServerAuthChallenge,
   JsonExt,
   type RouterAuthRole as ServerAuthRole,
   signRouterAuthChallenge as signServerAuthChallenge,
   UserRole,
 } from '@argonprotocol/apps-core';
 import type { KeyringPair } from '@argonprotocol/mainchain';
-import type { IRouterAuthSessionResponse as IServerAuthSessionResponse } from '@argonprotocol/apps-router';
+import type {
+  IRouterAuthChallengeResponse as IServerAuthChallenge,
+  IRouterAuthSessionResponse as IServerAuthSessionResponse,
+} from '@argonprotocol/apps-router';
 import type { WalletKeys } from './WalletKeys.ts';
 
 export type ServerAuthOptions = {
   forceVerify?: boolean;
+};
+
+export type MemberRestoreStore = {
+  getRestorePackage: () => string | undefined;
+  applyRestoreResult: (restore: NonNullable<IServerAuthSessionResponse['restore']>) => Promise<void> | void;
 };
 
 type VerifiedServerSession = {
@@ -46,7 +53,10 @@ export class ServerAuthClient {
   private sessionPromisesBySessionKey = new Map<string, Promise<VerifiedServerSession>>();
   private verifiedSessionsBySessionKey = new Map<string, VerifiedServerSession>();
 
-  constructor(private readonly getWalletKeys: () => ServerAuthWalletKeys) {}
+  constructor(
+    private readonly getWalletKeys: () => ServerAuthWalletKeys,
+    private readonly memberRestoreStore?: MemberRestoreStore,
+  ) {}
 
   public async getAdminOperatorSessionId(baseUrl: string, options: ServerAuthOptions = {}): Promise<string> {
     const walletKeys = this.getWalletKeys();
@@ -140,17 +150,24 @@ export class ServerAuthClient {
     this.invalidateSession(cacheKey);
 
     try {
-      const challenge = await requestAuth<IServerAuthChallenge>(`${baseUrl}/auth/challenge`, {
+      const restorePackage = role === UserRole.Member ? this.memberRestoreStore?.getRestorePackage() : undefined;
+      const challengeRequest = {
         role,
         authAccountId,
-      });
+        ...(role === UserRole.Member ? { hasRestorePackage: !!restorePackage } : {}),
+      };
+      const challenge = await requestAuth<IServerAuthChallenge>(`${baseUrl}/auth/challenge`, challengeRequest);
       if (!challenge) {
         throw new Error('Server auth is not configured.');
+      }
+      if (challenge.restorePackageRequired && !restorePackage) {
+        throw new Error('The upstream operator no longer recognizes this member, and no restore package is available.');
       }
 
       const authKeypair = await getAuthKeypair();
       const session = await requestAuth<IServerAuthSessionResponse>(`${baseUrl}/auth/login`, {
         ...challenge,
+        ...(challenge.restorePackageRequired && restorePackage ? { restorePackage } : {}),
         signature: signServerAuthChallenge(authKeypair, challenge),
       });
       if (!session) {
@@ -159,6 +176,9 @@ export class ServerAuthClient {
 
       if (!(await verifySession(baseUrl, role, session.sessionId))) {
         throw new Error('Server auth session was not accepted.');
+      }
+      if (role === UserRole.Member && session.restore) {
+        await this.memberRestoreStore?.applyRestoreResult(session.restore);
       }
 
       return this.markSessionVerified(cacheKey, session.sessionId, Date.parse(session.expiresAt));

--- a/src-vue/lib/UpstreamOperatorClient.ts
+++ b/src-vue/lib/UpstreamOperatorClient.ts
@@ -90,8 +90,8 @@ export class UpstreamOperatorClient {
     inviteCode: string;
     defaultAccountKeypair: KeyringPair;
     authKeypair: KeyringPair;
-  }): Promise<{ fromName: string; referrer: string; invite: IMemberInvite }> {
-    const body = await this.postJson<IOpenInviteResponse>(
+  }): Promise<IOpenInviteResponse> {
+    return await this.postJson<IOpenInviteResponse>(
       args.operatorHost,
       `/invites/${encodeURIComponent(args.inviteCode)}/open`,
       {
@@ -103,12 +103,6 @@ export class UpstreamOperatorClient {
         }),
       },
     );
-
-    return {
-      fromName: body.fromName,
-      referrer: body.referrer,
-      invite: body.invite,
-    };
   }
 
   public async initializeBitcoinLock(

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -109,6 +109,11 @@ export class WalletKeys {
     return u8aToHex(seed);
   }
 
+  public async getRouterRestoreSealingKey(): Promise<string> {
+    const seed = await invokeWithTimeout<Uint8Array>('derive_ed25519_seed', { suri: '//router-restore-sealing' }, 60e3);
+    return u8aToHex(seed);
+  }
+
   // TODO: move signing to backend instead of passing around key
   public async getDefaultArgonKeypair(): Promise<KeyringPair> {
     const account = await invokeWithTimeout<Uint8Array>(

--- a/src-vue/navigation/AlertBars.vue
+++ b/src-vue/navigation/AlertBars.vue
@@ -357,7 +357,6 @@ function openVaultCollect() {
 }
 
 function openBitcoinLock(args?: { lock?: IBitcoinLockRecord }) {
-  if (!myVault.createdVault) return;
   isExpanded.value = false;
   closeSharedOverlays();
   selectedUnlockLock.value = undefined;

--- a/src-vue/overlays/UpgradeToTreasuryOverlay.vue
+++ b/src-vue/overlays/UpgradeToTreasuryOverlay.vue
@@ -253,7 +253,8 @@ async function connectToNetwork() {
       ...config.upstreamOperator,
       name: body.fromName,
       vaultId: body.invite.vaultId,
-      accountId: body.referrer,
+      accountId: body.operatorAccountId,
+      restorePackage: body.restorePackage,
     };
     config.hasExtensionTreasury = true;
     config.showWelcomeOverlay = false;

--- a/src-vue/overlays/UpgradeToTreasuryOverlay.vue
+++ b/src-vue/overlays/UpgradeToTreasuryOverlay.vue
@@ -253,7 +253,7 @@ async function connectToNetwork() {
       ...config.upstreamOperator,
       name: body.fromName,
       vaultId: body.invite.vaultId,
-      accountId: body.operatorAccountId,
+      accountId: body.operatorAccountId ?? body.referrer,
       restorePackage: body.restorePackage,
     };
     config.hasExtensionTreasury = true;

--- a/src-vue/stores/bitcoin.ts
+++ b/src-vue/stores/bitcoin.ts
@@ -108,8 +108,13 @@ function createBitcoinLockCouponsState() {
     couponOfferLiquidityMicrogons,
     currentCoupon,
     openCouponCount,
+    applyRestore,
     refresh,
   });
+
+  function applyRestore(nextCoupons: IBitcoinLockCouponStatus[]) {
+    coupons.value = nextCoupons;
+  }
 
   async function refresh(subscriptionKey = selectedVaultSubscriptionKey) {
     await Promise.all([config.isLoadedPromise, bitcoinLocks.load(), vaults.load().catch(() => null)]);

--- a/src-vue/stores/server.ts
+++ b/src-vue/stores/server.ts
@@ -27,13 +27,16 @@ export function getUpstreamOperatorAuthClient(): ServerAuthClient {
     },
     applyRestoreResult: async restore => {
       const config = getConfig();
-      const upstreamOperator = config.upstreamOperator;
-      if (!upstreamOperator) return;
+      const vaultId = restore.bitcoinLockCoupons[0]?.coupon.vaultId;
 
       config.upstreamOperator = {
-        ...upstreamOperator,
+        ...config.upstreamOperator,
+        name: restore.fromName,
+        accountId: restore.operatorAccountId,
+        ...(vaultId !== undefined ? { vaultId } : {}),
         restorePackage: restore.restorePackage,
       };
+      config.hasExtensionTreasury = true;
       await config.save();
 
       const { getBitcoinLockCoupons } = await import('./bitcoin.ts');

--- a/src-vue/stores/server.ts
+++ b/src-vue/stores/server.ts
@@ -5,6 +5,7 @@ import { getWalletKeys } from './wallets.ts';
 
 let serverApiClient: ServerApiClient | undefined;
 let serverAuthClient: ServerAuthClient | undefined;
+let upstreamOperatorAuthClient: ServerAuthClient | undefined;
 
 export function getServerApiClient(): ServerApiClient {
   serverApiClient ??= new ServerApiClient(() => getConfig().serverDetails, getServerAuthClient());
@@ -14,4 +15,30 @@ export function getServerApiClient(): ServerApiClient {
 export function getServerAuthClient(): ServerAuthClient {
   serverAuthClient ??= new ServerAuthClient(getWalletKeys);
   return serverAuthClient;
+}
+
+export function getUpstreamOperatorAuthClient(): ServerAuthClient {
+  upstreamOperatorAuthClient ??= new ServerAuthClient(getWalletKeys, {
+    getRestorePackage: () => {
+      const config = getConfig();
+      if (!config.isLoaded) return;
+
+      return config.upstreamOperator?.restorePackage;
+    },
+    applyRestoreResult: async restore => {
+      const config = getConfig();
+      const upstreamOperator = config.upstreamOperator;
+      if (!upstreamOperator) return;
+
+      config.upstreamOperator = {
+        ...upstreamOperator,
+        restorePackage: restore.restorePackage,
+      };
+      await config.save();
+
+      const { getBitcoinLockCoupons } = await import('./bitcoin.ts');
+      getBitcoinLockCoupons().applyRestore(restore.bitcoinLockCoupons);
+    },
+  });
+  return upstreamOperatorAuthClient;
 }

--- a/src-vue/stores/upstreamOperator.ts
+++ b/src-vue/stores/upstreamOperator.ts
@@ -1,11 +1,11 @@
 import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
 import { getConfig } from './config.ts';
-import { getServerAuthClient } from './server.ts';
+import { getUpstreamOperatorAuthClient } from './server.ts';
 
 let upstreamOperatorClient: UpstreamOperatorClient | undefined;
 
 export function getUpstreamOperatorClient(): UpstreamOperatorClient {
-  upstreamOperatorClient ??= new UpstreamOperatorClient(getServerAuthClient(), () => {
+  upstreamOperatorClient ??= new UpstreamOperatorClient(getUpstreamOperatorAuthClient(), () => {
     const config = getConfig();
     if (!config.upstreamOperator) return;
 


### PR DESCRIPTION
## Summary

Downstream members can now recover their operator-assigned router and coupon state after an upstream server rebuild without introducing a second identity or discovery system. Recovery is negotiated through the existing signed member login: the router requests the downstream-held opaque package only when local state is missing, applies it after signature verification, and returns refreshed canonical operator and coupon metadata.

The package remains off-chain and is sealed with a mnemonic-derived, domain-separated router key. Coupon sequences prevent an older recovery package from replacing a newer issued coupon, while full server wipes preserve the router and bot databases for automatic restoration during reinstall.

Mixed-version invite responses remain compatible through the deprecated `referrer` alias, and downstream clients persist the canonical operator account, operator name, Treasury context, coupons, and replacement package returned by the handshake.

## Limitations

If both the upstream state and downstream-held package are lost, the package cannot restore that member. A surviving upstream can issue a replacement package, but package revocation currently requires rotating the shared sealing key.

Chain endpoint discovery and bootstrap recovery-key lookups remain outside this change.

## Validation

Focused router, authentication, coupon, and frontend integration tests pass, along with typechecking and formatting checks. A manual full-wipe recovery restored the member, invite, and coupon state.
