### PR TITLE
fix: stabilize mining startup and ethereum relay

### DIFF
--- a/bot/__test__/BitcoinLockRelayService.integration.test.ts
+++ b/bot/__test__/BitcoinLockRelayService.integration.test.ts
@@ -37,6 +37,28 @@ afterEach(() => {
 });
 
 describe.sequential('BitcoinLockRelayService integration', () => {
+  it('retries startup after an initial failure', async () => {
+    const harness = await createRelayServiceHarness();
+    const service = harness.service as unknown as TestRelayService;
+    let attempts = 0;
+
+    try {
+      vi.spyOn(service, 'startInternal').mockImplementation(async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('Pruned client is not ready');
+        }
+      });
+
+      await expect(harness.service.start()).rejects.toThrow('Pruned client is not ready');
+      await expect(harness.service.start()).resolves.toBeUndefined();
+
+      expect(attempts).toBe(2);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it('stores the btc percent fee on created coupons', async () => {
     const harness = await createRelayServiceHarness();
     const service = harness.service as unknown as TestRelayService;

--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -113,6 +113,7 @@ let currentClientArgs:
 describe('EthereumGatewayProverService', () => {
   afterEach(() => {
     vi.useRealTimers();
+    gatewayProofMock.buildGatewayActivityProofPayload.mockReset();
   });
 
   beforeEach(() => {
@@ -129,8 +130,15 @@ describe('EthereumGatewayProverService', () => {
     });
   });
 
-  it('returns Noop when the mainchain helper reports nothing new to prove', async () => {
-    gatewayProofMock.buildGatewayActivityProofPayload.mockResolvedValue(null);
+  it('returns Noop without falling back when the primary RPC reports nothing new to prove', async () => {
+    NetworkConfig.setRuntimeOverride('dev-docker', {
+      ethereumNetwork: {
+        executionRpcUrls: ['http://paid-ethereum.test', 'http://public-ethereum.test'],
+      },
+    });
+    gatewayProofMock.buildGatewayActivityProofPayload
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error('Public Ethereum RPC should not be called'));
     const service = new EthereumGatewayProverService(
       createSubmitLane(createClient({ runtimeGatewayActivityNonce: 5n })),
     );
@@ -145,7 +153,7 @@ describe('EthereumGatewayProverService', () => {
       throughGatewayActivityNonce: 5n,
     });
     expect(gatewayProofMock.buildGatewayActivityProofPayload).toHaveBeenCalledWith(expect.anything(), {
-      executionRpcUrl: 'http://ethereum.test',
+      executionRpcUrl: 'http://paid-ethereum.test',
       gatewayAddress: '0xgateway',
       throughExecutionBlockNumber: 160n,
     });

--- a/bot/src/BitcoinLockRelayService.ts
+++ b/bot/src/BitcoinLockRelayService.ts
@@ -82,7 +82,10 @@ export class BitcoinLockRelayService {
   ) {}
 
   public async start(): Promise<void> {
-    this.startedPromise ??= this.startInternal();
+    this.startedPromise ??= this.startInternal().catch(error => {
+      this.startedPromise = undefined;
+      throw error;
+    });
     return this.startedPromise;
   }
 

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -720,18 +720,13 @@ async function buildGatewayActivityProofPayloadWithFallback(
   args: Omit<Parameters<typeof buildGatewayActivityProofPayload>[1], 'executionRpcUrl'>,
 ): ReturnType<typeof buildGatewayActivityProofPayload> {
   let lastError: unknown;
-  let hadNullPayload = false;
 
   for (const executionRpcUrl of executionRpcUrls) {
     try {
-      const payload = await buildGatewayActivityProofPayload(client, {
+      return await buildGatewayActivityProofPayload(client, {
         ...args,
         executionRpcUrl,
       });
-      if (payload !== null) {
-        return payload;
-      }
-      hadNullPayload = true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // These errors come from Argon runtime bounds, so another execution RPC cannot resolve them.
@@ -753,10 +748,6 @@ async function buildGatewayActivityProofPayloadWithFallback(
 
   if (lastError instanceof Error) {
     throw lastError;
-  }
-
-  if (hadNullPayload) {
-    return null;
   }
 
   throw new Error(lastError ? String(lastError) : 'Ethereum execution RPC is not configured on this network.');

--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -134,7 +134,7 @@ describe('EthereumClient', () => {
     expect(requestBody.params).toEqual(['0x0000000000000000000000000000000000000001', 'latest']);
   });
 
-  it('uses the configured RPC before the built-in fallbacks', async () => {
+  it('falls back from the configured RPC when it returns a provider error', async () => {
     NetworkConfig.setRuntimeOverride('dev-docker', {
       ethereumNetwork: {
         executionRpcUrls: ['https://ethereum-fallback.test'],

--- a/src-vue/screens/mining-screen/Dashboard.vue
+++ b/src-vue/screens/mining-screen/Dashboard.vue
@@ -649,6 +649,7 @@ async function refreshLiveFrameDetail() {
 
 async function refreshPendingHistoricalFrameDetail() {
   const frameId = currentFrame.value.id;
+  if (frameId !== myMiningSeats.selectedFrameId) return;
   if (frameId >= myMiningSeats.latestFrameId) return;
 
   await loadHistoricalFrameDetail(frameId);


### PR DESCRIPTION
Bot and mining startup no longer get stuck when local chain services are still settling. Bitcoin relay startup can retry after a temporary pruned-client failure, while the dashboard avoids requesting placeholder historical frame 0 before the selected frame is ready.

Ethereum gateway proof lookup now treats a successful “nothing to prove” response as final, so the configured provider is not discarded in favor of failing public fallbacks. Focused Bitcoin, Ethereum, and mining tests pass (49 tests).
