### PR TITLE
fix(e2e): allow normal reload disconnects

### DIFF
--- a/e2e/driver/client.ts
+++ b/e2e/driver/client.ts
@@ -328,12 +328,13 @@ function formatFrontendError(payload: UnknownRecord): string {
 function isFatalFrontendError(payload: UnknownRecord): boolean {
   const label = typeof payload.label === 'string' ? payload.label : '';
   const message = typeof payload.message === 'string' ? payload.message : '';
+  const normalizedMessage = message.toLowerCase();
   const isBenignResizeObserverNotification =
     label === 'window.error' && message === 'ResizeObserver loop completed with undelivered notifications.';
   const isExpectedReloadDisconnect =
     label === 'unhandledrejection' &&
-    (message.includes('disconnected from ws://') || message.includes('disconnected from wss://')) &&
-    message.includes(': 1000:: Normal Closure');
+    (normalizedMessage.includes('disconnected from ws://') || normalizedMessage.includes('disconnected from wss://')) &&
+    normalizedMessage.includes(': 1000:: normal closure');
 
   return label !== 'console.error' && !isBenignResizeObserverNotification && !isExpectedReloadDisconnect;
 }

--- a/e2e/driver/client.ts
+++ b/e2e/driver/client.ts
@@ -330,6 +330,10 @@ function isFatalFrontendError(payload: UnknownRecord): boolean {
   const message = typeof payload.message === 'string' ? payload.message : '';
   const isBenignResizeObserverNotification =
     label === 'window.error' && message === 'ResizeObserver loop completed with undelivered notifications.';
+  const isExpectedReloadDisconnect =
+    label === 'unhandledrejection' &&
+    (message.includes('disconnected from ws://') || message.includes('disconnected from wss://')) &&
+    message.includes(': 1000:: Normal Closure');
 
-  return label !== 'console.error' && !isBenignResizeObserverNotification;
+  return label !== 'console.error' && !isBenignResizeObserverNotification && !isExpectedReloadDisconnect;
 }

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -199,6 +199,12 @@ async function main(): Promise<void> {
     void devEthereumReadyPromise.catch(() => undefined);
   }
 
+  // E2E onboarding starts another Compose build for this project after the app connects.
+  // Finish upstream startup first so Docker Compose and Bake do not mutate the project concurrently.
+  if (isE2EAppRun && devUpstreamPromise) {
+    await devUpstreamPromise;
+  }
+
   const child = spawn('yarn', tauriArgs, {
     env: tauriEnv,
     stdio: 'inherit',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,6 +106,9 @@ export default defineConfig(async ({ mode }) => {
         events: require.resolve('events/'),
       },
     },
+    optimizeDeps: {
+      include: ['@ngraveio/bc-ur'],
+    },
     plugins: [
       wasm(),
       vitePluginTopLevelAwait(),


### PR DESCRIPTION
Intentional app reloads no longer abort E2E flows when mainchain transport cleanup closes a WebSocket normally. Code-1000 ws/wss closures reported as unhandled rejections remain in frontend diagnostics but are treated as expected reload noise; abnormal closures and unrelated frontend errors remain fatal.

The full GitHub Actions Test matrix passed on Linux, macOS, and Windows: https://github.com/argonprotocol/apps/actions/runs/30914029271.
