### PR TITLE
fix: cap bond purchases at activated securitization

### DIFF
--- a/core/__test__/TreasuryBonds.test.ts
+++ b/core/__test__/TreasuryBonds.test.ts
@@ -5,9 +5,7 @@ import {
   type PalletTreasuryBondLot,
   type PalletTreasuryBondLotSummary,
   type PalletTreasuryVaultBondState,
-  PriceIndex,
   type Vec,
-  Vault,
 } from '@argonprotocol/mainchain';
 import { encodeAddress } from '@polkadot/util-crypto';
 
@@ -147,14 +145,10 @@ describe('TreasuryBonds', () => {
     ).toBe(800_000n * oneArgonot);
   });
 
-  it('keeps owner display lots separate from current runtime capacity', async () => {
+  it('keeps owner display lots separate from activated securitization capacity', async () => {
     const oneArgon = BigInt(MICROGONS_PER_ARGON);
-    let capacityBonds = 10n;
-    const vault = createCapacityVault(() => capacityBonds);
-    const priceIndex = new PriceIndex();
-    vi.spyOn(priceIndex, 'getSatoshiPriceInTargetMicrogons').mockImplementation(
-      satoshis => BigInt(satoshis) * oneArgon,
-    );
+    let activatedSecuritization = 10n * oneArgon;
+    const vault = createCapacityVault(() => activatedSecuritization);
 
     const runtimeState = registry.createType<PalletTreasuryVaultBondState>('PalletTreasuryVaultBondState', {
       bondLots: [{ bondLotId: 1, bonds: 3 }],
@@ -176,7 +170,6 @@ describe('TreasuryBonds', () => {
     expect(
       TreasuryBonds.availableBondSpace({
         vault,
-        priceIndex,
         bondState: bondState.capacityState,
       }),
     ).toBe(5n * oneArgon);
@@ -192,17 +185,15 @@ describe('TreasuryBonds', () => {
     expect(
       TreasuryBonds.availableBondSpace({
         vault,
-        priceIndex,
         bondState: moreBackfillBondState.capacityState,
       }),
     ).toBe(5n * oneArgon);
 
-    capacityBonds = 4n;
+    activatedSecuritization = 4n * oneArgon;
 
     expect(
       TreasuryBonds.availableBondSpace({
         vault,
-        priceIndex,
         bondState: bondState.capacityState,
       }),
     ).toBe(0n);
@@ -210,11 +201,7 @@ describe('TreasuryBonds', () => {
 
   it('uses only legacy storage summaries for capacity', async () => {
     const oneArgon = BigInt(MICROGONS_PER_ARGON);
-    const vault = createCapacityVault(() => 10n);
-    const priceIndex = new PriceIndex();
-    vi.spyOn(priceIndex, 'getSatoshiPriceInTargetMicrogons').mockImplementation(
-      satoshis => BigInt(satoshis) * oneArgon,
-    );
+    const vault = createCapacityVault(() => 10n * oneArgon);
 
     const legacyState = registry.createType<Vec<PalletTreasuryBondLotSummary>>('Vec<PalletTreasuryBondLotSummary>', [
       { bondLotId: 1, bonds: 3 },
@@ -229,26 +216,24 @@ describe('TreasuryBonds', () => {
     expect(
       TreasuryBonds.availableBondSpace({
         vault,
-        priceIndex,
         bondState: bondState.capacityState,
       }),
     ).toBe(7n * oneArgon);
   });
 
-  it('uses the larger of vault securitization and securitized Bitcoin value for bond capacity', () => {
+  it('caps purchases at activated securitization instead of full vault securitization', () => {
     const oneArgon = BigInt(MICROGONS_PER_ARGON);
-    const vault = createCapacityVault(() => 4n, 10n * oneArgon);
-    const priceIndex = new PriceIndex();
-    vi.spyOn(priceIndex, 'getSatoshiPriceInTargetMicrogons').mockImplementation(
-      satoshis => BigInt(satoshis) * oneArgon,
-    );
-    const bondState = [{ activeBonds: 3 }];
+    const vault = {
+      activatedSecuritization: () => 4n * oneArgon,
+      securitization: 10n * oneArgon,
+    };
 
-    expect(TreasuryBonds.availableBondSpace({ vault, priceIndex, bondState })).toBe(7n * oneArgon);
-
-    vault.securitization = 2n * oneArgon;
-
-    expect(TreasuryBonds.availableBondSpace({ vault, priceIndex, bondState })).toBe(1n * oneArgon);
+    expect(
+      TreasuryBonds.availableBondSpace({
+        vault,
+        bondState: [{ activeBonds: 3 }],
+      }),
+    ).toBe(oneArgon);
   });
 });
 
@@ -298,12 +283,8 @@ function createVaultBondLot({
   });
 }
 
-function createCapacityVault(getCapacityBonds: () => bigint, securitization = 0n) {
-  const vault = Object.assign(Object.create(Vault.prototype), {
-    effectiveSecuritizedSatoshis: getCapacityBonds,
-    securitization,
-  }) as Vault;
-
-  vault.availableBondSpace = vault.availableBondSpace.bind(vault);
-  return vault;
+function createCapacityVault(activatedSecuritization: () => bigint) {
+  return {
+    activatedSecuritization,
+  };
 }

--- a/core/src/TreasuryBonds.ts
+++ b/core/src/TreasuryBonds.ts
@@ -6,7 +6,6 @@ import {
   type PalletTreasuryFrameVaultCapital,
   type PalletTreasuryVaultBondState,
   type PalletTreasuryVaultCapital,
-  type PriceIndex,
   type SubmittableExtrinsic,
   type Vec,
   type Vault,
@@ -253,33 +252,16 @@ export class TreasuryBonds {
 
   public static availableBondSpace({
     vault,
-    priceIndex,
     bondState,
   }: {
-    vault: Pick<Vault, 'effectiveSecuritizedSatoshis' | 'securitization'>;
-    priceIndex: PriceIndex;
+    vault: Pick<Vault, 'activatedSecuritization'>;
     bondState?: VaultBondCapacityState;
   }): bigint {
-    const capacityMicrogons = TreasuryBonds.getVaultBondCapacityMicrogons({
-      vault,
-      priceIndex,
-    });
-    const bondCapacity = TreasuryBonds.getBondPurchaseCapacity(capacityMicrogons);
+    const bondCapacity = TreasuryBonds.getBondPurchaseCapacity(vault.activatedSecuritization());
     const unavailableBonds = [...(bondState ?? [])].reduce((total, state) => total + state.activeBonds, 0);
     const availableBonds = bondCapacity > unavailableBonds ? bondCapacity - unavailableBonds : 0;
 
     return BondLot.bondsToMicrogons(availableBonds);
-  }
-
-  public static getVaultBondCapacityMicrogons({
-    vault,
-    priceIndex,
-  }: {
-    vault: Pick<Vault, 'effectiveSecuritizedSatoshis' | 'securitization'>;
-    priceIndex: PriceIndex;
-  }): bigint {
-    const bitcoinCapacityMicrogons = priceIndex.getSatoshiPriceInTargetMicrogons(vault.effectiveSecuritizedSatoshis());
-    return vault.securitization > bitcoinCapacityMicrogons ? vault.securitization : bitcoinCapacityMicrogons;
   }
 
   public static async getBondLotsByAccount(client: ArgonQueryClient, accountId: string): Promise<BondLot[]> {

--- a/src-vue/lib/ArgonBonds.ts
+++ b/src-vue/lib/ArgonBonds.ts
@@ -430,8 +430,4 @@ export class ArgonBonds {
     if (blockNumber === undefined) throw new Error('Finalized bond transaction is missing its inclusion block');
     return this.miningFrames.blockWatch.getHeader(blockNumber);
   }
-
-  private get runtimeSpecVersion(): number {
-    return this.miningFrames.blockWatch.subscriptionClient?.runtimeVersion.specVersion.toNumber() ?? 0;
-  }
 }

--- a/src-vue/lib/ArgonBonds.ts
+++ b/src-vue/lib/ArgonBonds.ts
@@ -53,8 +53,6 @@ type IVaultBondSubscription = {
   frameId?: number;
 };
 
-const VAULT_SECURITIZATION_BOND_CAPACITY_SPEC_VERSION = 157;
-
 export class ArgonBonds {
   public data = {
     bondLots: [] as BondLot[],
@@ -101,28 +99,14 @@ export class ArgonBonds {
   }
 
   public getVaultBondCapacityMicrogons(vault: Vault): bigint {
-    const bitcoinCapacityMicrogons = this.currency.priceIndex.getSatoshiPriceInTargetMicrogons(
-      vault.effectiveSecuritizedSatoshis(),
-    );
-    if (this.runtimeSpecVersion < VAULT_SECURITIZATION_BOND_CAPACITY_SPEC_VERSION) {
-      return bitcoinCapacityMicrogons;
-    }
-
-    return TreasuryBonds.getVaultBondCapacityMicrogons({
-      vault,
-      priceIndex: this.currency.priceIndex,
-    });
+    return vault.activatedSecuritization();
   }
 
   public availableBondSpace(vault: Vault): bigint {
     const bondState = this.data.capacityStatesByVault[vault.vaultId];
-    if (this.runtimeSpecVersion < VAULT_SECURITIZATION_BOND_CAPACITY_SPEC_VERSION) {
-      return vault.availableBondSpace(this.currency.priceIndex, bondState, true);
-    }
 
     return TreasuryBonds.availableBondSpace({
       vault,
-      priceIndex: this.currency.priceIndex,
       bondState,
     });
   }

--- a/src-vue/stores/vaultingAssetBreakdown.ts
+++ b/src-vue/stores/vaultingAssetBreakdown.ts
@@ -102,7 +102,7 @@ export const useVaultingAssetBreakdown = defineStore('vaultingAssetBreakdown', (
     return treasuryBondTotals.value.returningBondMicrogons;
   });
 
-  // What the connected runtime lets this vault support.
+  // What the vault can support with its activated securitization.
   const treasuryBondCapacityMicrogons = Vue.computed(() => {
     if (!myVault.createdVault) return 0n;
 


### PR DESCRIPTION
Bond purchase controls can no longer offer capital that has been committed but not activated. The app now derives both displayed capacity and remaining purchasable bonds from activated securitization while continuing to subtract active and reserved backfill bonds.

Mainchain may still admit bonds up to its broader full-securitization limit, but the app intentionally exposes the activated amount. Regression coverage confirms that a 10-bond commitment with 4 activated and 3 unavailable offers only 1 additional bond.
