### PR TITLE
feat: retain server logs across upgrades

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -1,9 +1,6 @@
 x-common-config: &common-config
   logging:
-    driver: 'json-file'
-    options:
-      max-size: '25m'
-      max-file: '5'
+    driver: '${DOCKER_LOG_DRIVER:-local}'
   networks:
     - default
   extra_hosts:

--- a/server/scripts/conf/argon-journald.conf
+++ b/server/scripts/conf/argon-journald.conf
@@ -1,0 +1,8 @@
+[Journal]
+Storage=persistent
+Compress=yes
+SystemMaxUse=1G
+SystemKeepFree=10G
+SystemMaxFileSize=64M
+MaxFileSec=1day
+MaxRetentionSec=14day

--- a/server/scripts/create_troubleshooting_gz.sh
+++ b/server/scripts/create_troubleshooting_gz.sh
@@ -105,6 +105,28 @@ docker ps -a --format '{{.ID}} {{.Names}}' | while read -r id name; do
   docker inspect "$id" > "${OUT}/docker/${safe}.inspect.json" 2>&1 || true
 done
 
+if command -v journalctl >/dev/null 2>&1; then
+  echo "[*] Capturing retained logs across container upgrades"
+  if ! journalctl --disk-usage > "${OUT}/docker/journal-disk-usage.txt" 2>&1; then
+    record_collection_error "Could not read journal disk usage."
+  fi
+
+  JOURNAL_CONTAINER_NAMES="${OUT}/docker/journal-container-names.txt"
+  JOURNAL_CONTAINER_NAMES_ERROR="${OUT}/docker/journal-container-names.error.txt"
+  if journalctl --no-pager -F CONTAINER_NAME > "$JOURNAL_CONTAINER_NAMES" 2> "$JOURNAL_CONTAINER_NAMES_ERROR"; then
+    while read -r name; do
+      [[ -z "$name" ]] && continue
+      safe="${name//[^[:alnum:]_.-]/_}"
+      if ! journalctl --no-pager -o short-iso-precise CONTAINER_NAME="$name" \
+        > "${OUT}/logs/${safe}.journal.log" 2>&1; then
+        record_collection_error "Could not collect retained journal logs for container '$name'."
+      fi
+    done < "$JOURNAL_CONTAINER_NAMES"
+  else
+    record_collection_error "Could not enumerate retained container journals."
+  fi
+fi
+
 echo "[*] Copying install logs"
 if [[ -d "$INSTALL_LOG_DIR" ]]; then
   rsync -a --delete "$INSTALL_LOG_DIR"/ "${OUT}/install/" || true

--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -26,6 +26,7 @@ fi
 if [ -f "$SERVER_DIR/.env" ]; then
   . "$SERVER_DIR/.env"
 fi
+
 MIN_FREE_DISK_GB=10
 
 # Debug logging
@@ -117,6 +118,13 @@ read_router_syncstatus() {
 reset "FileUpload"
 start "FileUpload"
 
+if [ "$NEEDS_FULL_SETUP" = true ]; then
+    if grep -q '^DOCKER_LOG_DRIVER=' "$SERVER_DIR/.env" 2>/dev/null; then
+        run_command "sed -i 's/^DOCKER_LOG_DRIVER=.*/DOCKER_LOG_DRIVER=journald/' $SERVER_DIR/.env"
+    else
+        run_command "echo 'DOCKER_LOG_DRIVER=journald' >> $SERVER_DIR/.env"
+    fi
+fi
 
 finish "FileUpload"
 
@@ -223,6 +231,13 @@ if ! (already_ran "UbuntuCheck"); then
         run_command "sudo cp $SCRIPTS_DIR/conf/fail2ban_recidive.local /etc/fail2ban/jail.d/recidive.local"
         run_command "sudo systemctl enable fail2ban --now"
         run_command "sudo systemctl restart fail2ban"
+
+        echo "-----------------------------------------------------------------"
+        echo "CONFIGURING PERSISTENT SYSTEM LOGGING"
+        run_command "sudo install -D -m 0644 $SCRIPTS_DIR/conf/argon-journald.conf /etc/systemd/journald.conf.d/argon.conf"
+        run_command "sudo systemctl restart systemd-journald"
+        run_command "sudo journalctl --flush"
+        run_command "sudo journalctl --rotate --vacuum-size=1G --vacuum-time=14days"
     fi
 
     finish "UbuntuCheck"


### PR DESCRIPTION
## Summary

Server operators will retain container logs after upgrades instead of losing them when Docker replaces old containers. Remote installations write future container output to a persistent, compressed system journal bounded to 1 GB and 14 days while preserving 10 GB of free disk; local installations continue using Docker's bounded local driver. Troubleshooting packages now include retained journal history alongside `docker logs` output for current containers.

Existing `json-file` logs are intentionally not migrated, so retained history begins with the first upgrade containing this change.

## Validation

- Upgraded a testnet server and confirmed all six services were healthy on `journald`.
- Confirmed the same entries remained available through `journalctl` after deleting a test container and rotating the journal.
- Confirmed the retained entry appeared in a troubleshooting package with no collection errors.
- Verified shell syntax and rendered Compose configurations for both `local` and `journald` drivers.

## Post-Deploy Monitoring & Validation

During the first 24 hours after the next mainnet upgrade, the release operator should confirm all services report `journald`, remain healthy, and that `journalctl --disk-usage` stays within the configured bound. Failure signals are a container unable to initialize its logging driver, missing journal entries, or unexpected disk growth; roll back the release and recreate services with `DOCKER_LOG_DRIVER=local` if container startup is affected.
