### PR TITLE
fix: preserve mining and vault state during recovery

### DIFF
--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -5,16 +5,10 @@ import { createMockedDbPromise, createTestDb } from './helpers/db';
 import { instanceChecks } from '../lib/Utils.js';
 import { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestWallet } from './helpers/wallet.ts';
-import {
-  BootstrapType,
-  type IConfig,
-  InstallStepStatus,
-  MiningSetupStatus,
-  ServerType,
-  VaultingSetupStatus,
-} from '../interfaces/IConfig.ts';
+import { BootstrapType, MiningSetupStatus, ServerType, VaultingSetupStatus } from '../interfaces/IConfig.ts';
 import { JsonExt } from '@argonprotocol/apps-core';
-import type PluginSql from '@tauri-apps/plugin-sql';
+import Restarter from '../lib/Restarter.ts';
+import PluginSql from '@tauri-apps/plugin-sql';
 
 beforeAll(() => {
   WalletKeys.prototype.didWalletHavePreviousLife = vi.fn().mockResolvedValue(false);
@@ -92,90 +86,33 @@ it('can load config from db state', async () => {
   expect(config.postWelcomeLaunchCount).toBe(4);
 });
 
-it('trusts saved mining seats without querying cached activity', async () => {
+it('does not recover operation state from cached mining or vault activity', async () => {
   const dbPromise = createMockedDbPromise({
-    miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+    miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,
+    vaultingSetupStatus: `"${VaultingSetupStatus.Installing}"`,
     hasMiningBids: 'false',
-    hasMiningSeats: 'true',
+    hasMiningSeats: 'false',
+    vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules'), 2),
   });
   const db = await dbPromise;
-  vi.spyOn(db, 'select').mockRejectedValue(new Error('cached mining activity should not be queried'));
+  const miningActivitySpy = vi
+    .spyOn(db, 'select')
+    .mockRejectedValue(new Error('cached mining activity should not be queried'));
+  const vaultActivitySpy = vi
+    .spyOn(db.vaultsTable, 'get')
+    .mockRejectedValue(new Error('cached vault activity should not be queried'));
   const { walletKeys } = createTestWallet('//Alice');
   instanceChecks.delete(Config.prototype.constructor);
   const config = new Config(dbPromise, walletKeys);
 
   await config.load();
 
-  expect(config.hasMiningBids).toBe(true);
-  expect(config.hasMiningSeats).toBe(true);
-});
-
-it('restores established mining flags from cached activity on app restart', async () => {
-  const db = await createTestDb();
-  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
-  biddingRules.initialCapitalCommitment = 1n;
-  await db.configTable.insertOrReplace({
-    miningSetupStatus: `"${MiningSetupStatus.Installing}"`,
-    isServerInstalled: 'true',
-    isServerInstalling: 'true',
-    hasMiningBids: 'false',
-    hasMiningSeats: 'false',
-    biddingRules: JsonExt.stringify(biddingRules),
-  });
-  await db.frameBidsTable.insertOrUpdate(20, 200, [
-    {
-      address: '5cachedBid',
-      subAccountIndex: 1,
-      microgonsPerSeat: 10n,
-      micronotsStakedPerSeat: 20n,
-      bidPosition: 0,
-      lastBidAtTick: 100,
-    },
-  ]);
-  await db.framesTable.insertOrUpdate({
-    id: 19,
-    firstTick: 1,
-    rewardTicksRemaining: 0,
-    firstBlockNumber: 100,
-    lastBlockNumber: 199,
-    microgonToUsd: [],
-    microgonToBtc: [],
-    microgonToArgonot: [],
-    accruedMicrogonProfits: 0n,
-    accruedMicronotProfits: 0n,
-    progress: 100,
-  });
-  await db.cohortsTable.insertOrUpdate({
-    id: 19,
-    transactionFeesTotal: 0n,
-    micronotsStakedPerSeat: 20n,
-    microgonsBidPerSeat: 10n,
-    seatCountWon: 1,
-    microgonsToBeMinedPerSeat: 30n,
-    micronotsToBeMinedPerSeat: 40n,
-    argonotPriceAtBid: 50n,
-  });
-  const { walletKeys } = createTestWallet('//Alice');
-  instanceChecks.delete(Config.prototype.constructor);
-  const config = new Config(Promise.resolve(db), walletKeys);
-
-  try {
-    await config.load();
-
-    expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
-    expect(config.hasMiningBids).toBe(true);
-    expect(config.hasMiningSeats).toBe(true);
-    await expect(db.configTable.fetchAllAsObject()).resolves.toEqual(
-      expect.objectContaining({
-        miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
-        hasMiningBids: 'true',
-        hasMiningSeats: 'true',
-      }),
-    );
-  } finally {
-    await db.close();
-    instanceChecks.delete(db.constructor);
-  }
+  expect(miningActivitySpy).not.toHaveBeenCalled();
+  expect(vaultActivitySpy).not.toHaveBeenCalled();
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Checklist);
+  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Installing);
+  expect(config.hasMiningBids).toBe(false);
+  expect(config.hasMiningSeats).toBe(false);
 });
 
 it('migrates old server port field to sshPort', async () => {
@@ -216,122 +153,76 @@ it.each(['loading', 'ARGON_NETWORK_NAME'])('clears fake upstream state stored wi
   expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({ bootstrapDetails: '', upstreamOperator: '' }));
 });
 
-it.each([MiningSetupStatus.Checklist, MiningSetupStatus.Installing])(
-  'finishes interrupted mining setup from %s when bidding rules and the server were already saved',
-  async miningSetupStatus => {
-    const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
-    biddingRules.initialCapitalCommitment = 1n;
-    const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
-    serverInstaller.MiningLaunch.status = InstallStepStatus.Completed;
-    const dbPromise = createMockedDbPromise({
-      miningSetupStatus: `"${miningSetupStatus}"`,
+it('preserves established operation state when recreating the local database', async () => {
+  const db = await createTestDb();
+  const replacementDb = await createTestDb();
+  const miningHistory = [{ frameId: 10, bids: [], seats: [] }];
+  const pluginSqlLoad = vi.spyOn(PluginSql, 'load').mockResolvedValue(replacementDb.sql);
+
+  try {
+    await db.configTable.insertOrReplace({
+      hasExtensionTreasury: 'true',
+      hasExtensionOperations: 'true',
+      miningSetupStatus: `"${MiningSetupStatus.Finished}"`,
+      vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"`,
       isServerInstalled: 'true',
-      biddingRules: JsonExt.stringify(biddingRules),
-      serverInstaller: JsonExt.stringify(serverInstaller),
+      hasMiningBids: 'true',
+      hasMiningSeats: 'true',
+      walletAccountsHadPreviousLife: 'true',
+      walletPreviousLifeRecovered: 'true',
+      miningBotAccountPreviousHistory: JsonExt.stringify(miningHistory),
     });
-    const db = await dbPromise;
-    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
-    const { walletKeys } = createTestWallet('//Alice');
-    instanceChecks.delete(Config.prototype.constructor);
-    const config = new Config(dbPromise, walletKeys);
-
-    await config.load();
-
-    expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
-    expect(saveSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ miningSetupStatus: `"${MiningSetupStatus.Finished}"` }),
-    );
-  },
-);
-
-it('keeps mining setup active while the final server install step is still running', async () => {
-  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
-  biddingRules.initialCapitalCommitment = 1n;
-  const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
-  serverInstaller.MiningLaunch.status = InstallStepStatus.Working;
-  const dbPromise = createMockedDbPromise({
-    miningSetupStatus: `"${MiningSetupStatus.Installing}"`,
-    isServerInstalled: 'true',
-    isServerInstalling: 'true',
-    biddingRules: JsonExt.stringify(biddingRules),
-    serverInstaller: JsonExt.stringify(serverInstaller),
-  });
-  const { walletKeys } = createTestWallet('//Alice');
-  instanceChecks.delete(Config.prototype.constructor);
-  const config = new Config(dbPromise, walletKeys);
-
-  await config.load();
-
-  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Installing);
-});
-
-it.each([VaultingSetupStatus.None, VaultingSetupStatus.Checklist, VaultingSetupStatus.Installing])(
-  'recovers completed vault setup from %s when vaulting rules and an open vault were saved',
-  async vaultingSetupStatus => {
-    const dbPromise = createMockedDbPromise({
-      vaultingSetupStatus: `"${vaultingSetupStatus}"`,
-      vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
-    });
-    const db = await dbPromise;
-    vi.spyOn(db.vaultsTable, 'get').mockResolvedValue({
+    await db.vaultsTable.insert({
       id: 1,
-      hdPath: '//1',
+      hdPath: '//vaulting',
       createdAtBlockHeight: 10,
+      lastTermsUpdateHeight: 20,
+      operationalFeeMicrogons: 30n,
       isClosed: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
     });
-    const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
     const { walletKeys } = createTestWallet('//Alice');
     instanceChecks.delete(Config.prototype.constructor);
-    const config = new Config(dbPromise, walletKeys);
-
+    const config = new Config(Promise.resolve(db), walletKeys);
     await config.load();
 
-    expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
-    expect(saveSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"` }),
+    const previousLifeSpy = vi.spyOn(walletKeys, 'didWalletHavePreviousLife');
+    const restarter = new Restarter(Promise.resolve(db), config);
+    vi.spyOn(restarter, 'deleteAndCreateLocalDatabase').mockResolvedValue();
+    vi.spyOn(restarter, 'restart').mockImplementation(() => undefined);
+    await restarter.migrateToFreshLocalDatabase();
+
+    const recoverAccount = vi.fn(async () => ({}));
+    const { walletKeys: restoredWalletKeys } = createTestWallet('//Alice');
+    instanceChecks.delete(Config.prototype.constructor);
+    const restoredConfig = new Config(Promise.resolve(replacementDb), restoredWalletKeys, recoverAccount);
+    await restoredConfig.load();
+
+    expect(previousLifeSpy).not.toHaveBeenCalled();
+    expect(recoverAccount).not.toHaveBeenCalled();
+    expect(restoredConfig.isBootingUpPreviousWalletHistory).toBe(false);
+    expect(restoredConfig.hasExtensionTreasury).toBe(true);
+    expect(restoredConfig.hasExtensionOperations).toBe(true);
+    expect(restoredConfig.miningSetupStatus).toBe(MiningSetupStatus.Finished);
+    expect(restoredConfig.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
+    expect(restoredConfig.isServerInstalled).toBe(true);
+    expect(restoredConfig.hasMiningBids).toBe(true);
+    expect(restoredConfig.hasMiningSeats).toBe(true);
+    expect(restoredConfig.walletAccountsHadPreviousLife).toBe(true);
+    expect(restoredConfig.walletPreviousLifeRecovered).toBe(true);
+    expect(restoredConfig.miningBotAccountPreviousHistory).toEqual(miningHistory);
+    await expect(replacementDb.vaultsTable.get()).resolves.toEqual(
+      expect.objectContaining({
+        id: 1,
+        hdPath: '//vaulting',
+        createdAtBlockHeight: 10,
+        lastTermsUpdateHeight: 20,
+        operationalFeeMicrogons: 30n,
+        isClosed: false,
+      }),
     );
-  },
-);
-
-it('preserves completed vaulting setup when recreating the local database', async () => {
-  const dbPromise = createMockedDbPromise({
-    vaultingSetupStatus: `"${VaultingSetupStatus.Finished}"`,
-    hasExtensionTreasury: 'true',
-    hasExtensionOperations: 'true',
-  });
-  const { walletKeys } = createTestWallet('//Alice');
-  instanceChecks.delete(Config.prototype.constructor);
-  const config = new Config(dbPromise, walletKeys);
-  await config.load();
-
-  await config.restoreToConnection({} as PluginSql);
-
-  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Finished);
-  expect(config.hasExtensionTreasury).toBe(true);
-  expect(config.hasExtensionOperations).toBe(true);
-});
-
-it('keeps interrupted setup active without durable evidence that creation finished', async () => {
-  const biddingRules = Config.getDefault('biddingRules') as IConfig['biddingRules'];
-  biddingRules.initialCapitalCommitment = 0n;
-  const serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
-  serverInstaller.MiningLaunch.status = InstallStepStatus.Completed;
-  const dbPromise = createMockedDbPromise({
-    miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,
-    isServerInstalled: 'true',
-    vaultingSetupStatus: `"${VaultingSetupStatus.Installing}"`,
-    biddingRules: JsonExt.stringify(biddingRules),
-    vaultingRules: JsonExt.stringify(Config.getDefault('vaultingRules')),
-    serverInstaller: JsonExt.stringify(serverInstaller),
-  });
-  const { walletKeys } = createTestWallet('//Alice');
-  instanceChecks.delete(Config.prototype.constructor);
-  const config = new Config(dbPromise, walletKeys);
-
-  await config.load();
-
-  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Checklist);
-  expect(config.vaultingSetupStatus).toBe(VaultingSetupStatus.Installing);
+  } finally {
+    pluginSqlLoad.mockRestore();
+    await db.close();
+    await replacementDb.close();
+  }
 });

--- a/src-vue/__test__/Importer.test.ts
+++ b/src-vue/__test__/Importer.test.ts
@@ -1,0 +1,176 @@
+import './helpers/mocks.ts';
+import { expect, it, vi } from 'vitest';
+import Importer from '../lib/Importer.ts';
+import { Config } from '../lib/Config.ts';
+import { createMockedDbPromise } from './helpers/db.ts';
+import { createTestWallet } from './helpers/wallet.ts';
+import { instanceChecks } from '../lib/Utils.ts';
+import { SSH } from '../lib/SSH.ts';
+import { type IConfig, MiningSetupStatus, VaultingSetupStatus } from '../interfaces/IConfig.ts';
+import { JsonExt, Mining } from '@argonprotocol/apps-core';
+import Restarter from '../lib/Restarter.ts';
+import { MemoryWalletKeys } from '../lib/MemoryWalletKeys.ts';
+import type { Db } from '../lib/Db.ts';
+
+const importMocks = vi.hoisted(() => ({
+  closeWallets: vi.fn(),
+  getFinalizedClient: vi.fn(),
+  readBalances: vi.fn(),
+  stopBlockWatch: vi.fn(),
+}));
+
+vi.mock('../stores/mainchain.ts', () => ({
+  getFinalizedClient: importMocks.getFinalizedClient,
+  getBlockWatch: () => ({ stop: importMocks.stopBlockWatch }),
+}));
+
+vi.mock('../stores/wallets.ts', () => ({
+  getWalletsForArgon: () => ({ close: importMocks.closeWallets }),
+}));
+
+vi.mock('../lib/WalletsForArgon.ts', async importOriginal => ({
+  ...(await importOriginal()),
+  readArgonWalletBalanceValues: importMocks.readBalances,
+}));
+
+it('reconstructs operation state from the imported mnemonic account', async () => {
+  const mnemonic = 'test test test test test test test test test test test junk';
+  const { walletKeys } = createTestWallet('//Alice');
+  const importWalletKeys = new MemoryWalletKeys({
+    substrateSuri: mnemonic,
+    masterMnemonic: mnemonic,
+  });
+  const insertOrReplace = vi.fn();
+  const db = {
+    reconnect: vi.fn(),
+    configTable: { insertOrReplace },
+  } as unknown as Db;
+  const operationalDetails = {
+    miningSeatAccrual: { toNumber: () => 0 },
+    miningSeatAppliedTotal: { toNumber: () => 1 },
+    miningAccount: { toHuman: () => importWalletKeys.miningBotAddress },
+    vaultCreated: { toPrimitive: () => true },
+  };
+  importMocks.getFinalizedClient.mockResolvedValue({
+    query: {
+      operationalAccounts: {
+        operationalAccounts: vi.fn().mockImplementation(async address => {
+          const isSome = address === importWalletKeys.operationalAddress;
+          return {
+            isSome,
+            unwrap: () => operationalDetails,
+          };
+        }),
+      },
+      system: {
+        account: vi.fn().mockImplementation(async address => ({
+          nonce: { toBigInt: () => (address === importWalletKeys.miningBotAddress ? 1n : 0n) },
+          providers: { toNumber: () => 0 },
+          consumers: { toNumber: () => 0 },
+          sufficients: { toNumber: () => 0 },
+        })),
+      },
+    },
+  });
+  importMocks.readBalances.mockImplementation(async (_api, addresses: string[]) => {
+    expect(addresses).toEqual([
+      importWalletKeys.legacyMiningHoldAddress,
+      importWalletKeys.miningBotAddress,
+      importWalletKeys.vaultingAddress,
+      importWalletKeys.operationalAddress,
+    ]);
+    return [emptyBalance, emptyBalance, { ...emptyBalance, availableMicrogons: 1n }, emptyBalance];
+  });
+  vi.spyOn(Mining, 'fetchMiningSeatsForAccount').mockImplementation(async address => {
+    if (address !== importWalletKeys.miningBotAddress) {
+      throw new Error('Queried mining seats for the active wallet');
+    }
+    return {};
+  });
+  vi.spyOn(Mining, 'fetchWinningBids').mockResolvedValue([]);
+  vi.spyOn(MemoryWalletKeys.prototype, 'getMiningBotSubaccounts').mockResolvedValue({});
+  vi.spyOn(Restarter.prototype, 'deleteAndCreateLocalDatabase').mockResolvedValue();
+  const restart = vi.spyOn(Restarter.prototype, 'restart').mockImplementation(() => undefined);
+
+  await new Importer({} as Config, walletKeys, Promise.resolve(db)).importFromMnemonic(mnemonic);
+
+  expect(insertOrReplace).toHaveBeenCalledWith({
+    showWelcomeOverlay: 'false',
+    walletAccountsHadPreviousLife: 'true',
+    walletPreviousLifeRecovered: 'false',
+    hasExtensionTreasury: 'true',
+    hasExtensionOperations: 'true',
+    miningSetupStatus: JsonExt.stringify(MiningSetupStatus.Finished, 2),
+    vaultingSetupStatus: JsonExt.stringify(VaultingSetupStatus.Finished, 2),
+    hasMiningBids: 'true',
+    hasMiningSeats: 'true',
+  });
+  expect(restart).toHaveBeenCalledOnce();
+});
+
+it('rejects a matching server without bidding rules before restoring mining setup', async () => {
+  const dbPromise = createMockedDbPromise();
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  vi.spyOn(SSH, 'tryConnection').mockResolvedValue({
+    walletAddress: walletKeys.miningBotAddress,
+    biddingRules: undefined,
+    oldestFrameIdToSync: 10,
+    ethereumBeaconApiUrl: 'http://beacon',
+    ethereumExecutionRpcUrl: 'http://execution',
+  });
+
+  const importer = new Importer(config, walletKeys, dbPromise);
+  await expect(importer.importFromServer('10.0.0.1')).rejects.toThrow('No bidding rules found on server');
+
+  expect(config.isServerInstalled).toBe(false);
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.None);
+  expect(config.hasExtensionTreasury).toBe(false);
+  expect(config.hasExtensionOperations).toBe(false);
+});
+
+it('restores completed mining setup from a matching server with bidding rules', async () => {
+  const dbPromise = createMockedDbPromise();
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(dbPromise, walletKeys);
+  await config.load();
+
+  vi.spyOn(SSH, 'tryConnection').mockResolvedValue({
+    walletAddress: walletKeys.miningBotAddress,
+    biddingRules: Config.getDefault('biddingRules') as IConfig['biddingRules'],
+    oldestFrameIdToSync: 10,
+    ethereumBeaconApiUrl: 'http://beacon',
+    ethereumExecutionRpcUrl: 'http://execution',
+  });
+
+  const db = await dbPromise;
+  const saveSpy = vi.spyOn(db.configTable, 'insertOrReplace');
+  await new Importer(config, walletKeys, dbPromise).importFromServer('10.0.0.1');
+
+  expect(config.serverDetails.ipAddress).toBe('10.0.0.1');
+  expect(config.isServerInstalled).toBe(true);
+  expect(config.isServerInstalling).toBe(false);
+  expect(config.miningSetupStatus).toBe(MiningSetupStatus.Finished);
+  expect(config.hasExtensionTreasury).toBe(true);
+  expect(config.hasExtensionOperations).toBe(true);
+  expect(saveSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      biddingRules: JsonExt.stringify(Config.getDefault('biddingRules'), 2),
+      isServerInstalled: 'true',
+      miningSetupStatus: JsonExt.stringify(MiningSetupStatus.Finished, 2),
+      hasExtensionTreasury: 'true',
+      hasExtensionOperations: 'true',
+    }),
+  );
+});
+
+const emptyBalance = {
+  availableMicrogons: 0n,
+  reservedMicrogons: 0n,
+  availableMicronots: 0n,
+  reservedMicronots: 0n,
+};

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -134,16 +134,23 @@ export class Config implements IConfig {
     const preserveFields: (keyof IConfig)[] = [
       'upstreamOperator',
       'bootstrapDetails',
-      'serverAdd',
-      'serverDetails',
-      'biddingRules',
-      'vaultingRules',
-      'vaultingSetupStatus',
-      'oldestFrameIdToSync',
-      'defaultCurrencyKey',
-      'requiresPassword',
       'hasExtensionTreasury',
       'hasExtensionOperations',
+      'serverAdd',
+      'serverDetails',
+      'isServerInstalled',
+      'biddingRules',
+      'vaultingRules',
+      'miningSetupStatus',
+      'vaultingSetupStatus',
+      'hasMiningBids',
+      'hasMiningSeats',
+      'oldestFrameIdToSync',
+      'miningBotAccountPreviousHistory',
+      'walletAccountsHadPreviousLife',
+      'walletPreviousLifeRecovered',
+      'defaultCurrencyKey',
+      'requiresPassword',
     ];
 
     for (const key of Object.keys(defaults) as (keyof IConfig)[]) {
@@ -154,7 +161,6 @@ export class Config implements IConfig {
         (this._loadedData as any)[key] = defaultValue as any;
       }
     }
-    await this._injectFirstTimeAppData(this._loadedData, this._rawData, this._fieldsToSave);
     const data = Config.extractDataToSave(this._fieldsToSave, this._rawData);
     await this._db.configTable.insertOrReplace(data, sql);
   }
@@ -267,53 +273,11 @@ export class Config implements IConfig {
         await this._injectFirstTimeAppData(loadedData, rawData, fieldsToSave);
       }
 
-      let hasMiningSeats = loadedData.hasMiningSeats;
-      let hasMiningBids = loadedData.hasMiningBids || hasMiningSeats;
-      if (!hasMiningSeats) {
-        const [savedMiningActivity] = await db.select<[{ hasMiningBids: number; hasMiningSeats: number }]>(`
-          SELECT
-            EXISTS(SELECT 1 FROM FrameBids WHERE json_array_length(bidsJson) > 0) AS hasMiningBids,
-            EXISTS(SELECT 1 FROM Cohorts WHERE seatCountWon > 0) AS hasMiningSeats
-        `);
-        hasMiningSeats = !!savedMiningActivity?.hasMiningSeats;
-        hasMiningBids ||= !!savedMiningActivity?.hasMiningBids || hasMiningSeats;
-      }
-      if (hasMiningSeats !== loadedData.hasMiningSeats) {
-        loadedData.hasMiningSeats = hasMiningSeats;
-        fieldsToSave.add(dbFields.hasMiningSeats);
-        rawData[dbFields.hasMiningSeats] = JsonExt.stringify(hasMiningSeats, 2);
-      }
+      const hasMiningBids = loadedData.hasMiningBids || loadedData.hasMiningSeats;
       if (hasMiningBids !== loadedData.hasMiningBids) {
         loadedData.hasMiningBids = hasMiningBids;
         fieldsToSave.add(dbFields.hasMiningBids);
         rawData[dbFields.hasMiningBids] = JsonExt.stringify(hasMiningBids, 2);
-      }
-
-      if (hasMiningBids && loadedData.miningSetupStatus !== MiningSetupStatus.Finished) {
-        loadedData.miningSetupStatus = MiningSetupStatus.Finished;
-        fieldsToSave.add(dbFields.miningSetupStatus);
-        rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
-      } else if (
-        (loadedData.miningSetupStatus === MiningSetupStatus.Checklist ||
-          loadedData.miningSetupStatus === MiningSetupStatus.Installing) &&
-        loadedData.isServerInstalled &&
-        !loadedData.isServerInstalling &&
-        loadedData.serverInstaller.MiningLaunch.status === InstallStepStatus.Completed &&
-        rawData[dbFields.biddingRules] &&
-        (loadedData.biddingRules.initialCapitalCommitment ?? 0n) > 0n
-      ) {
-        loadedData.miningSetupStatus = MiningSetupStatus.Finished;
-        fieldsToSave.add(dbFields.miningSetupStatus);
-        rawData[dbFields.miningSetupStatus] = JsonExt.stringify(loadedData.miningSetupStatus, 2);
-      }
-
-      if (loadedData.vaultingSetupStatus !== VaultingSetupStatus.Finished && rawData[dbFields.vaultingRules]) {
-        const savedVault = await db.vaultsTable.get();
-        if (savedVault && !savedVault.isClosed) {
-          loadedData.vaultingSetupStatus = VaultingSetupStatus.Finished;
-          fieldsToSave.add(dbFields.vaultingSetupStatus);
-          rawData[dbFields.vaultingSetupStatus] = JsonExt.stringify(loadedData.vaultingSetupStatus, 2);
-        }
       }
 
       const hasLegacyAccountState =

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -2,8 +2,13 @@ import { type Config } from './Config';
 import Restarter from './Restarter';
 import { Db } from './Db';
 import { invokeWithTimeout } from './tauriApi';
-import { ITryServerData, SSH } from './SSH';
-import { IConfigServerDetails } from '../interfaces/IConfig';
+import { type ITryServerData, SSH } from './SSH';
+import {
+  type IConfigServerDetails,
+  type IConfigStringified,
+  MiningSetupStatus,
+  VaultingSetupStatus,
+} from '../interfaces/IConfig';
 import { IS_LOCAL_BUILD, NETWORK_NAME, SECURITY } from './Env.ts';
 import { hasArgonWalletValue } from './WalletForArgon.ts';
 import { WalletKeys } from './WalletKeys.ts';
@@ -11,6 +16,7 @@ import { MemoryWalletKeys } from './MemoryWalletKeys.ts';
 import { readArgonWalletBalanceValues } from './WalletsForArgon.ts';
 import { getWalletsForArgon } from '../stores/wallets.ts';
 import { getBlockWatch, getFinalizedClient } from '../stores/mainchain.ts';
+import { JsonExt, Mining } from '@argonprotocol/apps-core';
 
 export default class Importer {
   private readonly config: Config;
@@ -28,28 +34,55 @@ export default class Importer {
   }
 
   public async importFromMnemonic(mnemonic: string) {
-    if (NETWORK_NAME === 'mainnet' && !IS_LOCAL_BUILD) {
-      const importWalletKeys = new MemoryWalletKeys({
-        substrateSuri: mnemonic,
-        masterMnemonic: mnemonic,
-      });
-      const finalizedApi = await getFinalizedClient();
-      const addresses = [
-        importWalletKeys.defaultArgonAddress,
-        importWalletKeys.miningBotAddress,
-        importWalletKeys.vaultingAddress,
-        importWalletKeys.operationalAddress,
-        importWalletKeys.defaultArgonAddress,
-      ];
-      const balances = await readArgonWalletBalanceValues(finalizedApi, addresses);
+    const importWalletKeys = new MemoryWalletKeys({
+      substrateSuri: mnemonic,
+      masterMnemonic: mnemonic,
+    });
+    const finalizedApi = await getFinalizedClient();
+    const addresses = [
+      importWalletKeys.legacyMiningHoldAddress,
+      importWalletKeys.miningBotAddress,
+      importWalletKeys.vaultingAddress,
+      importWalletKeys.operationalAddress,
+    ];
+    const [balances, operationalAccount, miningAccount, miningSeats, currentBids, miningSubaccounts] =
+      await Promise.all([
+        readArgonWalletBalanceValues(finalizedApi, addresses),
+        finalizedApi.query.operationalAccounts.operationalAccounts(importWalletKeys.operationalAddress),
+        finalizedApi.query.system.account(importWalletKeys.miningBotAddress),
+        Mining.fetchMiningSeatsForAccount(importWalletKeys.miningBotAddress, finalizedApi),
+        Mining.fetchWinningBids(finalizedApi),
+        importWalletKeys.getMiningBotSubaccounts(),
+      ]);
 
-      const hasExistingWalletValue = balances.some(balance => {
-        return hasArgonWalletValue(balance);
+    const hasExistingWalletValue = balances.some(balance => {
+      return hasArgonWalletValue(balance);
+    });
+    const operationalDetails = operationalAccount.isSome ? operationalAccount.unwrap() : undefined;
+    const hasLiveMiningSeats = Object.keys(miningSeats).length > 0;
+    const hasRecordedMiningSeats =
+      (operationalDetails?.miningSeatAccrual?.toNumber() ?? 0) +
+        (operationalDetails?.miningSeatAppliedTotal?.toNumber() ?? 0) >
+      0;
+    const hasMiningSeats = hasLiveMiningSeats || hasRecordedMiningSeats;
+    const hasMiningBids =
+      hasMiningSeats ||
+      currentBids.some(bid => {
+        return bid.managedByAddress === importWalletKeys.miningBotAddress || !!miningSubaccounts[bid.address];
       });
+    const hasMiningAccountInfo =
+      hasArgonWalletValue(balances[1]) ||
+      miningAccount.nonce.toBigInt() > 0n ||
+      miningAccount.providers.toNumber() > 0 ||
+      miningAccount.consumers.toNumber() > 0 ||
+      miningAccount.sufficients.toNumber() > 0;
+    const hasLinkedMiningAccount = operationalDetails?.miningAccount.toHuman() === importWalletKeys.miningBotAddress;
+    const hasMiningAccount = hasLinkedMiningAccount || hasMiningAccountInfo || hasMiningBids;
+    const hasVault = operationalDetails?.vaultCreated?.toPrimitive() ?? false;
+    const hasPreviousLife = hasExistingWalletValue || !!operationalDetails || hasMiningAccount;
 
-      if (!hasExistingWalletValue) {
-        throw new Error('No existing wallet value was found for that mnemonic on this network.');
-      }
+    if (NETWORK_NAME === 'mainnet' && !IS_LOCAL_BUILD && !hasPreviousLife) {
+      throw new Error('No existing wallet value was found for that mnemonic on this network.');
     }
 
     await this.shutdownBackgroundSync();
@@ -61,16 +94,21 @@ export default class Importer {
     const security = await invokeWithTimeout('overwrite_mnemonic', { mnemonic }, 10_000);
     Object.assign(SECURITY, security);
 
-    await this.config.load(true);
-    this.config.showWelcomeOverlay = false;
-    await this.config.save();
+    // The live Config and wallet singletons still reference the previous mnemonic until the app reloads.
+    const importedConfig: Partial<IConfigStringified> = {
+      showWelcomeOverlay: JsonExt.stringify(false, 2),
+      walletAccountsHadPreviousLife: JsonExt.stringify(hasPreviousLife, 2),
+      walletPreviousLifeRecovered: JsonExt.stringify(!hasPreviousLife, 2),
+      hasExtensionTreasury: JsonExt.stringify(hasPreviousLife, 2),
+      hasExtensionOperations: JsonExt.stringify(!!operationalDetails || hasMiningAccount, 2),
+      miningSetupStatus: JsonExt.stringify(hasMiningAccount ? MiningSetupStatus.Finished : MiningSetupStatus.None, 2),
+      vaultingSetupStatus: JsonExt.stringify(hasVault ? VaultingSetupStatus.Finished : VaultingSetupStatus.None, 2),
+      hasMiningBids: JsonExt.stringify(hasMiningBids, 2),
+      hasMiningSeats: JsonExt.stringify(hasMiningSeats, 2),
+    };
+    await db.configTable.insertOrReplace(importedConfig);
 
     restarter.restart();
-  }
-
-  private async shutdownBackgroundSync() {
-    await getWalletsForArgon().close();
-    getBlockWatch().stop();
   }
 
   public async importFromServer(ipAddress: string) {
@@ -88,16 +126,30 @@ export default class Importer {
       throw new Error('Failed to fetch server data');
     } else if (serverData.walletAddress !== this.walletKeys.miningBotAddress) {
       throw new Error('Wallet address mismatch');
+    } else if (!serverData.biddingRules) {
+      throw new Error('No bidding rules found on server');
     }
 
     // TODO: We might want to return this data to the caller (BotCreatePanel) so they can hold it in case the user
     // wants to click the Cancel button.
-    this.config.biddingRules = serverData.biddingRules!;
-    this.config.oldestFrameIdToSync = serverData.oldestFrameIdToSync!;
+    this.config.biddingRules = serverData.biddingRules;
+    if (serverData.oldestFrameIdToSync !== undefined) {
+      this.config.oldestFrameIdToSync = serverData.oldestFrameIdToSync;
+    }
     this.config.ethereumBeaconApiUrl = serverData.ethereumBeaconApiUrl;
     this.config.ethereumExecutionRpcUrl = serverData.ethereumExecutionRpcUrl;
     this.config.serverDetails = { ...this.config.serverDetails, ipAddress };
-    await this.config.save();
+    this.config.isServerInstalled = true;
+    this.config.isServerInstalling = false;
+    this.config.miningSetupStatus = MiningSetupStatus.Finished;
+    this.config.hasExtensionTreasury = true;
+    this.config.hasExtensionOperations = true;
+    await this.config.saveBiddingRules();
+  }
+
+  private async shutdownBackgroundSync() {
+    await getWalletsForArgon().close();
+    getBlockWatch().stop();
   }
 
   private async fetchServerData(serverDetails: IConfigServerDetails): Promise<ITryServerData | undefined> {

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -1596,7 +1596,13 @@ export class MyVault {
   }): Promise<void> {
     const { vault, createBlockNumber, masterXpubPath, txFee } = data;
     const table = await this.getTable();
-    this.data.metadata = await table.insert(vault.vaultId, masterXpubPath, createBlockNumber, txFee);
+    this.data.metadata = await table.insert({
+      id: vault.vaultId,
+      hdPath: masterXpubPath,
+      createdAtBlockHeight: createBlockNumber,
+      operationalFeeMicrogons: txFee,
+      isClosed: false,
+    });
     this.data.createdVault = vault;
     this.vaults.vaultsById[vault.vaultId] = vault;
   }

--- a/src-vue/lib/Restarter.ts
+++ b/src-vue/lib/Restarter.ts
@@ -82,6 +82,7 @@ export default class Restarter {
   public async migrateToFreshLocalDatabase(restartAfter: boolean = true) {
     const db = await this.dbPromise;
     const config = this._config;
+    const vault = await db.vaultsTable.get().catch(() => undefined);
 
     await this.deleteAndCreateLocalDatabase();
     if (restartAfter) {
@@ -93,6 +94,9 @@ export default class Restarter {
     const sql = await PluginSql.load(`sqlite:${Db.relativePath}`);
 
     await config.restoreToConnection(sql);
+    if (vault) {
+      await db.vaultsTable.insert(vault, sql);
+    }
 
     if (restartAfter) {
       this.restart();

--- a/src-vue/lib/db/VaultsTable.ts
+++ b/src-vue/lib/db/VaultsTable.ts
@@ -1,5 +1,6 @@
 import { BaseTable, IFieldTypes } from './BaseTable';
 import { convertFromSqliteFields, toSqlParams } from '../Utils';
+import type PluginSql from '@tauri-apps/plugin-sql';
 
 export interface IVaultRecord {
   id: number;
@@ -12,31 +13,47 @@ export interface IVaultRecord {
   updatedAt: Date;
 }
 
+export type IVaultInsert = Omit<IVaultRecord, 'createdAt' | 'updatedAt'> &
+  Partial<Pick<IVaultRecord, 'createdAt' | 'updatedAt'>>;
+
 export class VaultsTable extends BaseTable {
   private fieldTypes: IFieldTypes = {
     date: ['createdAt', 'updatedAt'],
     bigint: ['operationalFeeMicrogons'],
+    boolean: ['isClosed'],
   };
 
-  public async insert(
-    vaultId: number,
-    hdPath: string,
-    updatedAtBlockHeight: number,
-    operationalFeeMicrogons: bigint,
-  ): Promise<IVaultRecord> {
-    const result = await this.db.select<IVaultRecord[]>(
-      `INSERT INTO Vaults (id, hdPath, createdAtBlockHeight, operationalFeeMicrogons)
-       VALUES (?, ?, ?, ?)
+  public async insert(vault: IVaultInsert, overrideSqlInstance?: PluginSql): Promise<IVaultRecord> {
+    const sql = overrideSqlInstance ?? this.db;
+    const createdAt = vault.createdAt ?? new Date();
+    const updatedAt = vault.updatedAt ?? createdAt;
+    const result = await sql.select<IVaultRecord[]>(
+      `INSERT INTO Vaults (
+         id, hdPath, createdAtBlockHeight, lastTermsUpdateHeight,
+         operationalFeeMicrogons, isClosed, createdAt, updatedAt
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          hdPath = excluded.hdPath,
          createdAtBlockHeight = excluded.createdAtBlockHeight,
          operationalFeeMicrogons = excluded.operationalFeeMicrogons,
-         updatedAt = CURRENT_TIMESTAMP
+         lastTermsUpdateHeight = excluded.lastTermsUpdateHeight,
+         isClosed = excluded.isClosed,
+         updatedAt = excluded.updatedAt
        RETURNING *`,
-      toSqlParams([vaultId, hdPath, updatedAtBlockHeight, operationalFeeMicrogons]),
+      toSqlParams([
+        vault.id,
+        vault.hdPath,
+        vault.createdAtBlockHeight,
+        vault.lastTermsUpdateHeight,
+        vault.operationalFeeMicrogons,
+        vault.isClosed,
+        createdAt,
+        updatedAt,
+      ]),
     );
     if (!result || result.length === 0) {
-      throw new Error(`Failed to insert vault with id ${vaultId}`);
+      throw new Error(`Failed to insert vault with id ${vault.id}`);
     }
     return convertFromSqliteFields<IVaultRecord[]>(result, this.fieldTypes)[0];
   }


### PR DESCRIPTION
## Summary

Account and server recovery now restores established mining, vaulting, extension, and setup state instead of inferring it from stale local activity tables.

Same-wallet database rebuilds retain usable mining and vault state without reopening previous-life recovery, while mnemonic switches remain isolated from the previous wallet.

## Validation

- Verified mnemonic and existing-server imports restore their intended setup state.
- Verified a rebuilt local database preserves config and vault metadata across a fresh load.
- Focused tests, typecheck, lint, and ESLint pass.
