### PR TITLE
Show the correct Bitcoin capacity for vault operators

### DIFF
--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -13,6 +13,7 @@ import { bigintCodec, numberCodec, optionCodec } from '../../core/__test__/helpe
 import { encodeAddress } from '@polkadot/util-crypto';
 import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
 import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
+import * as vaultStore from '../stores/vaults.ts';
 
 function createStore(
   options: { blockWatch?: BlockWatch; transactionTracker?: TransactionTracker; walletKeys?: WalletKeys } = {},
@@ -1227,6 +1228,7 @@ describe('BitcoinLocks ratchet preview', () => {
       createdAt: '2026-01-01T00:00:00Z',
     });
     lock.lockedTargetPrice = 3_000n;
+    lock.lockDetails.ownerAccount = 'stale-bitcoin-owner';
 
     const client = {
       query: {
@@ -1235,9 +1237,10 @@ describe('BitcoinLocks ratchet preview', () => {
         },
       },
     };
+    const availableSecuritization = vi.fn(() => 10_000n);
     const vault = {
       operatorAccountId,
-      availableSecuritization: () => 10_000n,
+      availableSecuritization,
     };
     const calculateRatchetingCosts = vi.fn(async () => ({ burnAmount: 1_500n, ratchetingFee: 50n }));
     Object.assign(store, {
@@ -1257,7 +1260,50 @@ describe('BitcoinLocks ratchet preview', () => {
     const preview = await store.getRatchetPreview(lock);
 
     expect(calculateRatchetingCosts).toHaveBeenCalledWith(client, expect.anything(), vault, 2_000n);
+    expect(availableSecuritization).toHaveBeenCalledWith('bitcoin-owner');
     expect(preview.ratchetingFee).toBe(expectedFee);
+  });
+});
+
+describe('BitcoinLocks capacity owners', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('uses the prospective owner for lockable capacity', async () => {
+    const store = createStore();
+    const availableBitcoinSpace = vi.fn(() => 300n);
+    vi.spyOn(store, 'satoshisForArgonLiquidity').mockResolvedValue(300n);
+    vi.spyOn(BitcoinLock, 'calculateRedemptionAmountFromSatoshis').mockReturnValue(300n);
+
+    const capacity = await store.getLockableBitcoinCapacity({
+      vault: { availableBitcoinSpace } as never,
+      lockOwner: 'bitcoin-owner',
+    });
+
+    expect(availableBitcoinSpace).toHaveBeenCalledWith('bitcoin-owner');
+    expect(capacity.vaultCapacityLiquidityMicrogons).toBe(300n);
+  });
+
+  it('uses the existing lock owner for mismatch capacity', () => {
+    const store = createStore();
+    const availableBitcoinSpace = vi.fn(() => 300n);
+    vi.spyOn(vaultStore, 'getVaults').mockReturnValue({
+      vaultsById: { 1: { availableBitcoinSpace } },
+    } as never);
+    const lock = createLock({
+      uuid: 'mismatch-capacity',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    lock.satoshis = 100n;
+    lock.liquidityPromised = 100n;
+    lock.lockDetails.ownerAccount = 'bitcoin-owner';
+    const candidate = { satoshis: 500n } as never;
+
+    expect(store.getUnderSecuritizedMicrogons(lock, candidate)).toBe(100n);
+    expect(store.getIncreaseSecuritizationMicrogons(lock, candidate)).toBe(300n);
+    expect(availableBitcoinSpace).toHaveBeenNthCalledWith(1, 'bitcoin-owner');
+    expect(availableBitcoinSpace).toHaveBeenNthCalledWith(2, 'bitcoin-owner');
   });
 });
 

--- a/src-vue/components/SelectAVault.vue
+++ b/src-vue/components/SelectAVault.vue
@@ -36,7 +36,8 @@
             >
               BTC Space
               <br />
-              {{ currency.symbol }}{{ microgonToMoneyNm(vault.availableBitcoinSpace()).format('0,0.00') }}
+              {{ currency.symbol
+              }}{{ microgonToMoneyNm(vault.availableBitcoinSpace(walletKeys.liquidLockingAddress)).format('0,0.00') }}
             </div>
             <div
               v-else
@@ -72,6 +73,7 @@ import { Vault } from '@argonprotocol/mainchain';
 import { useFinancials } from '../stores/financials.ts';
 import { getArgonBonds } from '../stores/argonBonds.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
+import { getWalletKeys } from '../stores/wallets.ts';
 
 const emit = defineEmits<{
   (e: 'load', vaults: Vault[]): void;
@@ -90,6 +92,7 @@ const props = withDefaults(
 const currency = getCurrency();
 const financials = useFinancials();
 const argonBonds = getArgonBonds();
+const walletKeys = getWalletKeys();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -677,14 +677,14 @@ export default class BitcoinLocks {
     return BitcoinLock.satoshisRequiredForRedemptionAmount(this.#currency.priceIndex, microgonLiquidity);
   }
 
-  public async getLockableBitcoinCapacity(args: { vault: Vault; maxSatoshis?: bigint }): Promise<{
+  public async getLockableBitcoinCapacity(args: { vault: Vault; lockOwner?: string; maxSatoshis?: bigint }): Promise<{
     availableSatoshis: bigint;
     availableLiquidityMicrogons: bigint;
     vaultCapacitySatoshis: bigint;
     vaultCapacityLiquidityMicrogons: bigint;
   }> {
-    const { vault, maxSatoshis } = args;
-    const vaultCapacityLiquidityMicrogons = vault.availableBitcoinSpace() ?? 0n;
+    const { vault, lockOwner, maxSatoshis } = args;
+    const vaultCapacityLiquidityMicrogons = vault.availableBitcoinSpace(lockOwner) ?? 0n;
     const vaultCapacitySatoshis = await this.satoshisForArgonLiquidity(vaultCapacityLiquidityMicrogons);
     let availableSatoshis =
       maxSatoshis != null && maxSatoshis < vaultCapacitySatoshis ? maxSatoshis : vaultCapacitySatoshis;
@@ -1370,7 +1370,7 @@ export default class BitcoinLocks {
     const oldTargetPrice = bitcoinLock.lockedTargetPrice;
     const newTargetPrice = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(lock.satoshis);
     const lockSecuritizationRatio = await this.getLockSecuritizationRatio(client, lock);
-    const availableVaultFunds = vault.availableSecuritization();
+    const availableVaultFunds = vault.availableSecuritization(bitcoinLock.ownerAccount);
     const isUpRatchet = newTargetPrice > oldTargetPrice;
 
     let newLiquidityPromised: bigint;
@@ -1869,7 +1869,7 @@ export default class BitcoinLocks {
       receivedSatoshis: received,
     });
     if (extraLiquidity === null || extraLiquidity <= 0n) return null;
-    const availableLiquidity = vault.availableBitcoinSpace();
+    const availableLiquidity = vault.availableBitcoinSpace(lock.lockDetails.ownerAccount);
     if (availableLiquidity >= extraLiquidity) return null;
     return extraLiquidity - availableLiquidity;
   }
@@ -1888,7 +1888,7 @@ export default class BitcoinLocks {
       receivedSatoshis: received,
     });
     if (extraLiquidity === null || extraLiquidity <= 0n) return 0n;
-    const availableLiquidity = vault.availableBitcoinSpace();
+    const availableLiquidity = vault.availableBitcoinSpace(lock.lockDetails.ownerAccount);
     if (availableLiquidity <= 0n) return 0n;
     return extraLiquidity > availableLiquidity ? availableLiquidity : extraLiquidity;
   }

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -296,6 +296,10 @@ const isOperatorCouponLock = Vue.computed(() => {
   return !!operatorCoupon.value;
 });
 
+const capacityLockOwner = Vue.computed(() => {
+  return isOperatorCouponLock.value ? undefined : walletKeys.liquidLockingAddress;
+});
+
 const couponProviderLabel = Vue.computed(() => {
   const name = config.upstreamOperator?.name;
   return name || 'The vault operator';
@@ -440,7 +444,7 @@ async function submitLiquidLock() {
     }
     if (
       BitcoinLock.calculateRedemptionAmountFromSatoshis(currency.priceIndex, satoshis) >
-      (props.vault.availableBitcoinSpace() ?? 0n)
+      (props.vault.availableBitcoinSpace(capacityLockOwner.value) ?? 0n)
     ) {
       throw new Error(
         "This amount rounds above the vault's remaining capacity. Lower the requested Argons slightly and try again.",
@@ -477,6 +481,7 @@ async function setLiquidityVariables() {
   const [capacity, nextMinimumLockSatoshis] = await Promise.all([
     bitcoinLocks.getLockableBitcoinCapacity({
       vault: props.vault,
+      lockOwner: capacityLockOwner.value,
       maxSatoshis: coupon && isOperatorCouponLock.value ? coupon.coupon.maxSatoshis : undefined,
     }),
     bitcoinLocks.minimumSatoshiPerLock(),


### PR DESCRIPTION
Vault operators were shown public Bitcoin capacity that their own locks cannot use, so the app could offer an amount the runtime would reject.

Capacity displays and lock calculations now use the prospective or existing lock owner, while shared public capacity views remain owner-neutral. This keeps vault selection, amount validation, extra-funding handling, and ratchet previews aligned with runtime behavior.

The focused Bitcoin lock tests cover prospective-owner capacity, existing-lock mismatch capacity, and ratchet capacity.
