### PR TITLE
fix: clean up transports and keep mining frames current

### DIFF
--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -159,6 +159,7 @@ import BitcoinLockingOverlay from './overlays/BitcoinLockingOverlay.vue';
 import BondPurchaseOverlay from './overlays/BondPurchaseOverlay.vue';
 import StakePurchaseOverlay from './overlays/StakePurchaseOverlay.vue';
 import SponsorOverlay from './overlays/SponsorOverlay.vue';
+import { getMainchainClients } from './stores/mainchain.ts';
 
 const controller = useCertificationController();
 const config = getConfig();
@@ -200,6 +201,11 @@ function externalLinkHandler(event: MouseEvent) {
   void tauriOpenUrl(anchor.href);
 }
 
+function disposeAppTransports() {
+  bot.dispose();
+  void getMainchainClients().disconnect();
+}
+
 Vue.onBeforeMount(async () => {
   await waitForLoad();
 });
@@ -208,6 +214,7 @@ Vue.onMounted(async () => {
   // Add keyboard shortcuts for panel switching
   document.addEventListener('keydown', keydownHandler);
   document.addEventListener('click', externalLinkHandler);
+  window.addEventListener('beforeunload', disposeAppTransports);
 
   const appWindow = getCurrentWindow();
   await appWindow.onCloseRequested(async (event: CloseRequestedEvent) => {
@@ -221,6 +228,7 @@ Vue.onMounted(async () => {
 Vue.onBeforeUnmount(() => {
   document.removeEventListener('keydown', keydownHandler);
   document.removeEventListener('click', externalLinkHandler);
+  window.removeEventListener('beforeunload', disposeAppTransports);
 });
 
 Vue.onErrorCaptured((error, instance) => {

--- a/src-vue/__test__/BotSyncer.test.ts
+++ b/src-vue/__test__/BotSyncer.test.ts
@@ -36,6 +36,29 @@ describe('BotSyncer', () => {
     expect(installer.refreshLocalGatewayPort).toHaveBeenCalledTimes(1);
   });
 
+  it('disposes a websocket client that connects after the syncer is disposed', async () => {
+    const { syncer } = createSyncer();
+    let resolveClient!: (client: BotWsClient) => void;
+    const connection = new Promise<BotWsClient>(resolve => {
+      resolveClient = resolve;
+    });
+    const connect = vi.spyOn(BotWsClient, 'connectToServerGateway').mockReturnValue(connection);
+    const dispose = vi.fn();
+    const client = {
+      dispose,
+      events: { on: vi.fn() },
+    } as unknown as BotWsClient;
+
+    const pendingClient = syncer.getClient();
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    syncer.dispose();
+    resolveClient(client);
+
+    await expect(pendingClient).rejects.toThrow('BotSyncer disposed');
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
   it('does not mark the bot broken for transient rpc errors', async () => {
     const { syncer, botFns } = createSyncer();
     const testSyncer = syncer as unknown as IBotSyncerTestTarget;

--- a/src-vue/__test__/BotWsClient.test.ts
+++ b/src-vue/__test__/BotWsClient.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BotWsClient } from '../lib/BotWsClient.ts';
+
+const sockets: FakeWebSocket[] = [];
+
+class FakeWebSocket {
+  public static readonly CONNECTING = 0;
+  public static readonly OPEN = 1;
+  public static readonly CLOSING = 2;
+  public static readonly CLOSED = 3;
+
+  public readyState = FakeWebSocket.CONNECTING;
+  private listeners = new Map<string, ((event: any) => void)[]>();
+
+  constructor() {
+    sockets.push(this);
+  }
+
+  public addEventListener(type: string, listener: (event: any) => void) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  public open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit('open', {});
+  }
+
+  public close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit('close', { code: 1000, reason: 'disposed' });
+  }
+
+  public fail(error: Error) {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit('error', error);
+    this.emit('close', { code: 1006, reason: 'connection failed' });
+  }
+
+  public emit(type: string, event: any) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+describe('BotWsClient', () => {
+  beforeEach(() => {
+    sockets.length = 0;
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('closes its websocket without reconnecting when disposed', async () => {
+    vi.useFakeTimers();
+    const client = new BotWsClient({
+      getAdminOperatorSessionId: vi.fn().mockResolvedValue('session-id'),
+      getGatewayWebsocketUrl: vi.fn().mockReturnValue('wss://gateway.test/bot/'),
+    } as any);
+
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].open();
+    await client.connectDeferred.promise;
+
+    client.dispose();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sockets[0].readyState).toBe(FakeWebSocket.CLOSED);
+    expect(sockets).toHaveLength(1);
+  });
+
+  it('disposes a client whose initial connection fails', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const connection = BotWsClient.connectToServerGateway({
+      getAdminOperatorSessionId: vi.fn().mockResolvedValue('session-id'),
+      getGatewayWebsocketUrl: vi.fn().mockReturnValue('wss://gateway.test/bot/'),
+    } as any);
+
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    const initialError = new Error('connection failed');
+    sockets[0].fail(initialError);
+
+    await expect(connection).rejects.toBe(initialError);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sockets).toHaveLength(1);
+  });
+});

--- a/src-vue/__test__/MyMiningSeats.test.ts
+++ b/src-vue/__test__/MyMiningSeats.test.ts
@@ -70,6 +70,21 @@ describe('MyMiningSeats', () => {
 
     expect(onSpy).toHaveBeenCalledTimes(4);
   });
+
+  it('advances automatically but only moves backward for explicit frame navigation', () => {
+    const { myMiningSeats } = createMyMiningSeats();
+    myMiningSeats.latestFrameId = 13;
+    myMiningSeats.selectedFrameId = 12;
+
+    expect(myMiningSeats.selectFrameId(13, { skipDashboardUpdate: true })).toBe(true);
+    expect(myMiningSeats.selectedFrameId).toBe(13);
+
+    expect(myMiningSeats.selectFrameId(12, { skipDashboardUpdate: true })).toBe(false);
+    expect(myMiningSeats.selectedFrameId).toBe(13);
+
+    expect(myMiningSeats.selectFrameId(12, { isUserAction: true, skipDashboardUpdate: true })).toBe(true);
+    expect(myMiningSeats.selectedFrameId).toBe(12);
+  });
 });
 
 function createMyMiningSeats(

--- a/src-vue/components/FrameSlider.vue
+++ b/src-vue/components/FrameSlider.vue
@@ -24,7 +24,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: 'changedFrame', index: number): void;
+  (e: 'changedFrame', index: number, isUserAction: boolean): void;
 }>();
 
 let dragMeta: any = {};
@@ -125,7 +125,7 @@ function updateFrameSliderPos(index: number, isUserAction = true) {
   if (!item) return;
 
   syncFrameSliderPos(nextFrameIndex);
-  emit('changedFrame', nextFrameIndex);
+  emit('changedFrame', nextFrameIndex, isUserAction);
 }
 
 function handleKeyDown(e: KeyboardEvent) {

--- a/src-vue/lib/Bot.ts
+++ b/src-vue/lib/Bot.ts
@@ -95,6 +95,10 @@ export class Bot {
     await this.botSyncer.refresh();
   }
 
+  public dispose(): void {
+    this.botSyncer?.dispose();
+  }
+
   public async restart(): Promise<void> {
     const server = new ServerAdmin(await SSH.getOrCreateConnection(), this.config.serverDetails);
     this.botSyncer.isPaused = true;

--- a/src-vue/lib/BotSyncer.ts
+++ b/src-vue/lib/BotSyncer.ts
@@ -46,6 +46,7 @@ export class BotSyncer {
   private miningFrames: MiningFrames;
   private botWsClient: BotWsClient | undefined;
   private botWsClientPromise: Promise<BotWsClient> | undefined;
+  private isDisposed = false;
   private nextBotWsClientAttemptAt: number = 0;
   private lastStateRefreshAt: number = 0;
   private pendingState: IBotState | IBotStateStarting | undefined;
@@ -82,6 +83,7 @@ export class BotSyncer {
   }
 
   public async getClient(): Promise<BotWsClient> {
+    if (this.isDisposed) throw new Error('BotSyncer disposed');
     if (this.botWsClient) return this.botWsClient;
     if (Date.now() < this.nextBotWsClientAttemptAt) {
       throw new Error('Bot websocket connection is waiting before retrying.');
@@ -99,6 +101,11 @@ export class BotSyncer {
 
     this.botWsClientPromise = BotWsClient.connectToServerGateway(this.serverApiClient)
       .then(client => {
+        if (this.isDisposed) {
+          client.dispose();
+          throw new Error('BotSyncer disposed');
+        }
+
         this.botWsClient = client;
         this.nextBotWsClientAttemptAt = 0;
 
@@ -132,9 +139,12 @@ export class BotSyncer {
   }
 
   public dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
     this.isPaused = true;
     this.botWsClient?.dispose();
     this.botWsClient = undefined;
+    this.botWsClientPromise = undefined;
   }
 
   private async loopToStayConnected(): Promise<void> {

--- a/src-vue/lib/BotSyncer.ts
+++ b/src-vue/lib/BotSyncer.ts
@@ -131,6 +131,12 @@ export class BotSyncer {
     await this.runSync(state);
   }
 
+  public dispose(): void {
+    this.isPaused = true;
+    this.botWsClient?.dispose();
+    this.botWsClient = undefined;
+  }
+
   private async loopToStayConnected(): Promise<void> {
     try {
       if (this.isRunnable) {

--- a/src-vue/lib/BotWsClient.ts
+++ b/src-vue/lib/BotWsClient.ts
@@ -27,8 +27,9 @@ export class BotWsClient {
   private requestIdCounter = 0;
   private webSocket?: WebSocket;
   private messageWaiters: Map<number, IDeferred<any>> = new Map();
+  private isDisposed = false;
 
-  // Temporary behavior: disable automatic reconnect attempts.
+  // Lifecycle gate for automatic reconnect attempts.
   private shouldReconnect = true;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -52,8 +53,33 @@ export class BotWsClient {
 
   public static async connectToServerGateway(serverApiClient: ServerApiClient): Promise<BotWsClient> {
     const client = new BotWsClient(serverApiClient);
-    await client.connectDeferred.promise;
-    return client;
+    try {
+      await client.connectDeferred.promise;
+      return client;
+    } catch (error) {
+      client.dispose();
+      throw error;
+    }
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    this.shouldReconnect = false;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.stopHeartbeatWatchdog();
+
+    const error = new Error('BotWsClient disposed');
+    if (!this.connectDeferred.isSettled) this.connectDeferred.reject(error);
+    for (const waiter of this.messageWaiters.values()) waiter.reject(error);
+    this.messageWaiters.clear();
+
+    this.webSocket?.close();
+    this.webSocket = undefined;
   }
 
   private preventUnhandledConnectRejection(): void {
@@ -100,6 +126,8 @@ export class BotWsClient {
   }
 
   private beginConnect(): void {
+    if (this.isDisposed) return;
+
     // New connection attempt -> new deferred for callers waiting on readiness.
     if (this.connectDeferred.isSettled) {
       this.connectDeferred = createDeferred<void>();
@@ -130,6 +158,8 @@ export class BotWsClient {
       }
       return;
     }
+
+    if (this.isDisposed) return;
 
     this.webSocket = new WebSocket(this.serverApiClient.getGatewayWebsocketUrl('/bot/', sessionId));
 
@@ -250,6 +280,7 @@ export class BotWsClient {
   }
 
   private async ensureConnected(): Promise<void> {
+    if (this.isDisposed) throw new Error('BotWsClient disposed');
     if (this.webSocket?.readyState === WebSocket.OPEN) return;
 
     // If we're closed or closing, nudge the reconnect loop.

--- a/src-vue/lib/MyMiningSeats.ts
+++ b/src-vue/lib/MyMiningSeats.ts
@@ -162,11 +162,23 @@ export class MyMiningSeats {
     return newFrameId;
   }
 
-  public selectFrameId(frameId: number, skipDashboardUpdate: boolean = false) {
+  public selectFrameId(
+    frameId: number,
+    {
+      isUserAction = false,
+      skipDashboardUpdate = false,
+    }: {
+      isUserAction?: boolean;
+      skipDashboardUpdate?: boolean;
+    } = {},
+  ): boolean {
+    if (!isUserAction && frameId < this.selectedFrameId) return false;
+
     this.selectedFrameId = frameId;
-    if (skipDashboardUpdate) return;
+    if (skipDashboardUpdate) return true;
 
     this.updateDashboard().catch(console.error);
+    return true;
   }
 
   public async load() {
@@ -215,7 +227,7 @@ export class MyMiningSeats {
           const isOnLatestFrame = this.selectedFrameId === this.latestFrameId;
           if (frameId > this.latestFrameId) {
             this.latestFrameId = frameId;
-            if (isOnLatestFrame) this.selectFrameId(frameId, true);
+            if (isOnLatestFrame) this.selectFrameId(frameId, { skipDashboardUpdate: true });
           }
 
           const fromFrameId = this.hasRefreshedCompletedMiningHistory
@@ -282,7 +294,7 @@ export class MyMiningSeats {
   public async subscribeToDashboard({
     selectLatestFrame = false,
   }: { selectLatestFrame?: boolean } = {}): Promise<void> {
-    if (selectLatestFrame) this.selectFrameId(this.latestFrameId, true);
+    if (selectLatestFrame) this.selectFrameId(this.latestFrameId, { skipDashboardUpdate: true });
 
     this.dashboardSubscribers++;
     if (this.dashboardSubscribers > 1) return;

--- a/src-vue/screens/mining-screen/Dashboard.vue
+++ b/src-vue/screens/mining-screen/Dashboard.vue
@@ -569,16 +569,20 @@ function prefetchHistoricalFrameDetail(frameId: number) {
   });
 }
 
-async function updateSliderFrame(newFrameIndex: number) {
+async function updateSliderFrame(newFrameIndex: number, isUserAction = false) {
   const lastIndex = Math.max(myMiningSeats.frames.length - 1, 0);
   const nextFrameIndex = Math.min(Math.max(newFrameIndex, 0), lastIndex);
   const nextFrame = myMiningSeats.frames[nextFrameIndex];
   if (!nextFrame) return;
 
-  currentFrame.value = nextFrame;
-  const frameId = currentFrame.value.id;
+  const frameId = nextFrame.id;
+  const didSelectFrame = myMiningSeats.selectFrameId(frameId, {
+    isUserAction,
+    skipDashboardUpdate: true,
+  });
+  if (!didSelectFrame) return;
 
-  myMiningSeats.selectFrameId(frameId, true);
+  currentFrame.value = nextFrame;
 
   if (frameId === myMiningSeats.latestFrameId) {
     loadingFrameId.value = null;


### PR DESCRIPTION
## Summary

Repeated desktop refreshes now dispose the bot and mainchain transports before the WebView unloads, preventing old `/bot/` clients from continuing to reconnect and consuming the gateway connection budget. Failed initial bot connections are also disposed before `BotSyncer` retries, while active clients retain their existing reconnect behavior.

Mining automatically advances to newer frames but no longer moves backward to stale history unless the user explicitly navigates there.

## Validation

During live mainnet testing, Argon remained at two established server connections after several reloads, and Mining reopened on the current frame. The focused bot and mining tests and the Vue TypeScript check pass.
