### PR TITLE
fix: prevent and recover reverted Ethereum transfers

### DIFF
--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -3,9 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { keccak256, TransactionNotFoundError, TransactionReceiptNotFoundError } from 'viem';
 import {
   createEthereumPublicClient,
+  EthereumClient,
+  EthereumTransactionRevertedError,
   getEthereumUserErrorMessage,
   submitEthereumTransaction,
 } from '../lib/EthereumClient.ts';
+import { createMockWalletKeys } from './helpers/wallet.ts';
 
 const runtimeFetchMock = vi.fn();
 
@@ -146,5 +149,28 @@ describe('EthereumClient', () => {
       'https://ethereum-configured.test/',
       'https://ethereum-fallback.test/',
     ]);
+  });
+
+  it('rejects a reverted receipt instead of counting its confirmations', async () => {
+    const txHash = `0x${'11'.repeat(32)}` as const;
+    const ethereumClient = new EthereumClient(createMockWalletKeys(), 'https://ethereum.test');
+    const getBlockNumber = vi.fn(async () => 100n);
+
+    Object.assign(ethereumClient, {
+      createExecutionClient: async () => ({
+        publicClient: {
+          getTransactionReceipt: vi.fn(async () => ({
+            blockNumber: 90n,
+            blockHash: `0x${'22'.repeat(32)}`,
+            transactionHash: txHash,
+            status: 'reverted',
+          })),
+          getBlockNumber,
+        },
+      }),
+    });
+
+    await expect(ethereumClient.getTransactionProgress({ txHash })).rejects.toThrow(EthereumTransactionRevertedError);
+    expect(getBlockNumber).not.toHaveBeenCalled();
   });
 });

--- a/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
@@ -10,7 +10,11 @@ import {
   setInboundRelayStepProgress,
 } from '../lib/CrosschainTransferProgress.ts';
 import { EthereumInboundTransferTracker } from '../lib/EthereumInboundTransferTracker.ts';
-import type { EthereumClient, IEthereumTransactionProgress } from '../lib/EthereumClient.ts';
+import {
+  EthereumTransactionRevertedError,
+  type EthereumClient,
+  type IEthereumTransactionProgress,
+} from '../lib/EthereumClient.ts';
 import {
   CrosschainInboundTransferStatus,
   type ICrosschainInboundTransferRecord,
@@ -1052,6 +1056,74 @@ describe('EthereumInboundTransferTracker integration', () => {
     expect(ethereumClient.waitForTransactionFinality).toHaveBeenCalledTimes(2);
   });
 
+  it('marks a reverted source transaction failed and clears it after dismissal', async () => {
+    const db = await createTestDb();
+    const walletKeys = createMockWalletKeys();
+    const sourceTxHash = `0x${'93'.repeat(32)}` as const;
+    const persistedRecord = await insertTransferRecord(db, walletKeys.ethereumAddress, {
+      id: 'eth-transfer-reverted',
+      token: MoveToken.ARGNOT,
+      argonDestinationAddress: walletKeys.defaultArgonAddress,
+      sourceTxHash,
+      status: CrosschainInboundTransferStatus.SourceSubmitted,
+    });
+    const ethereumClient = createEthereumClient({
+      sourceAddress: walletKeys.ethereumAddress,
+      destinationAddress: persistedRecord.argonDestinationAddress,
+      sourceTxHash,
+      sourceBlockNumber: 54,
+      sourceBlockHash: `0x${'94'.repeat(32)}`,
+      sourceLogIndex: 0,
+      gatewayActivityNonce: 9n,
+    });
+    ethereumClient.waitForTransactionFinality = vi.fn(async () => {
+      throw new EthereumTransactionRevertedError(sourceTxHash);
+    });
+    const tracker = new EthereumInboundTransferTracker(
+      Promise.resolve(db),
+      createTransactionTracker(),
+      createBlockWatch(
+        createMainchainClient({
+          getProvenNonce: () => 8n,
+        }),
+      ),
+      walletKeys,
+      ethereumClient,
+      undefined,
+      {
+        operatorHost: undefined,
+        requestEthereumGatewayCatchUp: vi.fn(),
+      },
+    );
+
+    await tracker.load();
+
+    await vi.waitFor(async () => {
+      const failedRecord = await db.crosschainInboundTransfersTable.get(persistedRecord.id);
+      expect(failedRecord?.failureReason).toContain('reverted');
+      expect(failedRecord?.isFailureAcknowledged).toBe(false);
+      expect(tracker.getTransfer(persistedRecord.id)?.transferState).toMatchObject({
+        isSubmitting: false,
+        hasPersistedTransfer: true,
+        needsAttention: true,
+        isComplete: false,
+      });
+    });
+    expect(ethereumClient.waitForTransactionFinality).toHaveBeenCalledTimes(1);
+
+    await tracker.dismissFailedTransfer(persistedRecord.id);
+
+    expect(tracker.getTransfer(persistedRecord.id)).toBeUndefined();
+    await expect(db.crosschainInboundTransfersTable.get(persistedRecord.id)).resolves.toMatchObject({
+      isFailureAcknowledged: true,
+    });
+    expect(tracker.getTransferStateForToken(MoveToken.ARGNOT)).toMatchObject({
+      isSubmitting: false,
+      hasPersistedTransfer: false,
+      needsAttention: false,
+    });
+  });
+
   it('surfaces a clear error when the Ethereum wallet cannot cover the network fee', async () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
@@ -1397,10 +1469,10 @@ async function insertTransferRecord(
     token: MoveToken.ARGN | MoveToken.ARGNOT;
     argonDestinationAddress: string;
     sourceTxHash: `0x${string}`;
-    sourceBlockNumber: number;
-    sourceBlockHash: `0x${string}`;
-    sourceLogIndex: number;
-    gatewayActivityNonce: bigint;
+    sourceBlockNumber?: number;
+    sourceBlockHash?: `0x${string}`;
+    sourceLogIndex?: number;
+    gatewayActivityNonce?: bigint;
     status: CrosschainInboundTransferStatus;
   },
 ): Promise<ICrosschainInboundTransferRecord> {

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -89,6 +89,16 @@ export type IFinalizedEthereumTransactionProgress = IEthereumTransactionProgress
   blockNumber: number;
   blockHash: Hash;
 };
+
+export class EthereumTransactionRevertedError extends Error {
+  constructor(txHash: Hash) {
+    super(
+      `Ethereum transaction ${txHash} reverted. Its contract changes were not applied, but the Ethereum network fee was still charged.`,
+    );
+    this.name = 'EthereumTransactionRevertedError';
+  }
+}
+
 type IEthereumSubmissionClient = {
   sendRawTransaction(args: { serializedTransaction: Hex }): Promise<Hash>;
   getTransaction(args: { hash: Hash }): Promise<unknown>;
@@ -1363,7 +1373,9 @@ async function buildEthereumUnsignedTransaction(args: {
     publicClient.estimateFeesPerGas(),
   ]);
   const fallbackGasPrice = fees.gasPrice ?? (await publicClient.getGasPrice());
-  const gas = (gasEstimate * 12n) / 10n;
+  // The gateway estimate can update the current block's activity locator, while the mined
+  // transaction may need the more expensive path that creates the next block locator.
+  const gas = (gasEstimate * 12n) / 10n + 50_000n;
   const maxFeePerGas = fees.maxFeePerGas ?? fallbackGasPrice;
   const maxPriorityFeePerGas = fees.maxPriorityFeePerGas ?? fallbackGasPrice;
 
@@ -1478,6 +1490,7 @@ async function waitForIndexedReceipt(publicClient: PublicClient, hash: Hash): Pr
         timeout: 5_000,
       });
       if (receipt.blockNumber !== null) {
+        assertEthereumTransactionSucceeded(receipt);
         return receipt;
       }
     } catch (error) {
@@ -1503,13 +1516,24 @@ async function getIndexedReceiptIfAvailable(
 ): Promise<EthereumExecutionReceipt | undefined> {
   try {
     const receipt = await publicClient.getTransactionReceipt({ hash });
-    return receipt.blockNumber !== null ? receipt : undefined;
+    if (receipt.blockNumber === null) {
+      return;
+    }
+
+    assertEthereumTransactionSucceeded(receipt);
+    return receipt;
   } catch (error) {
     if (error instanceof TransactionReceiptNotFoundError || isIndexingInProgressError(error)) {
       return;
     }
 
     throw error;
+  }
+}
+
+function assertEthereumTransactionSucceeded(receipt: EthereumExecutionReceipt) {
+  if (receipt.status === 'reverted') {
+    throw new EthereumTransactionRevertedError(receipt.transactionHash);
   }
 }
 

--- a/src-vue/lib/EthereumInboundTransferTracker.ts
+++ b/src-vue/lib/EthereumInboundTransferTracker.ts
@@ -14,7 +14,7 @@ import {
   setInboundRelayStepProgress,
   type ICrosschainTransferProgress,
 } from './CrosschainTransferProgress.ts';
-import { EthereumClient, type IEthereumMoveToken } from './EthereumClient.ts';
+import { EthereumClient, EthereumTransactionRevertedError, type IEthereumMoveToken } from './EthereumClient.ts';
 import { sleep } from './Utils.ts';
 import {
   CrosschainInboundTransferStatus,
@@ -425,7 +425,7 @@ export class EthereumInboundTransferTracker {
             return;
           }
         } catch (error) {
-          if (error instanceof InboundTransferInvariantError) {
+          if (error instanceof InboundTransferInvariantError || error instanceof EthereumTransactionRevertedError) {
             throw error;
           }
 


### PR DESCRIPTION
## Summary

Ethereum-to-Argon transfers no longer remain at 32 confirmations when their source transaction reverted. Receipt status now sends the persisted transfer through the existing failed and dismissible path, so already-stuck records recover after upgrade. Gateway transactions also carry a fixed gas reserve for the next-block activity-locator branch that caused the observed revert; unused gas is not charged.

## Validation

- Focused Vitest suite: 23 tests passed.
- The patched receipt path classified the exact affected mainnet transaction as reverted through the production public RPC.
- `yarn vue-tsc --noEmit`
- Prettier and ESLint on the touched files.
