### PR TITLE
fix: use runtime mining account capacity

### DIFF
--- a/bot/src/Bot.ts
+++ b/bot/src/Bot.ts
@@ -256,7 +256,7 @@ export default class Bot {
       const commonAccountsetOptions = {
         client: this.localClient,
         sessionMiniSecretOrMnemonic: this.options.sessionMiniSecret,
-        subaccountRange: getRange(0, 144),
+        subaccountRange: getRange(0, this.localClient.consts.mint.maxPossibleMiners.toNumber()),
         txSubmitter: this.options.bidderKeypair,
       };
       const accountsetOptions: AccountsetOptions = isProxyBidder

--- a/src-vue/__test__/WalletKeys.test.ts
+++ b/src-vue/__test__/WalletKeys.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from 'vitest';
+import { WalletKeys } from '../lib/WalletKeys.ts';
 import type { IWalletRecord } from '../lib/db/WalletsTable.ts';
 import { createTestWallet } from './helpers/wallet.ts';
 
@@ -26,4 +27,55 @@ it('keeps the core Ethereum address separate from the active external wallet', (
   walletKeys.configureEthereumWallet();
 
   expect(walletKeys.ethereumAddress).toBe(defaultEthereumAddress);
+});
+
+it('falls back after a capacity load error, retries, and incrementally reuses generated subaccounts', async () => {
+  const { walletKeys: sourceWalletKeys } = createTestWallet();
+  let capacityLoadCount = 0;
+  const walletKeys = new WalletKeys(
+    {
+      sshPublicKey: sourceWalletKeys.sshPublicKey,
+      miningHoldAddress: sourceWalletKeys.legacyMiningHoldAddress,
+      miningBotAddress: sourceWalletKeys.miningBotAddress,
+      vaultingAddress: sourceWalletKeys.defaultArgonAddress,
+      operationalAddress: sourceWalletKeys.operationalAddress,
+      ethereumAddress: sourceWalletKeys.defaultEthereumAddress,
+      ethereumHdPrefixes: sourceWalletKeys.ethereumHdPrefixes,
+    },
+    async () => false,
+    async () => {
+      capacityLoadCount += 1;
+      if (capacityLoadCount === 1) {
+        throw new Error('capacity unavailable');
+      }
+      return 150;
+    },
+  );
+
+  const fallbackSubaccounts = await walletKeys.getMiningBotSubaccounts();
+  const fallbackValues = Object.values(fallbackSubaccounts);
+
+  expect(fallbackValues).toHaveLength(144);
+  expect(fallbackValues[0]?.index).toBe(0);
+  expect(fallbackValues[143]?.index).toBe(143);
+
+  const runtimeSubaccounts = await walletKeys.getMiningBotSubaccounts();
+  const runtimeValues = Object.values(runtimeSubaccounts);
+
+  expect(runtimeSubaccounts).toBe(fallbackSubaccounts);
+  expect(runtimeValues).toHaveLength(150);
+  expect(runtimeValues[149]?.index).toBe(149);
+
+  const expandedSubaccounts = await walletKeys.getMiningBotSubaccounts(152);
+  const expandedValues = Object.values(expandedSubaccounts);
+
+  expect(expandedSubaccounts).toBe(runtimeSubaccounts);
+  expect(expandedValues).toHaveLength(152);
+  expect(expandedValues[150]?.index).toBe(150);
+  expect(expandedValues[151]?.index).toBe(151);
+
+  const reusedSubaccounts = await walletKeys.getMiningBotSubaccounts(140);
+
+  expect(reusedSubaccounts).toBe(expandedSubaccounts);
+  expect(Object.values(reusedSubaccounts)).toHaveLength(152);
 });

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -51,10 +51,12 @@ export class WalletKeys {
 
   public miningBotSubaccountsCache: { [address: string]: { index: number } } = {};
   private upstreamOperatorAuthKeypair?: KeyringPair;
+  private miningBotSubaccountCountPromise?: Promise<number>;
 
   constructor(
     security: ISecurity,
     public didWalletHavePreviousLife: () => Promise<boolean>,
+    private readonly loadMiningBotSubaccountCount?: () => Promise<number>,
   ) {
     this.sshPublicKey = security.sshPublicKey;
     this.defaultArgonAddress = security.vaultingAddress;
@@ -91,12 +93,19 @@ export class WalletKeys {
     return (await this.getMiningBidProxyKeypair()).toJson(passphrase);
   }
 
-  public async getMiningBotSubaccounts(count = 144): Promise<{ [address: string]: { index: number } }> {
-    if (Object.keys(this.miningBotSubaccountsCache).length >= count) {
+  public async getMiningBotSubaccounts(count?: number): Promise<{ [address: string]: { index: number } }> {
+    if (count === undefined && this.loadMiningBotSubaccountCount) {
+      this.miningBotSubaccountCountPromise ??= this.loadMiningBotSubaccountCount();
+      count = await this.miningBotSubaccountCountPromise;
+    }
+    count ??= 144;
+
+    const currentCount = Object.keys(this.miningBotSubaccountsCache).length;
+    if (currentCount >= count) {
       return this.miningBotSubaccountsCache;
     }
 
-    const indexes = getRange(0, count);
+    const indexes = getRange(currentCount, count);
     for (const index of indexes) {
       const address = Accountset.createMiningSubaccount(this.miningBotAddress, index);
       this.miningBotSubaccountsCache[address] = { index };

--- a/src-vue/lib/WalletKeys.ts
+++ b/src-vue/lib/WalletKeys.ts
@@ -95,8 +95,12 @@ export class WalletKeys {
 
   public async getMiningBotSubaccounts(count?: number): Promise<{ [address: string]: { index: number } }> {
     if (count === undefined && this.loadMiningBotSubaccountCount) {
-      this.miningBotSubaccountCountPromise ??= this.loadMiningBotSubaccountCount();
-      count = await this.miningBotSubaccountCountPromise;
+      try {
+        this.miningBotSubaccountCountPromise ??= this.loadMiningBotSubaccountCount();
+        count = await this.miningBotSubaccountCountPromise;
+      } catch {
+        this.miningBotSubaccountCountPromise = undefined;
+      }
     }
     count ??= 144;
 

--- a/src-vue/stores/wallets.ts
+++ b/src-vue/stores/wallets.ts
@@ -12,7 +12,7 @@ import { getSpendableDefaultArgonMicrogons, IArgonWalletType, WalletForArgon } f
 import { IWallet, defaultWalletData } from '../lib/Wallet.ts';
 import { WalletsForArgon, IWalletEvents, readArgonWalletBalanceValues } from '../lib/WalletsForArgon.ts';
 import { getDbPromise } from './helpers/dbPromise.ts';
-import { getBlockWatch, getFinalizedClient } from './mainchain.ts';
+import { getBlockWatch, getFinalizedClient, getMainchainClient } from './mainchain.ts';
 import { getMyVault } from './vaults.ts';
 import { loadEthereumChainConfig } from '../lib/EthereumClient.ts';
 import { WalletForEthereum } from '../lib/WalletForEthereum.ts';
@@ -30,11 +30,18 @@ let legacyMiningHoldCleanupPromise: Promise<void> | undefined;
 
 let walletKeys: WalletKeys;
 export function getWalletKeys() {
-  walletKeys ??= new WalletKeys(SECURITY, async () => {
-    const walletsForArgon = getWalletsForArgon();
-    await walletsForArgon.load();
-    return walletsForArgon.didWalletHavePreviousLife();
-  });
+  walletKeys ??= new WalletKeys(
+    SECURITY,
+    async () => {
+      const walletsForArgon = getWalletsForArgon();
+      await walletsForArgon.load();
+      return walletsForArgon.didWalletHavePreviousLife();
+    },
+    async () => {
+      const client = await getMainchainClient(false);
+      return client.consts.mint.maxPossibleMiners.toNumber();
+    },
+  );
   return walletKeys;
 }
 


### PR DESCRIPTION
## Summary

Mining account pools now cover the runtime's full supported miner capacity instead of stopping at 144 deterministic subaccounts. Bot startup and wallet generation both use `mint.maxPossibleMiners`; the wallet resolves it lazily once and caches the count and derived account IDs. Cohort bids remain bounded by the requested seat count, so this expands account availability without increasing bid batch sizes.

## Validation

- Deriving 1,440 account IDs completed in about 38–70 ms after warm-up (147 ms cold), and the results are cached.
- `yarn vitest --run src-vue/__test__/WalletKeys.test.ts`
- `yarn typecheck`
- ESLint and Prettier checks on the touched files
