### PR TITLE
fix: persist Linux wallet encryption keys

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -2259,6 +2259,24 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -4641,8 +4659,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
+ "dbus-secret-service",
  "linux-keyutils",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.5.1",
  "windows-sys 0.60.2",
@@ -5302,6 +5322,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -5405,6 +5426,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5429,6 +5464,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -8088,6 +8132,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.10.9",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9587,7 +9650,7 @@ dependencies = [
  "thiserror 2.0.17",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -11742,7 +11805,7 @@ dependencies = [
  "widestring",
  "windows 0.61.3",
  "xcb",
- "zbus",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -11754,6 +11817,16 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
  "quick-xml 0.30.0",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11793,6 +11866,38 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
@@ -11821,9 +11926,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.12.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -11836,9 +11954,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -11850,7 +11979,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.8.0",
 ]
 
 [[package]]
@@ -12073,6 +12202,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
@@ -12082,8 +12224,21 @@ dependencies = [
  "serde",
  "url",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -12096,7 +12251,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "zvariant_utils",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,7 +62,7 @@ alloy-sol-types = "1.5"
 alloy-rlp = { version = "0.3.15", features = ["derive"] }
 alloy-primitives = { version = "1.5", features = ["rlp"] }
 tauri-plugin-log = { version = "2", features = ["colored" ] }
-keyring = {version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+keyring = {version = "3", features = ["apple-native", "windows-native", "linux-native", "sync-secret-service", "crypto-rust"] }
 hex = "0.4.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
 sp-core = { version="38.1.0", features = ["default"] }

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -328,7 +328,15 @@ impl Security {
         let raw = fs::read_to_string(&wallet_path)?;
         if let Ok(wallet) = serde_json::from_str::<WalletFile>(&raw) {
             let app_id = app.config().identifier.as_str();
-            let existing_key = Self::read_encryption_key_for_app_id(app_id)?;
+            let existing_key = match Self::read_encryption_key_for_app_id(app_id) {
+                Ok(key) => key,
+                Err(error) => {
+                    log::warn!(
+                        "Could not read the wallet encryption key; trying local mnemonic bridge recovery: {error}"
+                    );
+                    None
+                }
+            };
             let Some(mnemonic) = wallet_recovery_mnemonic(
                 &wallet,
                 existing_key.as_ref(),
@@ -666,15 +674,26 @@ impl Security {
 }
 
 fn read_wallet_recovery_mnemonic(wallet: &WalletFile, mnemonic_path: &Path) -> Result<String> {
-    let mnemonic = fs::read_to_string(mnemonic_path)?.trim().to_string();
-    let security = Security::derive_security_from_mnemonic(&mnemonic)?;
+    let mnemonic = fs::read_to_string(mnemonic_path).map_err(|error| {
+        anyhow::anyhow!(
+            "Could not read the local mnemonic bridge file for wallet recovery: {error}"
+        )
+    })?;
+    let mnemonic = mnemonic.trim();
+
+    anyhow::ensure!(
+        !mnemonic.is_empty(),
+        "Local mnemonic bridge file is empty; manual wallet recovery is required"
+    );
+
+    let security = Security::derive_security_from_mnemonic(mnemonic)?;
 
     anyhow::ensure!(
         security.vaulting_address == wallet.meta.vaulting_address,
         "Local mnemonic does not match wallet.json; manual wallet recovery is required"
     );
 
-    Ok(mnemonic)
+    Ok(mnemonic.to_string())
 }
 
 fn wallet_recovery_mnemonic(
@@ -1084,6 +1103,37 @@ mod tests {
                 .expect_err("a different mnemonic must not replace the wallet key")
                 .to_string()
                 .contains("does not match wallet.json")
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn reports_unavailable_local_mnemonic_for_wallet_recovery() {
+        let test_dir = unique_test_dir("reports-unavailable-local-mnemonic-for-wallet-recovery");
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let mnemonic = "test test test test test test test test test test test junk";
+        let wallet = WalletFile {
+            encrypted_mnemonic: "unreadable without the missing key".to_string(),
+            meta: Security::derive_security_from_mnemonic(mnemonic)
+                .expect("wallet metadata should derive"),
+        };
+        let mnemonic_path = test_dir.join("mnemonic");
+
+        assert!(
+            read_wallet_recovery_mnemonic(&wallet, &mnemonic_path)
+                .expect_err("a missing mnemonic bridge file must not be parsed")
+                .to_string()
+                .contains("Could not read the local mnemonic bridge file for wallet recovery")
+        );
+
+        fs::write(&mnemonic_path, " \n").expect("empty mnemonic file should be written");
+        assert!(
+            read_wallet_recovery_mnemonic(&wallet, &mnemonic_path)
+                .expect_err("an empty mnemonic bridge file must not be parsed")
+                .to_string()
+                .contains("Local mnemonic bridge file is empty")
         );
 
         fs::remove_dir_all(&test_dir).expect("test dir should be removed");

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -153,6 +153,10 @@ impl Security {
             return Ok(key);
         }
 
+        Self::replace_encryption_key_for_app_id(app_id)
+    }
+
+    fn replace_encryption_key_for_app_id(app_id: &str) -> Result<[u8; 32]> {
         let service = format!("{app_id}.mnemonic");
         let account = Utils::get_relative_config_instance_dir(app_id)
             .to_string_lossy()
@@ -204,10 +208,18 @@ impl Security {
                             None, &service, &account,
                         )?;
                         match legacy_entry.get_password() {
-                            Ok(key) => {
-                                entry.set_password(&key)?;
-                                Some(key)
-                            }
+                            Ok(key) => match Self::decode_wallet_key(&key) {
+                                Ok(_) => {
+                                    entry.set_password(&key)?;
+                                    Some(key)
+                                }
+                                Err(error) => {
+                                    log::warn!(
+                                        "Ignoring invalid legacy Linux wallet encryption key: {error}"
+                                    );
+                                    None
+                                }
+                            },
                             Err(keyring::Error::NoEntry) => None,
                             Err(error) => return Err(error.into()),
                         }
@@ -299,12 +311,20 @@ impl Security {
     }
 
     fn write_wallet_file(app: &AppHandle, mnemonic: &str) -> Result<Security> {
+        let key = Self::encryption_key(app)?;
+        Self::write_wallet_file_with_key(app, mnemonic, &key)
+    }
+
+    fn write_wallet_file_with_key(
+        app: &AppHandle,
+        mnemonic: &str,
+        key: &[u8; 32],
+    ) -> Result<Security> {
         let (_, ssh_public_key) = Self::derive_ssh_key(mnemonic)?;
         let security = Self::create_with_addresses(mnemonic, &ssh_public_key)?;
 
-        let key = Self::encryption_key(app)?;
         let wallet = WalletFile {
-            encrypted_mnemonic: Self::encrypt_mnemonic(&key, mnemonic)?,
+            encrypted_mnemonic: Self::encrypt_mnemonic(key, mnemonic)?,
             meta: security.clone(),
         };
 
@@ -346,7 +366,8 @@ impl Security {
                 return Ok(Some(wallet.meta));
             };
 
-            let security = Self::write_wallet_file(app, &mnemonic)?;
+            let replacement_key = Self::replace_encryption_key_for_app_id(app_id)?;
+            let security = Self::write_wallet_file_with_key(app, &mnemonic, &replacement_key)?;
             log::warn!("Recovered the wallet encryption key from the local mnemonic bridge");
             return Ok(Some(security));
         }

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -203,7 +203,7 @@ impl Security {
                 Err(keyring::Error::NoEntry) => {
                     #[cfg(target_os = "linux")]
                     {
-                        // keyring 3.6.3's persistent builder does not probe the old keyutils store.
+                        // The persistent Secret Service backend does not probe legacy keyutils entries.
                         let legacy_key =
                             match keyring::keyutils::KeyutilsCredential::new_with_target(
                                 None, &service, &account,

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -204,11 +204,30 @@ impl Security {
                     #[cfg(target_os = "linux")]
                     {
                         // keyring 3.6.3's persistent builder does not probe the old keyutils store.
-                        let legacy_entry = keyring::keyutils::KeyutilsCredential::new_with_target(
-                            None, &service, &account,
-                        )?;
-                        match legacy_entry.get_password() {
-                            Ok(key) => match Self::decode_wallet_key(&key) {
+                        let legacy_key =
+                            match keyring::keyutils::KeyutilsCredential::new_with_target(
+                                None, &service, &account,
+                            ) {
+                                Ok(legacy_entry) => match legacy_entry.get_password() {
+                                    Ok(key) => Some(key),
+                                    Err(keyring::Error::NoEntry) => None,
+                                    Err(error) => {
+                                        log::warn!(
+                                            "Could not read the optional legacy Linux wallet encryption key; continuing without migration: {error}"
+                                        );
+                                        None
+                                    }
+                                },
+                                Err(error) => {
+                                    log::warn!(
+                                        "Could not initialize the optional legacy Linux wallet key store; continuing without migration: {error}"
+                                    );
+                                    None
+                                }
+                            };
+
+                        match legacy_key {
+                            Some(key) => match Self::decode_wallet_key(&key) {
                                 Ok(_) => {
                                     if let Err(error) = entry.set_password(&key) {
                                         log::warn!(
@@ -224,8 +243,7 @@ impl Security {
                                     None
                                 }
                             },
-                            Err(keyring::Error::NoEntry) => None,
-                            Err(error) => return Err(error.into()),
+                            None => None,
                         }
                     }
 

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -210,7 +210,11 @@ impl Security {
                         match legacy_entry.get_password() {
                             Ok(key) => match Self::decode_wallet_key(&key) {
                                 Ok(_) => {
-                                    entry.set_password(&key)?;
+                                    if let Err(error) = entry.set_password(&key) {
+                                        log::warn!(
+                                            "Could not persist the migrated legacy Linux wallet encryption key; using it for this session and retrying migration later: {error}"
+                                        );
+                                    }
                                     Some(key)
                                 }
                                 Err(error) => {

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -1166,7 +1166,13 @@ mod tests {
         fs::create_dir_all(&test_dir).expect("test dir should be created");
 
         let mnemonic = "test test test test test test test test test test test junk";
-        let original_key = [1u8; 32];
+        let original_key = rand::random::<[u8; 32]>();
+
+        let mut wrong_key = rand::random::<[u8; 32]>();
+        if wrong_key == original_key {
+            wrong_key[0] ^= 1;
+        }
+
         let wallet = WalletFile {
             encrypted_mnemonic: Security::encrypt_mnemonic(&original_key, mnemonic)
                 .expect("mnemonic should encrypt"),
@@ -1177,7 +1183,7 @@ mod tests {
         fs::write(&mnemonic_path, mnemonic).expect("mnemonic should be written");
 
         assert_eq!(
-            wallet_recovery_mnemonic(&wallet, Some(&[2u8; 32]), &mnemonic_path)
+            wallet_recovery_mnemonic(&wallet, Some(&wrong_key), &mnemonic_path)
                 .expect("matching mnemonic should recover the stranded wallet"),
             Some(mnemonic.to_string())
         );

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -7,6 +7,8 @@ use bip32::{ExtendedKey, Prefix, XPrv};
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use hkdf::Hkdf;
+#[cfg(target_os = "linux")]
+use keyring::credential::CredentialApi;
 use secrecy::SecretString;
 use sha2::{Digest, Sha256, Sha512};
 use sp_core::crypto::AddressUri;
@@ -194,7 +196,28 @@ impl Security {
             let entry = keyring::Entry::new(&service, &account)?;
             match entry.get_password() {
                 Ok(key) => Some(key),
-                Err(keyring::Error::NoEntry) => None,
+                Err(keyring::Error::NoEntry) => {
+                    #[cfg(target_os = "linux")]
+                    {
+                        // keyring 3.6.3's persistent builder does not probe the old keyutils store.
+                        let legacy_entry = keyring::keyutils::KeyutilsCredential::new_with_target(
+                            None, &service, &account,
+                        )?;
+                        match legacy_entry.get_password() {
+                            Ok(key) => {
+                                entry.set_password(&key)?;
+                                Some(key)
+                            }
+                            Err(keyring::Error::NoEntry) => None,
+                            Err(error) => return Err(error.into()),
+                        }
+                    }
+
+                    #[cfg(not(target_os = "linux"))]
+                    {
+                        None
+                    }
+                }
                 Err(error) => return Err(error.into()),
             }
         };
@@ -304,7 +327,20 @@ impl Security {
 
         let raw = fs::read_to_string(&wallet_path)?;
         if let Ok(wallet) = serde_json::from_str::<WalletFile>(&raw) {
-            return Ok(Some(wallet.meta));
+            let app_id = app.config().identifier.as_str();
+            let existing_key = Self::read_encryption_key_for_app_id(app_id)?;
+            let Some(mnemonic) = wallet_recovery_mnemonic(
+                &wallet,
+                existing_key.as_ref(),
+                &Self::legacy_mnemonic_path(app),
+            )?
+            else {
+                return Ok(Some(wallet.meta));
+            };
+
+            let security = Self::write_wallet_file(app, &mnemonic)?;
+            log::warn!("Recovered the wallet encryption key from the local mnemonic bridge");
+            return Ok(Some(security));
         }
 
         let mnemonic = Self::expose_mnemonic(app)?;
@@ -629,6 +665,32 @@ impl Security {
     }
 }
 
+fn read_wallet_recovery_mnemonic(wallet: &WalletFile, mnemonic_path: &Path) -> Result<String> {
+    let mnemonic = fs::read_to_string(mnemonic_path)?.trim().to_string();
+    let security = Security::derive_security_from_mnemonic(&mnemonic)?;
+
+    anyhow::ensure!(
+        security.vaulting_address == wallet.meta.vaulting_address,
+        "Local mnemonic does not match wallet.json; manual wallet recovery is required"
+    );
+
+    Ok(mnemonic)
+}
+
+fn wallet_recovery_mnemonic(
+    wallet: &WalletFile,
+    existing_key: Option<&[u8; 32]>,
+    mnemonic_path: &Path,
+) -> Result<Option<String>> {
+    if existing_key
+        .is_some_and(|key| Security::decrypt_mnemonic(key, &wallet.encrypted_mnemonic).is_ok())
+    {
+        return Ok(None);
+    }
+
+    read_wallet_recovery_mnemonic(wallet, mnemonic_path).map(Some)
+}
+
 fn default_ethereum_hd_prefixes() -> EthereumHdPrefixes {
     EthereumHdPrefixes {
         primary: DEFAULT_PRIMARY_ETHEREUM_HD_PREFIX.to_string(),
@@ -763,8 +825,9 @@ fn write_mnemonic_file_if_missing(path: &Path, mnemonic: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Security, copy_dir_contents_if_missing, default_ethereum_hd_prefixes, get_ethereum_hd_path,
-        legacy_operations_app_id, write_mnemonic_file_if_missing,
+        Security, WalletFile, copy_dir_contents_if_missing, default_ethereum_hd_prefixes,
+        get_ethereum_hd_path, legacy_operations_app_id, read_wallet_recovery_mnemonic,
+        wallet_recovery_mnemonic, write_mnemonic_file_if_missing,
     };
     use crate::ethereum_signer;
     use sp_core::Pair;
@@ -984,6 +1047,73 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&mnemonic_path).expect("mnemonic file should exist"),
             "existing mnemonic"
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn recovers_only_matching_mnemonic_when_wallet_key_is_missing() {
+        let test_dir =
+            unique_test_dir("recovers-only-matching-mnemonic-when-wallet-key-is-missing");
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let mnemonic = "test test test test test test test test test test test junk";
+        let wallet = WalletFile {
+            encrypted_mnemonic: "unreadable without the missing key".to_string(),
+            meta: Security::derive_security_from_mnemonic(mnemonic)
+                .expect("wallet metadata should derive"),
+        };
+        let mnemonic_path = test_dir.join("mnemonic");
+        fs::write(&mnemonic_path, mnemonic).expect("mnemonic should be written");
+
+        assert_eq!(
+            read_wallet_recovery_mnemonic(&wallet, &mnemonic_path)
+                .expect("matching mnemonic should recover the wallet"),
+            mnemonic
+        );
+
+        let other_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let other_wallet = WalletFile {
+            encrypted_mnemonic: wallet.encrypted_mnemonic,
+            meta: Security::derive_security_from_mnemonic(other_mnemonic)
+                .expect("other wallet metadata should derive"),
+        };
+        assert!(
+            read_wallet_recovery_mnemonic(&other_wallet, &mnemonic_path)
+                .expect_err("a different mnemonic must not replace the wallet key")
+                .to_string()
+                .contains("does not match wallet.json")
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn recovers_when_stored_key_cannot_decrypt_wallet() {
+        let test_dir = unique_test_dir("recovers-when-stored-key-cannot-decrypt-wallet");
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let mnemonic = "test test test test test test test test test test test junk";
+        let original_key = [1u8; 32];
+        let wallet = WalletFile {
+            encrypted_mnemonic: Security::encrypt_mnemonic(&original_key, mnemonic)
+                .expect("mnemonic should encrypt"),
+            meta: Security::derive_security_from_mnemonic(mnemonic)
+                .expect("wallet metadata should derive"),
+        };
+        let mnemonic_path = test_dir.join("mnemonic");
+        fs::write(&mnemonic_path, mnemonic).expect("mnemonic should be written");
+
+        assert_eq!(
+            wallet_recovery_mnemonic(&wallet, Some(&[2u8; 32]), &mnemonic_path)
+                .expect("matching mnemonic should recover the stranded wallet"),
+            Some(mnemonic.to_string())
+        );
+        assert_eq!(
+            wallet_recovery_mnemonic(&wallet, Some(&original_key), &mnemonic_path)
+                .expect("the original key should still decrypt the wallet"),
+            None
         );
 
         fs::remove_dir_all(&test_dir).expect("test dir should be removed");


### PR DESCRIPTION
## Summary

Linux desktop wallets now keep their encryption key across reboots, so users can accept invites and sign transactions after restarting the app.

Existing kernel-keyring entries migrate into Secret Service. If the stored key is missing or cannot decrypt the wallet, startup rebuilds it only from a local mnemonic that matches the wallet identity.

Validated with the Rust test suite, Clippy, formatting checks, and a Debian 13 compile check of the Linux key migration path.
