### PR TITLE
fix: block unsupported Safari versions

### DIFF
--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -2,7 +2,7 @@
 <template>
   <template v-if="shouldShowCompatibilityScreen">
     <RuntimeCompatibilityScreen />
-    <SecuritySettingsOverlay />
+    <SecuritySettingsOverlay v-if="!isBrowserUnsupported" />
   </template>
   <div v-else class="h-screen w-screen flex flex-col overflow-hidden cursor-default">
     <TopBar />
@@ -161,17 +161,24 @@ import StakePurchaseOverlay from './overlays/StakePurchaseOverlay.vue';
 import SponsorOverlay from './overlays/SponsorOverlay.vue';
 import { getMainchainClients } from './stores/mainchain.ts';
 
-const controller = useCertificationController();
-const config = getConfig();
-const tour = useTour();
-const bot = getBot();
-
-const updater = useAppUpdater();
 const runtimeCompatibility = useRuntimeCompatibility();
-const { shouldShowCompatibilityScreen } = storeToRefs(runtimeCompatibility);
+const { isBrowserUnsupported, shouldShowCompatibilityScreen } = storeToRefs(runtimeCompatibility);
+const updater = useAppUpdater();
 
-updater.start();
 runtimeCompatibility.start();
+
+let controller!: ReturnType<typeof useCertificationController>;
+let config!: ReturnType<typeof getConfig>;
+let tour!: ReturnType<typeof useTour>;
+let bot!: ReturnType<typeof getBot>;
+
+if (!isBrowserUnsupported.value) {
+  controller = useCertificationController();
+  config = getConfig();
+  tour = useTour();
+  bot = getBot();
+  updater.start();
+}
 
 const order = [TopTab.Home, TopTab.Mining, TopTab.Vaulting];
 
@@ -207,10 +214,18 @@ function disposeAppTransports() {
 }
 
 Vue.onBeforeMount(async () => {
+  if (isBrowserUnsupported.value) {
+    return;
+  }
+
   await waitForLoad();
 });
 
 Vue.onMounted(async () => {
+  if (isBrowserUnsupported.value) {
+    return;
+  }
+
   // Add keyboard shortcuts for panel switching
   document.addEventListener('keydown', keydownHandler);
   document.addEventListener('click', externalLinkHandler);
@@ -236,5 +251,7 @@ Vue.onErrorCaptured((error, instance) => {
   return false;
 });
 
-createMenu();
+if (!isBrowserUnsupported.value) {
+  createMenu();
+}
 </script>

--- a/src-vue/__test__/RuntimeCompatibility.test.ts
+++ b/src-vue/__test__/RuntimeCompatibility.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useRuntimeCompatibility } from '../stores/runtimeCompatibility.ts';
+
+const findLastIndex = Array.prototype.findLastIndex;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.stubGlobal('ResizeObserver', class ResizeObserver {});
+});
+
+afterEach(() => {
+  Object.defineProperty(Array.prototype, 'findLastIndex', {
+    configurable: true,
+    writable: true,
+    value: findLastIndex,
+  });
+  vi.unstubAllGlobals();
+});
+
+it.each([
+  ['AbortSignal.timeout', () => vi.stubGlobal('AbortSignal', class AbortSignal {})],
+  [
+    'Array.prototype.findLastIndex',
+    () => {
+      Object.defineProperty(Array.prototype, 'findLastIndex', {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+    },
+  ],
+  ['ResizeObserver', () => vi.stubGlobal('ResizeObserver', undefined)],
+  ['crypto.subtle', () => vi.stubGlobal('crypto', {})],
+])('hard-blocks the app when %s is unavailable', (_capability, removeCapability) => {
+  const runtimeCompatibility = useRuntimeCompatibility();
+
+  removeCapability();
+  runtimeCompatibility.start();
+
+  expect(runtimeCompatibility.phase).toBe('browser-unsupported');
+  expect(runtimeCompatibility.shouldShowCompatibilityScreen).toBe(true);
+});
+
+it('keeps the existing compatibility behavior when browser capabilities are available', () => {
+  const runtimeCompatibility = useRuntimeCompatibility();
+
+  runtimeCompatibility.start();
+
+  expect(runtimeCompatibility.phase).toBe('disabled');
+  expect(runtimeCompatibility.shouldShowCompatibilityScreen).toBe(false);
+});

--- a/src-vue/screens/RuntimeCompatibilityScreen.vue
+++ b/src-vue/screens/RuntimeCompatibilityScreen.vue
@@ -16,13 +16,14 @@
 
       <div class="pointer-events-none relative top-px mr-3 flex w-1/2 grow flex-row items-center justify-end space-x-2">
         <button
+          v-if="!isBrowserUnsupported"
           class="text-argon-600/70 hover:text-argon-600 decoration-argon-600/30 hover:decoration-argon-600/70 pointer-events-auto cursor-pointer px-2 py-2 text-xs font-medium underline underline-offset-4 transition"
           @click="openMnemonicExport"
         >
           Export recovery phrase
         </button>
         <button
-          v-if="phase !== 'upgrade-required'"
+          v-if="!isBrowserUnsupported && phase !== 'upgrade-required'"
           class="text-argon-600 border-argon-600/20 hover:border-argon-600/40 hover:bg-argon-600/6 pointer-events-auto cursor-pointer rounded-full border bg-white/70 px-4 py-2 text-sm font-semibold transition disabled:opacity-70"
           :disabled="isLoading"
           @click="runtimeCompatibility.refreshCompatibility('manual')"
@@ -49,7 +50,13 @@
       >
         <div class="mb-8">
           <div
-            v-if="phase === 'paused'"
+            v-if="isBrowserUnsupported"
+            class="text-argon-600/70 mb-3 text-xs font-semibold tracking-[0.35em] uppercase"
+          >
+            {{ webRuntimeRequirement.name }} Required
+          </div>
+          <div
+            v-else-if="phase === 'paused'"
             class="text-argon-600/70 mb-3 text-xs font-semibold tracking-[0.35em] uppercase"
           >
             Network Upgrade In Progress
@@ -62,7 +69,8 @@
           </div>
 
           <h1 class="text-argon-text-primary mb-4 text-4xl leading-tight font-semibold">
-            <template v-if="isNewDownloadRequired">
+            <template v-if="isBrowserUnsupported">Argon Desktop requires {{ webRuntimeRequirement.name }}.</template>
+            <template v-else-if="isNewDownloadRequired">
               {{ APP_NAME }} is becoming Argon Desktop. Download the new app to continue.
             </template>
             <template v-else-if="phase === 'paused'">
@@ -115,7 +123,12 @@
             Restart App to Activate Update
           </button>
           <div class="text-argon-text-primary/80 max-w-2xl text-xl leading-7">
-            <template v-if="isNewDownloadRequired">Download Argon Desktop from the Argon website to continue.</template>
+            <template v-if="isBrowserUnsupported">
+              {{ webRuntimeRequirement.updateInstructions }} Then close and reopen Argon Desktop.
+            </template>
+            <template v-else-if="isNewDownloadRequired">
+              Download Argon Desktop from the Argon website to continue.
+            </template>
             <template v-else-if="phase === 'upgrade-required'">Install the latest app update to continue.</template>
             <template v-else>Waiting for a compatible app update...</template>
           </div>
@@ -135,11 +148,28 @@ import ExternalIcon from '../assets/external.svg';
 import { APP_NAME } from '../lib/Env.ts';
 import { useAppUpdater } from '../stores/appUpdater.ts';
 import { useRuntimeCompatibility } from '../stores/runtimeCompatibility.ts';
+import { platformType } from '../tauri-controls/utils/os.ts';
 import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';
 import { NetworkConfig } from '@argonprotocol/apps-core';
 
 const updater = useAppUpdater();
 const runtimeCompatibility = useRuntimeCompatibility();
+
+const webRuntimeRequirement = {
+  macos: {
+    name: 'Safari 16.4 or later',
+    updateInstructions: 'Update Safari to version 16.4 or later, or update macOS.',
+  },
+  windows: {
+    name: 'Microsoft Edge WebView2 Runtime 111 or later',
+    updateInstructions: 'Update Microsoft Edge WebView2 Runtime to version 111 or later, or update Windows.',
+  },
+  gnome: {
+    name: 'WebKitGTK 2.40 or later',
+    updateInstructions: 'Update WebKitGTK to version 2.40 or later using your Linux distribution.',
+  },
+}[platformType];
+
 const {
   downloadProgress,
   errorMessage: updaterErrorMessage,
@@ -149,6 +179,7 @@ const {
 } = storeToRefs(updater);
 const {
   errorMessage: compatibilityErrorMessage,
+  isBrowserUnsupported,
   isLoading,
   newDownloadRequired: isNewDownloadRequired,
   phase,

--- a/src-vue/stores/runtimeCompatibility.ts
+++ b/src-vue/stores/runtimeCompatibility.ts
@@ -6,7 +6,13 @@ import { ENABLE_AUTO_UPDATE, IS_EXPERIMENTAL_BUILD } from '../lib/Env.ts';
 import { getMainchainClients } from './mainchain.ts';
 import { useAppUpdater } from './appUpdater.ts';
 
-export type RuntimeCompatibilityPhase = 'disabled' | 'loading' | 'compatible' | 'paused' | 'upgrade-required';
+export type RuntimeCompatibilityPhase =
+  | 'disabled'
+  | 'loading'
+  | 'compatible'
+  | 'paused'
+  | 'upgrade-required'
+  | 'browser-unsupported';
 
 type CompatibilityInfo = { maxSpecVersion?: number; newDownloadRequired?: boolean };
 type Unsubscribe = () => void | Promise<void>;
@@ -23,8 +29,10 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
   const errorMessage = Vue.ref('');
   const newDownloadRequired = Vue.ref(false);
   const isLoading = Vue.computed(() => phase.value === 'loading');
+  const isBrowserUnsupported = Vue.computed(() => phase.value === 'browser-unsupported');
   const shouldShowCompatibilityScreen = Vue.computed(
-    () => isLoading.value || phase.value === 'paused' || phase.value === 'upgrade-required',
+    () =>
+      isBrowserUnsupported.value || isLoading.value || phase.value === 'paused' || phase.value === 'upgrade-required',
   );
 
   const updater = useAppUpdater();
@@ -46,6 +54,18 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
     }
 
     isStarted = true;
+
+    if (
+      typeof AbortSignal === 'undefined' ||
+      typeof AbortSignal.timeout !== 'function' ||
+      typeof Array.prototype.findLastIndex !== 'function' ||
+      typeof ResizeObserver !== 'function' ||
+      typeof crypto === 'undefined' ||
+      !crypto.subtle
+    ) {
+      phase.value = 'browser-unsupported';
+      return;
+    }
 
     if (!ENABLE_AUTO_UPDATE) {
       phase.value = 'disabled';
@@ -247,6 +267,7 @@ export const useRuntimeCompatibility = defineStore('runtimeCompatibility', () =>
     errorMessage,
     newDownloadRequired,
     isLoading,
+    isBrowserUnsupported,
     shouldShowCompatibilityScreen,
     start,
     refreshCompatibility,


### PR DESCRIPTION
## Summary

Older Safari versions can no longer enter a partially initialized Argon Desktop session. The app now stops on its existing compatibility screen before wallet or network initialization and tells the user that Safari 16.4 or later is required.

The gate checks the browser capabilities the application relies on instead of parsing the user agent. Supported browsers retain the existing startup behavior.

## Validation

- 510 `src-vue` tests passed.
- The production Vite 8.1 build completed successfully.
- Repository typecheck, formatting, and ESLint checks passed.
