### PR TITLE
fix(e2e): follow redesigned bitcoin funding screen

### DIFF
--- a/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
+++ b/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
@@ -26,11 +26,10 @@ export default createBitcoinFundLockExactOperation();
 function createBitcoinFundLockExactOperation(): Operation<IBitcoinFlowContext, IFundLockExactState> {
   const operation = new Operation<IBitcoinFlowContext, IFundLockExactState>(import.meta, {
     async inspect({ flow }) {
-      const [panelState, lockingEntryVisible, lockOverlay, fundingBip21] = await Promise.all([
+      const [panelState, lockingEntryVisible, lockOverlay] = await Promise.all([
         flow.inspect(bitcoinEnsureMismatchActionPanel),
         hasBitcoinLockEntry(flow),
         flow.isVisible('BitcoinLockingOverlay'),
-        flow.isVisible('fundingBip21.copyContent()'),
       ]);
       const lockingOverlayState = lockOverlay.visible
         ? await flow.getAttribute('BitcoinLockingOverlay', 'data-e2e-state', { timeoutMs: 1_000 }).catch(() => null)
@@ -39,9 +38,7 @@ function createBitcoinFundLockExactOperation(): Operation<IBitcoinFlowContext, I
       const inFundingState = panelState.chainState.isPendingFunding;
       const fundingReadyToResume = panelState.chainState.isFundingReadyToResume;
       const fundingEntryVisible =
-        fundingBip21.visible ||
-        lockingEntryVisible ||
-        (lockOverlay.visible && lockingOverlayState === 'ReadyForBitcoin');
+        lockingEntryVisible || (lockOverlay.visible && lockingOverlayState === 'ReadyForBitcoin');
       const processingOnBitcoinVisible = lockingOverlayState === 'ProcessingOnBitcoin';
       const isComplete = panelState.chainState.isPostFundingLock || processingOnBitcoinVisible;
       const canRun =

--- a/e2e/flows/operations/Bitcoin.op.fundLockMismatch.ts
+++ b/e2e/flows/operations/Bitcoin.op.fundLockMismatch.ts
@@ -137,18 +137,16 @@ async function readFundLockMismatchUiState(flow: IE2EFlowRuntime): Promise<{
   fundingEntryVisible: boolean;
   mismatchPanelVisible: boolean;
 }> {
-  const [lockingEntryVisible, lockOverlay, fundingBip21, mismatchPanel] = await Promise.all([
+  const [lockingEntryVisible, lockOverlay, mismatchPanel] = await Promise.all([
     hasBitcoinLockEntry(flow),
     flow.isVisible('BitcoinLockingOverlay'),
-    flow.isVisible('fundingBip21.copyContent()'),
     flow.isVisible('LockFundingMismatch'),
   ]);
   const lockingOverlayState = lockOverlay.visible
     ? await flow.getAttribute('BitcoinLockingOverlay', 'data-e2e-state', { timeoutMs: 1_000 }).catch(() => null)
     : null;
   return {
-    fundingEntryVisible:
-      lockingEntryVisible || fundingBip21.visible || (lockOverlay.visible && lockingOverlayState === 'ReadyForBitcoin'),
+    fundingEntryVisible: lockingEntryVisible || (lockOverlay.visible && lockingOverlayState === 'ReadyForBitcoin'),
     mismatchPanelVisible: mismatchPanel.visible || (lockOverlay.visible && lockingOverlayState === 'FundingMismatch'),
   };
 }

--- a/e2e/flows/operations/Bitcoin.op.openLockFundingOverlay.ts
+++ b/e2e/flows/operations/Bitcoin.op.openLockFundingOverlay.ts
@@ -10,7 +10,6 @@ type IOpenLockFundingOverlayUiState = {
   lockingEntryVisible: boolean;
   lockOverlayVisible: boolean;
   lockOverlayState: string | null;
-  fundingBip21Visible: boolean;
 };
 
 type IOpenLockFundingOverlayState = IE2EOperationInspectState<
@@ -21,16 +20,12 @@ type IOpenLockFundingOverlayState = IE2EOperationInspectState<
 export default new Operation<IBitcoinFlowContext, IOpenLockFundingOverlayState>(import.meta, {
   async inspect({ flow }) {
     const panelState = await flow.inspect(bitcoinEnsureMismatchActionPanel);
-    const [lockOverlay, fundingBip21] = await Promise.all([
-      flow.isVisible('BitcoinLockingOverlay'),
-      flow.isVisible('fundingBip21.copyContent()'),
-    ]);
+    const lockOverlay = await flow.isVisible('BitcoinLockingOverlay');
     const lockingEntryVisible = panelState.lockingEntryVisible;
     const lockOverlayVisible = lockOverlay.visible;
     const lockOverlayState = lockOverlay.visible
       ? await flow.getAttribute('BitcoinLockingOverlay', 'data-e2e-state', { timeoutMs: 1_000 }).catch(() => null)
       : null;
-    const fundingBip21Visible = fundingBip21.visible;
     const readyForBitcoinVisible = lockOverlayState === 'ReadyForBitcoin';
     const wrongLockingPhaseVisible = lockOverlayVisible && !!lockOverlayState && lockOverlayState !== 'ReadyForBitcoin';
     const isComplete = readyForBitcoinVisible;
@@ -65,7 +60,6 @@ export default new Operation<IBitcoinFlowContext, IOpenLockFundingOverlayState>(
         lockingEntryVisible,
         lockOverlayVisible,
         lockOverlayState,
-        fundingBip21Visible,
       },
       state: operationState,
       phase:

--- a/e2e/flows/operations/Bitcoin.op.readLockFundingDetails.ts
+++ b/e2e/flows/operations/Bitcoin.op.readLockFundingDetails.ts
@@ -90,10 +90,15 @@ export default new Operation<IBitcoinFlowContext, IReadLockFundingDetailsState>(
   async run({ flow, flowName, state: flowState }, state) {
     if (state.state === 'complete') return;
 
+    const visibleLockAddress = (await flow.getText('LockReadyForBitcoin.address')).trim();
+    if (!visibleLockAddress) {
+      throw new Error(`${flowName}: missing lock address`);
+    }
+
     const lockAddress = await readClipboardWithRetries(
       flow,
       () => flow.click('LockReadyForBitcoin.copyAddress()'),
-      value => value.startsWith('bcrt1'),
+      value => value === visibleLockAddress,
     );
     const lockAmount = (await flow.getText('LockReadyForBitcoin.amount')).trim().replaceAll(',', '');
     if (!lockAmount) {

--- a/e2e/flows/operations/Bitcoin.op.readLockFundingDetails.ts
+++ b/e2e/flows/operations/Bitcoin.op.readLockFundingDetails.ts
@@ -1,7 +1,7 @@
 import type { IBitcoinVaultMismatchState } from '../types/srcVue.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import { readClipboardWithRetries } from '../helpers/readClipboardWithRetries.ts';
-import { formatUnitsToDecimal, parseBip21, parseDecimalToUnits } from '../helpers/utils.ts';
+import { formatUnitsToDecimal, parseDecimalToUnits } from '../helpers/utils.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
 import { Operation } from './index.ts';
@@ -13,7 +13,8 @@ type IReadLockFundingDetailsChainState = IBitcoinVaultMismatchState & {
 };
 
 type IReadLockFundingDetailsUiState = {
-  fundingBip21Visible: boolean;
+  fundingAddressVisible: boolean;
+  fundingAmountVisible: boolean;
   lockOverlayState: string | null;
 };
 
@@ -25,25 +26,30 @@ type IReadLockFundingDetailsState = IE2EOperationInspectState<
 export default new Operation<IBitcoinFlowContext, IReadLockFundingDetailsState>(import.meta, {
   async inspect({ flow, state: flowState }) {
     const hasLockFundingDetails = !!flowState.lockFundingDetails;
-    const [panelState, lockOverlay, fundingBip21] = await Promise.all([
+    const [panelState, lockOverlay, fundingAddress, fundingAmount] = await Promise.all([
       flow.inspect(bitcoinEnsureMismatchActionPanel),
       flow.isVisible('BitcoinLockingOverlay'),
-      flow.isVisible('fundingBip21.copyContent()'),
+      flow.isVisible('LockReadyForBitcoin.address'),
+      flow.isVisible('LockReadyForBitcoin.amount'),
     ]);
     const lockOverlayState = lockOverlay.visible
       ? await flow.getAttribute('BitcoinLockingOverlay', 'data-e2e-state', { timeoutMs: 1_000 }).catch(() => null)
       : null;
     const readyForBitcoinVisible = lockOverlayState === 'ReadyForBitcoin';
+    const fundingDetailsVisible = fundingAddress.visible && fundingAmount.visible;
     const wrongLockingPhaseVisible =
       lockOverlay.visible && !!lockOverlayState && lockOverlayState !== 'ReadyForBitcoin';
     const isComplete = hasLockFundingDetails;
-    const canRun = !isComplete && panelState.chainState.isPendingFunding && readyForBitcoinVisible;
+    const canRun =
+      !isComplete && panelState.chainState.isPendingFunding && readyForBitcoinVisible && fundingDetailsVisible;
     let operationState: IE2EOperationState = 'processing';
     if (isComplete) {
       operationState = 'complete';
     } else if (wrongLockingPhaseVisible) {
       operationState = 'uiStateMismatch';
     } else if (panelState.chainState.isPendingFunding && !readyForBitcoinVisible) {
+      operationState = 'uiStateMismatch';
+    } else if (readyForBitcoinVisible && !fundingDetailsVisible) {
       operationState = 'uiStateMismatch';
     } else if (canRun) {
       operationState = 'runnable';
@@ -62,13 +68,17 @@ export default new Operation<IBitcoinFlowContext, IReadLockFundingDetailsState>(
     if (!isComplete && !readyForBitcoinVisible) {
       blockers.push('ReadyForBitcoin funding details are not visible.');
     }
+    if (!isComplete && readyForBitcoinVisible && !fundingDetailsVisible) {
+      blockers.push('ReadyForBitcoin funding address or amount is not visible.');
+    }
     return {
       chainState: {
         hasLockFundingDetails,
         ...panelState.chainState,
       },
       uiState: {
-        fundingBip21Visible: fundingBip21.visible,
+        fundingAddressVisible: fundingAddress.visible,
+        fundingAmountVisible: fundingAmount.visible,
         lockOverlayState,
       },
       state: operationState,
@@ -80,20 +90,12 @@ export default new Operation<IBitcoinFlowContext, IReadLockFundingDetailsState>(
   async run({ flow, flowName, state: flowState }, state) {
     if (state.state === 'complete') return;
 
-    if (!state.uiState.fundingBip21Visible) {
-      await flow.click({ selector: '.BitcoinLockingOverlay .text-argon-600.cursor-pointer' }, { timeoutMs: 5_000 });
-      await flow.waitFor('fundingBip21.copyContent()', { timeoutMs: 5_000 });
-    }
-
-    const bip21 = await readClipboardWithRetries(
+    const lockAddress = await readClipboardWithRetries(
       flow,
-      () => flow.click('fundingBip21.copyContent()'),
-      value => value.startsWith('bitcoin:'),
+      () => flow.click('LockReadyForBitcoin.copyAddress()'),
+      value => value.startsWith('bcrt1'),
     );
-    const { address: lockAddress, amount: lockAmount } = parseBip21(bip21);
-    if (!lockAddress) {
-      throw new Error(`${flowName}: missing lock address`);
-    }
+    const lockAmount = (await flow.getText('LockReadyForBitcoin.amount')).trim().replaceAll(',', '');
     if (!lockAmount) {
       throw new Error(`${flowName}: missing lock amount`);
     }

--- a/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
+++ b/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
@@ -15,7 +15,6 @@ type IStartBitcoinLockUiState = {
   lockOverlayVisible: boolean;
   lockOverlayState: string | null;
   lockStartVisible: boolean;
-  fundingBip21Visible: boolean;
 };
 
 type IStartBitcoinLockState = IE2EOperationInspectState<IBitcoinVaultMismatchState, IStartBitcoinLockUiState>;
@@ -23,12 +22,11 @@ type IStartBitcoinLockState = IE2EOperationInspectState<IBitcoinVaultMismatchSta
 export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import.meta, {
   async inspect({ flow }) {
     const panelState = await flow.inspect(bitcoinEnsureMismatchActionPanel);
-    const [bitcoinLocksScreen, lockStartEntry, lockOverlay, lockStart, fundingBip21] = await Promise.all([
+    const [bitcoinLocksScreen, lockStartEntry, lockOverlay, lockStart] = await Promise.all([
       flow.isVisible('BitcoinLocksScreen'),
       flow.isVisible('BitcoinLocks.openLockingOverlay()'),
       flow.isVisible('BitcoinLockingOverlay'),
       flow.isVisible('LockStart.submitLiquidLock()'),
-      flow.isVisible('fundingBip21.copyContent()'),
     ]);
     const bitcoinLocksScreenVisible = bitcoinLocksScreen.visible;
     const lockStartEntryVisible = lockStartEntry.visible;
@@ -37,8 +35,7 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
       ? await flow.getAttribute('BitcoinLockingOverlay', 'data-e2e-state', { timeoutMs: 1_000 }).catch(() => null)
       : null;
     const lockStartVisible = lockStart.visible;
-    const fundingBip21Visible = fundingBip21.visible;
-    const isComplete = panelState.chainState.isPendingFunding || fundingBip21Visible;
+    const isComplete = panelState.chainState.isPendingFunding || lockOverlayState === 'ReadyForBitcoin';
     const canRun =
       !isComplete &&
       !panelState.chainState.hasActiveLock &&
@@ -67,7 +64,6 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
         lockOverlayVisible,
         lockOverlayState,
         lockStartVisible,
-        fundingBip21Visible,
       },
       state: operationState,
       phase:

--- a/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
@@ -19,7 +19,9 @@
 
       <p class="mt-5 text-gray-600 select-text">
         2. Send exactly
-        <strong>{{ satToBtcNm(props.personalLock.satoshis).format('0,0.[00000000]') }}</strong>
+        <strong data-testid="LockReadyForBitcoin.amount">
+          {{ satToBtcNm(props.personalLock.satoshis).format('0,0.[00000000]') }}
+        </strong>
         BTC (&asymp; {{ currency.symbol }}{{ satToMoneyNm(props.personalLock.satoshis).format('0,0.00') }}) to this
         address:
       </p>
@@ -31,7 +33,7 @@
             :content="scriptPaytoAddress"
             class="relative min-w-0 grow cursor-pointer"
           >
-            <span class="flex min-w-0 items-center opacity-80">
+            <span data-testid="LockReadyForBitcoin.address" class="flex min-w-0 items-center opacity-80">
               <span class="truncate">{{ scriptPaytoAddressPrefix }}</span>
               <span class="shrink-0">{{ scriptPaytoAddressSuffix }}</span>
               <CopyIcon class="ml-2 h-4 w-4 shrink-0" />
@@ -46,6 +48,7 @@
           </CopyToClipboard>
         </div>
         <button
+          data-testid="LockReadyForBitcoin.copyAddress()"
           class="border-argon-600 shrink-0 rounded-md border px-3 whitespace-nowrap"
           @click.stop="scriptPaytoAddressCopy?.copy()"
         >


### PR DESCRIPTION
## Summary

All three Bitcoin funding flows can read locking details again after v2.3.0 redesigned the funding overlay. The flows now use the visible amount and existing Copy button for the address, while surrounding transitions rely on the overlay state instead of the removed BIP21 control. This addresses the identical failures seen in the [release PR](https://github.com/argonprotocol/apps/actions/runs/30600164662) and [post-merge main](https://github.com/argonprotocol/apps/actions/runs/30601064160) runs.

## Validation

Local typechecking, selector enforcement, lint and formatting checks, and all 492 `src-vue` tests pass. The Docker Bitcoin flow was not rerun locally because another worktree owns the shared stack; CI is the intended full-path validation.
