### PR TITLE
fix: keep mining dashboard on current frame

### DIFF
--- a/src-vue/lib/MyMiningSeats.ts
+++ b/src-vue/lib/MyMiningSeats.ts
@@ -213,8 +213,11 @@ export class MyMiningSeats {
           if (this.serverStateRefreshPromise) await this.serverStateRefreshPromise;
 
           const isOnLatestFrame = this.selectedFrameId === this.latestFrameId;
-          this.latestFrameId = frameId;
-          if (isOnLatestFrame) this.selectFrameId(frameId, true);
+          if (frameId > this.latestFrameId) {
+            this.latestFrameId = frameId;
+            if (isOnLatestFrame) this.selectFrameId(frameId, true);
+          }
+
           const fromFrameId = this.hasRefreshedCompletedMiningHistory
             ? Math.max(0, frameId - NetworkConfig.framesPerCohort)
             : 0;
@@ -276,7 +279,11 @@ export class MyMiningSeats {
     return await this.loadPromise;
   }
 
-  public async subscribeToDashboard(): Promise<void> {
+  public async subscribeToDashboard({
+    selectLatestFrame = false,
+  }: { selectLatestFrame?: boolean } = {}): Promise<void> {
+    if (selectLatestFrame) this.selectFrameId(this.latestFrameId, true);
+
     this.dashboardSubscribers++;
     if (this.dashboardSubscribers > 1) return;
 

--- a/src-vue/screens/mining-screen/Dashboard.vue
+++ b/src-vue/screens/mining-screen/Dashboard.vue
@@ -690,7 +690,7 @@ Vue.watch(isSelectedLiveFrame, isLiveFrame => {
 });
 
 Vue.onMounted(() => {
-  void myMiningSeats.subscribeToDashboard();
+  void myMiningSeats.subscribeToDashboard({ selectLatestFrame: true });
   void myMiningSeats.subscribeToActivity();
   loadChartData();
   void updateSliderFrame(sliderFrameIndex.value);


### PR DESCRIPTION
## Summary

- Prevent stale bot cohort snapshots from moving the mining dashboard to an earlier frame.
- Select the current frame whenever the mining dashboard mounts, while preserving intentional historical navigation during the active page session.

## Why

Settings and other bot refreshes can return a server `currentFrameId` that temporarily trails the chain-backed frame already shown by the app. The cohort update listener previously accepted that older value and moved both the latest and selected frame backward. The dashboard also restored a historical selection when navigating back to the page.

## Validation

- `yarn vitest --run --project src-vue src-vue/__test__/MyMiningSeats.test.ts`
- `yarn vue-tsc --noEmit`
- ESLint and Prettier checks
- Repository pre-commit checks