### PR TITLE
fix: replan mining bids after funding

### DIFF
--- a/bot/src/BlockSync.ts
+++ b/bot/src/BlockSync.ts
@@ -4,7 +4,6 @@ import {
   type GenericEvent,
   type Header,
   type SpRuntimeDispatchError,
-  type Vec,
 } from '@argonprotocol/mainchain';
 import {
   AccountMiners,
@@ -341,8 +340,10 @@ export class BlockSync {
     console.log(`[BlockSync] Processing block ${blockNumber}`, blockMeta);
 
     const client = this.getRpcClient(blockNumber);
-    const api = await client.at(blockMeta.hash);
-    const events = await api.query.system.events();
+    const { api, events } = await this.blockWatch.getEventsWithSpec({
+      blockNumber,
+      blockHash: blockMeta.hash,
+    });
     const cohortEarningsAtFrameId = await this.accountMiners.onBlock(
       blockMeta,
       events.map(x => x.event),
@@ -480,7 +481,7 @@ export class BlockSync {
     currentFrameId: number,
     biddingFrameId: number,
     block: IBlock,
-    events: Vec<FrameSystemEventRecord>,
+    events: readonly FrameSystemEventRecord[],
     argonotPriceAtBid?: bigint,
   ): Promise<{ hasMiningBids: boolean; hasMiningSeats: boolean; transactionFeesTotal: bigint }> {
     const client = this.getRpcClient(block.number);

--- a/core/__test__/CohortBidder.test.ts
+++ b/core/__test__/CohortBidder.test.ts
@@ -601,6 +601,71 @@ describe('CohortBidder unit tests', () => {
     expect(cohortBidder.nextBid?.microgonsPerSeat).toBe(610_000n);
   });
 
+  it.each([
+    {
+      currency: 'ARGON',
+      eventSection: 'balances',
+      initialMicrogons: 500_000n,
+      initialMicronots: 100_000n,
+    },
+    {
+      currency: 'ARGNOT',
+      eventSection: 'ownership',
+      initialMicrogons: 1_000_000n,
+      initialMicronots: 0n,
+    },
+  ])('replans when the funding account receives $currency without new cohort bids', async options => {
+    let accountBalance = options.initialMicrogons;
+    let accountMicronots = options.initialMicronots;
+    const { cohortBidder } = await createBidderWithMocks(accountset, [0, 0], {
+      minBid: 500_000n,
+      maxBid: 1_000_000n,
+      accountBalance,
+      accountMicronots,
+    });
+    vi.spyOn(accountset, 'submitterBalance').mockImplementation(() => Promise.resolve(accountBalance));
+    vi.spyOn(accountset, 'accountMicronots').mockImplementation(() => Promise.resolve(accountMicronots));
+    vi.spyOn(cohortBidder, 'submitNextBid' as any).mockResolvedValue(undefined);
+    cohortBidder.currentBids.atBlockNumber = 100;
+    cohortBidder.currentBids.atTick = 100;
+
+    // @ts-expect-error exercising the private planning flow
+    await cohortBidder.planNextBid(20);
+    expect(cohortBidder.nextBid).toBeUndefined();
+
+    accountBalance = 1_000_000n;
+    accountMicronots = 100_000n;
+    const bidsHash = `0x${'01'.repeat(32)}`;
+    const blockWatch = {
+      subscriptionClient: {
+        rpc: {
+          state: {
+            getStorageHash: vi.fn().mockResolvedValue({ toHex: () => bidsHash }),
+          },
+        },
+      },
+      getEvents: vi.fn().mockResolvedValue([
+        {
+          event: {
+            section: options.eventSection,
+            data: [{ toString: () => accountset.fundingAccountId }],
+          },
+        },
+      ]),
+    };
+    cohortBidder.miningFrames = { blockWatch } as unknown as MiningFrames;
+    // @ts-expect-error setting the current private bid hash for an unchanged auction
+    cohortBidder.lastBidsHash = bidsHash;
+    // @ts-expect-error setting the private storage key used by the header flow
+    cohortBidder.bidsForNextSlotCohortKey = 'bids-key';
+
+    // @ts-expect-error exercising the private best-block flow
+    await cohortBidder.onHeader(createBlockHeader(101, `0x${'02'.repeat(32)}`), false);
+
+    expect(cohortBidder.nextBid?.microgonsPerSeat).toBe(500_000n);
+    expect(cohortBidder.nextBid?.subaccounts).toHaveLength(1);
+  });
+
   it('claims a planned bid before asynchronous transaction creation begins', async () => {
     const header = createBlockHeader(100, `0x${'01'.repeat(32)}`);
     const blockWatch = {

--- a/core/src/CohortBidder.ts
+++ b/core/src/CohortBidder.ts
@@ -331,6 +331,17 @@ export class CohortBidder {
         }
         throw error;
       }
+    } else {
+      const events = await this.blockWatch.getEvents(header);
+      const fundingBalanceChanged = events.some(({ event }) => {
+        if (event.section !== 'balances' && event.section !== 'ownership') return false;
+
+        return [...event.data].some(value => value.toString() === this.accountset.fundingAccountId);
+      });
+
+      if (fundingBalanceChanged) {
+        await this.planNextBid(header.frameRewardTicksRemaining!);
+      }
     }
 
     if (this.nextBid && this.nextBid.bidAtTick <= header.tick) {


### PR DESCRIPTION
Mining bidders now replan when their funding account receives ARGON or ARGNOT, even when cohort bid storage is unchanged. This prevents a bidder that started without enough balance from remaining idle after it is funded.

Block synchronization and bidding now share BlockWatch's cached event read, preserving one storage query per block hash. Regression coverage confirms both funding currencies trigger a new affordable bid plan; the full bidder suite, BlockSync unit tests, workspace typecheck, lint, and formatting checks pass.
