### PR TITLE
fix: relay global council rotations

### DIFF
--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -1,6 +1,14 @@
 import { NetworkConfig, setFetchImplementation, type FetchImplementation } from '@argonprotocol/apps-core';
+import { decodeAddress, EvmContracts } from '@argonprotocol/mainchain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { keccak256, TransactionNotFoundError, TransactionReceiptNotFoundError } from 'viem';
+import {
+  decodeFunctionData,
+  keccak256,
+  TransactionNotFoundError,
+  TransactionReceiptNotFoundError,
+  type Hex,
+  toHex,
+} from 'viem';
 import {
   createEthereumPublicClient,
   EthereumClient,
@@ -173,4 +181,293 @@ describe('EthereumClient', () => {
     await expect(ethereumClient.getTransactionProgress({ txHash })).rejects.toThrow(EthereumTransactionRevertedError);
     expect(getBlockNumber).not.toHaveBeenCalled();
   });
+
+  // The published mainchain declarations reference a missing generated module, so ESLint sees these
+  // native EvmContracts helpers as error-typed even though the runtime exports are present.
+  /* eslint-disable @typescript-eslint/no-unsafe-call */
+  it('relays a council rotation and the next contiguous ready update', async () => {
+    const fixture = createCouncilRotationRelayFixture();
+    const receipt = await fixture.ethereumClient.applyReadyGatewayUpdates(
+      fixture.finalizedClient as any,
+      fixture.walletKeys.vaultingAddress,
+      {
+        address: fixture.walletKeys.ethereumAddress,
+        hdPath: `m/44'/60'/0'/0'`,
+      },
+      { allowUncompensatedRelay: true },
+    );
+    const decoded = decodeFunctionData({
+      abi: EvmContracts.mintingGatewayAbi,
+      data: fixture.submittedTransaction.data!,
+    });
+
+    expect(receipt?.transactionHash).toBe(fixture.transactionHash);
+    expect(fixture.sendRawTransaction).toHaveBeenCalledOnce();
+    expect(decoded.functionName).toBe('applyGatewayUpdates');
+    expect(decoded.args?.[0]).toEqual(fixture.currentCouncil);
+    expect(decoded.args?.[1]).toEqual([
+      {
+        queueNonce: 1n,
+        kind: EvmContracts.MINTING_GATEWAY_UPDATE_KINDS.globalIssuanceCouncilRotate,
+        payload: EvmContracts.encodeMintingGatewayGlobalIssuanceCouncilRotateTarget(fixture.rotationTarget),
+        signatures: fixture.currentCouncilSignatures,
+      },
+      {
+        queueNonce: 2n,
+        kind: EvmContracts.MINTING_GATEWAY_UPDATE_KINDS.mintingAuthorityActivate,
+        payload: EvmContracts.encodeMintingGatewayMintingAuthorityActivationTarget(fixture.activationTarget),
+        signatures: fixture.rotatedCouncilSignatures,
+      },
+    ]);
+  });
+
+  it.each([
+    ['target council hash', 'council', 'target council hash does not match council'],
+    ['target payload hash', 'payload', 'target payload hash does not match council'],
+    ['approval hash', 'approval', 'approval hash does not match council rotation'],
+  ] as const)('rejects a rotation whose %s is invalid', async (_label, corruption, expectedError) => {
+    const fixture = createCouncilRotationRelayFixture(corruption);
+
+    await expect(
+      fixture.ethereumClient.applyReadyGatewayUpdates(
+        fixture.finalizedClient as any,
+        fixture.walletKeys.vaultingAddress,
+        {
+          address: fixture.walletKeys.ethereumAddress,
+          hdPath: `m/44'/60'/0'/0'`,
+        },
+        { allowUncompensatedRelay: true },
+      ),
+    ).rejects.toThrow(`Queue nonce 1 ${expectedError}`);
+    expect(fixture.sendRawTransaction).not.toHaveBeenCalled();
+  });
+  /* eslint-enable @typescript-eslint/no-unsafe-call */
 });
+
+const ZERO_HASH = repeatHex('00', 32);
+
+function repeatHex(byte: string, count: number): Hex {
+  return `0x${byte.repeat(count)}`;
+}
+
+function amount(value: bigint) {
+  return {
+    toBigInt: () => value,
+  };
+}
+
+function hexValue(value: Hex) {
+  return {
+    toHex: () => value,
+  };
+}
+
+function some<T>(value: T) {
+  return {
+    isSome: true,
+    isNone: false,
+    unwrap: () => value,
+  };
+}
+
+function none() {
+  return {
+    isSome: false,
+    isNone: true,
+  };
+}
+
+// The published mainchain declarations reference a missing generated module, so ESLint sees these
+// native EvmContracts helpers as error-typed even though the runtime exports are present.
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+function createCouncilRotationRelayFixture(corruption?: 'council' | 'payload' | 'approval') {
+  const gatewayAddress = repeatHex('11', 20);
+  const authoritySigningKey = repeatHex('22', 20);
+  const currentCouncilSignerA = repeatHex('33', 20);
+  const currentCouncilSignerB = repeatHex('44', 20);
+  const rotatedCouncilSignerA = repeatHex('55', 20);
+  const rotatedCouncilSignerB = repeatHex('66', 20);
+  const currentCouncil = {
+    signers: [currentCouncilSignerA, currentCouncilSignerB],
+    weights: [70n, 30n],
+  };
+  const currentCouncilHash = EvmContracts.hashMintingGatewayGlobalIssuanceCouncil({
+    ...currentCouncil,
+    epochMicrogonsPerArgonot: 2_000_000n,
+  });
+  const rotationTarget: Parameters<typeof EvmContracts.encodeMintingGatewayGlobalIssuanceCouncilRotateTarget>[0] = {
+    council: {
+      signers: [rotatedCouncilSignerA, rotatedCouncilSignerB],
+      weights: [60n, 40n],
+    },
+    epochMicrogonsPerArgonot: 6_000_000n,
+  };
+  const rotatedCouncilHash = EvmContracts.hashMintingGatewayGlobalIssuanceCouncil({
+    ...rotationTarget.council,
+    epochMicrogonsPerArgonot: rotationTarget.epochMicrogonsPerArgonot,
+  });
+  const queuedRotatedCouncilHash = corruption === 'council' ? repeatHex('77', 32) : rotatedCouncilHash;
+  const hashContext = { chainId: 1n, gatewayAddress };
+  const rotationPayloadHash = EvmContracts.hashMintingGatewayRotateGlobalIssuanceCouncil(hashContext, rotationTarget);
+  const rotationApprovalHash = EvmContracts.hashMintingGatewayRotateGlobalIssuanceCouncilApproval(hashContext, {
+    queueNonce: 1n,
+    approvingCouncilHash: currentCouncilHash,
+    previousUpdateHash: ZERO_HASH,
+    target: rotationTarget,
+  });
+  const queuedRotationApprovalHash = corruption === 'approval' ? repeatHex('88', 32) : rotationApprovalHash;
+  const activationTarget = {
+    microgonCollateral: 1_500n,
+    micronotCollateral: 250n,
+    signingKey: authoritySigningKey,
+  };
+  const activationPayloadHash = EvmContracts.hashMintingGatewayActivateMintingAuthority(hashContext, activationTarget);
+  const activationApprovalHash = EvmContracts.hashMintingGatewayActivateMintingAuthorityApproval(hashContext, {
+    queueNonce: 2n,
+    approvingCouncilHash: rotatedCouncilHash,
+    previousUpdateHash: queuedRotationApprovalHash,
+    target: activationTarget,
+  });
+  const currentCouncilSignatures = [repeatHex('99', 65), repeatHex('aa', 65)];
+  const rotatedCouncilSignatures = [repeatHex('bb', 65), repeatHex('cc', 65)];
+  const entries = new Map([
+    [
+      1n,
+      {
+        approvingCouncilHash: hexValue(currentCouncilHash),
+        target: {
+          isGlobalIssuanceCouncilRotation: true,
+          isMintingAuthorityActivation: false,
+          isMintingAuthorityDeactivation: false,
+          asGlobalIssuanceCouncilRotation: hexValue(queuedRotatedCouncilHash),
+          type: 'GlobalIssuanceCouncilRotation',
+        },
+        targetPayloadHash: hexValue(corruption === 'payload' ? repeatHex('dd', 32) : rotationPayloadHash),
+        previousApprovalHash: hexValue(ZERO_HASH),
+        approvalHash: hexValue(queuedRotationApprovalHash),
+        signatures: new Map([
+          [hexValue(currentCouncilSignerB), hexValue(currentCouncilSignatures[1])],
+          [hexValue(currentCouncilSignerA), hexValue(currentCouncilSignatures[0])],
+        ]),
+      },
+    ],
+    [
+      2n,
+      {
+        approvingCouncilHash: hexValue(rotatedCouncilHash),
+        target: {
+          isGlobalIssuanceCouncilRotation: false,
+          isMintingAuthorityActivation: true,
+          isMintingAuthorityDeactivation: false,
+          asMintingAuthorityActivation: hexValue(authoritySigningKey),
+          type: 'MintingAuthorityActivation',
+        },
+        targetPayloadHash: hexValue(activationPayloadHash),
+        previousApprovalHash: hexValue(queuedRotationApprovalHash),
+        approvalHash: hexValue(activationApprovalHash),
+        signatures: new Map([
+          [hexValue(rotatedCouncilSignerB), hexValue(rotatedCouncilSignatures[1])],
+          [hexValue(rotatedCouncilSignerA), hexValue(rotatedCouncilSignatures[0])],
+        ]),
+      },
+    ],
+  ]);
+  const walletKeys = createMockWalletKeys();
+  const finalizedClient = {
+    query: {
+      crosschainTransfer: {
+        activeGlobalIssuanceCouncilByDestinationChain: async () => some(hexValue(currentCouncilHash)),
+        globalIssuanceCouncilByHash: async (hash: Hex) => {
+          if (hash === currentCouncilHash) {
+            return some({
+              epochMicrogonsPerArgonot: amount(2_000_000n),
+              totalWeight: amount(100n),
+              members: new Map([
+                [hexValue(currentCouncilSignerB), { weight: amount(30n) }],
+                [hexValue(currentCouncilSignerA), { weight: amount(70n) }],
+              ]),
+            });
+          }
+
+          return some({
+            epochMicrogonsPerArgonot: amount(rotationTarget.epochMicrogonsPerArgonot),
+            totalWeight: amount(100n),
+            members: new Map([
+              [hexValue(rotatedCouncilSignerB), { weight: amount(40n) }],
+              [hexValue(rotatedCouncilSignerA), { weight: amount(60n) }],
+            ]),
+          });
+        },
+        mintingAuthorityActivationRepaymentPricingByDestinationChain: async () => none(),
+        councilApprovalQueueByDestinationChainAndNonce: async (_chain: string, nonce: bigint) =>
+          entries.has(nonce) ? some(entries.get(nonce)) : none(),
+        mintingAuthoritiesBySigner: async () =>
+          some({
+            accountId: hexValue(toHex(decodeAddress(walletKeys.vaultingAddress), { size: 32 })),
+            destinationChain: { type: 'Ethereum' },
+            gatewayRemainingMicrogonCollateral: amount(activationTarget.microgonCollateral),
+            gatewayRemainingMicronotCollateral: amount(activationTarget.micronotCollateral),
+            activationBaseRepaymentQuote: amount(0n),
+            activationSignatureRepaymentQuote: amount(0n),
+          }),
+      },
+    },
+  };
+  const submittedTransaction: { data?: Hex } = {};
+  const transactionHash = repeatHex('ee', 32);
+  const sendRawTransaction = vi.fn(async () => transactionHash);
+  const publicClient = {
+    readContract: async ({ functionName }: { functionName: string }) => {
+      if (functionName === 'argonApprovalsNonce') return 0n;
+      if (functionName === 'argonApprovalsHash') return ZERO_HASH;
+      if (functionName === 'paused') return false;
+      throw new Error(`Unexpected function ${functionName}`);
+    },
+    getBalance: async () => 1_000_000n,
+    getTransactionCount: async () => 0,
+    estimateGas: async ({ data }: { data: Hex }) => {
+      submittedTransaction.data = data;
+      return 100_000n;
+    },
+    estimateFeesPerGas: async () => ({
+      gasPrice: 1n,
+      maxFeePerGas: 1n,
+      maxPriorityFeePerGas: 1n,
+    }),
+    sendRawTransaction,
+    waitForTransactionReceipt: async () => ({
+      blockNumber: 1n,
+      status: 'success',
+      transactionHash,
+    }),
+  };
+  const ethereumClient = new EthereumClient(walletKeys, 'https://ethereum.test');
+
+  Object.assign(ethereumClient, {
+    loadChainConfig: async () => ({
+      chainId: 1,
+      gatewayAddress,
+      argonTokenAddress: repeatHex('ff', 20),
+      argonotTokenAddress: repeatHex('ee', 20),
+    }),
+    createExecutionClient: async () => ({
+      chain: { id: 1 },
+      publicClient,
+    }),
+  });
+
+  return {
+    activationTarget,
+    currentCouncil,
+    currentCouncilSignatures,
+    ethereumClient,
+    finalizedClient,
+    rotatedCouncilSignatures,
+    rotationTarget,
+    sendRawTransaction,
+    submittedTransaction,
+    transactionHash,
+    walletKeys,
+  };
+}
+/* eslint-enable @typescript-eslint/no-unsafe-call */

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -104,16 +104,17 @@ type IEthereumSubmissionClient = {
   getTransaction(args: { hash: Hash }): Promise<unknown>;
   getTransactionReceipt(args: { hash: Hash }): Promise<unknown>;
 };
-type IEthereumGatewayCouncilSnapshot = {
-  signers: Address[];
-  weights: bigint[];
-};
-type IEthereumGatewayUpdate = {
-  queueNonce: bigint;
-  kind: bigint;
-  payload: Hex;
-  signatures: Hex[];
-};
+type ApplyGatewayUpdatesArgs = ContractFunctionArgs<
+  typeof EvmContracts.mintingGatewayAbi,
+  'nonpayable',
+  'applyGatewayUpdates'
+>;
+type IEthereumGatewayCouncilSnapshot = ApplyGatewayUpdatesArgs[0];
+type IEthereumGatewayUpdate = ApplyGatewayUpdatesArgs[1][number];
+type MintingGatewayHashContext = Parameters<typeof EvmContracts.hashMintingGatewayGatewayUpdateApproval>[0];
+type MintingGatewayGlobalIssuanceCouncilRotateTarget = Parameters<
+  typeof EvmContracts.encodeMintingGatewayGlobalIssuanceCouncilRotateTarget
+>[0];
 const ethereumChainConfigPromises = new Map<string, Promise<IEthereumChainConfig | undefined>>();
 type EthereumExecutionReceipt = Awaited<ReturnType<PublicClient['getTransactionReceipt']>>;
 type MintingGatewayTransferOutOfArgonAuthorization = {
@@ -129,6 +130,7 @@ export type IEthereumFinalizeTransferOutOfArgonArgs = {
   proof: MintingGatewayTransferOutOfArgonProof;
 };
 type LoadedCouncil = {
+  epochMicrogonsPerArgonot: bigint;
   totalWeight: bigint;
   members: {
     signer: Address;
@@ -991,13 +993,11 @@ async function getReadyEthereumGatewayUpdates(
         );
       }
 
-      const relayableUpdate = await buildGatewayUpdate(
-        finalizedClient,
-        hashContext,
-        queueNonce,
+      const relayableUpdate = await buildGatewayUpdate(finalizedClient, hashContext, queueNonce, {
         entry,
         approvingCouncilHash,
-      );
+        councilCache,
+      });
       relayableUpdates.push(relayableUpdate);
       expectedPreviousApprovalHash = toHexValue(entry.approvalHash);
     }
@@ -1018,6 +1018,8 @@ async function getReadyEthereumGatewayUpdates(
     readyRelayableUpdates = lastOwnedUpdateIndex >= 0 ? relayableUpdates.slice(0, lastOwnedUpdateIndex + 1) : [];
   }
 
+  // ESLint loses the ABI-derived update type through the EvmContracts namespace here.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   const updates = readyRelayableUpdates.map(({ update }) => update);
   for (let index = 0; index < updates.length; index += 1) {
     const isBorder =
@@ -1045,15 +1047,60 @@ async function getReadyEthereumGatewayUpdates(
   };
 }
 
-// ESLint loses the helper call types through the EvmContracts namespace here.
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+// The published mainchain declarations reference a missing generated module, so ESLint sees these
+// native EvmContracts helpers as error-typed even though the runtime exports are present.
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 async function buildGatewayUpdate(
   finalizedClient: IArgonQueryable,
-  hashContext: { chainId: bigint; gatewayAddress: Address },
+  hashContext: MintingGatewayHashContext,
   queueNonce: bigint,
-  entry: PalletCrosschainTransferCouncilApprovalQueueEntry,
-  approvingCouncilHash: Hex,
+  queueItem: {
+    entry: PalletCrosschainTransferCouncilApprovalQueueEntry;
+    approvingCouncilHash: Hex;
+    councilCache: Map<Hex, LoadedCouncil>;
+  },
 ): Promise<RelayableGatewayUpdate> {
+  const { entry, approvingCouncilHash, councilCache } = queueItem;
+  if (entry.target.isGlobalIssuanceCouncilRotation) {
+    const signatures = getSortedSignatures(entry.signatures);
+    const nextCouncilHash = toHexValue(entry.target.asGlobalIssuanceCouncilRotation);
+    const nextCouncil = await loadCouncilByHash(finalizedClient, nextCouncilHash, councilCache);
+    const target: MintingGatewayGlobalIssuanceCouncilRotateTarget = {
+      council: councilToSnapshot(nextCouncil),
+      epochMicrogonsPerArgonot: nextCouncil.epochMicrogonsPerArgonot,
+    };
+    const calculatedCouncilHash = EvmContracts.hashMintingGatewayGlobalIssuanceCouncil({
+      ...target.council,
+      epochMicrogonsPerArgonot: target.epochMicrogonsPerArgonot,
+    });
+    const targetPayloadHash = EvmContracts.hashMintingGatewayRotateGlobalIssuanceCouncil(hashContext, target);
+    const approvalHash = EvmContracts.hashMintingGatewayRotateGlobalIssuanceCouncilApproval(hashContext, {
+      queueNonce,
+      approvingCouncilHash,
+      previousUpdateHash: toHexValue(entry.previousApprovalHash),
+      target,
+    });
+
+    if (calculatedCouncilHash !== nextCouncilHash) {
+      throw new Error(`Queue nonce ${queueNonce} target council hash does not match council`);
+    }
+    if (toHexValue(entry.targetPayloadHash) !== targetPayloadHash) {
+      throw new Error(`Queue nonce ${queueNonce} target payload hash does not match council`);
+    }
+    if (toHexValue(entry.approvalHash) !== approvalHash) {
+      throw new Error(`Queue nonce ${queueNonce} approval hash does not match council rotation`);
+    }
+
+    return {
+      update: {
+        queueNonce,
+        kind: EvmContracts.MINTING_GATEWAY_UPDATE_KINDS.globalIssuanceCouncilRotate,
+        payload: EvmContracts.encodeMintingGatewayGlobalIssuanceCouncilRotateTarget(target),
+        signatures,
+      },
+    };
+  }
+
   if (entry.target.isMintingAuthorityDeactivation) {
     const signingKey = getAddress(toHexValue(entry.target.asMintingAuthorityDeactivation));
     const authorityOption = await finalizedClient.query.crosschainTransfer.mintingAuthoritiesBySigner(signingKey);
@@ -1123,7 +1170,7 @@ async function buildGatewayUpdate(
     signingKey,
   };
   const payload = EvmContracts.encodeMintingGatewayMintingAuthorityActivationTarget(target);
-  const targetPayloadHash = payloadHashFromActivationPayload(hashContext, target);
+  const targetPayloadHash = EvmContracts.hashMintingGatewayActivateMintingAuthority(hashContext, target);
   const approvalHash = EvmContracts.hashMintingGatewayGatewayUpdateApproval(hashContext, {
     queueNonce,
     approvingCouncilHash,
@@ -1177,6 +1224,7 @@ async function loadCouncilByHash(
 
   const council = councilOption.unwrap();
   const loaded = {
+    epochMicrogonsPerArgonot: council.epochMicrogonsPerArgonot.toBigInt(),
     totalWeight: council.totalWeight.toBigInt(),
     members: [...council.members.entries()]
       .map(([signer, member]) => ({
@@ -1221,13 +1269,7 @@ function councilToSnapshot(council: LoadedCouncil): IEthereumGatewayCouncilSnaps
   };
 }
 
-function payloadHashFromActivationPayload(
-  hashContext: { chainId: bigint; gatewayAddress: Address },
-  target: { microgonCollateral: bigint; micronotCollateral: bigint; signingKey: Address },
-): Hex {
-  return EvmContracts.hashMintingGatewayActivateMintingAuthority(hashContext, target);
-}
-/* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+/* eslint-enable @typescript-eslint/no-unsafe-call */
 
 function calculateExpectedGatewayRelayRepaymentMicrogons(args: {
   relayableUpdates: RelayableGatewayUpdate[];


### PR DESCRIPTION
## Summary

Scheduled global issuance council rotations can now pass through the app's Ethereum gateway relay instead of stopping the approval queue. The relay uses the pinned mainchain contract helpers to construct the rotation payload and validates the council hash, target payload hash, approving council, previous approval hash, and approval hash before submission. Contiguous updates after a rotation are submitted under the rotated council with signatures in signer order.

## Validation

- Apps Ethereum relay and council tests: 16 passed.
- v1.4.11 `MintingGateway` contract suite: 21 passed, including rotations followed by later updates under the new council.
- Targeted ESLint and `vue-tsc --noEmit` passed.
