### PR TITLE
fix: support WebAssembly on older Safari

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,8 @@
         ],
         "script-src": [
           "'self'",
-          "'wasm-unsafe-eval'"
+          "'wasm-unsafe-eval'",
+          "'unsafe-eval'"
         ],
         "style-src": [
           "'self'",


### PR DESCRIPTION
## Summary

Allow `'unsafe-eval'` in the packaged app's production `script-src` so WebAssembly can initialize on older WebKit versions.

An affected macOS Monterey 12.7.6 machine running Safari 17.6 rejects WebAssembly with an `EvalError` even though the policy already contains `'wasm-unsafe-eval'`. The rejection occurs during startup and leaves the Vue mount point empty, producing a white screen.

This applies to more than Polkadot crypto: the Bitcoin client also embeds and instantiates its own Rust-generated WebAssembly and does not have an equivalent JavaScript fallback. Enabling an ASM.js fallback for Polkadot alone would therefore not restore the full application.

## Security scope

This is a compatibility exception for a packaged Tauri application, not permission to load scripts from the web. Production `script-src` remains limited to `'self'`, so executable JavaScript must still come from the application's bundled local assets. The existing `base-uri 'self'`, `frame-src 'none'`, and `object-src 'none'` restrictions are unchanged, and `'unsafe-eval'` does not add any remote script origin.

The directive does allow already-loaded renderer code to compile strings as JavaScript, so it is not literally risk-free and would increase the impact of a renderer injection bug. That residual risk is limited by the packaged/local script boundary and is accepted here because affected WebKit versions otherwise cannot initialize either required WebAssembly implementation.

## Validation

Confirmed the failure from Web Inspector on the affected machine and validated the updated Tauri configuration as JSON.