### PR TITLE
fix: restore recovered financial and mining state

### DIFF
--- a/src-tauri/migrations/30-repair-mining-cohort-frames/up.sql
+++ b/src-tauri/migrations/30-repair-mining-cohort-frames/up.sql
@@ -1,0 +1,33 @@
+-- Cohort-frame write suppression previously keyed its cache by frame alone,
+-- so equal earnings for different cohorts could be skipped. These records are
+-- replayed in place from bot history to restore complete mining RTD.
+UPDATE Frames AS frame
+SET isProcessed = 0
+WHERE frame.isProcessed = 1
+  AND (
+    frame.blocksMinedTotal != COALESCE((
+      SELECT SUM(cohortFrame.blocksMinedTotal)
+      FROM CohortFrames AS cohortFrame
+      WHERE cohortFrame.frameId = frame.id
+    ), 0)
+    OR frame.micronotsMinedTotal != COALESCE((
+      SELECT SUM(cohortFrame.micronotsMinedTotal)
+      FROM CohortFrames AS cohortFrame
+      WHERE cohortFrame.frameId = frame.id
+    ), 0)
+    OR frame.microgonsMinedTotal != COALESCE((
+      SELECT SUM(cohortFrame.microgonsMinedTotal)
+      FROM CohortFrames AS cohortFrame
+      WHERE cohortFrame.frameId = frame.id
+    ), 0)
+    OR frame.microgonsMintedTotal != COALESCE((
+      SELECT SUM(cohortFrame.microgonsMintedTotal)
+      FROM CohortFrames AS cohortFrame
+      WHERE cohortFrame.frameId = frame.id
+    ), 0)
+    OR frame.microgonFeesCollectedTotal != COALESCE((
+      SELECT SUM(cohortFrame.microgonFeesCollectedTotal)
+      FROM CohortFrames AS cohortFrame
+      WHERE cohortFrame.frameId = frame.id
+    ), 0)
+  );

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -257,13 +257,57 @@ describe('BitcoinLocks recovery', () => {
     const setHistoryRecoveryPending = vi.fn();
     vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending } as never);
 
-    await store.recovery.beginHistoryReplay({ recoverExistingLocks: true });
+    await store.recovery.beginHistoryReplay({ lockScope: 'all' });
 
     expect(record.isHistoryRecoveryPending).toBe(true);
     expect(store.getActiveLocks()).toEqual([]);
     expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, true);
 
     await store.recovery.commitHistoryReplay();
+  });
+
+  it('repairs pending locks without replaying healthy locks', async () => {
+    const blockWatch = Object.assign(Object.create(null), {
+      getApi: async () => ({}),
+    }) as BlockWatch;
+    const store = createStore({ blockWatch });
+    const pendingRecord = createLock({
+      uuid: 'pending-recovery',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    pendingRecord.isHistoryRecoveryPending = true;
+    const healthyRecord = createLock({
+      uuid: 'healthy-lock',
+      utxoId: 8,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-02T00:00:00Z',
+    });
+    store.data.locksByUtxoId[7] = pendingRecord;
+    store.data.locksByUtxoId[8] = healthyRecord;
+    const setHistoryRecoveryPending = vi.fn();
+    const recordRemoval = vi.fn(async (record: IBitcoinLockRecord, status: BitcoinLockStatus) => {
+      record.status = status;
+      record.removalReason = 'released';
+    });
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      recordRemoval,
+      setHistoryRecoveryPending,
+    } as never);
+
+    await store.recovery.beginHistoryReplay({ lockScope: 'pending' });
+    await store.recovery.recoverBlock(historyBlock(200), [
+      historyEvent(151, 'bitcoinLocks', 'BitcoinSpentAfterRelease', { utxoId: 7, vaultId: 1 }),
+      historyEvent(151, 'bitcoinLocks', 'BitcoinSpentAfterRelease', { utxoId: 8, vaultId: 1 }),
+    ]);
+    await store.recovery.commitHistoryReplay();
+
+    expect(pendingRecord.removalReason).toBe('released');
+    expect(healthyRecord.removalReason).toBeUndefined();
+    expect(healthyRecord.isHistoryRecoveryPending).toBeUndefined();
+    expect(recordRemoval).toHaveBeenCalledOnce();
+    expect(setHistoryRecoveryPending).not.toHaveBeenCalledWith(healthyRecord.uuid, true);
   });
 
   it('serializes history replay with the affected lock queue without yielding or waiting behind itself', async () => {

--- a/src-vue/__test__/BotSyncer.test.ts
+++ b/src-vue/__test__/BotSyncer.test.ts
@@ -132,6 +132,48 @@ describe('BotSyncer', () => {
     });
   });
 
+  it('resumes historical sync at the first missing cohort instead of the latest frame cursor', async () => {
+    const { syncer, config, framesTable, cohortsTable } = createSyncer();
+    const testSyncer = syncer as unknown as IBotSyncerTestTarget;
+    const syncDbFrame = vi.spyOn(testSyncer, 'syncDbFrame').mockRejectedValue(new Error('stop after first frame'));
+    config.latestFrameIdProcessed = 865;
+    framesTable.fetchLastProcessedFrame.mockResolvedValue(864);
+    framesTable.fetchProcessedFrameIdsSince.mockResolvedValue(Array.from({ length: 817 }, (_, index) => index + 48));
+    cohortsTable.fetchCohortIdsSince.mockResolvedValue(Array.from({ length: 407 }, (_, index) => index + 48));
+
+    await testSyncer.syncThePast(98.6, {
+      oldestFrameIdToSync: 48,
+      currentFrameId: 865,
+      currentTick: 1,
+    });
+
+    await vi.waitFor(() => {
+      expect(syncDbFrame).toHaveBeenCalledWith(455, expect.anything());
+    });
+  });
+
+  it('replays incomplete frames without downloading the processed frames between them', async () => {
+    const { syncer, botFns, config, framesTable, cohortsTable } = createSyncer();
+    const testSyncer = syncer as unknown as IBotSyncerTestTarget;
+    const syncDbFrame = vi.spyOn(testSyncer, 'syncDbFrame').mockResolvedValue(undefined);
+    vi.spyOn(syncer as any, 'calculateDbSyncProgress').mockResolvedValue(100);
+    config.latestFrameIdProcessed = 8;
+    framesTable.fetchLastProcessedFrame.mockResolvedValue(8);
+    framesTable.fetchProcessedFrameIdsSince.mockResolvedValue([1, 2, 4, 5, 7, 8]);
+    cohortsTable.fetchCohortIdsSince.mockResolvedValue([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    await testSyncer.syncThePast(75, {
+      oldestFrameIdToSync: 1,
+      currentFrameId: 8,
+      currentTick: 1,
+    });
+
+    await vi.waitFor(() => {
+      expect(botFns.onEvent).toHaveBeenCalledWith('updated-cohort-history', 8);
+    });
+    expect(syncDbFrame.mock.calls.map(([frameId]) => frameId)).toEqual([3, 6]);
+  });
+
   it.each([
     {
       name: 'captured with the winning bid',
@@ -211,10 +253,18 @@ function createSyncer(options: { gatewayReady?: boolean } = {}) {
   const serverApiClient = {
     isGatewayReady: vi.fn().mockResolvedValue(options.gatewayReady ?? true),
   };
+  const config = { isServerInstalled: true, latestFrameIdProcessed: 1 };
+  const framesTable = {
+    fetchLastProcessedFrame: vi.fn().mockResolvedValue(1),
+    fetchProcessedFrameIdsSince: vi.fn<() => Promise<number[]>>().mockResolvedValue([]),
+  };
+  const cohortsTable = {
+    fetchCohortIdsSince: vi.fn<() => Promise<number[]>>().mockResolvedValue([]),
+  };
 
   const syncer = new BotSyncer(
-    { isServerInstalled: true, latestFrameIdProcessed: 1 } as any,
-    { framesTable: { fetchLastProcessedFrame: vi.fn().mockResolvedValue(1) } } as any,
+    config as any,
+    { framesTable, cohortsTable } as any,
     installer as any,
     serverApiClient as any,
     { load: vi.fn() } as any,
@@ -222,5 +272,5 @@ function createSyncer(options: { gatewayReady?: boolean } = {}) {
     botFns,
   );
 
-  return { syncer, botFns, installer, serverApiClient };
+  return { syncer, botFns, installer, serverApiClient, config, framesTable, cohortsTable };
 }

--- a/src-vue/__test__/CohortFramesTable.test.ts
+++ b/src-vue/__test__/CohortFramesTable.test.ts
@@ -2,6 +2,65 @@ import { describe, expect, it, vi } from 'vitest';
 import { createTestDb } from './helpers/db.ts';
 
 describe('CohortFramesTable', () => {
+  it('stores equal earnings for different cohorts in the same frame', async () => {
+    const db = await createTestDb();
+    const earnings = {
+      frameId: 12,
+      blocksMinedTotal: 0,
+      micronotsMinedTotal: 0n,
+      microgonsMinedTotal: 0n,
+      microgonsMintedTotal: 0n,
+      microgonFeesCollectedTotal: 0n,
+    };
+
+    try {
+      await Promise.all(
+        [11, 12].map(id =>
+          db.framesTable.insertOrUpdate({
+            id,
+            firstTick: id * 1_000,
+            rewardTicksRemaining: 0,
+            firstBlockNumber: id * 100,
+            lastBlockNumber: id * 100 + 99,
+            microgonToUsd: [],
+            microgonToBtc: [],
+            microgonToArgonot: [],
+            accruedMicrogonProfits: 0n,
+            accruedMicronotProfits: 0n,
+            progress: 100,
+          }),
+        ),
+      );
+      await Promise.all(
+        [11, 12].map(id =>
+          db.cohortsTable.insertOrUpdate({
+            id,
+            transactionFeesTotal: 0n,
+            micronotsStakedPerSeat: 0n,
+            microgonsBidPerSeat: 0n,
+            seatCountWon: 0,
+            microgonsToBeMinedPerSeat: 0n,
+            micronotsToBeMinedPerSeat: 0n,
+            argonotPriceAtBid: 0n,
+          }),
+        ),
+      );
+      await db.cohortFramesTable.insertOrUpdate({ ...earnings, cohortActivationFrameId: 11 });
+      await db.cohortFramesTable.insertOrUpdate({ ...earnings, cohortActivationFrameId: 12 });
+
+      await expect(
+        db.select<{ frameId: number; cohortId: number }[]>(
+          'SELECT frameId, cohortId FROM CohortFrames ORDER BY cohortId',
+        ),
+      ).resolves.toEqual([
+        { frameId: 12, cohortId: 11 },
+        { frameId: 12, cohortId: 12 },
+      ]);
+    } finally {
+      await db.close();
+    }
+  });
+
   it('round-trips a bid-time Argonot price above the SQLite integer range', async () => {
     const db = await createTestDb();
     const largeValue = 9_876_543_210_123_456_789n;

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -30,6 +30,7 @@ describe('FinancialHistoryImporter', () => {
         db,
         accountId: '5owner',
         enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
       }),
     ).resolves.toBe(true);
 
@@ -46,8 +47,34 @@ describe('FinancialHistoryImporter', () => {
         db,
         accountId: '5owner',
         enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
       }),
     ).resolves.toBe(false);
+  });
+
+  it('only treats missing checkpoints as previous-wallet recovery', async () => {
+    const db = {
+      syncStateTable: {
+        get: vi.fn(async () => undefined),
+      },
+    } as any;
+
+    await expect(
+      needsFinancialHistoryRecovery({
+        db,
+        accountId: '5owner',
+        enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: false,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      needsFinancialHistoryRecovery({
+        db,
+        accountId: '5owner',
+        enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
+      }),
+    ).resolves.toBe(true);
   });
 
   it('initializes Bitcoin recovery when a loaded lock is still quarantined', async () => {
@@ -70,6 +97,7 @@ describe('FinancialHistoryImporter', () => {
         accountId: '5owner',
         enabledDomains: ['bitcoin'],
         bitcoinLockRecovery: { hasPendingHistoryRecovery: true } as any,
+        recoverMissingCheckpoints: false,
       }),
     ).resolves.toBe(true);
   });
@@ -92,6 +120,7 @@ describe('FinancialHistoryImporter', () => {
         argonBonds: {} as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
         minimumAsOfBlock: 100,
         onCheckStart,
       }),
@@ -100,7 +129,7 @@ describe('FinancialHistoryImporter', () => {
     expect(onCheckStart).not.toHaveBeenCalled();
   });
 
-  it('resumes a loaded Bitcoin recovery from its saved partial checkpoint', async () => {
+  it('restarts a loaded Bitcoin recovery when its saved lock state may be newer than its checkpoint', async () => {
     const upsert = vi.fn(async () => undefined);
     const beginHistoryReplay = vi.fn();
     const commitHistoryReplay = vi.fn();
@@ -108,7 +137,7 @@ describe('FinancialHistoryImporter', () => {
       asOfBlock: 100,
       definitionVersion: 2,
       blocks: [],
-      coverage: { fromBlock: 90, toBlock: 100, gaps: [] },
+      coverage: { fromBlock: 0, toBlock: 100, gaps: [] },
     });
 
     await restoreFinancialHistory({
@@ -145,17 +174,69 @@ describe('FinancialHistoryImporter', () => {
       } as any,
       vaultHistory: {} as any,
       enabledDomains: ['bitcoin'],
+      recoverMissingCheckpoints: true,
       minimumAsOfBlock: 100,
     });
 
     expect(findAddressActivity).toHaveBeenCalledWith('5owner', {
-      afterBlock: 90,
+      afterBlock: 0,
       toBlock: 100,
       activityMask: AccountActivityKind.BitcoinLock | AccountActivityKind.BitcoinMint,
     });
-    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: false });
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ lockScope: 'pending' });
     expect(commitHistoryReplay).toHaveBeenCalledWith(true);
     expect(upsert).toHaveBeenCalledOnce();
+  });
+
+  it('repairs only pending Bitcoin locks when a fresh wallet has no recovery checkpoint', async () => {
+    const upsert = vi.fn(async () => undefined);
+    const beginHistoryReplay = vi.fn();
+    const commitHistoryReplay = vi.fn();
+    vi.mocked(findAddressActivity).mockResolvedValue({
+      asOfBlock: 100,
+      definitionVersion: 2,
+      blocks: [],
+      coverage: { fromBlock: 0, toBlock: 100, gaps: [] },
+    });
+    const restoreArgs = {
+      db: {
+        syncStateTable: { get: vi.fn(async () => undefined), upsert },
+        bondLotHistoryTable: { fetchAll: vi.fn(async () => []) },
+      } as any,
+      blockWatch: {
+        finalizedBlockHeader: { blockNumber: 100 },
+        getFinalizedApi: vi.fn(async () => ({})),
+      } as any,
+      accountId: '5owner',
+      argonBonds: { data: { bondLots: [] } } as any,
+      bitcoinLockRecovery: {
+        hasPendingHistoryRecovery: true,
+        beginHistoryReplay,
+        findMissingActiveLockIds: vi.fn(async () => []),
+        commitHistoryReplay,
+        cancelHistoryReplay: vi.fn(),
+      } as any,
+      vaultHistory: {} as any,
+      enabledDomains: ['bitcoin', 'bonds'] as const,
+      recoverMissingCheckpoints: false,
+      minimumAsOfBlock: 100,
+    };
+
+    await restoreFinancialHistory(restoreArgs);
+
+    expect(findAddressActivity).toHaveBeenCalledOnce();
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ lockScope: 'pending' });
+    expect(commitHistoryReplay).toHaveBeenCalledWith(true);
+    expect(upsert).toHaveBeenLastCalledWith(
+      SyncStateKeys.FinancialHistory,
+      expect.objectContaining({
+        asOfBlock: 100,
+        domains: ['bitcoin'],
+        domainCheckpoints: {
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 6 },
+        },
+      }),
+    );
   });
 
   it('returns the minimum safe checkpoint across enabled financial domains', async () => {
@@ -179,6 +260,7 @@ describe('FinancialHistoryImporter', () => {
         argonBonds: {} as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds', 'vaulting'],
+        recoverMissingCheckpoints: true,
         minimumAsOfBlock: 100,
       }),
     ).resolves.toEqual({ importedBlockCount: 0, asOfBlock: 100, targetBlock: 100 });
@@ -219,6 +301,7 @@ describe('FinancialHistoryImporter', () => {
       argonBonds: { data: { bondLots: [] }, importHistoryBlock: vi.fn() } as any,
       vaultHistory: { importBlock: vi.fn() } as any,
       enabledDomains: ['bonds', 'vaulting'],
+      recoverMissingCheckpoints: true,
       minimumAsOfBlock: 100,
     });
 
@@ -307,6 +390,7 @@ describe('FinancialHistoryImporter', () => {
         } as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds', 'bitcoin'],
+        recoverMissingCheckpoints: true,
         minimumAsOfBlock: 10,
       }),
     ).rejects.toThrow('Bitcoin lock history failed at block 9: archive unavailable');
@@ -389,6 +473,7 @@ describe('FinancialHistoryImporter', () => {
       } as any,
       vaultHistory: {} as any,
       enabledDomains: ['bitcoin'],
+      recoverMissingCheckpoints: true,
       minimumAsOfBlock: 100,
       onActiveBitcoinLocksFound,
       onProgress,
@@ -411,7 +496,7 @@ describe('FinancialHistoryImporter', () => {
       }),
     );
     expect(beginHistoryReplay).toHaveBeenCalledOnce();
-    expect(beginHistoryReplay).toHaveBeenCalledWith({ recoverExistingLocks: true });
+    expect(beginHistoryReplay).toHaveBeenCalledWith({ lockScope: 'all' });
     expect(commitHistoryReplay).toHaveBeenCalledOnce();
     expect(commitHistoryReplay).toHaveBeenCalledWith(true);
     expect(cancelHistoryReplay).not.toHaveBeenCalled();
@@ -463,6 +548,7 @@ describe('FinancialHistoryImporter', () => {
         } as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
         minimumAsOfBlock: 100,
       }),
     ).rejects.toThrow('not restored all active bond purchases');
@@ -497,6 +583,7 @@ describe('FinancialHistoryImporter', () => {
         argonBonds: { data: { bondLots: [], bondHistory: [] } } as any,
         vaultHistory: {} as any,
         enabledDomains: ['bonds'],
+        recoverMissingCheckpoints: true,
         minimumAsOfBlock: 100,
       }),
     ).rejects.toThrow('coverage gap from block 50 to 60');

--- a/src-vue/__test__/Financials.loading.test.ts
+++ b/src-vue/__test__/Financials.loading.test.ts
@@ -243,7 +243,7 @@ describe('financials store lifecycle', () => {
     mocks.stableSwaps.refreshWalletSnapshot.mockResolvedValue();
     mocks.restoreFinancialHistory.mockResolvedValue({ asOfBlock: 1, importedBlockCount: 0 });
     mocks.restoreFinancialHistory.mockClear();
-    mocks.needsFinancialHistoryRecovery.mockResolvedValue(true);
+    mocks.needsFinancialHistoryRecovery.mockResolvedValue(false);
     mocks.needsFinancialHistoryRecovery.mockClear();
     mocks.blockWatch.bestBlockHeader = {
       blockNumber: 1,
@@ -642,6 +642,22 @@ describe('financials store lifecycle', () => {
     expect(mocks.walletsForArgon.readAccountSnapshot).toHaveBeenCalledTimes(2);
   });
 
+  it('resumes and surfaces pending domain recovery without imported-account history', async () => {
+    mocks.config.hasExtensionTreasury = true;
+    mocks.needsFinancialHistoryRecovery.mockResolvedValue(true);
+    mocks.restoreFinancialHistory.mockRejectedValue(new Error('history unavailable'));
+
+    const financials = useFinancials();
+
+    await vi.waitFor(() => expect(financials.historyRecovery.state).toBe('error'));
+    expect(mocks.needsFinancialHistoryRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bitcoinLockRecovery: mocks.bitcoinLocks.recovery,
+        recoverMissingCheckpoints: false,
+      }),
+    );
+  });
+
   it('exposes persisted Bitcoin rows and settled performance before the complete financial snapshot is ready', () => {
     const cachedSummary = createBitcoinSummary(0n);
     const persistedSummary = {
@@ -692,15 +708,18 @@ describe('financials store lifecycle', () => {
       | undefined;
     expect(gapListener).toBeDefined();
 
+    vi.useFakeTimers();
     gapListener!({ afterBlock: 1, toBlock: 10 });
+    await vi.advanceTimersByTimeAsync(30_000);
 
-    await vi.waitFor(() => expect(mocks.restoreFinancialHistory).toHaveBeenCalled());
+    expect(mocks.restoreFinancialHistory).toHaveBeenCalled();
     expect(mocks.restoreFinancialHistory).toHaveBeenCalledWith(expect.objectContaining({ minimumAsOfBlock: 10 }));
   });
 
   it('keeps local positions available while recovery is unavailable', async () => {
     mocks.config.hasExtensionTreasury = true;
     mocks.config.walletAccountsHadPreviousLife = true;
+    mocks.needsFinancialHistoryRecovery.mockResolvedValue(true);
     mocks.restoreFinancialHistory.mockRejectedValue(new Error('indexer unavailable'));
 
     const financials = useFinancials();

--- a/src-vue/__test__/HistoryRecoveryScheduler.test.ts
+++ b/src-vue/__test__/HistoryRecoveryScheduler.test.ts
@@ -37,15 +37,43 @@ describe('FinalizedHistoryScheduler', () => {
     await scheduler.close();
   });
 
-  it('keeps retrying an unavailable source with capped backoff', async () => {
+  it('stops retrying when a newer target arrives during the final automatic attempt', async () => {
+    vi.useFakeTimers();
+    const refresh = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('indexer unavailable'))
+      .mockRejectedValueOnce(new Error('indexer unavailable'))
+      .mockRejectedValueOnce(new Error('indexer unavailable'))
+      .mockImplementationOnce(async () => {
+        await Promise.resolve();
+        scheduler.queue(13);
+        throw new Error('indexer unavailable');
+      });
+    const scheduler = new FinalizedHistoryScheduler(refresh, 10);
+
+    scheduler.queue(12);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(refresh).toHaveBeenCalledTimes(4);
+    await scheduler.close();
+  });
+
+  it('stays paused across new background targets until explicitly retried', async () => {
     vi.useFakeTimers();
     const refresh = vi.fn().mockRejectedValue(new Error('indexer unavailable'));
     const scheduler = new FinalizedHistoryScheduler(refresh, 10);
 
     scheduler.queue(12);
-    await vi.advanceTimersByTimeAsync(120);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(refresh).toHaveBeenCalledTimes(4);
 
+    scheduler.queue(13);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(refresh).toHaveBeenCalledTimes(4);
+
+    await expect(scheduler.runNow(13)).rejects.toThrow('indexer unavailable');
     expect(refresh).toHaveBeenCalledTimes(5);
+    expect(refresh).toHaveBeenLastCalledWith(13, false);
     await scheduler.close();
   });
 });

--- a/src-vue/__test__/UpstreamOperatorClient.test.ts
+++ b/src-vue/__test__/UpstreamOperatorClient.test.ts
@@ -2,6 +2,27 @@ import { expect, it, vi } from 'vitest';
 import { RequestStatusError, ServerAuthClient } from '../lib/ServerAuthClient.ts';
 import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
 import { createMockWalletKeys } from './helpers/wallet.ts';
+import { BootstrapType } from '../interfaces/IConfig.ts';
+
+const storeMocks = vi.hoisted(() => ({
+  config: {
+    bootstrapDetails: undefined as { type: string; routerHost: string } | undefined,
+    upstreamOperator: undefined as { name: string } | undefined,
+    isLoadedPromise: Promise.resolve(),
+  },
+  recoverUpstreamHost: vi.fn(),
+}));
+
+vi.mock('../stores/config.ts', () => ({
+  getConfig: () => storeMocks.config,
+}));
+vi.mock('../stores/server.ts', () => ({
+  getUpstreamOperatorAuthClient: () => undefined,
+}));
+vi.mock('../stores/bootstrapRecovery.ts', () => ({
+  enrollUpstreamRecovery: vi.fn(),
+  recoverUpstreamHost: storeMocks.recoverUpstreamHost,
+}));
 
 it('queries a missing upstream endpoint only once', async () => {
   const recoverOperatorHost = vi.fn().mockResolvedValue(undefined);
@@ -11,6 +32,20 @@ it('queries a missing upstream endpoint only once', async () => {
   await expect(client.resolveOperatorHost()).resolves.toBeUndefined();
 
   expect(recoverOperatorHost).toHaveBeenCalledOnce();
+});
+
+it('does not treat a legacy public RPC host as an upstream operator', async () => {
+  storeMocks.config.bootstrapDetails = {
+    type: BootstrapType.Public,
+    routerHost: 'rpc.argon.network',
+  };
+  storeMocks.config.upstreamOperator = undefined;
+  storeMocks.recoverUpstreamHost.mockResolvedValue(undefined);
+  const { getUpstreamOperatorClient } = await import('../stores/upstreamOperator.ts');
+
+  await expect(getUpstreamOperatorClient().resolveOperatorHost()).resolves.toBeUndefined();
+
+  expect(storeMocks.recoverUpstreamHost).toHaveBeenCalledOnce();
 });
 
 it('retries upstream resolution after a transient failure', async () => {

--- a/src-vue/lib/BotSyncer.ts
+++ b/src-vue/lib/BotSyncer.ts
@@ -309,8 +309,22 @@ export class BotSyncer {
     const currentTick = botState.currentTick;
     const framesToSync = currentFrameId - oldestFrameIdToSync + 1;
 
-    const latestDbProcessedFrame = await this.db.framesTable.fetchLastProcessedFrame();
-    const startFrameToSync = Math.min(latestDbProcessedFrame, latestFrameIdProcessed);
+    const [latestDbProcessedFrame, processedFrameIds, existingCohortIds] = await Promise.all([
+      this.db.framesTable.fetchLastProcessedFrame(),
+      this.db.framesTable.fetchProcessedFrameIdsSince(oldestFrameIdToSync, framesToSync),
+      this.db.cohortsTable.fetchCohortIdsSince(oldestFrameIdToSync, framesToSync),
+    ]);
+    const processedFrames = new Set(processedFrameIds);
+    let firstIncompleteFrameId = oldestFrameIdToSync;
+    while (processedFrames.has(firstIncompleteFrameId) && firstIncompleteFrameId <= currentFrameId) {
+      firstIncompleteFrameId += 1;
+    }
+
+    const firstMissingCohortId = oldestFrameIdToSync + existingCohortIds.length;
+    const startFrameToSync = Math.max(
+      oldestFrameIdToSync,
+      Math.min(latestDbProcessedFrame, latestFrameIdProcessed, firstIncompleteFrameId, firstMissingCohortId),
+    );
 
     console.log('Syncing the past frames...', {
       oldestFrameIdToSync,
@@ -324,7 +338,13 @@ export class BotSyncer {
     const syncPromise = (async () => {
       try {
         for (let frameId = startFrameToSync; frameId <= currentFrameId; frameId++) {
+          const requiresCohortCatchUp = frameId >= firstMissingCohortId;
+          if (processedFrames.has(frameId) && !requiresCohortCatchUp) {
+            continue;
+          }
+
           await this.syncDbFrame(frameId, botState);
+          processedFrames.add(frameId);
           progress = await this.calculateDbSyncProgress(botState);
           this.botFns.setDbSyncProgress(progress);
         }

--- a/src-vue/lib/db/CohortFramesTable.ts
+++ b/src-vue/lib/db/CohortFramesTable.ts
@@ -23,7 +23,8 @@ export class CohortFramesTable extends BaseTable {
       microgonsMintedTotal,
       microgonFeesCollectedTotal,
     } = args;
-    const cache = this.cache.get(frameId);
+    const cacheKey = `${frameId}:${cohortActivationFrameId}`;
+    const cache = this.cache.get(cacheKey);
     if (cache) {
       // If nothing has changed, skip the database write
       if (
@@ -36,7 +37,7 @@ export class CohortFramesTable extends BaseTable {
         return;
       }
     }
-    this.cache.set(frameId, {
+    this.cache.set(cacheKey, {
       frameId,
       cohortId: cohortActivationFrameId,
       blocksMinedTotal,

--- a/src-vue/lib/db/FramesTable.ts
+++ b/src-vue/lib/db/FramesTable.ts
@@ -155,6 +155,14 @@ export class FramesTable extends BaseTable {
     return latest[0]?.maxId || 0;
   }
 
+  public async fetchProcessedFrameIdsSince(frameId: number, limit: number): Promise<number[]> {
+    const frames = await this.db.select<{ id: number }[]>(
+      'SELECT id FROM Frames WHERE id >= ? AND isProcessed = 1 ORDER BY id ASC LIMIT ?',
+      [frameId, limit],
+    );
+    return frames.map(frame => frame.id);
+  }
+
   public async fetchExistingCompleteSince(frameId: number, limit = 10): Promise<number[]> {
     if (this.processedFrames[frameId]) {
       const completedFrames = [];

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -29,6 +29,7 @@ export class BitcoinLockRecovery {
     | 'upsertUtxoRecord'
   >;
   private historyReplayLocksByUtxoId?: Record<number, IBitcoinLockRecord>;
+  private historyReplayLockScope?: BitcoinHistoryReplayLockScope;
   private readonly historyRecoveryPendingUtxoIds = new Set<number>();
   private readonly historyRecoveryPendingUuids = new Set<string>();
   private readonly insertPending: (
@@ -74,11 +75,12 @@ export class BitcoinLockRecovery {
   }
 
   public async beginHistoryReplay({
-    recoverExistingLocks = false,
-  }: { recoverExistingLocks?: boolean } = {}): Promise<void> {
+    lockScope = 'encountered',
+  }: { lockScope?: BitcoinHistoryReplayLockScope } = {}): Promise<void> {
     if (this.historyReplayLocksByUtxoId) throw new Error('Bitcoin lock history replay is already running');
 
     this.historyReplayLocksByUtxoId = {};
+    this.historyReplayLockScope = lockScope;
     for (const lock of [...Object.values(this.locksByUtxoId), ...this.pendingLocks]) {
       if (!lock.isHistoryRecoveryPending) continue;
 
@@ -86,7 +88,7 @@ export class BitcoinLockRecovery {
       if (lock.utxoId !== undefined) this.historyRecoveryPendingUtxoIds.add(lock.utxoId);
     }
 
-    if (!recoverExistingLocks) return;
+    if (lockScope !== 'all') return;
 
     for (const lock of Object.values(this.locksByUtxoId)) {
       await this.prepareHistoryRecoveryLock(lock);
@@ -99,6 +101,7 @@ export class BitcoinLockRecovery {
 
     if (!isComplete) {
       this.historyReplayLocksByUtxoId = undefined;
+      this.historyReplayLockScope = undefined;
       for (const recovered of Object.values(stagedLocks)) this.applyRecoveredRecord(recovered);
       return;
     }
@@ -107,6 +110,7 @@ export class BitcoinLockRecovery {
     await Promise.all([...this.historyRecoveryPendingUuids].map(uuid => table.setHistoryRecoveryPending(uuid, false)));
 
     this.historyReplayLocksByUtxoId = undefined;
+    this.historyReplayLockScope = undefined;
     for (const recovered of Object.values(stagedLocks)) this.applyRecoveredRecord(recovered);
     const completedLocks: IBitcoinLockRecord[] = [];
     for (const uuid of this.historyRecoveryPendingUuids) {
@@ -127,6 +131,7 @@ export class BitcoinLockRecovery {
 
   public cancelHistoryReplay(): void {
     this.historyReplayLocksByUtxoId = undefined;
+    this.historyReplayLockScope = undefined;
   }
 
   public async recoverBlock(
@@ -151,10 +156,13 @@ export class BitcoinLockRecovery {
         if (readRequiredEventField(event, 'accountId', block).toString() !== this.walletKeys.defaultArgonAddress)
           continue;
 
-        const candidateIds = new Set([
-          ...Object.keys(this.locksByUtxoId).map(Number),
-          ...Object.keys(this.historyReplayLocksByUtxoId ?? {}).map(Number),
-        ]);
+        let candidateIds = this.historyRecoveryPendingUtxoIds;
+        if (this.historyReplayLockScope !== 'pending') {
+          candidateIds = new Set([
+            ...Object.keys(this.locksByUtxoId).map(Number),
+            ...Object.keys(this.historyReplayLocksByUtxoId ?? {}).map(Number),
+          ]);
+        }
         for (const recoveryId of candidateIds) {
           const record = this.getRecoveryLock(recoveryId);
           if (record) await this.reconcilePendingMint(record, api, table, options.lockQueueOwnerUuid);
@@ -168,6 +176,7 @@ export class BitcoinLockRecovery {
       ) {
         continue;
       }
+      if (this.historyReplayLockScope === 'pending' && !this.historyRecoveryPendingUtxoIds.has(utxoId)) continue;
 
       const liveRecord = this.locksByUtxoId[utxoId];
       if (liveRecord) await this.prepareHistoryRecoveryLock(liveRecord, options.lockQueueOwnerUuid);
@@ -830,6 +839,8 @@ type BitcoinRecoveryEventRecord = {
     asApplyExtrinsic: Pick<FrameSystemEventRecord['phase']['asApplyExtrinsic'], 'toNumber'>;
   };
 };
+
+export type BitcoinHistoryReplayLockScope = 'all' | 'encountered' | 'pending';
 
 const bitcoinRecoveryEventMethods = new Set([
   'BitcoinCosignPastDue',

--- a/src-vue/lib/recovery/Scheduler.ts
+++ b/src-vue/lib/recovery/Scheduler.ts
@@ -19,9 +19,11 @@ export class FinalizedHistoryScheduler {
   public queue(finalizedBlockNumber: number, force = false): void {
     if (!force && finalizedBlockNumber <= Math.max(this.queuedBlockNumber, this.processedBlockNumber)) return;
 
-    const shouldInterruptRetry = this.retryAttempts > 0;
     this.queuedBlockNumber = Math.max(this.queuedBlockNumber, finalizedBlockNumber);
     this.forceQueued ||= force;
+    if (this.retryAttempts > 3 && !force) return;
+
+    const shouldInterruptRetry = this.retryAttempts > 0;
     if (shouldInterruptRetry && this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
@@ -36,6 +38,7 @@ export class FinalizedHistoryScheduler {
     }
     if (this.isClosed || (!this.forceQueued && this.queuedBlockNumber <= this.processedBlockNumber)) return;
 
+    if (this.retryAttempts > 3) this.retryAttempts = 0;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
@@ -55,6 +58,7 @@ export class FinalizedHistoryScheduler {
       this.isClosed ||
       this.timer ||
       this.runningPromise ||
+      (this.retryAttempts > 3 && !this.forceQueued) ||
       (!this.forceQueued && this.queuedBlockNumber <= this.processedBlockNumber)
     ) {
       return;
@@ -86,7 +90,9 @@ export class FinalizedHistoryScheduler {
       } catch (error) {
         if (isRetryableHistoryRecoveryError(error)) {
           this.retryAttempts += 1;
-          nextDelayMs = this.delayMs * 2 ** Math.min(this.retryAttempts - 1, 2);
+          if (this.retryAttempts <= 3) {
+            nextDelayMs = this.delayMs * 2 ** Math.min(this.retryAttempts - 1, 2);
+          }
         }
         if (surfaceError) throw error;
       } finally {

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -12,7 +12,7 @@ import { findAddressActivity } from '../IndexerClient.ts';
 import { SyncStateKeys, type IFinancialHistoryDomain, type ISyncSchemas } from '../db/SyncStateTable.ts';
 import type { ArgonBonds } from '../ArgonBonds.ts';
 import type { VaultHistory } from './MyVault.ts';
-import type { BitcoinLockRecovery } from './BitcoinLocks.ts';
+import type { BitcoinHistoryReplayLockScope, BitcoinLockRecovery } from './BitcoinLocks.ts';
 
 type IIndexedActivityBlock = IIndexerSpec['/v2/activity/:address']['responseType']['blocks'][number];
 export type { IFinancialHistoryDomain } from '../db/SyncStateTable.ts';
@@ -38,6 +38,7 @@ export async function needsFinancialHistoryRecovery(args: {
   accountId: string;
   enabledDomains: readonly IFinancialHistoryDomain[];
   bitcoinLockRecovery?: Pick<BitcoinLockRecovery, 'hasPendingHistoryRecovery'>;
+  recoverMissingCheckpoints: boolean;
 }): Promise<boolean> {
   const savedState = await args.db.syncStateTable.get(SyncStateKeys.FinancialHistory);
   const domainCheckpoints = getDomainCheckpoints(savedState, args.accountId);
@@ -46,11 +47,11 @@ export async function needsFinancialHistoryRecovery(args: {
     if (domain === 'bitcoin' && args.bitcoinLockRecovery?.hasPendingHistoryRecovery) return true;
 
     const checkpoint = domainCheckpoints[domain];
+    if (!checkpoint) return args.recoverMissingCheckpoints;
+
     const recoveryVersion = historyRecoveryVersions[domain];
     return (
-      !checkpoint ||
-      checkpoint.partialRecovery ||
-      (recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion)
+      checkpoint.partialRecovery || (recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion)
     );
   });
 }
@@ -90,6 +91,7 @@ export async function restoreFinancialHistory(args: {
   bitcoinLockRecovery?: BitcoinLockRecovery;
   vaultHistory: VaultHistory;
   enabledDomains: readonly IFinancialHistoryDomain[];
+  recoverMissingCheckpoints: boolean;
   force?: boolean;
   minimumAsOfBlock?: number;
   onCheckStart?: () => void;
@@ -115,12 +117,19 @@ export async function restoreFinancialHistory(args: {
     if (domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery) return true;
 
     const checkpoint = domainCheckpoints[domain];
+    if (!checkpoint) return args.force || args.recoverMissingCheckpoints;
+
     const recoveryVersion = historyRecoveryVersions[domain];
-    const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint?.recoveryVersion !== recoveryVersion;
-    return args.force || !checkpoint || checkpoint.asOfBlock < targetBlock || recoveryVersionChanged;
+    const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion;
+    return args.force || checkpoint.asOfBlock < targetBlock || recoveryVersionChanged;
   });
+  const checkpointDomains = enabledDomains.filter(
+    domain => domainCheckpoints[domain] || domainsToRestore.includes(domain),
+  );
   if (!domainsToRestore.length) {
-    const asOfBlock = Math.min(...enabledDomains.map(domain => domainCheckpoints[domain]!.asOfBlock));
+    const asOfBlock = checkpointDomains.length
+      ? Math.min(...checkpointDomains.map(domain => domainCheckpoints[domain]!.asOfBlock))
+      : targetBlock;
     return { importedBlockCount: 0, asOfBlock, targetBlock };
   }
 
@@ -134,13 +143,13 @@ export async function restoreFinancialHistory(args: {
   ): Promise<void> => {
     domainCheckpoints[domain] = checkpoint;
 
-    const enabledCheckpoints = enabledDomains.map(enabledDomain => domainCheckpoints[enabledDomain]);
-    const aggregateAsOfBlock = Math.min(...enabledCheckpoints.map(saved => saved?.asOfBlock ?? 0));
-    const aggregateCheckpoint = enabledCheckpoints.find(saved => saved?.asOfBlock === aggregateAsOfBlock);
+    const checkpoints = checkpointDomains.map(checkpointDomain => domainCheckpoints[checkpointDomain]);
+    const aggregateAsOfBlock = Math.min(...checkpoints.map(saved => saved?.asOfBlock ?? 0));
+    const aggregateCheckpoint = checkpoints.find(saved => saved?.asOfBlock === aggregateAsOfBlock);
     const recoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {};
-    for (const enabledDomain of enabledDomains) {
-      const recoveryVersion = domainCheckpoints[enabledDomain]?.recoveryVersion;
-      if (recoveryVersion !== undefined) recoveryVersions[enabledDomain] = recoveryVersion;
+    for (const checkpointDomain of checkpointDomains) {
+      const recoveryVersion = domainCheckpoints[checkpointDomain]?.recoveryVersion;
+      if (recoveryVersion !== undefined) recoveryVersions[checkpointDomain] = recoveryVersion;
     }
 
     await db.syncStateTable.upsert(SyncStateKeys.FinancialHistory, {
@@ -150,7 +159,7 @@ export async function restoreFinancialHistory(args: {
         ? { definitionVersion: aggregateCheckpoint.definitionVersion }
         : {}),
       ...(Object.keys(recoveryVersions).length ? { recoveryVersions } : {}),
-      domains: enabledDomains,
+      domains: checkpointDomains,
       domainCheckpoints,
     });
   };
@@ -170,6 +179,7 @@ export async function restoreFinancialHistory(args: {
         vaultHistory,
         domain,
         checkpoint,
+        recoverMissingCheckpoints: args.recoverMissingCheckpoints,
         force: args.force,
         targetBlock,
         onActiveBitcoinLocksFound: args.onActiveBitcoinLocksFound,
@@ -196,7 +206,7 @@ export async function restoreFinancialHistory(args: {
 
   if (recoveryErrors.length) throw new Error(recoveryErrors.join(' '));
 
-  const asOfBlock = Math.min(...enabledDomains.map(domain => domainCheckpoints[domain]!.asOfBlock));
+  const asOfBlock = Math.min(...checkpointDomains.map(domain => domainCheckpoints[domain]!.asOfBlock));
   return { importedBlockCount, asOfBlock, targetBlock };
 }
 
@@ -387,6 +397,7 @@ async function restoreFinancialHistoryDomain(args: {
   vaultHistory: VaultHistory;
   domain: IFinancialHistoryDomain;
   checkpoint?: IFinancialHistoryCheckpoint;
+  recoverMissingCheckpoints: boolean;
   force?: boolean;
   targetBlock: number;
   onActiveBitcoinLocksFound?: (count: number) => void;
@@ -395,13 +406,11 @@ async function restoreFinancialHistoryDomain(args: {
 }): Promise<{ checkpoint: IFinancialHistoryCheckpoint; importedBlockCount: number; error?: string }> {
   const { db, blockWatch, accountId, argonBonds, bitcoinLockRecovery, vaultHistory, domain, checkpoint } = args;
   const recoveryVersion = historyRecoveryVersions[domain];
-  const recoveryVersionChanged = recoveryVersion !== undefined && checkpoint?.recoveryVersion !== recoveryVersion;
-  const hasIncompleteBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
-  const canResumeBitcoinRecovery = hasIncompleteBitcoinRecovery && checkpoint?.partialRecovery;
+  const recoveryVersionChanged =
+    !!checkpoint && recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion;
+  const shouldRestartBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
   let afterBlock =
-    args.force || !checkpoint || recoveryVersionChanged || (hasIncompleteBitcoinRecovery && !canResumeBitcoinRecovery)
-      ? 0
-      : checkpoint.asOfBlock;
+    args.force || !checkpoint || recoveryVersionChanged || shouldRestartBitcoinRecovery ? 0 : checkpoint.asOfBlock;
 
   if (domain === 'bitcoin' && bitcoinLockRecovery && afterBlock === 0 && args.onActiveBitcoinLocksFound) {
     const finalizedApi = await blockWatch.getFinalizedApi();
@@ -415,7 +424,7 @@ async function restoreFinancialHistoryDomain(args: {
     activityMask: domainActivityMasks[domain],
   });
 
-  const definitionChanged = checkpoint?.definitionVersion !== indexedHistory.definitionVersion;
+  const definitionChanged = !!checkpoint && checkpoint.definitionVersion !== indexedHistory.definitionVersion;
   if (afterBlock > 0 && definitionChanged) {
     afterBlock = 0;
     indexedHistory = await findAddressActivity(accountId, {
@@ -433,7 +442,16 @@ async function restoreFinancialHistoryDomain(args: {
   }
 
   if (domain === 'bitcoin' && bitcoinLockRecovery) {
-    await bitcoinLockRecovery.beginHistoryReplay({ recoverExistingLocks: afterBlock === 0 });
+    let lockScope: BitcoinHistoryReplayLockScope = afterBlock === 0 ? 'all' : 'encountered';
+    const canRepairOnlyPendingLocks =
+      shouldRestartBitcoinRecovery &&
+      !args.force &&
+      !recoveryVersionChanged &&
+      !definitionChanged &&
+      (!!checkpoint || !args.recoverMissingCheckpoints);
+    if (canRepairOnlyPendingLocks) lockScope = 'pending';
+
+    await bitcoinLockRecovery.beginHistoryReplay({ lockScope });
   }
 
   const backlog =

--- a/src-vue/navigation/PortfolioDetailsMenu.vue
+++ b/src-vue/navigation/PortfolioDetailsMenu.vue
@@ -206,6 +206,12 @@
                     {{ currency.symbol }}{{ formatValue(bitcoinPositionBreakdown.lockedBtc) }}
                   </div>
                 </div>
+                <div v-if="bitcoinPositionBreakdown.pendingMint" class="flex items-center justify-between gap-6 py-1">
+                  <div class="font-normal text-slate-600">Pending mint</div>
+                  <div class="font-mono font-normal text-slate-600">
+                    {{ currency.symbol }}{{ formatValue(bitcoinPositionBreakdown.pendingMint) }}
+                  </div>
+                </div>
                 <div class="flex items-center justify-between gap-6 py-1">
                   <div class="font-normal text-slate-600">Debt</div>
                   <div class="font-mono font-normal text-slate-600">

--- a/src-vue/overlays/SyncingOverlay.vue
+++ b/src-vue/overlays/SyncingOverlay.vue
@@ -1,11 +1,10 @@
 <!-- prettier-ignore -->
 <template>
-  <TransitionRoot class="absolute inset-0 pointer-events-none" :show="isOpen">
-    <BgOverlay :showWindowControls="false" :style="{ zIndex: topBarMenuZIndex.zIndex - 1 }" />
+  <TransitionRoot class="pointer-events-none absolute inset-0 isolate z-30" :show="isOpen">
+    <BgOverlay :showWindowControls="false" rounded="none" />
 
     <div
-      class="absolute inset-0 overflow-y-auto pt-[1px] flex items-center justify-center pointer-events-none"
-      :style="{ zIndex: overlayZIndex.contentZIndex }"
+      class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-y-auto pt-px"
     >
       <TransitionChild
         as="template"
@@ -57,13 +56,10 @@ import ProgressBar from '../components/ProgressBar.vue';
 import AlertIcon from '../assets/alert.svg?component';
 import { getBot } from '../stores/bot.ts';
 import Draggable from './helpers/Draggable.ts';
-import { useFloatingZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 const isOpen = Vue.ref(true);
 const isRetrying = Vue.ref(false);
 const bot = getBot();
-const overlayZIndex = useOverlayZIndex(() => true);
-const topBarMenuZIndex = useFloatingZIndex();
 
 const draggable = Vue.reactive(new Draggable());
 

--- a/src-vue/screens/Mining.vue
+++ b/src-vue/screens/Mining.vue
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <template>
-  <div data-testid="MiningScreen" class="relative h-full w-full">
+  <div data-testid="MiningScreen" class="relative isolate h-full w-full">
     <BlankSlate v-if="config.miningSetupStatus === MiningSetupStatus.None && !config.miningBotAccountPreviousHistory" />
     <SetupChecklist v-else-if="config.miningSetupStatus === MiningSetupStatus.Checklist" />
     <SetupInstalling v-else-if="config.miningSetupStatus === MiningSetupStatus.Installing" />

--- a/src-vue/screens/mining-screen/components/MiningSeats.vue
+++ b/src-vue/screens/mining-screen/components/MiningSeats.vue
@@ -34,7 +34,7 @@
           </span>
           <span
             v-else
-            class="relative z-10 opacity-50"
+            class="seat-label relative z-10 opacity-50"
             :class="item.seat.miner?.isOurs && item.seat.slotId === currentAuctionSlot ? 'underline' : ''"
           >
             {{ item.seat.id }}
@@ -151,6 +151,7 @@ const seatGridStyle = Vue.computed((): Record<string, string> => {
     '--seat-dot-size': `${dotPx}px`,
     '--seat-dot-gap-x': `${gapX}px`,
     '--seat-dot-gap-y': `${gapY}px`,
+    '--seat-label-display': dotPx < 12 ? 'none' : 'inline',
     gridTemplateColumns: `repeat(${cols}, var(--seat-dot-size))`,
     justifyContent: 'start',
   };
@@ -426,6 +427,11 @@ function getVisibleStartingFrameIds(): number[] {
   width: var(--seat-dot-size, 14px);
   height: var(--seat-dot-size, 14px);
   text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.seat-label {
+  display: var(--seat-label-display, none);
+  font-size: clamp(6px, calc(var(--seat-dot-size) * 0.3), 0.875rem);
 }
 
 .seat-progress-ring {

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -1,16 +1,25 @@
 <template>
   <div class="BitcoinRecord Component flex flex-col">
-    <section RecoveryRecord v-if="lockSummary.record.isHistoryRecoveryPending">
-      <BitcoinIcon MainIcon class="bitcoin-spin" />
+    <section
+      RecoveryRecord
+      v-if="lockSummary.record.isHistoryRecoveryPending"
+      :class="isHistoryRecoveryPaused ? 'cursor-default' : 'cursor-wait'"
+    >
+      <BitcoinAlertIcon v-if="isHistoryRecoveryPaused" MainIcon />
+      <BitcoinIcon v-else MainIcon class="bitcoin-spin" />
       <div ContentWrapper>
         <div FirstRow>
           <header>{{ satToBtcNm(lockSummary.satoshis).format('0,0.[00000000]') }} of BTC</header>
-          <span class="inline-flex items-center gap-2 font-semibold text-slate-500">
+          <span v-if="isHistoryRecoveryPaused" class="font-semibold text-red-600">Recovery paused</span>
+          <span v-else class="inline-flex items-center gap-2 font-semibold text-slate-500">
             <Spinner class="h-4 w-4" />
             Syncing...
           </span>
         </div>
-        <div SecondRow>Restoring this Bitcoin transaction from chain history.</div>
+        <div SecondRow>
+          <template v-if="isHistoryRecoveryPaused">Open the RTD menu to retry Bitcoin history recovery.</template>
+          <template v-else>Restoring this Bitcoin transaction from chain history.</template>
+        </div>
       </div>
     </section>
 
@@ -223,6 +232,7 @@ import type { IBitcoinLockSummary } from '../../../interfaces/IBitcoinLockSummar
 import numeral, { createNumeralHelpers } from '../../../lib/numeral.ts';
 import { getCurrency } from '../../../stores/currency.ts';
 import { getBitcoinLocks } from '../../../stores/bitcoin.ts';
+import { useFinancials } from '../../../stores/financials.ts';
 import ProgressBar from '../../../components/ProgressBar.vue';
 import BitcoinRecordMismatch from './BitcoinRecordMismatch.vue';
 import Spinner from '../../../components/Spinner.vue';
@@ -231,6 +241,7 @@ dayjs.extend(utc);
 
 const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
+const financials = useFinancials();
 
 const { microgonToMoneyNm, satToBtcNm, satToMoneyNm } = createNumeralHelpers(currency);
 
@@ -245,6 +256,7 @@ const emit = defineEmits<{
 
 const isActionHovered = Vue.ref(false);
 const lockRecord = Vue.computed(() => props.lockSummary.record);
+const isHistoryRecoveryPaused = Vue.computed(() => financials.historyRecovery.state === 'error');
 const isRatchetPending = Vue.computed(() => !!bitcoinLocks.getPendingRatchetTxInfo(lockRecord.value));
 const mismatchAcceptProgress = Vue.computed(() => {
   if (!lockRecord.value.utxoId) {
@@ -282,7 +294,7 @@ async function acknowledgeExpiredNotice() {
 
 .BitcoinRecord.Component {
   section[RecoveryRecord] {
-    @apply flex cursor-wait flex-row items-center gap-2.5 rounded border border-slate-900/20 bg-slate-100 px-3.5 py-2 opacity-60;
+    @apply flex flex-row items-center gap-2.5 rounded border border-slate-900/20 bg-slate-100 px-3.5 py-2 opacity-60;
   }
 
   section[PendingRecord] {

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -785,7 +785,7 @@ export const useFinancials = defineStore('financials', () => {
   walletsForArgon.events.on('history:gap', gap => {
     if (!config.hasExtensionTreasury && !config.hasExtensionOperations) return;
 
-    void restoreFinancialHistory(false, gap.toBlock).catch(() => undefined);
+    finalizedHistoryScheduler.queue(gap.toBlock);
   });
 
   walletsForArgon.events.on('history:recovered', revisions => {
@@ -879,7 +879,7 @@ export const useFinancials = defineStore('financials', () => {
         // block when a domain activates so its positions can claim those holds.
         accountSnapshot.value = undefined;
         await queueAccountRefresh({ force: true });
-        if (config.walletAccountsHadPreviousLife && (config.hasExtensionTreasury || config.hasExtensionOperations)) {
+        if (config.hasExtensionTreasury || config.hasExtensionOperations) {
           void initializeFinancialHistoryRecovery().catch(error => {
             console.error('[FinancialHistory] Unable to initialize recovery', error);
           });
@@ -961,7 +961,7 @@ export const useFinancials = defineStore('financials', () => {
     if (config.hasExtensionTreasury) startLockSummaryProgressRefresh();
 
     isLoaded.value = true;
-    if (config.walletAccountsHadPreviousLife && (config.hasExtensionTreasury || config.hasExtensionOperations)) {
+    if (config.hasExtensionTreasury || config.hasExtensionOperations) {
       void initializeFinancialHistoryRecovery().catch(error => {
         console.error('[FinancialHistory] Unable to initialize recovery', error);
       });
@@ -984,14 +984,18 @@ export const useFinancials = defineStore('financials', () => {
       accountId: wallets.defaultArgonWallet.address,
       enabledDomains,
       bitcoinLockRecovery: bitcoinLocks.recovery,
+      recoverMissingCheckpoints: config.walletAccountsHadPreviousLife,
     });
     if (needsRecovery) {
+      hasConfirmedFinancialHistoryCoverage = false;
       await restoreFinancialHistory(false, targetBlock);
       return;
     }
 
-    hasConfirmedFinancialHistoryCoverage = true;
-    await queueAccountRefresh({ force: true });
+    if (!hasConfirmedFinancialHistoryCoverage) {
+      hasConfirmedFinancialHistoryCoverage = true;
+      await queueAccountRefresh({ force: true });
+    }
     historyRecovery.value = { state: 'ready', recoveredBlockCount: 0 };
   }
 
@@ -1024,6 +1028,7 @@ export const useFinancials = defineStore('financials', () => {
         bitcoinLockRecovery: bitcoinLocks.recovery,
         vaultHistory: myVault.history,
         enabledDomains,
+        recoverMissingCheckpoints: config.walletAccountsHadPreviousLife,
         force,
         minimumAsOfBlock: targetBlock,
         onCheckStart() {

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -970,7 +970,9 @@ export const useFinancials = defineStore('financials', () => {
 
   async function initializeFinancialHistoryRecovery(): Promise<void> {
     activeBitcoinLockCount.value = undefined;
-    historyRecovery.value = { state: 'checking', recoveredBlockCount: 0 };
+    if (!hasConfirmedFinancialHistoryCoverage) {
+      historyRecovery.value = { state: 'checking', recoveredBlockCount: 0 };
+    }
     const enabledDomains = getEnabledFinancialHistoryDomains({
       force: false,
       hasExtensionTreasury: config.hasExtensionTreasury,
@@ -988,6 +990,7 @@ export const useFinancials = defineStore('financials', () => {
     });
     if (needsRecovery) {
       hasConfirmedFinancialHistoryCoverage = false;
+      historyRecovery.value = { state: 'checking', recoveredBlockCount: 0 };
       await restoreFinancialHistory(false, targetBlock);
       return;
     }

--- a/src-vue/stores/upstreamOperator.ts
+++ b/src-vue/stores/upstreamOperator.ts
@@ -2,6 +2,7 @@ import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
 import { enrollUpstreamRecovery, recoverUpstreamHost } from './bootstrapRecovery.ts';
 import { getConfig } from './config.ts';
 import { getUpstreamOperatorAuthClient } from './server.ts';
+import { BootstrapType } from '../interfaces/IConfig.ts';
 
 let upstreamOperatorClient: UpstreamOperatorClient | undefined;
 
@@ -10,7 +11,13 @@ export function getUpstreamOperatorClient(): UpstreamOperatorClient {
     const config = getConfig();
     upstreamOperatorClient = new UpstreamOperatorClient(
       getUpstreamOperatorAuthClient(),
-      () => UpstreamOperatorClient.getBootstrapHost(config.bootstrapDetails),
+      () => {
+        // Legacy public RPC details do not imply upstream membership. Private details can exist
+        // briefly before member metadata is restored from the recovered operator.
+        if (!config.upstreamOperator && config.bootstrapDetails?.type !== BootstrapType.Private) return;
+
+        return UpstreamOperatorClient.getBootstrapHost(config.bootstrapDetails);
+      },
       recoverUpstreamHost,
     );
     void config.isLoadedPromise.then(() => {


### PR DESCRIPTION
## Summary

Recovered profiles no longer leave Bitcoin rows indefinitely “Syncing…” or omit mining cohort earnings from return-to-date. Recovery repairs only pending Bitcoin locks and inconsistent mining frames, preserving healthy history instead of replaying it on every startup.

Automatic history recovery stops after four failed attempts and exposes a paused state for an explicit retry. Mining catch-up stays within the mining screen, and labels scale away when seats become too small to remain readable.

Public RPC bootstrap details also remain separate from upstream membership, preventing member-auth calls to `rpc.argon.network` when no upstream operator exists.

## Validation

- Restored a copied production profile through repeated restarts: Bitcoin checkpoints completed, pending flags cleared, and no member-auth requests occurred after the fix.
- Confirmed the healthy profile did not replay completed mining frames; only the live incomplete frame refreshed.
- Focused recovery and mining tests pass.
