### PR TITLE
fix: allow zero-value mining bids

### DIFF
--- a/core/__test__/CohortBidder.test.ts
+++ b/core/__test__/CohortBidder.test.ts
@@ -130,6 +130,22 @@ describe('CohortBidder unit tests', () => {
     expect(cohortBidder.nextBid?.subaccounts.length).toBe(10);
   });
 
+  it('submits zero-value bids when no others are present', async () => {
+    const { cohortBidder } = await createBidderWithMocks(accountset, [0, 9], {
+      minBid: 0n,
+      maxBid: Argons(4.9),
+      accountBalance: Argons(1),
+    });
+    cohortBidder.currentBids.bids = [];
+    cohortBidder.currentBids.atTick = 10;
+
+    // @ts-expect-error - private var
+    await expect(cohortBidder.planNextBid()).resolves.toBeUndefined();
+
+    expect(cohortBidder.nextBid?.microgonsPerSeat).toBe(0n);
+    expect(cohortBidder.nextBid?.subaccounts.length).toBe(10);
+  });
+
   it('can bid up existing seats', async () => {
     const { cohortBidder } = await createBidderWithMocks(accountset, [0, 9], {
       maxBid: Argons(4.9),

--- a/core/__test__/CohortBidder.test.ts
+++ b/core/__test__/CohortBidder.test.ts
@@ -143,7 +143,7 @@ describe('CohortBidder unit tests', () => {
     await expect(cohortBidder.planNextBid()).resolves.toBeUndefined();
 
     expect(cohortBidder.nextBid?.microgonsPerSeat).toBe(0n);
-    expect(cohortBidder.nextBid?.subaccounts.length).toBe(10);
+    expect(cohortBidder.nextBid?.subaccounts).toEqual(cohortBidder.subaccounts.map(x => x.address));
   });
 
   it('can bid up existing seats', async () => {

--- a/core/src/BidPlan.ts
+++ b/core/src/BidPlan.ts
@@ -107,7 +107,7 @@ function planBidWithSortedSubaccounts(input: IBidPlanInput, sortedSubaccounts: I
   const alreadyWinningSeats = keptBids.length;
   const requestedAdditionalSeats = Math.max(0, seats - alreadyWinningSeats);
 
-  if (microgonsPerSeat <= 0n) {
+  if (microgonsPerSeat < 0n) {
     return createRejectedPlan('invalid-bid-amount', alreadyWinningSeats);
   }
   if (seats <= 0) {


### PR DESCRIPTION
Mining bots can again submit zero-value bids when auction seats are empty. The planner now accepts zero while continuing to reject negative bid values, so regular positive bidding, rebidding, and budget limits remain unchanged.

The bidder coverage now exercises an empty auction and verifies that all requested seats receive a zero-value bid plan.
