### PR TITLE
fix: include reserved backfill bonds in vault capacity

### DIFF
--- a/core/__test__/TreasuryBonds.test.ts
+++ b/core/__test__/TreasuryBonds.test.ts
@@ -1,7 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getOfflineRegistry,
+  MICROGONS_PER_ARGON,
+  type PalletTreasuryBondLot,
+  type PalletTreasuryBondLotSummary,
+  type PalletTreasuryVaultBondState,
+  PriceIndex,
+  type Vec,
+  Vault,
+} from '@argonprotocol/mainchain';
+import { encodeAddress } from '@polkadot/util-crypto';
 
 import { MICRONOTS_PER_ARGONOT } from '../src/Currency.ts';
 import { TreasuryBonds } from '../src/TreasuryBonds.ts';
+import { numberCodec, optionCodec } from './helpers/codecs.ts';
+
+const registry = getOfflineRegistry();
+const operatorAddress = encodeAddress(new Uint8Array(32).fill(0x11));
+const buyerAddress = encodeAddress(new Uint8Array(32).fill(0x22));
+const displayLotsById = new Map([
+  [1, createVaultBondLot({ owner: buyerAddress, bonds: 3 })],
+  [2, createVaultBondLot({ owner: operatorAddress, bonds: 20 })],
+  [3, createVaultBondLot({ owner: operatorAddress, bonds: 5, releaseReason: 'UserLiquidation' })],
+]);
 
 describe('TreasuryBonds', () => {
   it('limits Argonot purchases to the unfilled portion of the circulation cap', () => {
@@ -15,4 +36,139 @@ describe('TreasuryBonds', () => {
       }),
     ).toBe(75n * oneArgonot);
   });
+
+  it('keeps owner display lots separate from current runtime capacity', async () => {
+    const oneArgon = BigInt(MICROGONS_PER_ARGON);
+    let capacityBonds = 10n;
+    const vault = createCapacityVault(() => capacityBonds);
+    const priceIndex = new PriceIndex();
+    vi.spyOn(priceIndex, 'getSatoshiPriceInTargetMicrogons').mockImplementation(
+      satoshis => BigInt(satoshis) * oneArgon,
+    );
+
+    const runtimeState = registry.createType<PalletTreasuryVaultBondState>('PalletTreasuryVaultBondState', {
+      bondLots: [{ bondLotId: 1, bonds: 3 }],
+      backfillBonds: 20,
+      backfillBondsReserved: 2,
+    });
+    const client = createVaultBondClient(runtimeState, displayLotsById, [2, 3]);
+    const bondState = await TreasuryBonds.getVaultBondState(client as any, 1, operatorAddress);
+
+    expect(bondState.bondLots.map(({ id, isOwn, isReleasing }) => ({ id, isOwn, isReleasing }))).toEqual([
+      { id: 1, isOwn: false, isReleasing: false },
+      { id: 2, isOwn: true, isReleasing: false },
+      { id: 3, isOwn: true, isReleasing: true },
+    ]);
+
+    expect(
+      TreasuryBonds.availableBondSpace({
+        vault,
+        priceIndex,
+        bondState: bondState.capacityState,
+      }),
+    ).toBe(5n * oneArgon);
+
+    const moreBackfillState = registry.createType<PalletTreasuryVaultBondState>('PalletTreasuryVaultBondState', {
+      bondLots: [{ bondLotId: 1, bonds: 3 }],
+      backfillBonds: 200,
+      backfillBondsReserved: 2,
+    });
+    const moreBackfillClient = createVaultBondClient(moreBackfillState, displayLotsById, [2, 3]);
+    const moreBackfillBondState = await TreasuryBonds.getVaultBondState(moreBackfillClient as any, 1, operatorAddress);
+
+    expect(
+      TreasuryBonds.availableBondSpace({
+        vault,
+        priceIndex,
+        bondState: moreBackfillBondState.capacityState,
+      }),
+    ).toBe(5n * oneArgon);
+
+    capacityBonds = 4n;
+
+    expect(
+      TreasuryBonds.availableBondSpace({
+        vault,
+        priceIndex,
+        bondState: bondState.capacityState,
+      }),
+    ).toBe(0n);
+  });
+
+  it('uses only legacy storage summaries for capacity', async () => {
+    const oneArgon = BigInt(MICROGONS_PER_ARGON);
+    const vault = createCapacityVault(() => 10n);
+    const priceIndex = new PriceIndex();
+    vi.spyOn(priceIndex, 'getSatoshiPriceInTargetMicrogons').mockImplementation(
+      satoshis => BigInt(satoshis) * oneArgon,
+    );
+
+    const legacyState = registry.createType<Vec<PalletTreasuryBondLotSummary>>('Vec<PalletTreasuryBondLotSummary>', [
+      { bondLotId: 1, bonds: 3 },
+    ]);
+    const client = createVaultBondClient(legacyState, displayLotsById, [2, 3]);
+    const bondState = await TreasuryBonds.getVaultBondState(client as any, 1, operatorAddress);
+
+    expect(bondState.bondLots.map(lot => lot.id)).toEqual([1, 2, 3]);
+    expect(
+      TreasuryBonds.availableBondSpace({
+        vault,
+        priceIndex,
+        bondState: bondState.capacityState,
+      }),
+    ).toBe(7n * oneArgon);
+  });
 });
+
+function createVaultBondClient(
+  vaultState: PalletTreasuryVaultBondState | Vec<PalletTreasuryBondLotSummary>,
+  lotsById: Map<number, PalletTreasuryBondLot>,
+  ownerLotIds: number[],
+) {
+  return {
+    query: {
+      treasury: {
+        bondLotsByVault: vi.fn(async () => vaultState),
+        bondLotIdsByAccount: {
+          keys: vi.fn(async () => ownerLotIds.map(id => ({ args: [undefined, numberCodec(id)] }))),
+        },
+        bondLotById: {
+          multi: vi.fn(async (ids: number[]) => ids.map(id => optionCodec(lotsById.get(id)))),
+        },
+      },
+    },
+  };
+}
+
+function createVaultBondLot({
+  owner,
+  bonds,
+  releaseReason,
+}: {
+  owner: string;
+  bonds: number;
+  releaseReason?: 'UserLiquidation';
+}) {
+  return registry.createType<PalletTreasuryBondLot>('PalletTreasuryBondLot', {
+    owner,
+    program: { Vault: { vaultId: 1, sharingPercent: 0, bonusPercent: 0 } },
+    bonds,
+    createdFrameId: 1,
+    participatedFrames: 0,
+    lastFrameEarningsFrameId: null,
+    lastFrameEarnings: null,
+    cumulativeEarnings: 0,
+    releaseFrameId: releaseReason ? 2 : null,
+    releaseReason: releaseReason ?? null,
+  });
+}
+
+function createCapacityVault(getCapacityBonds: () => bigint) {
+  const vault = Object.assign(Object.create(Vault.prototype), {
+    effectiveSecuritizedSatoshis: getCapacityBonds,
+  }) as Vault;
+
+  return {
+    availableBondSpace: vault.availableBondSpace.bind(vault),
+  };
+}

--- a/core/src/TreasuryBonds.ts
+++ b/core/src/TreasuryBonds.ts
@@ -6,8 +6,10 @@ import {
   type PalletTreasuryFrameVaultCapital,
   type PalletTreasuryVaultBondState,
   type PalletTreasuryVaultCapital,
+  type PriceIndex,
   type SubmittableExtrinsic,
   type Vec,
+  type Vault,
 } from '@argonprotocol/mainchain';
 import { stringToU8a, u8aConcat } from '@polkadot/util';
 import { bigNumberToBigInt } from './utils.js';
@@ -43,6 +45,11 @@ export interface INextFrameBondAvailability {
 
 // Deployed runtime 156 returns the summaries directly. Live metadata decodes either storage shape.
 type ISpec156VaultBondLots = Vec<PalletTreasuryBondLotSummary>;
+
+export type VaultBondCapacityState = Extract<
+  NonNullable<Parameters<Vault['availableBondSpace']>[1]>,
+  Iterable<{ activeBonds: number }>
+>;
 
 export class TreasuryBonds {
   public static async getActiveBonds(
@@ -150,10 +157,12 @@ export class TreasuryBonds {
   }
 
   public static async getBondLots(client: ArgonQueryClient, vaultId: number, ownAddress?: string): Promise<BondLot[]> {
-    const vaultState: PalletTreasuryVaultBondState | ISpec156VaultBondLots =
-      await client.query.treasury.bondLotsByVault(vaultId);
-    const summaries = 'bondLots' in vaultState ? vaultState.bondLots : vaultState;
-    const idsBySourceOrder = summaries.map(summary => summary.bondLotId.toNumber());
+    return (await TreasuryBonds.getVaultBondState(client, vaultId, ownAddress)).bondLots;
+  }
+
+  public static async getVaultBondState(client: ArgonQueryClient, vaultId: number, ownAddress?: string) {
+    const { summaries, capacityState } = await TreasuryBonds.getVaultBondSources(client, vaultId);
+    const idsBySourceOrder = [...summaries].map(summary => summary.bondLotId.toNumber());
 
     if (ownAddress) {
       const accountKeys = await client.query.treasury.bondLotIdsByAccount.keys(ownAddress);
@@ -162,14 +171,30 @@ export class TreasuryBonds {
 
     const ids = [...new Set(idsBySourceOrder)];
     const lotsById = await TreasuryBonds.getBondLotsById(client, ids);
-
-    return ids.flatMap(id => {
+    const bondLots = ids.flatMap(id => {
       const lot = lotsById.get(id);
       if (!lot) return [];
 
       const bondLot = BondLot.fromRuntime(id, lot, ownAddress);
       return bondLot.vaultId === vaultId ? [bondLot] : [];
     });
+
+    return {
+      bondLots,
+      capacityState,
+    };
+  }
+
+  public static availableBondSpace({
+    vault,
+    priceIndex,
+    bondState,
+  }: {
+    vault: Pick<Vault, 'availableBondSpace'>;
+    priceIndex: PriceIndex;
+    bondState?: VaultBondCapacityState;
+  }): bigint {
+    return vault.availableBondSpace(priceIndex, bondState, true);
   }
 
   public static async getBondLotsByAccount(client: ArgonQueryClient, accountId: string): Promise<BondLot[]> {
@@ -307,16 +332,34 @@ export class TreasuryBonds {
   }
 
   private static async getBondLotsForVault(client: ArgonQueryClient, vaultId: number): Promise<IBondLotSource[]> {
-    const vaultState: PalletTreasuryVaultBondState | ISpec156VaultBondLots =
-      await client.query.treasury.bondLotsByVault(vaultId);
-    const summaries = 'bondLots' in vaultState ? vaultState.bondLots : vaultState;
-    const ids = summaries.map(summary => summary.bondLotId.toNumber());
+    const { summaries } = await TreasuryBonds.getVaultBondSources(client, vaultId);
+    const ids = [...summaries].map(summary => summary.bondLotId.toNumber());
     const lotsById = await TreasuryBonds.getBondLotsById(client, ids);
 
     return ids.flatMap(id => {
       const lot = lotsById.get(id);
       return lot ? [{ id, lot }] : [];
     });
+  }
+
+  private static async getVaultBondSources(client: ArgonQueryClient, vaultId: number) {
+    const vaultState: PalletTreasuryVaultBondState | ISpec156VaultBondLots =
+      await client.query.treasury.bondLotsByVault(vaultId);
+    const summaries = 'bondLots' in vaultState ? vaultState.bondLots : vaultState;
+    const capacityState = [...summaries].map(summary => ({
+      activeBonds: summary.bonds.toNumber(),
+    }));
+
+    if ('bondLots' in vaultState) {
+      capacityState.push({
+        activeBonds: vaultState.backfillBondsReserved.toNumber(),
+      });
+    }
+
+    return {
+      summaries,
+      capacityState,
+    };
   }
 
   private static async getBondLotsById(

--- a/src-vue/components/SelectAVault.vue
+++ b/src-vue/components/SelectAVault.vue
@@ -74,6 +74,7 @@ import { useFinancials } from '../stores/financials.ts';
 import { getArgonBonds } from '../stores/argonBonds.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
 import { getWalletKeys } from '../stores/wallets.ts';
+import { TreasuryBonds } from '@argonprotocol/apps-core';
 
 const emit = defineEmits<{
   (e: 'load', vaults: Vault[]): void;
@@ -101,8 +102,11 @@ const selectedVaultId = Vue.ref<number | null>(null);
 const vaultBondSubscriptions: VoidFunction[] = [];
 
 function availableBondSpace(vault: Vault): bigint {
-  const bondState = argonBonds.data.vaultsById[vault.vaultId];
-  return vault.availableBondSpace(currency.priceIndex, bondState?.bondLots ?? [], true);
+  return TreasuryBonds.availableBondSpace({
+    vault,
+    priceIndex: currency.priceIndex,
+    bondState: argonBonds.data.capacityStatesByVault[vault.vaultId],
+  });
 }
 
 function bitcoinAnnualPercentRate(vault: Vault) {
@@ -137,6 +141,7 @@ async function loadVaultBondState(vaults: Vault[]) {
         {
           vaultId: vault.vaultId,
           operatorAddress: vault.operatorAccountId,
+          accountId: walletKeys.defaultArgonAddress,
         },
         client,
       ),

--- a/src-vue/lib/ArgonBonds.ts
+++ b/src-vue/lib/ArgonBonds.ts
@@ -7,6 +7,7 @@ import {
   type IFrameBondLot,
   type MiningFrames,
   TreasuryBonds,
+  type VaultBondCapacityState,
 } from '@argonprotocol/apps-core';
 import type { Config } from './Config.ts';
 import type { Db } from './Db.ts';
@@ -59,6 +60,7 @@ export class ArgonBonds {
     distributableBidPool: 0n,
     totalActiveBonds: 0,
     vaultsById: {} as Record<number, IVaultArgonBondState>,
+    capacityStatesByVault: {} as Record<number, VaultBondCapacityState>,
   };
 
   private blockSubscription?: VoidFunction;
@@ -205,16 +207,17 @@ export class ArgonBonds {
 
     const vault = this.getVaultBonds(args.vaultId);
     const frameId = args.frameId ?? this.data.currentFrameId;
-    const [activeBonds, bondLots, frameBonds] = await Promise.all([
+    const [activeBonds, bondState, frameBonds] = await Promise.all([
       TreasuryBonds.getActiveBonds(client, args.vaultId),
-      TreasuryBonds.getBondLots(client, args.vaultId, args.accountId ?? args.operatorAddress),
+      TreasuryBonds.getVaultBondState(client, args.vaultId, args.accountId ?? args.operatorAddress),
       frameId > 0
         ? TreasuryBonds.getCurrentFrameBondLots(client, args.vaultId, args.operatorAddress)
         : Promise.resolve({ bondLots: [] }),
     ]);
 
     this.data.totalActiveBonds = activeBonds.totalActiveBonds;
-    vault.bondLots = bondLots;
+    this.data.capacityStatesByVault[args.vaultId] = bondState.capacityState;
+    vault.bondLots = bondState.bondLots;
     vault.currentFrame.frameId = frameId;
     vault.currentFrame.vaultBonds = activeBonds.vaultActiveBonds;
     vault.currentFrame.bondLots = frameBonds.bondLots;

--- a/src-vue/overlays/BondPurchaseOverlay.vue
+++ b/src-vue/overlays/BondPurchaseOverlay.vue
@@ -276,12 +276,14 @@ const vaultId = Vue.computed(() => {
 
 const availableMicrogons = Vue.computed(() => wallets.defaultArgonWallet.availableMicrogons);
 
-const vaultBondState = Vue.computed(() => {
-  return vaultId.value ? argonBonds.data.vaultsById[vaultId.value] : undefined;
-});
-
 const vaultAvailableCapacity = Vue.computed(() => {
-  return vault.value?.availableBondSpace(currency.priceIndex, vaultBondState.value?.bondLots ?? [], true) ?? 0n;
+  if (!vault.value) return 0n;
+
+  return TreasuryBonds.availableBondSpace({
+    vault: vault.value,
+    priceIndex: currency.priceIndex,
+    bondState: argonBonds.data.capacityStatesByVault[vault.value.vaultId],
+  });
 });
 
 const spendableWalletBalance = Vue.computed(() => {

--- a/src-vue/stores/vaultingAssetBreakdown.ts
+++ b/src-vue/stores/vaultingAssetBreakdown.ts
@@ -119,9 +119,13 @@ export const useVaultingAssetBreakdown = defineStore('vaultingAssetBreakdown', (
 
   // The remaining next-frame room for buying new bonds.
   const treasuryBondMicrogonsAvailable = Vue.computed(() => {
-    return (
-      myVault.createdVault?.availableBondSpace(currency.priceIndex, vaultBondState.value?.bondLots ?? [], true) ?? 0n
-    );
+    if (!myVault.createdVault) return 0n;
+
+    return TreasuryBonds.availableBondSpace({
+      vault: myVault.createdVault,
+      priceIndex: currency.priceIndex,
+      bondState: argonBonds.data.capacityStatesByVault[myVault.createdVault.vaultId],
+    });
   });
 
   // Operational Fees


### PR DESCRIPTION
## Summary

Vault bond availability now subtracts reserved backfill bonds, preventing the UI from offering capacity that is already committed to backfill. Treasury storage is normalized at ingestion for both the current vault bond state and the pre-update spec-156 summary array, so the app remains compatible before the runtime upgrade without carrying runtime codecs through Vue state.

Focused coverage verifies that capacity 10 with 3 existing bonds and 2 reserved bonds reports 5 available, and that availability clamps at zero. The full typecheck passes.
