### PR TITLE
fix: restore Ethereum inbound tracker typecheck

### DIFF
--- a/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumInboundTransferTracker.integration.test.ts
@@ -1091,7 +1091,7 @@ describe('EthereumInboundTransferTracker integration', () => {
       ethereumClient,
       undefined,
       {
-        operatorHost: undefined,
+        resolveOperatorHost: async () => undefined,
         requestEthereumGatewayCatchUp: vi.fn(),
       },
     );


### PR DESCRIPTION
The main branch typecheck now completes after the upstream-operator client contract changed during the chain recovery merge. The reverted-source transaction coverage remains intact, with the focused 16-case integration suite passing.
