### PR TITLE
fix: prevent bitcoin lock nonce collisions

### DIFF
--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -802,6 +802,7 @@ export default class BitcoinLocks {
     const txInfo = await this.#transactionTracker.submitAndWatch({
       tx,
       txSigner,
+      useLatestNonce: true,
       extrinsicType: ExtrinsicType.BitcoinRequestLock,
       metadata: {
         bitcoin: {


### PR DESCRIPTION
Bitcoin lock requests now refresh the account nonce before submission, preventing them from colliding with concurrent bootstrap-recovery transactions signed by the same account.

The original CI failures in Bitcoin lock/unlock and mismatch acceptance no longer reproduce: all Bitcoin flows completed. The full Test workflow is green on Ubuntu, Windows, and macOS, and Lints is green.
