### PR TITLE
feat: recover orphaned bitcoin deposits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   tests:
+    name: ${{ matrix.suite }} (${{ matrix.platform }})
     env:
       CI: true
       E2E_DRIVER_RECEIVED_TIMEOUT_MS: 30000
@@ -21,8 +22,13 @@ jobs:
       matrix:
         include:
           - platform: 'ubuntu-latest'
+            suite: non-e2e
           - platform: 'macos-latest'
+            suite: regular
           - platform: 'windows-latest'
+            suite: regular
+          - platform: 'ubuntu-latest'
+            suite: e2e
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -38,8 +44,8 @@ jobs:
         shell: bash
         run: |
           echo "CI_TEMP_DIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
-          echo "E2E_SCREENSHOT_DIR=$RUNNER_TEMP/e2e-screenshots" >> "$GITHUB_ENV"
-          if [ "$RUNNER_OS" = "Linux" ]; then
+          if [ "${{ matrix.suite }}" = "e2e" ]; then
+            echo "E2E_SCREENSHOT_DIR=$RUNNER_TEMP/e2e-screenshots" >> "$GITHUB_ENV"
             sudo mkdir -p /mnt/target
             sudo chown -R "$USER:$USER" /mnt/target
             sudo rm -rf src-tauri/target
@@ -47,8 +53,8 @@ jobs:
             echo "CARGO_TARGET_DIR=/mnt/target" >> "$GITHUB_ENV"
           fi
 
-      - name: Install system dependencies
-        if: matrix.platform == 'ubuntu-latest'
+      - name: Install desktop dependencies
+        if: matrix.suite == 'e2e'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -58,24 +64,21 @@ jobs:
             libspa-0.2-dev \
             libclang-dev \
             libgbm-dev \
+            gnome-keyring \
             webkit2gtk-driver \
             xvfb
 
-      # install latest stable Rust release
       - name: Setup rust-toolchain stable
+        if: matrix.suite == 'e2e'
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
         with:
           toolchain: stable
 
-      # setup caching for the Rust target folder
       - name: Setup Rust cache
+        if: matrix.suite == 'e2e'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           workspaces: src-tauri
-
-      - if: runner.os == 'Windows'
-        shell: bash
-        run: echo "AWS_LC_SYS_PREBUILT_NASM=1" >> "$GITHUB_ENV"
 
       - name: Enable Corepack
         run: corepack enable
@@ -83,8 +86,8 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Trust local gateway CA for Linux e2e
-        if: matrix.platform == 'ubuntu-latest'
+      - name: Trust local gateway CA
+        if: matrix.suite == 'e2e'
         run: |
           yarn dev:gateway-certs
           sudo cp "$HOME/.argon/dev-gateway-ca/rootCA.pem" /usr/local/share/ca-certificates/argon-dev-gateway-ca.crt
@@ -94,11 +97,11 @@ jobs:
         run: yarn build:indexer
 
       - name: Make docker.sock world-writable
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.suite != 'regular'
         run: sudo chmod 666 /var/run/docker.sock
 
       - name: Install Kurtosis
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.suite != 'regular'
         run: |
           echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
@@ -107,7 +110,7 @@ jobs:
           kurtosis analytics disable || true
 
       - name: Start Kurtosis engine
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.suite != 'regular'
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -124,25 +127,37 @@ jobs:
             sleep 15
           done
 
+      - name: Tests
+        if: matrix.suite == 'regular'
+        run: yarn vitest --run --project '!integration' --project '!e2e'
+
+      - name: Tests excluding e2e
+        if: matrix.suite == 'non-e2e'
+        run: yarn vitest --run --project '!e2e'
+
       # xvfb-run provides a virtual display required by WebKit/GTK in CI.
-      # dbus-run-session provides a D-Bus session bus that WebKit/GTK requires.
-      - name: Tests (Linux)
-        if: matrix.platform == 'ubuntu-latest'
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1400x1000x24" yarn test
+      # dbus-run-session provides a D-Bus session bus for WebKit/GTK and the wallet key store.
+      - name: E2E tests
+        if: matrix.suite == 'e2e'
+        run: |
+          gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'e2e'
+          xvfb-run --auto-servernum --server-args="-screen 0 1400x1000x24" yarn vitest --run --project e2e
         shell: dbus-run-session -- bash --noprofile --norc -eo pipefail {0}
         env:
           ARGON_E2E_HEADLESS: '0'
           E2E_FLOW_APP_LOGS: 'quiet'
           E2E_SCREENSHOT_MODE: '1'
 
-      - name: Tests (macOS/Windows)
-        if: matrix.platform != 'ubuntu-latest'
-        run: yarn test
-        env:
-          SKIP_E2E: '1'
-
       - name: Upload test artifacts
-        if: failure()
+        if: failure() && matrix.suite != 'e2e'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: test-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suite }}-${{ matrix.platform }}
+          path: /tmp/troubleshooting-*
+          if-no-files-found: ignore
+
+      - name: Upload e2e artifacts
+        if: failure() && matrix.suite == 'e2e'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: e2e-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.platform }}
@@ -152,7 +167,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload e2e screenshots
-        if: always() && matrix.platform == 'ubuntu-latest'
+        if: always() && matrix.suite == 'e2e'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: e2e-screenshots-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.platform }}

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -522,16 +522,13 @@ export class AppVaultOperator {
     throw new Error(`Minting authority registration for ${signingKey} never appeared on chain.`);
   }
 
-  public async approvePendingGatewayUpdates(args: { client: ArgonClient }): Promise<boolean> {
-    const txs = await this.globalCouncil.buildApprovePendingGatewayUpdateTxs(args.client);
-    if (!txs.length) {
+  public async approvePendingGatewayUpdates(): Promise<boolean> {
+    const txInfo = await this.myVault.collect({ moveTo: MoveTo.DefaultArgon });
+    if (!txInfo) {
       return false;
     }
 
-    await this.submitVaultingTx({
-      client: args.client,
-      tx: txs.length === 1 ? txs[0] : args.client.tx.utility.batchAll(txs),
-    });
+    await txInfo.waitForPostProcessing;
     return true;
   }
 

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from 'node:timers/promises';
 import {
   createOperationalAccessProof,
   Currency,
@@ -5,6 +6,7 @@ import {
   JsonExt,
   MainchainClients,
   MiningFrames,
+  MoveTo,
   TreasuryBonds,
 } from '@argonprotocol/apps-core';
 import {
@@ -461,6 +463,34 @@ export class AppVaultOperator {
         await runPromise.catch(() => undefined);
       },
     };
+  }
+
+  public async pollVaultAlerts(args: { signal: AbortSignal; pollMs?: number }): Promise<void> {
+    const pollMs = args.pollMs ?? 1_000;
+    await this.myVault.subscribe();
+
+    while (!args.signal.aborted) {
+      try {
+        const notice = this.myVault.collectBuilder.getNotice();
+        const hasVaultSubmission =
+          (notice?.collectRevenue ?? 0n) > 0n ||
+          (notice?.signatureCount ?? 0) > 0 ||
+          (notice?.councilApprovalCount ?? 0) > 0;
+
+        if (hasVaultSubmission && !notice?.processing) {
+          const txInfo = await this.myVault.collect({ moveTo: MoveTo.DefaultArgon });
+          await txInfo?.waitForPostProcessing;
+        }
+      } catch (error) {
+        console.warn('[dev-upstream] Unable to process vault alerts.', error);
+      }
+
+      try {
+        await delay(pollMs, undefined, { signal: args.signal });
+      } catch (error) {
+        if (!args.signal.aborted) throw error;
+      }
+    }
   }
 
   public async registerMintingAuthority(args: {

--- a/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
@@ -126,6 +126,7 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
 
     await clickIfVisible(flow, 'WalletOverlay.closeLeft()', { timeoutMs: 5_000 });
     await clickIfVisible(flow, 'WalletOverlay.closeRight()', { timeoutMs: 5_000 });
+    await flow.waitFor('WalletOverlay', { state: 'missing', timeoutMs: 10_000 });
 
     if (!(await flow.isVisible('VaultingScreen')).visible) {
       await flow.run(vaultingActivateTab);

--- a/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
@@ -105,7 +105,7 @@ export default new Operation<IVaultingFlowContext, ITransferOutToEthereumState>(
       await pollEvery(
         1_000,
         async () => {
-          if ((await flow.isVisible(moveToEthereumTarget)).visible) return true;
+          if ((await flow.isVisible(moveToEthereumTarget)).clickable) return true;
           await clickIfVisible(flow, 'WalletOverlay.chooseEthereumWallet()', { timeoutMs: 1_500 });
           return false;
         },

--- a/e2e/helpers/startDevEthereumMintingAuthority.ts
+++ b/e2e/helpers/startDevEthereumMintingAuthority.ts
@@ -72,7 +72,7 @@ export async function startDevEthereumMintingAuthority(args: {
       executionRpcUrl,
       logPrefix,
     });
-    await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+    let runtimeStateReady = false;
 
     authorizeTransfersPromise = (async () => {
       while (!shouldStopAuthorizing) {
@@ -86,6 +86,10 @@ export async function startDevEthereumMintingAuthority(args: {
             });
             if (activationStatus.authorityActive) {
               console.info(`[${logPrefix}] minting authority activation is finalized`);
+              if (!runtimeStateReady) {
+                await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+                runtimeStateReady = true;
+              }
             } else if (Date.now() - lastActivationProgressLogAt >= 10_000) {
               lastActivationProgressLogAt = Date.now();
               console.info(
@@ -94,6 +98,11 @@ export async function startDevEthereumMintingAuthority(args: {
             }
             await new Promise(resolve => setTimeout(resolve, 1_000));
             continue;
+          }
+
+          if (!runtimeStateReady) {
+            await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+            runtimeStateReady = true;
           }
 
           const didAuthorize = await actor.authorizeNextPendingTransfer(client);
@@ -295,7 +304,7 @@ async function activateDevEthereumMintingAuthority(args: {
   });
 
   console.info(`[${logPrefix}] approving pending council updates`);
-  if (!(await actor.approvePendingGatewayUpdates({ client }))) {
+  if (!(await actor.approvePendingGatewayUpdates())) {
     throw new Error(`${logPrefix}: minting authority activation approval disappeared before it could be signed.`);
   }
 
@@ -354,9 +363,7 @@ async function refreshMintingAuthorityActivation(args: {
 
   if (status.pendingApprovals > 0) {
     console.info(`[${args.logPrefix}] approving pending council updates`);
-    await args.actor.approvePendingGatewayUpdates({
-      client: args.client,
-    });
+    await args.actor.approvePendingGatewayUpdates();
     status = await args.actor.getEthereumMintingAuthorityStatus({
       client: args.client,
       priorStatus: status,

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -257,8 +257,10 @@ export async function startDevUpstreamServer(args: {
     walletKeys,
   });
   const bootstrapRecovery = new BootstrapRecovery(walletKeys);
+  const vaultAlertAbortController = new AbortController();
   let isShutdown = false;
   let operationsUpgradePoller: { shutdown(): Promise<void> } | undefined;
+  let vaultAlertPoller: Promise<void> | undefined;
   let endpointMonitor: NodeJS.Timeout | undefined;
   let isEndpointRefreshRunning = false;
   let publishedGatewayPort: string | undefined;
@@ -268,7 +270,11 @@ export async function startDevUpstreamServer(args: {
     }
     isShutdown = true;
     clearInterval(endpointMonitor);
-    await operationsUpgradePoller?.shutdown().catch(() => undefined);
+    vaultAlertAbortController.abort();
+    await Promise.all([
+      operationsUpgradePoller?.shutdown().catch(() => undefined),
+      vaultAlertPoller?.catch(() => undefined),
+    ]);
     await actor.dispose().catch(() => undefined);
     await clients.disconnect().catch(() => undefined);
   };
@@ -328,6 +334,10 @@ export async function startDevUpstreamServer(args: {
     operationsUpgradePoller = actor.startOperationsUpgradePoller({
       client,
       routerHost: `http://127.0.0.1:${routerPort}`,
+    });
+    vaultAlertPoller = actor.pollVaultAlerts({ signal: vaultAlertAbortController.signal });
+    void vaultAlertPoller.catch(error => {
+      console.warn('[dev-upstream] Vault alert poller stopped.', error);
     });
 
     return {

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -33,7 +33,6 @@ const defaultUpstreamRootDir = path.resolve(__dirname, '..', 'dev-upstream');
 const execFileAsync = promisify(execFile);
 
 export const DEV_UPSTREAM_MASTER_MNEMONIC = 'test test test test test test test test test test test junk';
-export const DEV_UPSTREAM_SUBSTRATE_SURI = '//DevUpstreamOperator';
 
 export const DEV_DOCKER_COMPOSE_FILES = [
   'docker-compose.yml',
@@ -58,6 +57,7 @@ export interface IDevUpstreamServerRuntime {
   botPort: string;
   gatewayPort: string;
   routerPort: string;
+  stopVaultAlertPoller(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -264,17 +264,18 @@ export async function startDevUpstreamServer(args: {
   let endpointMonitor: NodeJS.Timeout | undefined;
   let isEndpointRefreshRunning = false;
   let publishedGatewayPort: string | undefined;
+  const stopVaultAlertPoller = async () => {
+    vaultAlertAbortController.abort();
+    await vaultAlertPoller?.catch(() => undefined);
+    vaultAlertPoller = undefined;
+  };
   const shutdown = async () => {
     if (isShutdown) {
       return;
     }
     isShutdown = true;
     clearInterval(endpointMonitor);
-    vaultAlertAbortController.abort();
-    await Promise.all([
-      operationsUpgradePoller?.shutdown().catch(() => undefined),
-      vaultAlertPoller?.catch(() => undefined),
-    ]);
+    await Promise.all([operationsUpgradePoller?.shutdown().catch(() => undefined), stopVaultAlertPoller()]);
     await actor.dispose().catch(() => undefined);
     await clients.disconnect().catch(() => undefined);
   };
@@ -345,6 +346,7 @@ export async function startDevUpstreamServer(args: {
       botPort,
       gatewayPort,
       routerPort,
+      stopVaultAlertPoller,
       shutdown,
     };
   } catch (error) {
@@ -437,7 +439,7 @@ function getComposeArgs(context: DevDockerComposeContext): string[] {
 
 export async function createDevUpstreamWalletKeys(): Promise<MemoryWalletKeys> {
   return new MemoryWalletKeys({
-    substrateSuri: DEV_UPSTREAM_SUBSTRATE_SURI,
+    substrateSuri: DEV_UPSTREAM_MASTER_MNEMONIC,
     masterMnemonic: DEV_UPSTREAM_MASTER_MNEMONIC,
   });
 }

--- a/e2e/scripts/prepareDevUpstreamApp.ts
+++ b/e2e/scripts/prepareDevUpstreamApp.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env tsx
+
+import Fs from 'node:fs';
+import Os from 'node:os';
+import Path from 'node:path';
+import { DEV_UPSTREAM_MASTER_MNEMONIC } from './devUpstreamServer.ts';
+
+const appDir = Path.join(
+  Os.homedir(),
+  'Library',
+  'Application Support',
+  'com.argon.desktop.local',
+  'dev-docker',
+  'app2',
+);
+
+Fs.mkdirSync(appDir, { recursive: true });
+Fs.writeFileSync(Path.join(appDir, 'mnemonic'), `${DEV_UPSTREAM_MASTER_MNEMONIC}\n`);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev:ethereum:add-argn": "tsx e2e/scripts/fundDevEthereumTokens.ts --token=ARGN",
     "dev:ethereum:add-argnot": "tsx e2e/scripts/fundDevEthereumTokens.ts --token=ARGNOT",
     "dev:ethereum:force-update-global-issuance-council": "tsx e2e/scripts/forceUpdateGlobalIssuanceCouncil.ts",
+    "dev:upstream:app": "tsx e2e/scripts/prepareDevUpstreamApp.ts && ARGON_DEV_UPSTREAM=0 yarn tauri:dev:docker:app2",
     "dev:upstream:invite": "tsx e2e/scripts/devUpstreamInvite.ts",
     "e2e:prepare": "yarn build:server",
     "e2e:docker": "yarn workspace @argonprotocol/apps-e2e run flows",

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -291,7 +291,7 @@ async function main(): Promise<void> {
           serverEnvVars: tauriEnv,
         },
       });
-      console.log('[tauri-dev][ethereum-ready] local Ethereum minting authority is ready');
+      console.log('[tauri-dev] local Ethereum minting authority activation is running');
 
       if (isShuttingDown) {
         await devEthereumMintingAuthorityRuntime.shutdown().catch(() => undefined);

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -64,9 +64,7 @@ async function main(): Promise<void> {
   let startedDevEthereum: IStartDevEthereumResult | undefined;
   let isShuttingDown = false;
   if (network === 'dev-docker') {
-    const mintingAuthoritySetting = readNonEmpty(
-      process.env.ARGON_DEV_ETHEREUM_MINTING_AUTHORITY,
-    )?.toLowerCase();
+    const mintingAuthoritySetting = readNonEmpty(process.env.ARGON_DEV_ETHEREUM_MINTING_AUTHORITY)?.toLowerCase();
     shouldStartDevEthereumMintingAuthority =
       !!devEthereumConfig && !['0', 'false', 'no', 'off'].includes(mintingAuthoritySetting ?? '');
     await ensureDevGatewayCerts({ appInstance: argonAppInstance, network });
@@ -140,7 +138,10 @@ async function main(): Promise<void> {
   let devEthereumReadyPromise: Promise<void> | undefined;
   let devUpstreamPromise: Promise<void> | undefined;
   let devUpstreamRuntime: IDevUpstreamServerRuntime | undefined;
-  if (devDockerArchiveUrl && (!isE2EAppRun || devEthereumConfig)) {
+  const shouldStartDevUpstream = !['0', 'false', 'no', 'off'].includes(
+    readNonEmpty(process.env.ARGON_DEV_UPSTREAM)?.toLowerCase() ?? '',
+  );
+  if (devDockerArchiveUrl && shouldStartDevUpstream && (!isE2EAppRun || devEthereumConfig)) {
     devUpstreamPromise = startDevUpstreamServer({
       archiveUrl: devDockerArchiveUrl,
       devEthereum: startedDevEthereum,
@@ -148,7 +149,7 @@ async function main(): Promise<void> {
     })
       .then(runtime => {
         devUpstreamRuntime = runtime;
-        console.log('[tauri-dev][upstream-ready] upstream server is ready');
+        console.log(`[tauri-dev][upstream-ready] upstream server is ready (vault alert actor pid ${process.pid})`);
       })
       .catch(error => {
         console.error(`[tauri-dev] Failed to start upstream server: ${(error as Error).message}`);
@@ -157,6 +158,17 @@ async function main(): Promise<void> {
 
     void devUpstreamPromise.catch(() => undefined);
   }
+
+  process.on('SIGUSR2', () => {
+    void devUpstreamPromise
+      ?.then(async () => {
+        await devUpstreamRuntime?.stopVaultAlertPoller();
+        console.log('[tauri-dev] Vault alert actor stopped');
+      })
+      .catch(error => {
+        console.error(`[tauri-dev] Failed to stop vault alert actor: ${(error as Error).message}`);
+      });
+  });
 
   if (devEthereumSetup) {
     devEthereumRuntimeSetupPromise = devEthereumSetup.start();

--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -159,11 +159,15 @@ import BitcoinLockingOverlay from './overlays/BitcoinLockingOverlay.vue';
 import BondPurchaseOverlay from './overlays/BondPurchaseOverlay.vue';
 import StakePurchaseOverlay from './overlays/StakePurchaseOverlay.vue';
 import SponsorOverlay from './overlays/SponsorOverlay.vue';
-import { getMainchainClients } from './stores/mainchain.ts';
+import { getMainchainClient, getMainchainClients } from './stores/mainchain.ts';
+import { getMyVault } from './stores/vaults.ts';
+import { getArgonBonds } from './stores/argonBonds.ts';
 
 const runtimeCompatibility = useRuntimeCompatibility();
 const { isBrowserUnsupported, shouldShowCompatibilityScreen } = storeToRefs(runtimeCompatibility);
 const updater = useAppUpdater();
+let foregroundRefreshPromise: Promise<void> | undefined;
+let lastForegroundFinalizedHash: string | undefined;
 
 runtimeCompatibility.start();
 
@@ -213,6 +217,32 @@ function disposeAppTransports() {
   void getMainchainClients().disconnect();
 }
 
+function refreshFinalizedStateOnFocus() {
+  if (!controller.isLoaded || foregroundRefreshPromise) return;
+
+  foregroundRefreshPromise = (async () => {
+    const archiveClient = await getMainchainClient(true);
+    const finalizedHash = await archiveClient.rpc.chain.getFinalizedHead();
+    const blockHash = finalizedHash.toHex();
+    if (blockHash === lastForegroundFinalizedHash) return;
+
+    const finalizedClient = await archiveClient.at(finalizedHash);
+    const currentFrameId = await finalizedClient.query.miningSlot.nextFrameId().then(frameId => frameId.toNumber() - 1);
+    const myVault = getMyVault();
+    const argonBonds = getArgonBonds();
+
+    await Promise.all([
+      myVault.refreshFinalizedState({ client: finalizedClient, currentFrameId }),
+      argonBonds.refreshActiveState({ client: finalizedClient, currentFrameId }),
+    ]);
+    lastForegroundFinalizedHash = blockHash;
+  })()
+    .catch(error => console.error('[App] Unable to refresh finalized state after window focus', error))
+    .finally(() => {
+      foregroundRefreshPromise = undefined;
+    });
+}
+
 Vue.onBeforeMount(async () => {
   if (isBrowserUnsupported.value) {
     return;
@@ -229,6 +259,7 @@ Vue.onMounted(async () => {
   // Add keyboard shortcuts for panel switching
   document.addEventListener('keydown', keydownHandler);
   document.addEventListener('click', externalLinkHandler);
+  window.addEventListener('focus', refreshFinalizedStateOnFocus);
   window.addEventListener('beforeunload', disposeAppTransports);
 
   const appWindow = getCurrentWindow();
@@ -243,6 +274,7 @@ Vue.onMounted(async () => {
 Vue.onBeforeUnmount(() => {
   document.removeEventListener('keydown', keydownHandler);
   document.removeEventListener('click', externalLinkHandler);
+  window.removeEventListener('focus', refreshFinalizedStateOnFocus);
   window.removeEventListener('beforeunload', disposeAppTransports);
 });
 

--- a/src-vue/__test__/Alerts.test.ts
+++ b/src-vue/__test__/Alerts.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { NetworkConfig } from '@argonprotocol/apps-core';
+import { describe, expect, it, vi } from 'vitest';
+import { MoveTo, NetworkConfig } from '@argonprotocol/apps-core';
 import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
 import { BITCOIN_BLOCK_MILLIS, TICK_MILLIS } from '../lib/Env.ts';
 import { VaultCollectBuilder } from '../lib/VaultCollectBuilder.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
+import { AppVaultOperator } from '../../e2e/actors/AppVaultOperator.ts';
 
 type TestMismatchPhase =
   | 'none'
@@ -39,6 +40,7 @@ describe('VaultCollectBuilder.getNotice', () => {
       expiringCollectAmount: 7n,
       nextCollectDueDate: 1234,
       signatureCount: 1,
+      orphanSignatureCount: 0,
       nextCosignDueDate: 5678,
       councilApprovalCount: 1,
       authorizedTransferCount: 3,
@@ -72,6 +74,7 @@ describe('VaultCollectBuilder.getNotice', () => {
       expiringCollectAmount: 0n,
       nextCollectDueDate: 0,
       signatureCount: 0,
+      orphanSignatureCount: 0,
       nextCosignDueDate: 0,
       councilApprovalCount: 2,
       authorizedTransferCount: 1,
@@ -88,6 +91,18 @@ describe('VaultCollectBuilder.getNotice', () => {
 
   it('returns null when there is nothing to collect or sign', () => {
     expect(createCollectBuilder(vaultSource()).getNotice()).toBeNull();
+  });
+
+  it('surfaces orphan release signatures without other vault work', () => {
+    const notice = createCollectBuilder(
+      vaultSource({
+        pendingOrphanCosignCount: 2,
+      }),
+    ).getNotice();
+
+    expect(notice?.signatureCount).toBe(2);
+    expect(notice?.orphanSignatureCount).toBe(2);
+    expect(notice?.transactionCount).toBe(1);
   });
 
   it('marks revenue collection as processing only when the active submission is collecting revenue', () => {
@@ -107,6 +122,35 @@ describe('VaultCollectBuilder.getNotice', () => {
       signatureCount: 0,
       councilApprovalCount: 0,
     });
+  });
+});
+
+describe('AppVaultOperator vault alert poller', () => {
+  it('submits orphan signatures through the vault alert collect path', async () => {
+    const subscribe = vi.fn().mockResolvedValue(undefined);
+    const source = vaultSource({ pendingOrphanCosignCount: 1 });
+    const collectBuilder = createCollectBuilder(source);
+    const getNotice = vi.spyOn(collectBuilder, 'getNotice');
+    const collect = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(async () => {
+        source.data.pendingOrphanCosignCount = 0;
+        return { waitForPostProcessing: Promise.resolve() };
+      });
+    const actor = Object.assign(Object.create(AppVaultOperator.prototype), {
+      myVault: { subscribe, collectBuilder, collect },
+    }) as AppVaultOperator;
+
+    const abortController = new AbortController();
+    const poller = actor.pollVaultAlerts({ signal: abortController.signal, pollMs: 1 });
+    await vi.waitFor(() => expect(collect).toHaveBeenCalledTimes(2));
+    abortController.abort();
+    await poller;
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(getNotice).toHaveBeenCalled();
+    expect(collect).toHaveBeenCalledWith({ moveTo: MoveTo.DefaultArgon });
   });
 });
 
@@ -215,6 +259,7 @@ function vaultSource(
     globalCouncilPendingApprovals: number;
     pendingMintingAuthorizationTips: bigint[];
     pendingCosignUtxosById: Map<number, { targetValue: bigint }>;
+    pendingOrphanCosignCount: number;
     myPendingBitcoinCosignTxInfosByUtxoId: Map<number, unknown>;
     nextCollectDueDate: number;
     nextCosignDueDate: number;
@@ -241,6 +286,7 @@ function vaultSource(
       expiringCollectAmount: 0n,
       pendingCollectTxInfo: null,
       pendingCosignUtxosById: new Map(),
+      pendingOrphanCosignCount: 0,
       myPendingBitcoinCosignTxInfosByUtxoId: new Map(),
       nextCollectDueDate: 0,
       nextCosignDueDate: 0,

--- a/src-vue/__test__/BitcoinLocks.argonCosign.test.ts
+++ b/src-vue/__test__/BitcoinLocks.argonCosign.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { BitcoinLock, type ArgonClient } from '@argonprotocol/mainchain';
+import type { BlockWatch, Currency as CurrencyBase } from '@argonprotocol/apps-core';
 import BitcoinLocks from '../lib/BitcoinLocks.ts';
+import type { Db } from '../lib/Db.ts';
+import type { TransactionTracker } from '../lib/TransactionTracker.ts';
+import type { WalletKeys } from '../lib/WalletKeys.ts';
 import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
 import { TransactionStatus } from '../lib/db/TransactionsTable.ts';
@@ -10,6 +14,7 @@ vi.mock('../stores/mainchain.ts', () => ({
 }));
 
 type IBitcoinLocksTestTarget = {
+  checkIncomingArgonBlock(header: { blockHash: string; blockNumber: number }): Promise<void>;
   checkForMissingBitcoinLockState(lock: IBitcoinLockRecord): Promise<void>;
   onBitcoinLockFinalized(txInfo: {
     createPostProcessor: () => { resolve: () => void };
@@ -200,6 +205,104 @@ describe('BitcoinLocks Argon cosign gating', () => {
 
     expect(lock.lockDetails.couponFeesPaid).toBe(148_296_012n);
   });
+
+  it('subscribes to orphan counters for every vault receiving an owner return request', async () => {
+    const ownerAccount = createLock().lockDetails.ownerAccount;
+    const firstLock = createLock({ utxoId: 11, vaultId: 1 });
+    const secondLock = createLock({ uuid: 'lock-2', utxoId: 12, vaultId: 2 });
+    const sameVaultLock = createLock({ uuid: 'lock-3', utxoId: 13, vaultId: 1 });
+    const subscribe = vi.fn(async (_vaultId: number, _owner: string, callback: (count: unknown) => void) => {
+      callback({ toNumber: () => 1 });
+      return vi.fn();
+    });
+    const client = {
+      query: { vaults: { orphanedUtxoAccountsByVaultId: subscribe } },
+    } as unknown as ArgonClient;
+    const store = new BitcoinLocks(
+      Promise.resolve({} as Db),
+      { defaultArgonAddress: ownerAccount } as WalletKeys,
+      { bestBlockHeader: { blockNumber: 100 } } as BlockWatch,
+      {} as CurrencyBase,
+      {} as TransactionTracker,
+    );
+    store.data.locksByUtxoId = { 11: firstLock, 12: secondLock, 13: sameVaultLock };
+    vi.spyOn(store.utxoTracking, 'getUnresolvedOrphanRecords').mockReturnValue([
+      createFundingRecord({ lockUtxoId: 11 }),
+      createFundingRecord({ id: 2, lockUtxoId: 12 }),
+      createFundingRecord({ id: 3, lockUtxoId: 13 }),
+    ]);
+
+    await store.orphanReleases.syncCosignCounterSubscriptions(client);
+
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect(subscribe).toHaveBeenCalledWith(1, ownerAccount, expect.any(Function));
+    expect(subscribe).toHaveBeenCalledWith(2, ownerAccount, expect.any(Function));
+  });
+
+  it('reads orphan cosign events only after an owner vault counter decreases', async () => {
+    const lock = createLock({ status: BitcoinLockStatus.Released });
+    const orphanRecord = createFundingRecord();
+    const counterCallbacks: Array<(count: { toNumber: () => number }) => void> = [];
+    const subscribe = vi.fn(
+      async (_vaultId: number, _owner: string, callback: (count: { toNumber: () => number }) => void) => {
+        counterCallbacks.push(callback);
+        callback({ toNumber: () => 1 });
+        return vi.fn();
+      },
+    );
+    const subscriptionClient = {
+      query: { vaults: { orphanedUtxoAccountsByVaultId: subscribe } },
+    } as unknown as ArgonClient;
+    const blockHeaders = new Map([
+      [101, { blockNumber: 101, blockHash: '0x101' }],
+      [102, { blockNumber: 102, blockHash: '0x102' }],
+    ]);
+    const cosignEvent = {
+      event: { section: 'bitcoinLocks', method: 'OrphanedUtxoCosigned' },
+    };
+    const getEvents = vi.fn(async (block: { blockNumber: number }) => {
+      return block.blockNumber === 102 ? [cosignEvent] : [];
+    });
+    const blockWatchStub = {
+      bestBlockHeader: { blockNumber: 101, blockHash: '0x101' },
+      getHeaderByBlockNumber: vi.fn(async (blockNumber: number) => blockHeaders.get(blockNumber)),
+      getApi: vi.fn().mockResolvedValue({
+        query: {
+          bitcoinUtxos: {
+            confirmedBitcoinBlockTip: vi.fn().mockResolvedValue({ isSome: false }),
+          },
+        },
+      }),
+      getEvents,
+    };
+    const blockWatch = blockWatchStub as unknown as BlockWatch;
+    const store = new BitcoinLocks(
+      Promise.resolve({} as Db),
+      { defaultArgonAddress: lock.lockDetails.ownerAccount } as WalletKeys,
+      blockWatch,
+      {} as CurrencyBase,
+      {} as TransactionTracker,
+    );
+    store.data.locksByUtxoId = { 11: lock };
+    vi.spyOn(store.utxoTracking, 'getUnresolvedOrphanRecords').mockReturnValue([orphanRecord]);
+    const recoverBlock = vi.spyOn(store.recovery, 'recoverBlock').mockResolvedValue(undefined);
+    Object.assign(store, {
+      getTable: vi.fn().mockResolvedValue({}),
+    });
+    const testStore = store as unknown as IBitcoinLocksTestTarget;
+
+    await store.orphanReleases.syncCosignCounterSubscriptions(subscriptionClient);
+    await testStore.checkIncomingArgonBlock({ blockNumber: 102, blockHash: '0x102' });
+    expect(getEvents).not.toHaveBeenCalled();
+
+    counterCallbacks[0]({ toNumber: () => 0 });
+    blockWatchStub.bestBlockHeader = { blockNumber: 102, blockHash: '0x102' };
+    await testStore.checkIncomingArgonBlock({ blockNumber: 103, blockHash: '0x103' });
+
+    expect(getEvents).toHaveBeenCalledTimes(2);
+    expect(getEvents).toHaveBeenCalledWith(blockHeaders.get(102));
+    expect(recoverBlock).toHaveBeenCalledWith(blockHeaders.get(102), [cosignEvent]);
+  });
 });
 
 function createLock(overrides: Partial<IBitcoinLockRecord> = {}): IBitcoinLockRecord {
@@ -224,16 +327,16 @@ function createLock(overrides: Partial<IBitcoinLockRecord> = {}): IBitcoinLockRe
     fundingUtxoRecord: undefined,
     network: 'testnet',
     hdPath: "m/84'/0'/0'",
-    vaultId: 1,
+    vaultId: overrides.vaultId ?? 1,
     createdAt: new Date('2026-01-01T00:00:00Z'),
     updatedAt: new Date('2026-01-01T00:00:00Z'),
   };
 }
 
-function createFundingRecord(): IBitcoinUtxoRecord {
+function createFundingRecord(overrides: Partial<IBitcoinUtxoRecord> = {}): IBitcoinUtxoRecord {
   return {
-    id: 1,
-    lockUtxoId: 11,
+    id: overrides.id ?? 1,
+    lockUtxoId: overrides.lockUtxoId ?? 11,
     txid: 'a'.repeat(64),
     vout: 0,
     satoshis: 10_000n,

--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -470,7 +470,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
         esploraHost: network.networkConfigOverride.esploraHost,
         network: 'dev-docker',
       });
-      activeLock = await createLock(harness);
+      activeLock = await createLock(harness, harness.myVault.createdVault!);
 
       await docker.stopOne('indexer', {
         config: ['docker-compose.yml', 'indexer.docker-compose.yml'],

--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -1,14 +1,15 @@
 import Path from 'node:path';
 import docker from 'docker-compose';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { BitcoinLock } from '@argonprotocol/mainchain';
+import { BitcoinLock, Vault } from '@argonprotocol/mainchain';
 import { teardown } from '@argonprotocol/testing';
-import { MainchainClients, NetworkConfig } from '@argonprotocol/apps-core';
+import { MainchainClients, MoveTo, NetworkConfig } from '@argonprotocol/apps-core';
 import {
   startArgonTestNetwork,
   type StartedArgonTestNetwork,
 } from '@argonprotocol/apps-core/__test__/startArgonTestNetwork.js';
 import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
+import { sudoFundWallet } from '@argonprotocol/apps-core/__test__/helpers/sudoFundWallet.ts';
 import {
   createBitcoinAddress,
   generateBlocks as mineBitcoinBlocks,
@@ -21,14 +22,18 @@ import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLoc
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
 import { createBitcoinLockProgressStore } from '../stores/bitcoinLockProgress.ts';
 import type { Db } from '../lib/Db.ts';
+import type { MyVault } from '../lib/MyVault.ts';
 import {
+  type BitcoinLocksClientHarness as ClientHarness,
   type BitcoinLocksHarness as TestHarness,
   createBitcoinLocksClientHarness,
   createBitcoinLocksHarness as createHarness,
   cleanupBitcoinLocksClientHarness,
   cleanupBitcoinLocksHarness as cleanupHarness,
+  walletFundingMicrogons,
 } from './helpers/bitcoinLocksHarness.ts';
 import { MyVaultRecovery } from '../lib/recovery/MyVaultRecovery.ts';
+import { createMockWalletKeys } from './helpers/wallet.ts';
 
 const skipE2E = Boolean(JSON.parse(process.env.SKIP_E2E ?? '0'));
 
@@ -99,7 +104,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
     });
 
     try {
-      const lock = await createLock(harness);
+      const lock = await createLock(harness, harness.myVault.createdVault!);
       const stopTracking = progress.trackLock(lock);
 
       try {
@@ -143,7 +148,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
     try {
       const initialAvailableBitcoinSpace = harness.myVault.createdVault!.availableBitcoinSpace();
-      const lock = await createLock(harness);
+      const lock = await createLock(harness, harness.myVault.createdVault!);
       const stopTracking = progress.trackLock(lock);
 
       try {
@@ -169,7 +174,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
     });
 
     try {
-      const lock = await createLock(harness);
+      const lock = await createLock(harness, harness.myVault.createdVault!);
       const reservedAvailableBitcoinSpace = harness.myVault.createdVault!.availableBitcoinSpace();
       const stopTracking = progress.trackLock(lock);
 
@@ -219,6 +224,139 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
     }
   });
 
+  it('alerts a separate vault operator to return an orphaned deposit', async () => {
+    const operator = await createHarness({
+      archiveUrl: network.archiveUrl,
+      esploraHost: network.networkConfigOverride.esploraHost,
+      network: 'dev-docker',
+    });
+
+    try {
+      const ownerWalletKeys = createMockWalletKeys();
+      const owner = await createBitcoinLocksClientHarness({
+        archiveUrl: network.archiveUrl,
+        esploraHost: network.networkConfigOverride.esploraHost,
+        network: 'dev-docker',
+        walletKeys: ownerWalletKeys,
+      });
+
+      try {
+        await sudoFundWallet({
+          address: ownerWalletKeys.defaultArgonAddress,
+          microgons: walletFundingMicrogons,
+          micronots: 0n,
+          archiveUrl: network.archiveUrl,
+        });
+
+        const lock = await createLock(owner, operator.myVault.createdVault!);
+        const progress = createBitcoinLockProgressStore({
+          myVault: operator.myVault,
+          bitcoinLocks: owner.bitcoinLocks,
+          miningFrames: owner.miningFrames,
+        });
+        const stopTracking = progress.trackLock(lock);
+
+        try {
+          const observed = await observeMismatchCandidate(
+            owner,
+            lock,
+            getMismatchFundingSatoshis(lock.satoshis),
+            progress,
+          );
+          const client = await clients.get(false);
+          await client.tx.bitcoinUtxos
+            .rejectUtxoCandidate(lock.utxoId!, {
+              txid: observed.candidate.txid,
+              outputIndex: observed.candidate.vout,
+            })
+            .signAndSend(await owner.walletKeys.getLiquidLockingKeypair());
+
+          const orphan = await waitFor(
+            60e3,
+            'rejected deposit recorded as orphan',
+            async () => {
+              const currentLock = getCurrentLock(owner, lock.utxoId!);
+              await owner.bitcoinLocks.utxoTracking.syncArgonOrphans([currentLock], await clients.get(false));
+              return owner.bitcoinLocks.utxoTracking
+                .getUnresolvedOrphanRecords([currentLock])
+                .find(record => record.txid === observed.candidate.txid);
+            },
+            { pollMs: 1e3 },
+          );
+          expect(orphan.status).toBe(BitcoinUtxoStatus.Orphaned);
+          expect(orphan.satoshis).toBe(observed.candidate.satoshis);
+
+          const currentLock = getCurrentLock(owner, lock.utxoId!);
+          expect(owner.bitcoinLocks.utxoTracking.getUnresolvedOrphanRecords([currentLock])).toContain(orphan);
+
+          const returnDestination = createBitcoinAddress();
+          const bitcoinNetworkFee = await owner.bitcoinLocks.calculateBitcoinNetworkFee(
+            currentLock,
+            5n,
+            returnDestination,
+          );
+          const returnTx = await owner.bitcoinLocks.orphanReleases.requestOrphanReturn({
+            lock: currentLock,
+            record: orphan,
+            toScriptPubkey: returnDestination,
+            bitcoinNetworkFee,
+          });
+          expect(returnTx).toBeTruthy();
+          await returnTx!.txResult.waitForFinalizedBlock;
+
+          await collectVaultSignatureFromAlert(operator.myVault, 1);
+
+          const returningOrphan = await waitFor(120e3, 'orphan return seen on bitcoin', () => {
+            const current = owner.bitcoinLocks.utxoTracking.getUtxoRecord(
+              currentLock.utxoId!,
+              orphan.txid,
+              orphan.vout,
+            );
+            if (!current?.releaseTxid) return;
+            return current;
+          });
+          await waitForBitcoinTransactionOutputSatoshis({
+            flowName: 'BitcoinLocks.integration.orphanReturn',
+            txid: returningOrphan.releaseTxid!,
+            address: returnDestination,
+            minimumSatoshis: 1n,
+            minerAddress,
+            timeoutMs: 30e3,
+            pollMs: 500,
+          });
+          await waitForBitcoinTransactionConfirmations({
+            flowName: 'BitcoinLocks.integration.orphanReturn',
+            txid: returningOrphan.releaseTxid!,
+            minimumConfirmations: 8,
+            minerAddress,
+            mineMode: 'missing',
+            timeoutMs: 30e3,
+            pollMs: 500,
+          });
+
+          await waitFor(90e3, 'orphan return completed', () => {
+            const current = owner.bitcoinLocks.utxoTracking.getUtxoRecord(
+              currentLock.utxoId!,
+              orphan.txid,
+              orphan.vout,
+            );
+            if (current?.status !== BitcoinUtxoStatus.ReleaseComplete) return;
+            if (owner.bitcoinLocks.utxoTracking.getUnresolvedOrphanRecords([currentLock]).length) return;
+            if (operator.myVault.data.pendingOrphanCosignCount !== 0) return;
+            if (operator.myVault.collectBuilder.getNotice()?.orphanSignatureCount) return;
+            return current;
+          });
+        } finally {
+          stopTracking();
+        }
+      } finally {
+        await cleanupBitcoinLocksClientHarness(owner);
+      }
+    } finally {
+      await cleanupHarness(operator);
+    }
+  }, 420e3);
+
   it('keeps a new funded lock isolated after a prior release and a prior mismatch return', async () => {
     const harness = await createHarness({
       archiveUrl: network.archiveUrl,
@@ -233,7 +371,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
     try {
       const initialAvailableBitcoinSpace = harness.myVault.createdVault!.availableBitcoinSpace();
-      const firstLock = await createLock(harness);
+      const firstLock = await createLock(harness, harness.myVault.createdVault!);
       const firstStopTracking = progress.trackLock(firstLock);
 
       let firstReleasedRecordId = 0;
@@ -250,6 +388,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
         const firstRelease = await releaseLockAndWaitForChainRestore(
           harness,
+          harness.myVault,
           fundedFirst.lock,
           progress,
           initialAvailableBitcoinSpace,
@@ -260,7 +399,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
         firstStopTracking();
       }
 
-      const secondLock = await createLock(harness);
+      const secondLock = await createLock(harness, harness.myVault.createdVault!);
       const secondStopTracking = progress.trackLock(secondLock);
 
       let secondReturnedRecordId = 0;
@@ -290,7 +429,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
         secondStopTracking();
       }
 
-      const thirdLock = await createLock(harness);
+      const thirdLock = await createLock(harness, harness.myVault.createdVault!);
       const thirdStopTracking = progress.trackLock(thirdLock);
 
       try {
@@ -303,6 +442,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
         const thirdRelease = await releaseLockAndWaitForChainRestore(
           harness,
+          harness.myVault,
           fundedThird.lock,
           progress,
           initialAvailableBitcoinSpace,
@@ -397,19 +537,23 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
   });
 });
 
-async function createLock(harness: TestHarness, microgonLiquidity?: bigint): Promise<IBitcoinLockRecord> {
-  const availableBitcoinSpace = harness.myVault.createdVault!.availableBitcoinSpace();
+async function createLock(
+  harness: ClientHarness,
+  vault: Vault,
+  microgonLiquidity?: bigint,
+): Promise<IBitcoinLockRecord> {
+  const availableBitcoinSpace = vault.availableBitcoinSpace();
   const targetLiquidity = microgonLiquidity ?? (availableBitcoinSpace * 4n) / 5n;
   expect(targetLiquidity).toBeGreaterThan(0n);
   const satoshis = await harness.bitcoinLocks.satoshisForArgonLiquidity(targetLiquidity);
 
   await harness.bitcoinLocks.initializeLock({
     satoshis,
-    vault: harness.myVault.createdVault!,
+    vault,
   });
   return await waitFor(120e3, 'pending bitcoin lock finalization', () => {
     const lock = Object.values(harness.bitcoinLocks.data.locksByUtxoId)
-      .filter(record => record.vaultId === harness.myVault.createdVault!.vaultId)
+      .filter(record => record.vaultId === vault.vaultId)
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0];
     if (!lock) return;
     if (lock.status !== BitcoinLockStatus.LockPendingFunding) return;
@@ -418,7 +562,7 @@ async function createLock(harness: TestHarness, microgonLiquidity?: bigint): Pro
 }
 
 async function observeMismatchCandidate(
-  harness: TestHarness,
+  harness: ClientHarness,
   lock: IBitcoinLockRecord,
   satoshis: bigint,
   progress: ReturnType<typeof createBitcoinLockProgressStore>,
@@ -493,9 +637,13 @@ function getMismatchReturnRecord(
   lock: IBitcoinLockRecord,
   candidate: Pick<IBitcoinUtxoRecord, 'id'>,
 ): IBitcoinUtxoRecord | undefined {
-  return harness.bitcoinLocks.getMismatchViewState(lock).candidates.find(view => {
+  const mismatchRecord = harness.bitcoinLocks.getMismatchViewState(lock).candidates.find(view => {
     return view.record.id === candidate.id;
   })?.returnRecord;
+  if (mismatchRecord) return mismatchRecord;
+
+  const record = harness.bitcoinLocks.utxoTracking.getUtxoRecordById(candidate.id);
+  return harness.bitcoinLocks.utxoTracking.isReleaseStatus(record?.status) ? record : undefined;
 }
 
 async function waitForMismatchReturnTracked(args: {
@@ -578,7 +726,7 @@ async function returnMismatchAndWaitForReadyToResume(
 
   const returnDestination = createBitcoinAddress();
   const bitcoinNetworkFee = await harness.bitcoinLocks.calculateBitcoinNetworkFee(observed.lock, 5n, returnDestination);
-  const returnTx = await harness.bitcoinLocks.requestMismatchOrphanReturnOnArgon({
+  const returnTx = await harness.bitcoinLocks.orphanReleases.requestCandidateReturn({
     lock: observed.lock,
     candidateRecord: observed.candidate,
     toScriptPubkey: returnDestination,
@@ -685,7 +833,7 @@ async function returnMismatchAndWaitForReadyToResume(
 }
 
 async function acceptMismatchFunding(
-  harness: TestHarness,
+  harness: ClientHarness,
   lock: IBitcoinLockRecord,
   progress: ReturnType<typeof createBitcoinLockProgressStore>,
 ): Promise<{ lock: IBitcoinLockRecord; acceptedRecord: IBitcoinUtxoRecord; candidate: IBitcoinUtxoRecord }> {
@@ -816,7 +964,7 @@ async function returnExpiredMismatchAndWaitForChainRestore(
 
   const returnDestination = createBitcoinAddress();
   const bitcoinNetworkFee = await harness.bitcoinLocks.calculateBitcoinNetworkFee(expired.lock, 5n, returnDestination);
-  const returnTx = await harness.bitcoinLocks.requestMismatchOrphanReturnOnArgon({
+  const returnTx = await harness.bitcoinLocks.orphanReleases.requestCandidateReturn({
     lock: expired.lock,
     candidateRecord: expired.candidate,
     toScriptPubkey: returnDestination,
@@ -872,9 +1020,7 @@ async function returnExpiredMismatchAndWaitForChainRestore(
     async () => {
       const refreshed = getCurrentLock(harness, expired.lock.utxoId!);
       progress.updateLock(refreshed);
-      const record = harness.bitcoinLocks.getMismatchViewState(refreshed).candidates.find(candidate => {
-        return candidate.record.id === expired.candidate.id;
-      })?.returnRecord;
+      const record = getMismatchReturnRecord(harness, refreshed, expired.candidate);
       if (!record) return;
       if (record.status !== BitcoinUtxoStatus.ReleaseComplete) return;
       if (!record.releaseTxid) return;
@@ -886,7 +1032,7 @@ async function returnExpiredMismatchAndWaitForChainRestore(
       if (chainLock) return;
 
       const mismatchView = harness.bitcoinLocks.getMismatchViewState(refreshed);
-      if (mismatchView.phase !== 'returned') return;
+      if (mismatchView.candidates.some(candidate => candidate.record.id === expired.candidate.id)) return;
       if (
         refreshed.status !== BitcoinLockStatus.LockExpiredWaitingForFunding &&
         refreshed.status !== BitcoinLockStatus.LockExpiredWaitingForFundingAcknowledged
@@ -926,7 +1072,8 @@ async function returnExpiredMismatchAndWaitForChainRestore(
 }
 
 async function releaseLockAndWaitForChainRestore(
-  harness: TestHarness,
+  harness: ClientHarness,
+  operatorVault: MyVault,
   lock: IBitcoinLockRecord,
   progress: ReturnType<typeof createBitcoinLockProgressStore>,
   expectedAvailableBitcoinSpace: bigint,
@@ -941,6 +1088,8 @@ async function releaseLockAndWaitForChainRestore(
   });
   expect(releaseTx).toBeTruthy();
   await releaseTx!.txResult.waitForInFirstBlock;
+
+  await collectVaultSignatureFromAlert(operatorVault, 0);
 
   await waitFor(30e3, 'release request tracked on argon', () => {
     const refreshed = getCurrentLock(harness, currentLock.utxoId!);
@@ -1001,14 +1150,33 @@ async function releaseLockAndWaitForChainRestore(
     if (!vault.isSome) return;
     if (vault.unwrap().securitizationLocked.toBigInt() !== 0n) return;
     if (JSON.stringify(pendingCosign.toJSON()) !== '[]') return;
-    if (harness.myVault.createdVault?.availableBitcoinSpace() !== expectedAvailableBitcoinSpace) return;
+    if (operatorVault.createdVault?.availableBitcoinSpace() !== expectedAvailableBitcoinSpace) return;
     return true;
   });
 
   return seenOnBitcoin;
 }
 
-function getCurrentLock(harness: TestHarness, utxoId: number): IBitcoinLockRecord {
+async function collectVaultSignatureFromAlert(
+  operatorVault: MyVault,
+  expectedOrphanSignatureCount: number,
+): Promise<void> {
+  const notice = await waitFor(30e3, 'vault signature alert', () => {
+    const current = operatorVault.collectBuilder.getNotice();
+    if (!current?.signatureCount) return;
+    if (current.orphanSignatureCount !== expectedOrphanSignatureCount) return;
+    return current;
+  });
+
+  expect(notice.signatureCount).toBeGreaterThanOrEqual(1);
+  expect(notice.orphanSignatureCount).toBe(expectedOrphanSignatureCount);
+
+  const collectTx = await operatorVault.collect({ moveTo: MoveTo.DefaultArgon });
+  if (!collectTx) throw new Error('Expected the vault signature alert to produce a collect transaction.');
+  await collectTx.txResult.waitForFinalizedBlock;
+}
+
+function getCurrentLock(harness: ClientHarness, utxoId: number): IBitcoinLockRecord {
   const lock = harness.bitcoinLocks.getLockByUtxoId(utxoId);
   if (!lock) {
     throw new Error(`Missing current lock ${utxoId}`);

--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -27,9 +27,15 @@ import { encodeAddress } from '@polkadot/util-crypto';
 import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
 import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
 import * as vaultStore from '../stores/vaults.ts';
+import { createTestDb } from './helpers/db.ts';
 
 function createStore(
-  options: { blockWatch?: BlockWatch; transactionTracker?: TransactionTracker; walletKeys?: WalletKeys } = {},
+  options: {
+    blockWatch?: BlockWatch;
+    db?: Db;
+    transactionTracker?: TransactionTracker;
+    walletKeys?: WalletKeys;
+  } = {},
 ) {
   const blockWatch =
     options.blockWatch ??
@@ -54,7 +60,7 @@ function createStore(
     }) as TransactionTracker);
 
   return new BitcoinLocks(
-    Promise.resolve(Object.create(null) as Db),
+    Promise.resolve(options.db ?? (Object.create(null) as Db)),
     options.walletKeys ?? (Object.create(null) as WalletKeys),
     blockWatch,
     currency,
@@ -185,6 +191,78 @@ describe('BitcoinLocks recovery', () => {
     expect(lock.isHistoryRecoveryPending).toBeUndefined();
     expect(pendingLock.isHistoryRecoveryPending).toBeUndefined();
     expect(store.recovery.hasPendingHistoryRecovery).toBe(false);
+  });
+
+  it('replays each orphan UTXO through request and vault cosign history', async () => {
+    const db = await createTestDb();
+    const lock = createLock({
+      uuid: 'orphan-history',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const utxoRef = { txid: `0x${'44'.repeat(32)}`, outputIndex: 2 };
+    const api = {
+      query: {
+        ticks: { currentTick: vi.fn(async () => numberCodec(700)) },
+        bitcoinLocks: {
+          orphanedUtxosByAccount: vi.fn(async () =>
+            optionCodec({
+              utxoId: numberCodec(7),
+              satoshis: bigintCodec(12_000n),
+              cosignRequest: optionCodec({
+                toScriptPubkey: new Uint8Array([0, 20, 1, 2, 3]),
+                bitcoinNetworkFee: bigintCodec(120n),
+              }),
+            }),
+          ),
+        },
+      },
+    };
+    const store = createStore({
+      blockWatch: { getApi: vi.fn(async () => api) } as unknown as BlockWatch,
+      db,
+    });
+    store.data.locksByUtxoId[7] = lock;
+
+    await store.recovery.recoverBlock(historyBlock(201), [
+      historyEvent(147, 'bitcoinLocks', 'OrphanedUtxoReceived', {
+        utxoId: 7,
+        utxoRef,
+        vaultId: 1,
+        satoshis: 12_000n,
+      }),
+    ]);
+    await store.recovery.recoverBlock(historyBlock(202), [
+      historyEvent(147, 'bitcoinLocks', 'OrphanedUtxoReleaseRequested', {
+        utxoId: 7,
+        utxoRef,
+        vaultId: 1,
+        accountId: lock.lockDetails.ownerAccount,
+      }),
+    ]);
+    await store.recovery.recoverBlock(historyBlock(203), [
+      historyEvent(147, 'bitcoinLocks', 'OrphanedUtxoCosigned', {
+        utxoId: 7,
+        utxoRef,
+        vaultId: 1,
+        accountId: lock.lockDetails.ownerAccount,
+        signature: '0x010203',
+      }),
+    ]);
+
+    expect(store.utxoTracking.getUtxosForLock(lock)).toEqual([
+      expect.objectContaining({
+        txid: utxoRef.txid,
+        vout: utxoRef.outputIndex,
+        satoshis: 12_000n,
+        status: BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
+        releaseToDestinationAddress: '0014010203',
+        releaseBitcoinNetworkFee: 120n,
+        releaseCosignVaultSignature: hexToU8a('0x010203'),
+        releaseCosignHeight: 203,
+      }),
+    ]);
   });
 
   it('quarantines only recovering locks while regular locks remain active and syncable', async () => {
@@ -833,6 +911,38 @@ describe('BitcoinLocks recovery', () => {
 
     expect(setStatus).not.toHaveBeenCalled();
     expect(record.status).toBe(BitcoinLockStatus.LockPendingFunding);
+  });
+
+  it('keeps settled locks archived while allowing their orphan action', async () => {
+    const store = createStore({ db: await createTestDb() });
+    const record = createLock({
+      uuid: 'expired-lock-with-orphan',
+      utxoId: 7,
+      status: BitcoinLockStatus.Released,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.removalReason = 'released';
+    store.data.locksByUtxoId[7] = record;
+
+    const orphan = await store.utxoTracking.upsertUtxoRecord(
+      record,
+      { txid: '11'.repeat(32), vout: 0, satoshis: 7_500n },
+      { markOrphaned: true },
+    );
+
+    expect(store.getMismatchViewState(record).nextCandidate?.canReturn).toBe(false);
+    expect(store.isInactiveForVaultDisplay(record)).toBe(true);
+    expect(store.utxoTracking.getUnresolvedOrphanRecords([record])).toEqual([orphan]);
+    const runInQueueForUtxo = Reflect.get(store, 'runInQueueForUtxo') as <T>(
+      lock: IBitcoinLockRecord,
+      timeoutMs: number,
+      task: () => Promise<T>,
+      options: { allowOrphanRecovery: boolean },
+    ) => Promise<T>;
+
+    await expect(
+      runInQueueForUtxo.call(store, record, 1_000, async () => 'return-started', { allowOrphanRecovery: true }),
+    ).resolves.toBe('return-started');
   });
 
   it('publishes existing and out-of-order locks only after history replay is committed', async () => {
@@ -1578,6 +1688,7 @@ describe('BitcoinLocks recovery', () => {
     const blockWatch = {
       getHeaderByBlockNumber: vi.fn(async () => historyBlock(152)),
       getApi: vi.fn(async () => clientAt),
+      getEvents: vi.fn(async () => []),
     } as unknown as BlockWatch;
     const store = createStore({ blockWatch });
     const record = createLock({

--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -29,6 +29,10 @@ import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
 import * as vaultStore from '../stores/vaults.ts';
 import { createTestDb } from './helpers/db.ts';
 
+vi.mock('../stores/mainchain.ts', () => ({
+  getMainchainClient: vi.fn(async () => ({})),
+}));
+
 function createStore(
   options: {
     blockWatch?: BlockWatch;
@@ -870,6 +874,9 @@ describe('BitcoinLocks recovery', () => {
     const setRelayMetadata = vi.fn();
     vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending, setRelayMetadata } as never);
     vi.spyOn(store as any, 'runPendingLoadReconciliation').mockResolvedValue(undefined);
+    const syncCosignCounterSubscriptions = vi
+      .spyOn(store.orphanReleases, 'syncCosignCounterSubscriptions')
+      .mockResolvedValue(undefined);
 
     const syncRelayBackedPendingLock = Reflect.get(store, 'syncRelayBackedPendingLock') as (
       lock: IBitcoinLockRecord,
@@ -886,6 +893,7 @@ describe('BitcoinLocks recovery', () => {
     await store.recovery.commitHistoryReplay();
     await relaySync;
     expect(setRelayMetadata).toHaveBeenCalledOnce();
+    expect(syncCosignCounterSubscriptions).toHaveBeenCalledOnce();
   });
 
   it('keeps recovered expired locks in history without processing them as active', async () => {

--- a/src-vue/__test__/BitcoinReleaseFlow.test.ts
+++ b/src-vue/__test__/BitcoinReleaseFlow.test.ts
@@ -471,14 +471,15 @@ describe('BitcoinLocks release status sync', () => {
     expect(submitToBitcoin).not.toHaveBeenCalled();
   });
 
-  it('submitToBitcoin treats duplicate orphan broadcasts as already submitted', async () => {
+  it('submitToBitcoin keeps failed orphan broadcasts retryable and treats duplicates as submitted', async () => {
     const db = await createTestDb();
     const orphanReturnTxid = 'b'.repeat(64);
     const getTxStatus = vi.fn().mockResolvedValue(undefined);
     const getTipHeight = vi.fn().mockResolvedValue(321);
     const broadcastTx = vi
       .fn()
-      .mockRejectedValue(new Error('Failed to broadcast transaction: 400 Bad Request - txn-already-known'));
+      .mockRejectedValueOnce(new Error('Bitcoin service unavailable'))
+      .mockRejectedValueOnce(new Error('Failed to broadcast transaction: 400 Bad Request - txn-already-known'));
     const mempool = Object.assign(Object.create(BitcoinMempool.prototype), {
       getTxStatus,
       getTipHeight,
@@ -509,26 +510,38 @@ describe('BitcoinLocks release status sync', () => {
       isFinal: true,
       toBytes: () => new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
     } as any);
-    const setReleaseSeenOnBitcoinAndProcessing = vi
-      .spyOn(store.utxoTracking, 'setReleaseSeenOnBitcoinAndProcessing')
-      .mockResolvedValue(undefined);
+    const setReleaseSeenOnBitcoinAndProcessing = vi.spyOn(store.utxoTracking, 'setReleaseSeenOnBitcoinAndProcessing');
     const setReleaseError = vi.spyOn(store.utxoTracking, 'setReleaseError').mockResolvedValue(undefined);
+    const releaseArgs = {
+      toScriptPubkey: '0014abc123',
+      bitcoinNetworkFee: 10n,
+      vaultSignature: new Uint8Array([1, 2, 3]),
+    };
 
     try {
       // @ts-expect-error - private access
-      await store.orphanReleases.submitToBitcoin(lock, orphanRecord, {
-        toScriptPubkey: '0014abc123',
-        bitcoinNetworkFee: 10n,
-        vaultSignature: new Uint8Array([1, 2, 3]),
-      });
+      await store.orphanReleases.submitToBitcoin(lock, orphanRecord, releaseArgs);
+
+      expect(orphanRecord.status).toBe(BitcoinUtxoStatus.ReleaseIsProcessingOnArgon);
+      expect(orphanRecord.statusError).toBe('Error: Bitcoin service unavailable');
+
+      // @ts-expect-error - private access
+      await store.orphanReleases.submitToBitcoin(lock, orphanRecord, releaseArgs);
     } finally {
       cosignAndGenerateTx.mockRestore();
     }
 
-    expect(broadcastTx).toHaveBeenCalledWith('deadbeef');
-    expect(getTxStatus).toHaveBeenCalledWith(orphanReturnTxid, 0);
+    expect(broadcastTx).toHaveBeenCalledTimes(2);
+    expect(broadcastTx).toHaveBeenNthCalledWith(1, 'deadbeef');
+    expect(broadcastTx).toHaveBeenNthCalledWith(2, 'deadbeef');
+    expect(getTxStatus).toHaveBeenCalledTimes(2);
+    expect(getTxStatus).toHaveBeenNthCalledWith(1, orphanReturnTxid, 0);
+    expect(getTxStatus).toHaveBeenNthCalledWith(2, orphanReturnTxid, 0);
     expect(setReleaseSeenOnBitcoinAndProcessing).toHaveBeenCalledWith(orphanRecord, orphanReturnTxid, 321);
     expect(setReleaseError).not.toHaveBeenCalled();
+    expect(orphanRecord.status).toBe(BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin);
+    expect(orphanRecord.statusError).toBeUndefined();
+    expect(orphanRecord.releaseTxid).toBe(orphanReturnTxid);
   });
 
   it('submitToBitcoin reuses a confirmed orphan return txid on restart', async () => {

--- a/src-vue/__test__/BitcoinReleaseFlow.test.ts
+++ b/src-vue/__test__/BitcoinReleaseFlow.test.ts
@@ -4,6 +4,7 @@ import type { BlockWatch, Currency as CurrencyBase } from '@argonprotocol/apps-c
 import { CosignScript } from '@argonprotocol/bitcoin';
 import { createTestDb } from './helpers/db.ts';
 import BitcoinLocks from '../lib/BitcoinLocks.ts';
+import BitcoinOrphanReleases from '../lib/BitcoinOrphanReleases.ts';
 import BitcoinMempool, { type IMempoolTxStatus } from '../lib/BitcoinMempool.ts';
 import type { Db } from '../lib/Db.ts';
 import type { TransactionTracker } from '../lib/TransactionTracker.ts';
@@ -190,7 +191,7 @@ describe('BitcoinLocks release status sync', () => {
     expect(setStatusError).not.toHaveBeenCalled();
   });
 
-  it('reconcileMismatchReturnOnBlock resets stale orphan records that were never submitted', async () => {
+  it('reconcileCandidateReturns resets stale orphan records that were never submitted', async () => {
     const lock = { utxoId: 11 } as IBitcoinLockRecord;
     const orphanRecord = createFundingRecord({
       id: 7,
@@ -201,19 +202,20 @@ describe('BitcoinLocks release status sync', () => {
     });
     const setReleaseError = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
 
-    const store = createStoreStub({
-      utxoTracking: {
-        getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
-        getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
-        setReleaseError,
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
+          getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError,
+        },
       },
-      getOrphanedReturnTxInfoForRecord: vi.fn().mockReturnValue(undefined),
-      syncOrphanReleaseRequestFromChain: vi.fn<(...args: any[]) => Promise<boolean>>().mockResolvedValue(false),
-      submitOrphanReleaseToBitcoin: vi.fn().mockResolvedValue(undefined),
+      getTransactionInfo: vi.fn().mockReturnValue(undefined),
+      syncReleaseRequestFromChain: vi.fn<(...args: any[]) => Promise<boolean>>().mockResolvedValue(false),
+      submitToBitcoin: vi.fn().mockResolvedValue(undefined),
     });
 
-    // @ts-expect-error - private access
-    await store.reconcileMismatchReturnOnBlock(lock);
+    await orphanReleases.reconcileCandidateReturns(lock);
     expect(setReleaseError).toHaveBeenCalledTimes(1);
     expect(setReleaseError).toHaveBeenCalledWith(
       orphanRecord,
@@ -221,7 +223,7 @@ describe('BitcoinLocks release status sync', () => {
     );
   });
 
-  it('reconcileMismatchReturnOnBlock resumes bitcoin submission when argon state exists but tx tracking is missing', async () => {
+  it('reconcileCandidateReturns resumes bitcoin submission when argon state exists but tx tracking is missing', async () => {
     const lock = { utxoId: 11 } as IBitcoinLockRecord;
     const orphanRecord = createFundingRecord({
       id: 8,
@@ -232,29 +234,30 @@ describe('BitcoinLocks release status sync', () => {
       releaseBitcoinNetworkFee: 10n,
     });
     const setReleaseError = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
-    const submitOrphanReleaseToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const submitToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
 
-    const store = createStoreStub({
-      utxoTracking: {
-        getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
-        getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
-        setReleaseError,
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
+          getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError,
+        },
       },
-      getOrphanedReturnTxInfoForRecord: vi.fn().mockReturnValue(undefined),
-      submitOrphanReleaseToBitcoin,
+      getTransactionInfo: vi.fn().mockReturnValue(undefined),
+      submitToBitcoin,
     });
 
-    // @ts-expect-error - private access
-    await store.reconcileMismatchReturnOnBlock(lock);
-    expect(submitOrphanReleaseToBitcoin).toHaveBeenCalledTimes(1);
-    expect(submitOrphanReleaseToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
+    await orphanReleases.reconcileCandidateReturns(lock);
+    expect(submitToBitcoin).toHaveBeenCalledTimes(1);
+    expect(submitToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
       toScriptPubkey: orphanRecord.releaseToDestinationAddress,
       bitcoinNetworkFee: orphanRecord.releaseBitcoinNetworkFee,
     });
     expect(setReleaseError).not.toHaveBeenCalled();
   });
 
-  it('reconcileMismatchReturnOnBlock resumes bitcoin submission after recovering the orphan request from chain', async () => {
+  it('reconcileCandidateReturns resumes bitcoin submission after recovering the orphan request from chain', async () => {
     const lock = { utxoId: 11, lockDetails: createLockDetails() } as IBitcoinLockRecord;
     const orphanRecord = createFundingRecord({
       id: 18,
@@ -264,33 +267,34 @@ describe('BitcoinLocks release status sync', () => {
       releaseBitcoinNetworkFee: 10n,
     });
     const setReleaseError = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
-    const submitOrphanReleaseToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
-    const syncOrphanReleaseRequestFromChain = vi.fn<(...args: any[]) => Promise<boolean>>().mockResolvedValue(true);
+    const submitToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const syncReleaseRequestFromChain = vi.fn<(...args: any[]) => Promise<boolean>>().mockResolvedValue(true);
 
-    const store = createStoreStub({
-      utxoTracking: {
-        getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
-        getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
-        setReleaseError,
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
+          getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError,
+        },
       },
-      getOrphanedReturnTxInfoForRecord: vi.fn().mockReturnValue(undefined),
-      syncOrphanReleaseRequestFromChain,
-      submitOrphanReleaseToBitcoin,
+      getTransactionInfo: vi.fn().mockReturnValue(undefined),
+      syncReleaseRequestFromChain,
+      submitToBitcoin,
     });
 
-    // @ts-expect-error - private access
-    await store.reconcileMismatchReturnOnBlock(lock);
+    await orphanReleases.reconcileCandidateReturns(lock);
 
-    expect(syncOrphanReleaseRequestFromChain).toHaveBeenCalledWith(lock, orphanRecord);
-    expect(submitOrphanReleaseToBitcoin).toHaveBeenCalledTimes(1);
-    expect(submitOrphanReleaseToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
+    expect(syncReleaseRequestFromChain).toHaveBeenCalledWith(lock, orphanRecord);
+    expect(submitToBitcoin).toHaveBeenCalledTimes(1);
+    expect(submitToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
       toScriptPubkey: orphanRecord.releaseToDestinationAddress,
       bitcoinNetworkFee: orphanRecord.releaseBitcoinNetworkFee,
     });
     expect(setReleaseError).not.toHaveBeenCalled();
   });
 
-  it('reconcileMismatchReturnOnBlock stores confirmed orphan cosign data only after finalization', async () => {
+  it('reconcileCandidateReturns stores confirmed orphan cosign data only after finalization', async () => {
     const lock = { utxoId: 11 } as IBitcoinLockRecord;
     const orphanRecord = createFundingRecord({
       id: 9,
@@ -308,45 +312,122 @@ describe('BitcoinLocks release status sync', () => {
     const setReleaseCosign = vi.fn<(...args: any[]) => Promise<void>>().mockImplementation(async (record, update) => {
       Object.assign(record, update);
     });
-    const ensureOrphanReleaseObservedAtTick = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
-    const submitOrphanReleaseToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const ensureObservedAtTick = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const submitToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
     const txInfo = {
       tx: { status: TransactionStatus.Finalized },
       txResult: { blockNumber: 77 },
     } as any;
 
-    const store = createStoreStub({
-      utxoTracking: {
-        getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
-        getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
-        setReleaseError: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
-        setReleaseCosign,
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(undefined),
+          getMismatchOrphanReleases: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+          setReleaseCosign,
+        },
       },
-      getOrphanedReturnTxInfoForRecord: vi.fn().mockReturnValue(txInfo),
-      getTxFailureMessage: vi.fn().mockReturnValue(undefined),
-      ensureOrphanReleaseObservedAtTick,
-      createVaultSignatureForOrphanReturn: vi
-        .fn<(...args: any[]) => Promise<Uint8Array>>()
-        .mockResolvedValue(createdVaultSignature),
-      submitOrphanReleaseToBitcoin,
+      getTransactionInfo: vi.fn().mockReturnValue(txInfo),
+      ensureObservedAtTick,
+      createVaultSignature: vi.fn<(...args: any[]) => Promise<Uint8Array>>().mockResolvedValue(createdVaultSignature),
+      submitToBitcoin,
     });
 
-    // @ts-expect-error - private access
-    await store.reconcileMismatchReturnOnBlock(lock);
+    await orphanReleases.reconcileCandidateReturns(lock);
 
-    expect(ensureOrphanReleaseObservedAtTick).toHaveBeenCalledWith(orphanRecord, txInfo);
+    expect(ensureObservedAtTick).toHaveBeenCalledWith(orphanRecord, txInfo);
     expect(setReleaseCosign).toHaveBeenCalledWith(orphanRecord, {
       releaseCosignVaultSignature: createdVaultSignature,
       releaseCosignHeight: txInfo.txResult.blockNumber,
     });
-    expect(submitOrphanReleaseToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
+    expect(submitToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
       toScriptPubkey: orphanRecord.releaseToDestinationAddress,
       bitcoinNetworkFee: orphanRecord.releaseBitcoinNetworkFee,
       vaultSignature: createdVaultSignature,
     });
   });
 
-  it('reconcileMismatchReturnOnBlock excludes the accepted funding UTXO from orphan-return handling', async () => {
+  it('reconcileOrphanReturns keeps an observed chain request while waiting for the vault cosign', async () => {
+    const lock = { utxoId: 11 } as IBitcoinLockRecord;
+    const orphanRecord = createFundingRecord({
+      id: 19,
+      lockUtxoId: 11,
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
+      requestedReleaseAtTick: 123,
+      releaseToDestinationAddress: '0014abc123',
+      releaseBitcoinNetworkFee: 10n,
+    });
+    const submitToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const setReleaseError = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const getTransactionInfo = vi.fn().mockReturnValue({
+      tx: { status: TransactionStatus.Error },
+      txResult: { submissionError: new Error('A later duplicate attempt failed') },
+    });
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getUnresolvedOrphanRecords: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError,
+        },
+      },
+      getTransactionInfo,
+      submitToBitcoin,
+    });
+
+    await orphanReleases.reconcileOrphanReturns(lock);
+    expect(getTransactionInfo).not.toHaveBeenCalled();
+    expect(setReleaseError).not.toHaveBeenCalled();
+    expect(submitToBitcoin).not.toHaveBeenCalled();
+
+    orphanRecord.releaseCosignVaultSignature = new Uint8Array([4, 5, 6]);
+    orphanRecord.releaseCosignHeight = 77;
+    await orphanReleases.reconcileOrphanReturns(lock);
+
+    expect(submitToBitcoin).toHaveBeenCalledWith(lock, orphanRecord, {
+      toScriptPubkey: orphanRecord.releaseToDestinationAddress,
+      bitcoinNetworkFee: orphanRecord.releaseBitcoinNetworkFee,
+      vaultSignature: orphanRecord.releaseCosignVaultSignature,
+    });
+  });
+
+  it('reconcileOrphanReturns recovers a chain request before accepting a failed local attempt', async () => {
+    const lock = { utxoId: 11 } as IBitcoinLockRecord;
+    const orphanRecord = createFundingRecord({
+      id: 19,
+      lockUtxoId: 11,
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
+      requestedReleaseAtTick: undefined,
+      releaseToDestinationAddress: '0014abc123',
+      releaseBitcoinNetworkFee: 10n,
+    });
+    const setReleaseError = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const syncReleaseRequestFromChain = vi.fn().mockImplementation(async () => {
+      orphanRecord.requestedReleaseAtTick = 123;
+      return true;
+    });
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        utxoTracking: {
+          getUnresolvedOrphanRecords: vi.fn().mockReturnValue([orphanRecord]),
+          setReleaseError,
+        },
+      },
+      getTransactionInfo: vi.fn().mockReturnValue({
+        tx: { status: TransactionStatus.Error },
+        txResult: { submissionError: new Error('The local attempt failed') },
+      }),
+      syncReleaseRequestFromChain,
+      submitToBitcoin: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+    });
+
+    await orphanReleases.reconcileOrphanReturns(lock);
+
+    expect(syncReleaseRequestFromChain).toHaveBeenCalledWith(lock, orphanRecord);
+    expect(setReleaseError).not.toHaveBeenCalled();
+  });
+
+  it('reconcileCandidateReturns excludes the accepted funding UTXO from orphan-return handling', async () => {
     const fundingRecord = createFundingRecord({
       id: 12,
       lockUtxoId: 11,
@@ -355,7 +436,7 @@ describe('BitcoinLocks release status sync', () => {
       releaseToDestinationAddress: '0014abc123',
       releaseBitcoinNetworkFee: 10n,
     });
-    const submitOrphanReleaseToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
+    const submitToBitcoin = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined);
     const lockCases: IBitcoinLockRecord[] = [
       {
         utxoId: 11,
@@ -370,26 +451,27 @@ describe('BitcoinLocks release status sync', () => {
 
     for (const lock of lockCases) {
       const getMismatchOrphanReleases = vi.fn().mockReturnValue([]);
-      const store = createStoreStub({
-        utxoTracking: {
-          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(fundingRecord),
-          getMismatchOrphanReleases,
-          setReleaseError: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+      const orphanReleases = createOrphanReleasesStub({
+        bitcoinLocks: {
+          utxoTracking: {
+            getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(fundingRecord),
+            getMismatchOrphanReleases,
+            setReleaseError: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+          },
         },
-        getOrphanedReturnTxInfoForRecord: vi.fn().mockReturnValue(undefined),
-        submitOrphanReleaseToBitcoin,
+        getTransactionInfo: vi.fn().mockReturnValue(undefined),
+        submitToBitcoin,
       });
 
-      // @ts-expect-error - private access
-      await store.reconcileMismatchReturnOnBlock(lock);
+      await orphanReleases.reconcileCandidateReturns(lock);
 
       expect(getMismatchOrphanReleases).toHaveBeenCalledWith(lock.utxoId, undefined, fundingRecord.id);
     }
 
-    expect(submitOrphanReleaseToBitcoin).not.toHaveBeenCalled();
+    expect(submitToBitcoin).not.toHaveBeenCalled();
   });
 
-  it('submitOrphanReleaseToBitcoin treats duplicate orphan broadcasts as already submitted', async () => {
+  it('submitToBitcoin treats duplicate orphan broadcasts as already submitted', async () => {
     const db = await createTestDb();
     const orphanReturnTxid = 'b'.repeat(64);
     const getTxStatus = vi.fn().mockResolvedValue(undefined);
@@ -434,7 +516,7 @@ describe('BitcoinLocks release status sync', () => {
 
     try {
       // @ts-expect-error - private access
-      await store.submitOrphanReleaseToBitcoin(lock, orphanRecord, {
+      await store.orphanReleases.submitToBitcoin(lock, orphanRecord, {
         toScriptPubkey: '0014abc123',
         bitcoinNetworkFee: 10n,
         vaultSignature: new Uint8Array([1, 2, 3]),
@@ -449,7 +531,7 @@ describe('BitcoinLocks release status sync', () => {
     expect(setReleaseError).not.toHaveBeenCalled();
   });
 
-  it('submitOrphanReleaseToBitcoin reuses a confirmed orphan return txid on restart', async () => {
+  it('submitToBitcoin reuses a confirmed orphan return txid on restart', async () => {
     const db = await createTestDb();
     const orphanReturnTxid = 'c'.repeat(64);
     const existingTxStatus: IMempoolTxStatus = {
@@ -497,7 +579,7 @@ describe('BitcoinLocks release status sync', () => {
 
     try {
       // @ts-expect-error - private access
-      await store.submitOrphanReleaseToBitcoin(lock, orphanRecord, {
+      await store.orphanReleases.submitToBitcoin(lock, orphanRecord, {
         toScriptPubkey: '0014abc123',
         bitcoinNetworkFee: 10n,
         vaultSignature: new Uint8Array([1, 2, 3]),
@@ -583,10 +665,16 @@ function createStoreStub(overrides: object): BitcoinLocks {
   return Object.assign(Object.create(BitcoinLocks.prototype), overrides) as BitcoinLocks;
 }
 
+function createOrphanReleasesStub({ bitcoinLocks, ...overrides }: any): BitcoinOrphanReleases {
+  return Object.assign(Object.create(BitcoinOrphanReleases.prototype), {
+    bitcoinLocks,
+    ...overrides,
+  }) as BitcoinOrphanReleases;
+}
+
 function createReleaseFlowHarness(args?: {
   waitForInFirstBlock?: Promise<unknown>;
   waitForFinalizedBlock?: Promise<unknown>;
-  txFailure?: string | undefined;
 }) {
   const lock = createLockRecord({
     uuid: 'lock-1',
@@ -602,7 +690,6 @@ function createReleaseFlowHarness(args?: {
   });
   const state = {
     releaseCosignOnChain: undefined as { blockHeight: number; signature: Uint8Array } | undefined,
-    txFailure: args?.txFailure,
     blockNumber: undefined as number | undefined,
     waitForInFirstBlock: args?.waitForInFirstBlock ?? Promise.resolve('0x1234'),
     waitForFinalizedBlock: args?.waitForFinalizedBlock ?? Promise.resolve('0x1234'),
@@ -617,6 +704,7 @@ function createReleaseFlowHarness(args?: {
   const cosignMyLock = vi.fn<(...args: any[]) => Promise<any>>().mockImplementation(async () => {
     return {
       txInfo: {
+        tx: { status: TransactionStatus.Submitted },
         txResult: {
           blockNumber: state.blockNumber,
           waitForInFirstBlock: state.waitForInFirstBlock,
@@ -666,10 +754,8 @@ function createReleaseFlowHarness(args?: {
       vaultId: 1,
       cosignMyLock,
     },
-    reconcileMismatchReturnOnBlock: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
     getAcceptedFundingRecord: vi.fn().mockReturnValue(fundingRecord),
     getReleaseCosignOnChain: vi.fn(async () => state.releaseCosignOnChain),
-    getTxFailureMessage: vi.fn(() => state.txFailure),
     ensureLockReleaseProcessing,
     syncLockReleaseStatusFromFundingRecord: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
     syncLockReleaseArgonRequest: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),

--- a/src-vue/__test__/BitcoinUtxoTracking.test.ts
+++ b/src-vue/__test__/BitcoinUtxoTracking.test.ts
@@ -577,14 +577,26 @@ describe('BitcoinUtxoTracking', () => {
       uuid: 'lock-3',
       lockDetails: { ...createLockDetails(), ownerAccount: 'owner-2' },
     });
-    const orphanEntry = (utxoId: number, txid: string, vout: number, satoshis: bigint) => [
+    const orphanEntry = (
+      utxoId: number,
+      txid: string,
+      vout: number,
+      satoshis: bigint,
+      releaseRequest?: { bitcoinNetworkFee: bigint; toScriptPubkey: Uint8Array },
+    ) => [
       { args: [{}, { txid: { toHex: () => txid }, outputIndex: { toNumber: () => vout } }] },
       {
         isNone: false,
         unwrap: () => ({
           utxoId: { toNumber: () => utxoId },
           satoshis: { toBigInt: () => satoshis },
-          cosignRequest: { isSome: false },
+          cosignRequest: {
+            isSome: !!releaseRequest,
+            unwrap: () => ({
+              bitcoinNetworkFee: { toBigInt: () => releaseRequest!.bitcoinNetworkFee },
+              toScriptPubkey: releaseRequest!.toScriptPubkey,
+            }),
+          },
         }),
       },
     ];
@@ -593,7 +605,10 @@ describe('BitcoinUtxoTracking', () => {
         return [orphanEntry(3, 'c'.repeat(64), 0, 12_000n)];
       }
       return [
-        orphanEntry(1, 'a'.repeat(64), 0, 10_000n),
+        orphanEntry(1, 'a'.repeat(64), 0, 10_000n, {
+          bitcoinNetworkFee: 250n,
+          toScriptPubkey: new Uint8Array([0, 20, 171]),
+        }),
         orphanEntry(1, 'b'.repeat(64), 1, 11_000n),
         orphanEntry(99, 'f'.repeat(64), 0, 99_000n),
       ];
@@ -610,6 +625,12 @@ describe('BitcoinUtxoTracking', () => {
       `1:${'b'.repeat(64)}:1`,
       `3:${'c'.repeat(64)}:0`,
     ]);
+    expect(records[0]).toEqual(
+      expect.objectContaining({
+        releaseBitcoinNetworkFee: 250n,
+        releaseToDestinationAddress: '0014ab',
+      }),
+    );
 
     await tracking.syncArgonOrphans([firstLock, secondLock, thirdLock], client);
     expect(tracking.getUtxosForLock(firstLock)).toHaveLength(2);

--- a/src-vue/__test__/BitcoinUtxoTracking.test.ts
+++ b/src-vue/__test__/BitcoinUtxoTracking.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import * as Vue from 'vue';
 import { BitcoinNetwork } from '@argonprotocol/bitcoin';
 import { createTestDb } from './helpers/db.ts';
 import BitcoinUtxoTracking, { type IUtxoTrackingDeps } from '../lib/BitcoinUtxoTracking.ts';
@@ -489,6 +490,7 @@ describe('BitcoinUtxoTracking', () => {
   it('marks sibling funding candidates orphaned when a funding utxo is accepted', async () => {
     const db = await createTestDb();
     const tracking = createTracking(db);
+    tracking.data = Vue.reactive(tracking.data) as typeof tracking.data;
     const lock = createLock({ status: BitcoinLockStatus.LockPendingFunding, satoshis: 10_000n });
 
     const acceptedRecord = await tracking.upsertUtxoRecord(
@@ -501,14 +503,155 @@ describe('BitcoinUtxoTracking', () => {
       { txid: '9'.repeat(64), vout: 1, satoshis: lock.satoshis + 200n },
       { markArgonCandidate: true },
     );
+    const unresolvedOrphans = Vue.computed(() => tracking.getUnresolvedOrphanRecords([lock]));
+    expect(unresolvedOrphans.value).toEqual([]);
 
     await tracking.setAcceptedFundingRecordForLock(lock, acceptedRecord);
 
     expect(acceptedRecord.status).toBe(BitcoinUtxoStatus.FundingUtxo);
     expect(siblingCandidate.status).toBe(BitcoinUtxoStatus.Orphaned);
     expect(tracking.getFundingCandidateRecords(lock)).toEqual([]);
+    expect(unresolvedOrphans.value).toEqual([siblingCandidate]);
 
     const history = await db.bitcoinUtxosTable.fetchStatusHistory(siblingCandidate.id);
     expect(history.at(-1)?.newStatus).toBe(BitcoinUtxoStatus.Orphaned);
+  });
+
+  it('selects unresolved orphan records independently from their lock state', async () => {
+    const db = await createTestDb();
+    const tracking = createTracking(db);
+    const lock = createLock({ status: BitcoinLockStatus.LockedAndMinted });
+    const fundingRecord = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'a'.repeat(64), vout: 0, satoshis: lock.satoshis },
+      { markFundingUtxo: true },
+    );
+    const mismatchReturn = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'e'.repeat(64), vout: 4, satoshis: lock.satoshis + 1_000n },
+      { markArgonCandidate: true },
+    );
+    const exactAmountOrphan = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'b'.repeat(64), vout: 1, satoshis: lock.satoshis },
+      { markOrphaned: true },
+    );
+    const returningOrphan = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'c'.repeat(64), vout: 2, satoshis: lock.satoshis + 500n },
+      { markOrphaned: true },
+    );
+    const returnedOrphan = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'd'.repeat(64), vout: 3, satoshis: lock.satoshis - 500n },
+      { markOrphaned: true },
+    );
+
+    await tracking.setReleaseIsProcessingOnArgon(fundingRecord, {
+      releaseToDestinationAddress: '0014aaaa',
+      releaseBitcoinNetworkFee: 100n,
+    });
+    await tracking.setReleaseIsProcessingOnArgon(mismatchReturn, {
+      releaseToDestinationAddress: '0014cccc',
+      releaseBitcoinNetworkFee: 300n,
+    });
+    await tracking.setReleaseIsProcessingOnArgon(returningOrphan, {
+      releaseToDestinationAddress: '0014bbbb',
+      releaseBitcoinNetworkFee: 200n,
+    });
+    await tracking.setReleaseComplete(returnedOrphan, 120);
+
+    const records = tracking.getUnresolvedOrphanRecords([lock]);
+    expect(records).toHaveLength(2);
+    expect(records).toEqual(expect.arrayContaining([returningOrphan, exactAmountOrphan]));
+    expect(tracking.getMismatchOrphanReleases(lock.utxoId!, undefined, fundingRecord.id)).toEqual([mismatchReturn]);
+  });
+
+  it('synchronizes all chain orphans with one query per owner', async () => {
+    const db = await createTestDb();
+    const tracking = createTracking(db);
+    const firstLock = createLock({ utxoId: 1, uuid: 'lock-1' });
+    const secondLock = createLock({ utxoId: 2, uuid: 'lock-2' });
+    const thirdLock = createLock({
+      utxoId: 3,
+      uuid: 'lock-3',
+      lockDetails: { ...createLockDetails(), ownerAccount: 'owner-2' },
+    });
+    const orphanEntry = (utxoId: number, txid: string, vout: number, satoshis: bigint) => [
+      { args: [{}, { txid: { toHex: () => txid }, outputIndex: { toNumber: () => vout } }] },
+      {
+        isNone: false,
+        unwrap: () => ({
+          utxoId: { toNumber: () => utxoId },
+          satoshis: { toBigInt: () => satoshis },
+          cosignRequest: { isSome: false },
+        }),
+      },
+    ];
+    const entries = vi.fn().mockImplementation(async (owner: string) => {
+      if (owner === thirdLock.lockDetails.ownerAccount) {
+        return [orphanEntry(3, 'c'.repeat(64), 0, 12_000n)];
+      }
+      return [
+        orphanEntry(1, 'a'.repeat(64), 0, 10_000n),
+        orphanEntry(1, 'b'.repeat(64), 1, 11_000n),
+        orphanEntry(99, 'f'.repeat(64), 0, 99_000n),
+      ];
+    });
+    const client = {
+      query: { bitcoinLocks: { orphanedUtxosByAccount: { entries } } },
+    } as unknown as ArgonClient;
+
+    const records = await tracking.syncArgonOrphans([firstLock, secondLock, thirdLock], client);
+
+    expect(entries).toHaveBeenCalledTimes(2);
+    expect(records.map(record => `${record.lockUtxoId}:${record.txid}:${record.vout}`)).toEqual([
+      `1:${'a'.repeat(64)}:0`,
+      `1:${'b'.repeat(64)}:1`,
+      `3:${'c'.repeat(64)}:0`,
+    ]);
+
+    await tracking.syncArgonOrphans([firstLock, secondLock, thirdLock], client);
+    expect(tracking.getUtxosForLock(firstLock)).toHaveLength(2);
+    expect(tracking.getUtxosForLock(thirdLock)).toHaveLength(1);
+  });
+
+  it('restores an orphan return and its release state after restart', async () => {
+    const db = await createTestDb();
+    const lock = createLock();
+    const tracking = createTracking(db);
+    const record = await tracking.upsertUtxoRecord(
+      lock,
+      { txid: 'a'.repeat(64), vout: 2, satoshis: 12_000n },
+      { markOrphaned: true },
+    );
+
+    await tracking.setReleaseIsProcessingOnArgon(record, {
+      requestedReleaseAtTick: 321,
+      releaseToDestinationAddress: '0014abc123',
+      releaseBitcoinNetworkFee: 200n,
+    });
+    await tracking.setReleaseCosign(record, {
+      releaseCosignVaultSignature: new Uint8Array([1, 2, 3]),
+      releaseCosignHeight: 456,
+    });
+    await tracking.setReleaseSeenOnBitcoinAndProcessing(record, 'b'.repeat(64), 789);
+
+    const restartedTracking = createTracking(db);
+    await restartedTracking.load();
+
+    expect(restartedTracking.getUnresolvedOrphanRecords([lock])).toEqual([
+      expect.objectContaining({
+        id: record.id,
+        status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+        requestedReleaseAtTick: 321,
+        releaseToDestinationAddress: '0014abc123',
+        releaseBitcoinNetworkFee: 200n,
+        releaseCosignVaultSignature: new Uint8Array([1, 2, 3]),
+        releaseCosignHeight: 456,
+        releaseTxid: 'b'.repeat(64),
+        releaseFirstSeenBitcoinHeight: 789,
+      }),
+    ]);
   });
 });

--- a/src-vue/__test__/EthereumCrosschain.integration.test.ts
+++ b/src-vue/__test__/EthereumCrosschain.integration.test.ts
@@ -422,6 +422,7 @@ describe.skipIf(skipE2E || !TestEthereum.isInstalled())('EthereumCrosschain inte
       }
 
       const collectTx = await myVault.collect({ moveTo: MoveTo.DefaultArgon });
+      if (!collectTx) throw new Error('Expected the pending council approval to produce a collect transaction.');
       await collectTx.txResult.waitForFinalizedBlock;
       await collectTx.waitForPostProcessing;
       expect(collectTx.tx.extrinsicType).toBe('CrosschainTransferApproveCouncil');

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -151,7 +151,7 @@ describe('FinancialHistoryImporter', () => {
               bitcoin: {
                 asOfBlock: 90,
                 definitionVersion: 2,
-                recoveryVersion: 6,
+                recoveryVersion: 7,
                 partialRecovery: true,
               },
             },
@@ -233,7 +233,7 @@ describe('FinancialHistoryImporter', () => {
         asOfBlock: 100,
         domains: ['bitcoin'],
         domainCheckpoints: {
-          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 6 },
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 7 },
         },
       }),
     );
@@ -409,7 +409,7 @@ describe('FinancialHistoryImporter', () => {
           bitcoin: {
             asOfBlock: 8,
             definitionVersion: 2,
-            recoveryVersion: 6,
+            recoveryVersion: 7,
             partialRecovery: true,
           },
         },
@@ -503,9 +503,9 @@ describe('FinancialHistoryImporter', () => {
       SyncStateKeys.FinancialHistory,
       expect.objectContaining({
         asOfBlock: 100,
-        recoveryVersions: { bitcoin: 6 },
+        recoveryVersions: { bitcoin: 7 },
         domainCheckpoints: {
-          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 6 },
+          bitcoin: { asOfBlock: 100, definitionVersion: 2, recoveryVersion: 7 },
         },
       }),
     );

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -64,6 +64,75 @@ describe('MyVaultRecovery', () => {
 });
 
 describe('MyVault cosign recovery', () => {
+  it('keeps orphan release signatures in operator alert state', async () => {
+    const unsubscribe = vi.fn();
+    const subscribeStorage = vi.fn(async () => unsubscribe);
+    const orphanEntries = vi
+      .fn()
+      .mockResolvedValueOnce([[{}, numberCodec(2)]])
+      .mockResolvedValueOnce([[{}, numberCodec(3)]]);
+    const client = {
+      clientType: 'pruned',
+      query: {
+        vaults: {
+          vaultsById: subscribeStorage,
+          revenuePerFrameByVault: subscribeStorage,
+          pendingCosignByVaultId: subscribeStorage,
+          lastCollectFrameByVaultId: subscribeStorage,
+          argonotCommitmentByVaultId: subscribeStorage,
+          orphanedUtxoAccountsByVaultId: { entries: orphanEntries },
+        },
+      },
+      on: vi.fn(),
+    };
+    const requestEvent = { data: { vaultId: numberCodec(7) } };
+    const unrelatedEvent = { is: () => false };
+    const eventClient = {
+      events: {
+        bitcoinLocks: {
+          BitcoinLockCreated: unrelatedEvent,
+          BitcoinLockRatcheted: unrelatedEvent,
+          BitcoinUtxoCosignRequested: unrelatedEvent,
+          BitcoinUtxoCosigned: unrelatedEvent,
+          BitcoinCosignPastDue: unrelatedEvent,
+          BitcoinLockBurned: unrelatedEvent,
+          OrphanedUtxoReleaseRequested: { is: (event: unknown) => event === requestEvent },
+          OrphanedUtxoCosigned: unrelatedEvent,
+        },
+      },
+      query: {
+        vaults: {
+          orphanedUtxoAccountsByVaultId: { entries: orphanEntries },
+        },
+      },
+    };
+    const clients = {
+      get: vi.fn(async () => client),
+      events: { on: vi.fn(() => unsubscribe) },
+    };
+    const getMainchainClients = vi.spyOn(mainchainStore, 'getMainchainClients').mockReturnValue(clients as any);
+    const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue(eventClient as any);
+    const { myVault, blockWatchEventOn, getBlockEvents } = createVault({ blockEvents: [{ event: requestEvent }] });
+    myVault.data.createdVault = { vaultId: 7 } as Vault;
+    myVault.data.metadata = { id: 7 } as any;
+    vi.spyOn(myVault as unknown as IMyVaultTestTarget, 'updateCollectDeadlines').mockImplementation(() => undefined);
+
+    await myVault.subscribe();
+
+    expect(myVault.data.pendingOrphanCosignCount).toBe(2);
+
+    const onBestBlocks = blockWatchEventOn.mock.calls.find(([event]) => event === 'best-blocks')![1];
+    onBestBlocks([{ blockNumber: 10, blockHash: '0x10' }]);
+    await vi.waitFor(() => {
+      expect(myVault.data.pendingOrphanCosignCount).toBe(3);
+    });
+    expect(getBlockEvents).toHaveBeenCalledTimes(1);
+
+    myVault.unsubscribe();
+    getMainchainClient.mockRestore();
+    getMainchainClients.mockRestore();
+  });
+
   it('does not add the informational tip to the actual transaction fee twice', () => {
     const { myVault } = createVault();
     myVault.data.metadata = { operationalFeeMicrogons: 10n } as any;
@@ -689,7 +758,7 @@ describe('MyVault cosign recovery', () => {
       },
       submittedCosignUtxoIds: [],
     });
-    vi.spyOn(myVault as any, 'onVaultCollect').mockResolvedValue(undefined);
+    vi.spyOn(myVault as any, 'onVaultCollect').mockRejectedValue(new Error('post-processing failed'));
 
     const result = await myVault.collect({ moveTo: 'VaultingHold' as any });
 
@@ -709,13 +778,80 @@ describe('MyVault cosign recovery', () => {
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue({} as any);
     vi.spyOn(myVault.collectBuilder, 'buildPendingSubmission').mockResolvedValue(undefined);
 
-    await expect(myVault.collect({ moveTo: 'VaultingHold' as any })).rejects.toThrow(
-      'No vault actions are currently available to submit.',
-    );
+    await expect(myVault.collect({ moveTo: 'VaultingHold' as any })).resolves.toBeUndefined();
     expect(mintingAuthorities.authorize).not.toHaveBeenCalled();
 
     getFinalizedClient.mockRestore();
     getMainchainClient.mockRestore();
+  });
+
+  it('submits all current orphan cosigns before collecting revenue', async () => {
+    const firstOrphanTx = { kind: 'first-orphan-cosign' };
+    const secondOrphanTx = { kind: 'second-orphan-cosign' };
+    const collectTx = { kind: 'collect' };
+    const batchAll = vi.fn(() => ({ kind: 'batch' }));
+    const collect = vi.fn(() => collectTx);
+    const client = {
+      query: {
+        vaults: {
+          pendingCosignByVaultId: vi.fn().mockResolvedValue([]),
+          revenuePerFrameByVault: vi.fn().mockResolvedValue([{ uncollectedRevenue: { toBigInt: () => 40n } }]),
+        },
+      },
+      tx: {
+        utility: { batchAll },
+        vaults: { collect },
+      },
+    };
+    const finalizedClient = {};
+    const { myVault } = createVault();
+    myVault.data.createdVault = { vaultId: 7 } as any;
+    myVault.data.pendingOrphanCosignCount = 2;
+    const firstOrphanMetadata = {
+      lockUtxoId: 8,
+      ownerAccount: 'owner-1',
+      txid: 'a'.repeat(64),
+      vout: 2,
+      vaultSignatureHex: '0x1234',
+    };
+    const secondOrphanMetadata = {
+      ...firstOrphanMetadata,
+      txid: 'b'.repeat(64),
+    };
+    const buildPendingOrphanCosignTxs = vi
+      .spyOn(myVault as unknown as IMyVaultTestTarget, 'buildPendingOrphanCosignTxs')
+      .mockResolvedValueOnce([{ tx: firstOrphanTx, metadata: firstOrphanMetadata }])
+      .mockResolvedValueOnce([
+        { tx: firstOrphanTx, metadata: firstOrphanMetadata },
+        { tx: secondOrphanTx, metadata: secondOrphanMetadata },
+      ]);
+
+    const partialSubmission = await myVault.collectBuilder.buildPendingSubmission({
+      client: client as any,
+      finalizedClient: finalizedClient as any,
+      moveTo: 'VaultingHold' as any,
+    });
+
+    expect(collect).not.toHaveBeenCalled();
+    expect(partialSubmission?.tx).toBe(firstOrphanTx);
+    expect(partialSubmission?.metadata.actionType).toBe('cosignBitcoin');
+
+    const completeSubmission = await myVault.collectBuilder.buildPendingSubmission({
+      client: client as any,
+      finalizedClient: finalizedClient as any,
+      moveTo: 'VaultingHold' as any,
+    });
+
+    expect(buildPendingOrphanCosignTxs).toHaveBeenCalledWith({
+      finalizedClient,
+      submitClient: client,
+      vaultId: 7,
+    });
+    expect(batchAll).toHaveBeenCalledWith([firstOrphanTx, secondOrphanTx, collectTx]);
+    expect(completeSubmission?.metadata).toMatchObject({
+      actionType: 'collectRevenue',
+      cosignedOrphanUtxos: [firstOrphanMetadata, secondOrphanMetadata],
+    });
   });
 
   it('batches council approvals into collect work', async () => {
@@ -1295,9 +1431,16 @@ function createVault(args?: {
   db?: Record<string, unknown>;
   walletKeys?: ReturnType<typeof createMockWalletKeys>;
   ensureStoredEvents?: ReturnType<typeof vi.fn>;
+  blockEvents?: unknown[];
 }) {
+  const blockWatchEventOn = vi.fn(
+    (_event: string, _callback: (headers: { blockNumber: number; blockHash: string }[]) => void) => vi.fn(),
+  );
+  const getBlockEvents = vi.fn(async () => args?.blockEvents ?? []);
   const blockWatch = {
     finalizedBlockHeader: { blockNumber: args?.finalizedHeight ?? 100 },
+    events: { on: blockWatchEventOn },
+    getEvents: getBlockEvents,
     getFinalizedApi: vi.fn(async () => ({})),
     getHeader: vi.fn(async (blockHeight: number) => {
       return {
@@ -1396,8 +1539,10 @@ function createVault(args?: {
     }),
     getTxAttemptState,
   } as unknown as TransactionTracker;
+  const onFrameId = vi.fn((_callback: (frameId: number) => void) => ({ unsubscribe: vi.fn() }));
   const miningFrames = {
     blockWatch,
+    onFrameId,
     getFrameDate: vi.fn(() => new Date('2026-01-01T00:00:00Z')),
   } as unknown as MiningFrames;
   const bitcoinLocks = {} as BitcoinLocks;
@@ -1479,6 +1624,9 @@ function createVault(args?: {
   return {
     myVault,
     blockWatch,
+    blockWatchEventOn,
+    getBlockEvents,
+    onFrameId,
     globalCouncil,
     mintingAuthorities,
     submitAndWatch,

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -64,13 +64,41 @@ describe('MyVaultRecovery', () => {
 });
 
 describe('MyVault cosign recovery', () => {
-  it('keeps orphan release signatures in operator alert state', async () => {
+  it('updates collect alert state from finalized data', async () => {
     const unsubscribe = vi.fn();
     const subscribeStorage = vi.fn(async () => unsubscribe);
+    const frameRevenues = vi
+      .fn()
+      .mockResolvedValueOnce([{ frameId: numberCodec(1), uncollectedRevenue: bigintCodec(42n) }])
+      .mockResolvedValueOnce([{ frameId: numberCodec(1), uncollectedRevenue: bigintCodec(84n) }]);
     const orphanEntries = vi
       .fn()
       .mockResolvedValueOnce([[{}, numberCodec(2)]])
       .mockResolvedValueOnce([[{}, numberCodec(3)]]);
+    const requestEvent = {
+      section: 'bitcoinLocks',
+      method: 'OrphanedUtxoReleaseRequested',
+      data: { vaultId: numberCodec(7) },
+    };
+    const vaultEvent = { section: 'vaults', method: 'FundsLocked', data: { vaultId: numberCodec(7) } };
+    const blockEvents: { event: unknown }[] = [{ event: requestEvent }];
+    const eventMatcher = (method: string) => ({ is: (event: { method?: string }) => event.method === method });
+    const unrelatedEvent = eventMatcher('Unrelated');
+    const bitcoinEvents = {
+      BitcoinLockCreated: eventMatcher('BitcoinLockCreated'),
+      BitcoinLockRatcheted: unrelatedEvent,
+      BitcoinUtxoCosignRequested: unrelatedEvent,
+      BitcoinUtxoCosigned: unrelatedEvent,
+      BitcoinCosignPastDue: unrelatedEvent,
+      BitcoinLockBurned: unrelatedEvent,
+      OrphanedUtxoReleaseRequested: eventMatcher('OrphanedUtxoReleaseRequested'),
+      OrphanedUtxoCosigned: unrelatedEvent,
+    };
+    const vaultEvents = {
+      FundsLocked: eventMatcher('FundsLocked'),
+      VaultCollected: unrelatedEvent,
+      VaultRevenueUncollected: unrelatedEvent,
+    };
     const client = {
       clientType: 'pruned',
       query: {
@@ -80,28 +108,19 @@ describe('MyVault cosign recovery', () => {
           pendingCosignByVaultId: subscribeStorage,
           lastCollectFrameByVaultId: subscribeStorage,
           argonotCommitmentByVaultId: subscribeStorage,
-          orphanedUtxoAccountsByVaultId: { entries: orphanEntries },
         },
       },
       on: vi.fn(),
     };
-    const requestEvent = { data: { vaultId: numberCodec(7) } };
-    const unrelatedEvent = { is: () => false };
     const eventClient = {
-      events: {
-        bitcoinLocks: {
-          BitcoinLockCreated: unrelatedEvent,
-          BitcoinLockRatcheted: unrelatedEvent,
-          BitcoinUtxoCosignRequested: unrelatedEvent,
-          BitcoinUtxoCosigned: unrelatedEvent,
-          BitcoinCosignPastDue: unrelatedEvent,
-          BitcoinLockBurned: unrelatedEvent,
-          OrphanedUtxoReleaseRequested: { is: (event: unknown) => event === requestEvent },
-          OrphanedUtxoCosigned: unrelatedEvent,
-        },
-      },
+      events: { bitcoinLocks: bitcoinEvents },
+    };
+    const finalizedApi = {
+      events: { bitcoinLocks: bitcoinEvents, vaults: vaultEvents },
       query: {
         vaults: {
+          revenuePerFrameByVault: frameRevenues,
+          pendingCosignByVaultId: vi.fn(async () => []),
           orphanedUtxoAccountsByVaultId: { entries: orphanEntries },
         },
       },
@@ -112,7 +131,10 @@ describe('MyVault cosign recovery', () => {
     };
     const getMainchainClients = vi.spyOn(mainchainStore, 'getMainchainClients').mockReturnValue(clients as any);
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue(eventClient as any);
-    const { myVault, blockWatchEventOn, getBlockEvents } = createVault({ blockEvents: [{ event: requestEvent }] });
+    const { myVault, blockWatchEventOn, getBlockEvents, getBlockEventsWithSpec } = createVault({
+      blockEvents,
+      finalizedApi,
+    });
     myVault.data.createdVault = { vaultId: 7 } as Vault;
     myVault.data.metadata = { id: 7 } as any;
     vi.spyOn(myVault as unknown as IMyVaultTestTarget, 'updateCollectDeadlines').mockImplementation(() => undefined);
@@ -120,13 +142,40 @@ describe('MyVault cosign recovery', () => {
     await myVault.subscribe();
 
     expect(myVault.data.pendingOrphanCosignCount).toBe(2);
+    expect(myVault.data.pendingCollectRevenue).toBe(42n);
 
     const onBestBlocks = blockWatchEventOn.mock.calls.find(([event]) => event === 'best-blocks')![1];
     onBestBlocks([{ blockNumber: 10, blockHash: '0x10' }]);
     await vi.waitFor(() => {
-      expect(myVault.data.pendingOrphanCosignCount).toBe(3);
+      expect(getBlockEvents).toHaveBeenCalledTimes(1);
     });
-    expect(getBlockEvents).toHaveBeenCalledTimes(1);
+    expect(myVault.data.pendingOrphanCosignCount).toBe(2);
+    expect(myVault.data.pendingCollectRevenue).toBe(42n);
+
+    const onFinalized = blockWatchEventOn.mock.calls.find(([event]) => event === 'finalized')![1];
+    blockEvents.splice(
+      0,
+      1,
+      { event: { method: 'BitcoinLockCreated', data: { vaultId: numberCodec(7) } } },
+      { event: { method: 'OrphanedUtxoReleaseRequested', data: { vaultId: numberCodec(8) } } },
+      { event: { method: 'FundsLocked', data: { vaultId: numberCodec(8) } } },
+    );
+    await onFinalized([{ blockNumber: 9, blockHash: '0x09' }]);
+
+    expect(orphanEntries).toHaveBeenCalledTimes(1);
+    expect(frameRevenues).toHaveBeenCalledTimes(1);
+
+    blockEvents.splice(0, blockEvents.length, { event: requestEvent });
+    await onFinalized([{ blockNumber: 10, blockHash: '0x10' }]);
+
+    expect(myVault.data.pendingOrphanCosignCount).toBe(3);
+    expect(myVault.data.pendingCollectRevenue).toBe(42n);
+
+    blockEvents.splice(0, 1, { event: vaultEvent });
+    await onFinalized([{ blockNumber: 11, blockHash: '0x11' }]);
+
+    expect(myVault.data.pendingCollectRevenue).toBe(84n);
+    expect(getBlockEventsWithSpec).toHaveBeenCalledTimes(3);
 
     myVault.unsubscribe();
     getMainchainClient.mockRestore();
@@ -796,6 +845,9 @@ describe('MyVault cosign recovery', () => {
         vaults: {
           pendingCosignByVaultId: vi.fn().mockResolvedValue([]),
           revenuePerFrameByVault: vi.fn().mockResolvedValue([{ uncollectedRevenue: { toBigInt: () => 40n } }]),
+          orphanedUtxoAccountsByVaultId: {
+            entries: vi.fn().mockResolvedValue([[{}, numberCodec(2)]]),
+          },
         },
       },
       tx: {
@@ -803,7 +855,7 @@ describe('MyVault cosign recovery', () => {
         vaults: { collect },
       },
     };
-    const finalizedClient = {};
+    const finalizedClient = client;
     const { myVault } = createVault();
     myVault.data.createdVault = { vaultId: 7 } as any;
     myVault.data.pendingOrphanCosignCount = 2;
@@ -863,6 +915,7 @@ describe('MyVault cosign recovery', () => {
         vaults: {
           pendingCosignByVaultId: vi.fn().mockResolvedValue([]),
           revenuePerFrameByVault: vi.fn().mockResolvedValue([{ uncollectedRevenue: { toBigInt: () => 40n } }]),
+          orphanedUtxoAccountsByVaultId: { entries: vi.fn().mockResolvedValue([]) },
         },
       },
       tx: {
@@ -898,7 +951,7 @@ describe('MyVault cosign recovery', () => {
 
     const submission = await myVault.collectBuilder.buildPendingSubmission({
       client: client as any,
-      finalizedClient: {} as any,
+      finalizedClient: client as any,
       moveTo: 'VaultingHold' as any,
     });
 
@@ -932,6 +985,7 @@ describe('MyVault cosign recovery', () => {
         vaults: {
           pendingCosignByVaultId: vi.fn().mockResolvedValue([]),
           revenuePerFrameByVault: vi.fn().mockResolvedValue([{ uncollectedRevenue: { toBigInt: () => 40n } }]),
+          orphanedUtxoAccountsByVaultId: { entries: vi.fn().mockResolvedValue([]) },
         },
       },
       tx: {
@@ -972,7 +1026,7 @@ describe('MyVault cosign recovery', () => {
 
     const submission = await myVault.collectBuilder.buildPendingSubmission({
       client: client as any,
-      finalizedClient: {} as any,
+      finalizedClient: client as any,
       moveTo: 'VaultingHold' as any,
     });
 
@@ -1432,16 +1486,24 @@ function createVault(args?: {
   walletKeys?: ReturnType<typeof createMockWalletKeys>;
   ensureStoredEvents?: ReturnType<typeof vi.fn>;
   blockEvents?: unknown[];
+  finalizedApi?: object;
 }) {
   const blockWatchEventOn = vi.fn(
-    (_event: string, _callback: (headers: { blockNumber: number; blockHash: string }[]) => void) => vi.fn(),
+    (_event: string, _callback: (headers: { blockNumber: number; blockHash: string }[]) => void | Promise<void>) =>
+      vi.fn(),
   );
   const getBlockEvents = vi.fn(async () => args?.blockEvents ?? []);
+  const getBlockEventsWithSpec = vi.fn(async () => ({
+    api: args?.finalizedApi ?? {},
+    events: args?.blockEvents ?? [],
+  }));
   const blockWatch = {
     finalizedBlockHeader: { blockNumber: args?.finalizedHeight ?? 100 },
     events: { on: blockWatchEventOn },
     getEvents: getBlockEvents,
-    getFinalizedApi: vi.fn(async () => ({})),
+    getEventsWithSpec: getBlockEventsWithSpec,
+    getFinalizedApi: vi.fn(async () => args?.finalizedApi ?? {}),
+    getApi: vi.fn(async () => args?.finalizedApi ?? {}),
     getHeader: vi.fn(async (blockHeight: number) => {
       return {
         blockNumber: blockHeight,
@@ -1612,7 +1674,7 @@ function createVault(args?: {
       },
       ...args?.db,
     } as any),
-    { vaultsById: {} } as any,
+    { vaultsById: {}, updateVaultRevenue: vi.fn(async () => undefined) } as any,
     args?.walletKeys ?? createMockWalletKeys(),
     transactionTracker,
     bitcoinLocks,
@@ -1626,6 +1688,7 @@ function createVault(args?: {
     blockWatch,
     blockWatchEventOn,
     getBlockEvents,
+    getBlockEventsWithSpec,
     onFrameId,
     globalCouncil,
     mintingAuthorities,

--- a/src-vue/alerts/VaultAlert.vue
+++ b/src-vue/alerts/VaultAlert.vue
@@ -74,9 +74,11 @@
           {{ notice.signatureCount }} bitcoin transaction{{ notice.signatureCount === 1 ? '' : 's' }} require{{
             notice.signatureCount === 1 ? 's' : ''
           }}
-          signing at a penalty of {{ formatMoney(notice.signaturePenalty) }}
+          signing<template v-if="hasTimedCosigns(notice)">
+            at a penalty of {{ formatMoney(notice.signaturePenalty) }}
+          </template>
         </strong>
-        <span class="text-white/80">
+        <span v-if="hasTimedCosigns(notice)" class="text-white/80">
           (due in
           <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
             <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
@@ -109,15 +111,17 @@
             </span>
             <span v-else-if="seconds">{{ seconds }} second{{ seconds === 1 ? '' : 's' }}</span>
           </CountdownClock>
-          and {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
-          <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
-            <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
-            <template v-else>
-              <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
-              <span v-if="hours && minutes">&nbsp;</span>
-              <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
-            </template>
-          </CountdownClock>)
+          <template v-if="hasTimedCosigns(notice)">
+            and {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
+            <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
+              <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
+              <template v-else>
+                <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
+                <span v-if="hours && minutes">&nbsp;</span>
+                <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
+              </template>
+            </CountdownClock>
+          </template>)
         </span>
       </template>
     </div>
@@ -192,15 +196,18 @@
       </template>
 
       <template v-else-if="!notice.collectRevenue && notice.signatureCount">
-        {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
-        <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
-          <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
-          <template v-else>
-            <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
-            <span v-if="hours && minutes">&nbsp;</span>
-            <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
-          </template>
-        </CountdownClock>
+        <template v-if="hasTimedCosigns(notice)">
+          {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
+          <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
+            <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
+            <template v-else>
+              <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
+              <span v-if="hours && minutes">&nbsp;</span>
+              <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
+            </template>
+          </CountdownClock>
+        </template>
+        <template v-else>Complete the pending orphaned bitcoin return.</template>
       </template>
 
       <template v-else>
@@ -214,15 +221,17 @@
           </span>
           <span v-else-if="seconds">{{ seconds }} second{{ seconds === 1 ? '' : 's' }}</span>
         </CountdownClock>
-        and {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
-        <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
-          <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
-          <template v-else>
-            <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
-            <span v-if="hours && minutes">&nbsp;</span>
-            <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
-          </template>
-        </CountdownClock>
+        <template v-if="hasTimedCosigns(notice)">
+          and {{ formatMoney(notice.signaturePenalty) }} is at risk in securitization for
+          <CountdownClock :time="cosignDueDate" v-slot="{ hours, minutes, days }">
+            <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
+            <template v-else>
+              <span v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
+              <span v-if="hours && minutes">&nbsp;</span>
+              <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
+            </template>
+          </CountdownClock>
+        </template>
       </template>
     </template>
   </AlertDetailRow>
@@ -305,6 +314,10 @@ function isProcessingCollect(notice: IVaultCollectNotice): boolean {
 
 function isProcessingApprovals(notice: IVaultCollectNotice): boolean {
   return notice.processing?.actionType === 'approveCouncil';
+}
+
+function hasTimedCosigns(notice: IVaultCollectNotice): boolean {
+  return notice.nextCosignDueDate > 0;
 }
 
 function getButtonLabel(notice: IVaultCollectNotice): string {
@@ -401,6 +414,10 @@ function getCardTooltipContent(notice: IVaultCollectNotice): string {
 
   if (notice.collectRevenue > 0n) {
     return 'Collect your vault earnings.';
+  }
+
+  if (notice.orphanSignatureCount === notice.signatureCount) {
+    return 'Sign orphaned bitcoin return transactions.';
   }
 
   return 'Sign bitcoin transactions to avoid forfeiting vault security.';

--- a/src-vue/alerts/VaultAlert.vue
+++ b/src-vue/alerts/VaultAlert.vue
@@ -416,7 +416,7 @@ function getCardTooltipContent(notice: IVaultCollectNotice): string {
     return 'Collect your vault earnings.';
   }
 
-  if (notice.orphanSignatureCount === notice.signatureCount) {
+  if (notice.orphanSignatureCount > 0 && notice.orphanSignatureCount === notice.signatureCount) {
     return 'Sign orphaned bitcoin return transactions.';
   }
 

--- a/src-vue/lib/ArgonBonds.ts
+++ b/src-vue/lib/ArgonBonds.ts
@@ -198,6 +198,24 @@ export class ArgonBonds {
     ).bondLotHistoryTable.fetchAll(this.walletKeys.defaultArgonAddress);
   }
 
+  public async refreshActiveState(args: { client: ArgonQueryClient; currentFrameId: number }): Promise<void> {
+    if (!this.data.isLoaded) return;
+
+    this.data.currentFrameId = args.currentFrameId;
+
+    const refreshes: Promise<void>[] = [];
+    refreshes.push(this.refreshBondLots(args.client));
+    if (this.isGlobalSubscribed) {
+      refreshes.push(
+        TreasuryBonds.getDistributableBidPool(args.client).then(value => {
+          this.data.distributableBidPool = value;
+        }),
+      );
+    }
+    if (this.vaultSubscriptionArgs.size) refreshes.push(this.refreshSubscribedVaults(args.client));
+    await Promise.all(refreshes);
+  }
+
   public async subscribeGlobal(client?: ArgonClient): Promise<void> {
     if (this.isGlobalSubscribed) return;
 

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -515,6 +515,14 @@ export default class BitcoinLocks {
               recoveryLock = lock;
               processing = this.onRequestedReleaseInBlock(lock, txInfo);
             }
+          } else if (tx.extrinsicType === ExtrinsicType.BitcoinOrphanedUtxoRelease) {
+            const { utxoId, utxoRecordId } = tx.metadataJson as { utxoId: number; utxoRecordId: number };
+            const lock = this.locksByUtxoId[utxoId];
+            const record = this.utxoTracking.getUtxoRecordById(utxoRecordId);
+            if (lock && record) {
+              recoveryLock = lock;
+              processing = this.orphanReleases.onRequestedReleaseInBlock(record, txInfo);
+            }
           } else if (tx.extrinsicType === ExtrinsicType.BitcoinRatchet) {
             const { utxoId } = tx.metadataJson;
             const lock = this.locksByUtxoId[utxoId];

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -3118,7 +3118,15 @@ export default class BitcoinLocks {
 
     this.#needsLoadReconciliation = true;
     void this.#blockQueue
-      .add(async () => this.runPendingLoadReconciliation())
+      .add(async () => {
+        try {
+          const archiveClient = await getMainchainClient(true);
+          await this.orphanReleases.syncCosignCounterSubscriptions(archiveClient);
+        } catch (error) {
+          console.warn('[BitcoinLocks] Unable to refresh orphan return counters after history recovery', error);
+        }
+        await this.runPendingLoadReconciliation();
+      })
       .promise.catch(error =>
         console.warn('[BitcoinLocks] Unable to resume reconciliation after history recovery', error),
       );

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -41,6 +41,7 @@ import type {
   IBitcoinVaultUnlockStateDetails,
 } from '../interfaces/IBitcoinLocks.ts';
 import BitcoinUtxoTracking from './BitcoinUtxoTracking.ts';
+import BitcoinOrphanReleases from './BitcoinOrphanReleases.ts';
 import BitcoinMempool from './BitcoinMempool.ts';
 import { getVaults } from '../stores/vaults.ts';
 import { BITCOIN_BLOCK_MILLIS, ESPLORA_HOST } from './Env.ts';
@@ -64,7 +65,7 @@ import {
 import type { BitcoinLockRelayStatus, IBitcoinLockCouponStatus } from '@argonprotocol/apps-router';
 import { TransactionTracker } from './TransactionTracker.ts';
 import { deriveBitcoinLockHdKey, WalletKeys } from './WalletKeys.ts';
-import { TransactionInfo } from './TransactionInfo.ts';
+import { getTransactionFailureMessage, TransactionInfo } from './TransactionInfo.ts';
 import { ExtrinsicType, TransactionStatus } from './db/TransactionsTable.ts';
 import { MyVault } from './MyVault.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from './db/BitcoinUtxosTable.ts';
@@ -195,6 +196,7 @@ export default class BitcoinLocks {
   public myVault?: MyVault;
   public readonly utxoTracking: BitcoinUtxoTracking;
   public readonly recovery: BitcoinLockRecovery;
+  public readonly orphanReleases: BitcoinOrphanReleases;
 
   #config!: IBitcoinLockConfig;
 
@@ -256,10 +258,11 @@ export default class BitcoinLocks {
       getDerivedPubkey: (vaultId, index) => this.getDerivedPubkey(vaultId, index),
       trackDerivedBitcoinLockKey: (vaultId, derivedPubkey) => this.trackDerivedBitcoinLockKey(vaultId, derivedPubkey),
     });
+    this.orphanReleases = new BitcoinOrphanReleases(this, blockWatch, this.#mempool, transactionTracker, walletKeys);
   }
 
   public getActiveLocks(): IBitcoinLockRecord[] {
-    return this.getAllLocks().filter(lock => !this.isInactiveForVaultDisplay(lock));
+    return this.getAllLocks().filter(lock => !this.isTerminalLock(lock));
   }
 
   public getAllLocks({
@@ -478,6 +481,9 @@ export default class BitcoinLocks {
         });
       }
 
+      await this.utxoTracking.syncArgonOrphans(Object.values(this.locksByUtxoId), archiveClient).catch(error => {
+        console.warn(`[BitcoinLocks] Unable to restore orphaned Bitcoin`, error);
+      });
       for (const lock of Object.values(this.locksByUtxoId)) {
         if (!this.isTerminalLock(lock)) {
           await this.checkForMissingBitcoinLockState(lock).catch(error => {
@@ -566,6 +572,9 @@ export default class BitcoinLocks {
         await relaySync;
       }
 
+      await this.orphanReleases.syncCosignCounterSubscriptions(archiveClient).catch(error => {
+        console.warn('[BitcoinLocks] Unable to watch orphan return counters', error);
+      });
       this.#needsLoadReconciliation = true;
       const initialBestBlock = this.blockWatch.bestBlockHeader;
       void this.#blockQueue
@@ -605,14 +614,19 @@ export default class BitcoinLocks {
 
     try {
       for (const lock of Object.values(this.locksByUtxoId)) {
-        if (this.isHistoryRecoveryPendingForLock(lock) || this.isTerminalLock(lock)) continue;
+        if (this.isHistoryRecoveryPendingForLock(lock)) continue;
+        if (this.isTerminalLock(lock)) {
+          await this.orphanReleases.reconcileOrphanReturns(lock);
+          continue;
+        }
 
         await this.reconcileMismatchState(lock);
-        await this.reconcileMismatchReturnOnBlock(lock);
+        await this.orphanReleases.reconcileCandidateReturns(lock);
+        await this.orphanReleases.reconcileOrphanReturns(lock);
         await this.reconcileAcceptedFundingReleaseOnBlock(lock, false);
       }
       await this.syncLockReleaseBitcoinProcessing(this.locksByUtxoId);
-      await this.syncOrphanReturnBitcoinProcessing(this.oracleBitcoinBlockHeight);
+      await this.orphanReleases.syncBitcoinProcessing(this.oracleBitcoinBlockHeight);
       this.#needsLoadReconciliation = false;
     } catch (error) {
       console.warn('[BitcoinLocks] Startup reconciliation did not finish; will retry on the next block', error);
@@ -651,6 +665,7 @@ export default class BitcoinLocks {
 
   public async shutdown() {
     this.unsubscribeFromArgonBlocks();
+    this.orphanReleases.shutdown();
     await this.#blockQueue.stop(true);
     await Promise.all(Object.values(this.#txQueueByUuid).map(queue => queue.stop(true)));
   }
@@ -1289,36 +1304,6 @@ export default class BitcoinLocks {
     return fee.partialFee.toBigInt();
   }
 
-  public async estimatedMismatchReturnArgonTxFee(args: {
-    lock: IBitcoinLockRecord;
-    candidateRecord: IBitcoinUtxoRecord;
-    liquidLockingAddress: string;
-    toScriptPubkey: string;
-    feeRatePerSatVb?: bigint;
-    tip?: bigint;
-  }): Promise<bigint> {
-    const { lock, candidateRecord, toScriptPubkey, feeRatePerSatVb = 5n, liquidLockingAddress } = args;
-    if (!lock.utxoId) return 0n;
-
-    const client = await getMainchainClient(false);
-    const request = await this.getMismatchOrphanReturnRequest({
-      lock,
-      candidateRecord,
-      toScriptPubkey,
-      feeRatePerSatVb,
-    });
-    const tx = await this.buildMismatchOrphanReturnTx({
-      client,
-      lock,
-      candidateRecord,
-      request,
-      // Estimated fee only; signature bytes length needs to be valid, content is not used for weight estimation.
-      vaultSignature: new Uint8Array(71).fill(1),
-    });
-    const fee = await tx.paymentInfo(liquidLockingAddress, { tip: args.tip ?? 0n });
-    return fee.partialFee.toBigInt();
-  }
-
   public getMintPercent(lock: Pick<IBitcoinLockRecord, 'ratchets'>): number {
     const ratchets = lock.ratchets ?? [];
     const totalMint = ratchets.reduce((sum, r) => sum + (r.mintAmount ?? 0n), 0n);
@@ -1494,7 +1479,7 @@ export default class BitcoinLocks {
     return this.#transactionTracker.findLatestTxInfo<IBitcoinRatchetMetadata>(txInfo => {
       if (txInfo.tx.extrinsicType !== ExtrinsicType.BitcoinRatchet) return false;
       if (txInfo.tx.metadataJson.utxoId !== lock.utxoId) return false;
-      if (this.getTxFailureMessage(txInfo)) return false;
+      if (getTransactionFailureMessage(txInfo)) return false;
       return !txInfo.isPostProcessed;
     });
   }
@@ -1920,19 +1905,6 @@ export default class BitcoinLocks {
     return this.getMismatchAcceptTxInfoForCandidate(lock.utxoId, candidateRecord);
   }
 
-  public getOrphanedReturnTxInfoForRecord(
-    utxoId: number,
-    candidateRecord: Pick<IBitcoinUtxoRecord, 'id' | 'txid' | 'vout'>,
-  ): TransactionInfo | undefined {
-    const matches = this.#transactionTracker.data.txInfos.filter(txInfo => {
-      if (txInfo.tx.extrinsicType !== ExtrinsicType.BitcoinOrphanedUtxoRelease) return false;
-      const metadata = txInfo.tx.metadataJson as { utxoId?: number; utxoRecordId?: number } | undefined;
-      if (metadata?.utxoId !== utxoId) return false;
-      return metadata.utxoRecordId === candidateRecord.id;
-    });
-    return matches.at(-1);
-  }
-
   public getReleaseLifecycleProgress(record: IBitcoinUtxoRecord): {
     progressPct: number;
     confirmations: number;
@@ -2114,7 +2086,7 @@ export default class BitcoinLocks {
 
   private isMismatchAcceptTxActive(txInfo?: TransactionInfo): boolean {
     if (!txInfo) return false;
-    if (this.getTxFailureMessage(txInfo)) return false;
+    if (getTransactionFailureMessage(txInfo)) return false;
     return [TransactionStatus.Submitted, TransactionStatus.InBlock, TransactionStatus.Finalized].includes(
       txInfo.tx.status,
     );
@@ -2221,16 +2193,6 @@ export default class BitcoinLocks {
     return await this.runInQueueForUtxo(lock, 60e3, () => this.acceptMismatchedFundingUnqueued(lock, candidateRecord));
   }
 
-  public async requestMismatchOrphanReturnOnArgon(args: {
-    lock: IBitcoinLockRecord;
-    candidateRecord: IBitcoinUtxoRecord;
-    toScriptPubkey: string;
-    bitcoinNetworkFee?: bigint;
-    feeRatePerSatVb?: bigint;
-  }): Promise<TransactionInfo | undefined> {
-    return await this.runInQueueForUtxo(args.lock, 90e3, () => this.requestMismatchOrphanReturnUnqueued(args));
-  }
-
   public async resumeWaitingForFunding(lock: IBitcoinLockRecord): Promise<void> {
     await this.runInQueueForUtxo(lock, 30e3, () => this.resumeWaitingForFundingUnqueued(lock));
   }
@@ -2278,7 +2240,7 @@ export default class BitcoinLocks {
     const acceptTx = this.getLatestMismatchAcceptTxInfo(utxoId);
     const acceptInProgress = this.isTxInProgress(acceptTx);
     const acceptFinalized = this.isTxFinalized(acceptTx);
-    const acceptFailed = this.getTxFailureMessage(acceptTx);
+    const acceptFailed = getTransactionFailureMessage(acceptTx);
 
     if (!this.getAcceptedFundingState(lock).record && acceptFinalized) {
       const metadata = acceptTx?.tx.metadataJson as { utxoRecordId?: number } | undefined;
@@ -2300,8 +2262,8 @@ export default class BitcoinLocks {
     }
 
     if (activeOrphanedRecord?.status === BitcoinUtxoStatus.ReleaseIsProcessingOnArgon) {
-      const returnTx = this.getOrphanedReturnTxInfoForRecord(utxoId, activeOrphanedRecord);
-      const returnFailure = this.getTxFailureMessage(returnTx);
+      const returnTx = this.orphanReleases.getTransactionInfo(utxoId, activeOrphanedRecord);
+      const returnFailure = getTransactionFailureMessage(returnTx);
       if (returnFailure) {
         await this.utxoTracking.setReleaseError(activeOrphanedRecord, returnFailure);
       }
@@ -2411,102 +2373,6 @@ export default class BitcoinLocks {
     });
   }
 
-  private async requestMismatchOrphanReturnUnqueued(args: {
-    lock: IBitcoinLockRecord;
-    candidateRecord: IBitcoinUtxoRecord;
-    toScriptPubkey: string;
-    bitcoinNetworkFee?: bigint;
-    feeRatePerSatVb?: bigint;
-  }): Promise<TransactionInfo | undefined> {
-    const { lock } = args;
-    const candidateRecord =
-      this.utxoTracking
-        .getUtxosForLock(lock)
-        .find(record => record.txid === args.candidateRecord.txid && record.vout === args.candidateRecord.vout) ??
-      args.candidateRecord;
-    if (!lock.utxoId) {
-      throw new Error('This lock has no Bitcoin funding ID yet.');
-    }
-    if (
-      !this.isMismatchCandidate(lock, candidateRecord.satoshis) ||
-      !this.findMismatchCandidateView(lock, candidateRecord)?.canReturn
-    ) {
-      throw new Error('This mismatch return is not currently available.');
-    }
-
-    const client = await getMainchainClient(false);
-    let record: IBitcoinUtxoRecord | undefined;
-
-    try {
-      const request = await this.getMismatchOrphanReturnRequest({
-        lock,
-        candidateRecord,
-        toScriptPubkey: args.toScriptPubkey,
-        bitcoinNetworkFee: args.bitcoinNetworkFee,
-        feeRatePerSatVb: args.feeRatePerSatVb,
-      });
-
-      const vaultSignature = await this.createVaultSignatureForOrphanReturn(lock, candidateRecord, {
-        toScriptPubkey: request.toScriptPubkeyHex,
-        bitcoinNetworkFee: request.bitcoinNetworkFee,
-      });
-      const tx = await this.buildMismatchOrphanReturnTx({
-        client,
-        lock,
-        candidateRecord,
-        request,
-        vaultSignature,
-      });
-
-      if (
-        [
-          BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
-          BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
-          BitcoinUtxoStatus.ReleaseComplete,
-        ].includes(candidateRecord.status)
-      ) {
-        return this.getOrphanedReturnTxInfoForRecord(lock.utxoId, candidateRecord);
-      }
-
-      await this.utxoTracking.setReleaseIsProcessingOnArgon(candidateRecord, {
-        releaseToDestinationAddress: request.toScriptPubkeyHex,
-        releaseBitcoinNetworkFee: request.bitcoinNetworkFee,
-      });
-      record = candidateRecord;
-
-      const txSigner = await this.walletKeys.getLiquidLockingKeypair();
-      const txInfo = await this.#transactionTracker.submitAndWatch({
-        tx,
-        txSigner,
-        extrinsicType: ExtrinsicType.BitcoinOrphanedUtxoRelease,
-        metadata: {
-          releaseKind: 'Orphan',
-          utxoId: lock.utxoId,
-          utxoRecordId: candidateRecord.id,
-          utxoRef: request.utxoRef,
-        },
-      });
-
-      void this.continueOrphanReleaseAfterArgonInclusion(
-        lock,
-        record,
-        {
-          toScriptPubkey: request.toScriptPubkeyHex,
-          bitcoinNetworkFee: request.bitcoinNetworkFee,
-          vaultSignature,
-        },
-        txInfo,
-      );
-
-      return txInfo;
-    } catch (error) {
-      if (record) {
-        await this.utxoTracking.setReleaseError(record, String(error));
-      }
-      throw error;
-    }
-  }
-
   private async resumeWaitingForFundingUnqueued(lock: IBitcoinLockRecord): Promise<void> {
     if (!lock.utxoId) return;
     if (this.isFundingWindowExpired(lock)) {
@@ -2539,68 +2405,6 @@ export default class BitcoinLocks {
     }
     const lockTable = await this.getTable();
     await lockTable.setLockExpiredWaitingForFundingAcknowledged(lock);
-  }
-
-  private async reconcileMismatchReturnOnBlock(lock: IBitcoinLockRecord): Promise<void> {
-    if (!lock.utxoId) return;
-    const records = this.getMismatchReturnState(lock).records.filter(
-      record => record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
-    );
-    for (const record of records) {
-      if (!record.releaseToDestinationAddress || record.releaseBitcoinNetworkFee == null) continue;
-      const txInfo = this.getOrphanedReturnTxInfoForRecord(record.lockUtxoId, record);
-      if (!txInfo) {
-        if (record.requestedReleaseAtTick == null) {
-          const recoveredFromChain = await this.syncOrphanReleaseRequestFromChain(lock, record);
-          if (!recoveredFromChain) {
-            await this.utxoTracking.setReleaseError(
-              record,
-              'Mismatch return was interrupted before submission. Please retry return or collect the adjusted amount.',
-            );
-            continue;
-          }
-        }
-        await this.submitOrphanReleaseToBitcoin(lock, record, {
-          toScriptPubkey: record.releaseToDestinationAddress,
-          bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
-        });
-      } else {
-        const txFailure = this.getTxFailureMessage(txInfo);
-        if (txFailure) {
-          await this.utxoTracking.setReleaseError(record, txFailure);
-          continue;
-        }
-        if (txInfo.tx.status !== TransactionStatus.Finalized) {
-          continue;
-        }
-        await this.ensureOrphanReleaseObservedAtTick(record, txInfo);
-        const vaultSignature =
-          record.releaseCosignVaultSignature && record.releaseCosignHeight != null
-            ? record.releaseCosignVaultSignature
-            : await this.createVaultSignatureForOrphanReturn(lock, record, {
-                toScriptPubkey: record.releaseToDestinationAddress,
-                bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
-              });
-        if (!record.releaseCosignVaultSignature || record.releaseCosignHeight == null) {
-          await this.utxoTracking.setReleaseCosign(record, {
-            releaseCosignVaultSignature: vaultSignature,
-            releaseCosignHeight: txInfo.txResult.blockNumber!,
-          });
-        }
-        await this.submitOrphanReleaseToBitcoin(lock, record, {
-          toScriptPubkey: record.releaseToDestinationAddress,
-          bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
-          vaultSignature,
-        });
-      }
-    }
-  }
-
-  private async syncOrphanReturnBitcoinProcessing(oracleBitcoinBlockHeight: number): Promise<void> {
-    await this.syncOrphanReleaseProcessingOnBitcoin({
-      oracleBitcoinBlockHeight,
-      getLockByUtxoId: utxoId => this.data.locksByUtxoId[utxoId],
-    });
   }
 
   public async getTable(): Promise<BitcoinLocksTable> {
@@ -2712,7 +2516,7 @@ export default class BitcoinLocks {
 
     const result = await vault.cosignMyLock(lock);
     if (!result?.txInfo) return;
-    const txFailure = this.getTxFailureMessage(result.txInfo);
+    const txFailure = getTransactionFailureMessage(result.txInfo);
     if (txFailure) {
       throw new Error(txFailure);
     }
@@ -2739,7 +2543,7 @@ export default class BitcoinLocks {
       await this.waitForHistoryRecovery(lock);
       if (this.isTerminalLock(lock)) return;
 
-      const txFailure = this.getTxFailureMessage(txInfo);
+      const txFailure = getTransactionFailureMessage(txInfo);
       if (txFailure || txInfo.txResult.blockNumber == null) return;
 
       const fundingRecord = this.getAcceptedFundingRecord(lock);
@@ -2930,11 +2734,11 @@ export default class BitcoinLocks {
     await lockTable.setStatus(lock, nextStatus);
   }
 
-  private async runInQueueForUtxo<T>(
+  public async runInQueueForUtxo<T>(
     lockRecord: Pick<IBitcoinLockRecord, 'uuid'> & Partial<Pick<IBitcoinLockRecord, 'status' | 'removalReason'>>,
     timeoutMs: number,
     task: () => Promise<T>,
-    options: { waitForHistoryRecovery?: boolean } = {},
+    options: { allowOrphanRecovery?: boolean; waitForHistoryRecovery?: boolean } = {},
   ): Promise<T> {
     if (options.waitForHistoryRecovery) {
       const historyRecovery = this.waitForHistoryRecovery(lockRecord);
@@ -2948,7 +2752,9 @@ export default class BitcoinLocks {
     this.#txQueueByUuid[uuid] ??= new SingleFileQueue();
     return this.#txQueueByUuid[uuid].add(
       async () => {
-        if (!options.waitForHistoryRecovery) this.ensureBitcoinActionsAvailable(lockRecord);
+        if (!options.waitForHistoryRecovery) {
+          this.ensureBitcoinActionsAvailable(lockRecord, { allowOrphanRecovery: options.allowOrphanRecovery });
+        }
         return await task();
       },
       { timeoutMs },
@@ -3001,6 +2807,7 @@ export default class BitcoinLocks {
       // get stuck retrying a transient best-head hash that the pruned node has already discarded.
       const header = await this.blockWatch.getHeaderByBlockNumber(newestHeader.blockNumber - 1);
 
+      await this.orphanReleases.recoverPendingCosignEvents(header.blockNumber);
       if (header.blockNumber <= (this.data.latestArgonBlock?.blockNumber ?? 0)) {
         return;
       }
@@ -3014,6 +2821,11 @@ export default class BitcoinLocks {
         .then(x => (x.isSome ? (x.value?.blockHeight.toNumber() ?? 0) : 0));
 
       const hasNewOracleBitcoinBlockHeight = archivedBitcoinBlockHeight !== this.data.oracleBitcoinBlockHeight;
+      if (hasNewOracleBitcoinBlockHeight) {
+        await this.utxoTracking.syncArgonOrphans(Object.values(this.locksByUtxoId), clientAt).catch(error => {
+          console.warn('[BitcoinLocks] Unable to sync orphaned Bitcoin from current chain state', error);
+        });
+      }
 
       const promises = Object.values(this.data.locksByUtxoId)
         .map(lockRecord => {
@@ -3074,8 +2886,12 @@ export default class BitcoinLocks {
             });
 
             // Phase 4: mismatch return sync.
-            await this.reconcileMismatchReturnOnBlock(lockRecord).catch(err => {
+            await this.orphanReleases.reconcileCandidateReturns(lockRecord).catch(err => {
               console.warn(`[BitcoinLocks] Error reconciling mismatch return for utxo ${lockRecord.uuid}`, err);
+            });
+
+            await this.orphanReleases.reconcileOrphanReturns(lockRecord).catch(err => {
+              console.warn(`[BitcoinLocks] Error reconciling orphan return for utxo ${lockRecord.uuid}`, err);
             });
 
             // Phase 5: accepted funding release sync.
@@ -3091,7 +2907,7 @@ export default class BitcoinLocks {
         })
         .filter(x => x !== undefined);
       if (hasNewOracleBitcoinBlockHeight) {
-        await this.syncOrphanReturnBitcoinProcessing(this.data.oracleBitcoinBlockHeight).catch(err => {
+        await this.orphanReleases.syncBitcoinProcessing(this.data.oracleBitcoinBlockHeight).catch(err => {
           console.warn('[BitcoinLocks] Error syncing orphan return processing', err);
         });
       }
@@ -3252,14 +3068,15 @@ export default class BitcoinLocks {
 
   private ensureBitcoinActionsAvailable(
     lock: Pick<IBitcoinLockRecord, 'uuid'> & Partial<Pick<IBitcoinLockRecord, 'status' | 'removalReason'>>,
+    options: { allowOrphanRecovery?: boolean } = {},
   ): void {
     if (this.isHistoryRecoveryPendingForLock(lock)) {
       throw new Error('Bitcoin history recovery is still in progress. Please wait for it to finish.');
     }
-    if (
-      lock.removalReason ||
-      (lock.status && this.isTerminalLock({ status: lock.status, removalReason: lock.removalReason }))
-    ) {
+    const isSettled =
+      !!lock.removalReason ||
+      (lock.status != null && this.isTerminalLock({ status: lock.status, removalReason: lock.removalReason }));
+    if (!options.allowOrphanRecovery && isSettled) {
       throw new Error('This Bitcoin lock is already settled.');
     }
   }
@@ -3352,277 +3169,6 @@ export default class BitcoinLocks {
     };
   }
 
-  private async getMismatchOrphanReturnRequest(args: {
-    lock: IBitcoinLockRecord;
-    candidateRecord: IBitcoinUtxoRecord;
-    toScriptPubkey: string;
-    bitcoinNetworkFee?: bigint;
-    feeRatePerSatVb?: bigint;
-  }): Promise<{ utxoRef: { txid: string; vout: number }; toScriptPubkeyHex: string; bitcoinNetworkFee: bigint }> {
-    const { lock, candidateRecord, toScriptPubkey } = args;
-    const utxoRef = this.getUtxoRef(candidateRecord);
-    const toScriptPubkeyHex = addressBytesHex(toScriptPubkey, this.bitcoinNetwork);
-    const bitcoinNetworkFee =
-      args.bitcoinNetworkFee ??
-      (await this.calculateBitcoinNetworkFee(lock, args.feeRatePerSatVb ?? 5n, toScriptPubkey));
-
-    return {
-      utxoRef,
-      toScriptPubkeyHex,
-      bitcoinNetworkFee,
-    };
-  }
-
-  private async buildMismatchOrphanReturnTx(args: {
-    client: ArgonClient;
-    lock: IBitcoinLockRecord;
-    candidateRecord: Pick<IBitcoinUtxoRecord, 'txid' | 'vout'>;
-    request: { utxoRef: { txid: string; vout: number }; toScriptPubkeyHex: string; bitcoinNetworkFee: bigint };
-    vaultSignature: Uint8Array;
-  }): Promise<SubmittableExtrinsic> {
-    if (!args.lock.lockDetails?.ownerAccount) {
-      throw new Error('Missing lock owner account needed for orphan release.');
-    }
-    const txs: SubmittableExtrinsic[] = [];
-    const candidateRefs = await args.client.query.bitcoinUtxos.candidateUtxoRefsByUtxoId(args.lock.utxoId!);
-    const candidateStillOnChain =
-      !!candidateRefs &&
-      [...candidateRefs.entries()].some(([utxoRef]) => {
-        return (
-          utxoRef.txid.toHex() === args.request.utxoRef.txid &&
-          utxoRef.outputIndex.toNumber() === args.request.utxoRef.vout
-        );
-      });
-    if (candidateStillOnChain) {
-      txs.push(
-        args.client.tx.bitcoinUtxos.rejectUtxoCandidate(args.lock.utxoId!, {
-          txid: args.request.utxoRef.txid,
-          outputIndex: args.request.utxoRef.vout,
-        }),
-      );
-    }
-    const requestTx = await BitcoinLock.createOrphanedUtxoReleaseRequestTx({
-      client: args.client,
-      utxoRef: { txid: args.request.utxoRef.txid, outputIndex: args.request.utxoRef.vout },
-      releaseRequest: {
-        toScriptPubkey: args.request.toScriptPubkeyHex,
-        bitcoinNetworkFee: args.request.bitcoinNetworkFee,
-      },
-    });
-    if (!requestTx) {
-      throw new Error('Orphan release is not supported on this chain.');
-    }
-    const cosignTx = await BitcoinLock.createOrphanedUtxoCosignTx({
-      client: args.client,
-      orphanOwner: args.lock.lockDetails.ownerAccount,
-      utxoRef: { txid: args.request.utxoRef.txid, outputIndex: args.request.utxoRef.vout },
-      vaultSignature: args.vaultSignature,
-    });
-    if (!cosignTx) {
-      throw new Error('Orphan release is not supported on this chain.');
-    }
-    txs.push(requestTx, cosignTx);
-    return args.client.tx.utility.batchAll(txs);
-  }
-
-  private async createVaultSignatureForOrphanReturn(
-    lock: IBitcoinLockRecord,
-    candidateRecord: Pick<IBitcoinUtxoRecord, 'txid' | 'vout' | 'satoshis'>,
-    releaseRequest: { toScriptPubkey: string; bitcoinNetworkFee: bigint },
-  ): Promise<Uint8Array> {
-    const vault = this.myVault;
-    if (!vault) {
-      throw new Error('No vault available to cosign this release.');
-    }
-    const vaultSignature = await vault.createVaultSignatureForMyOrphanedUtxoRelease({
-      lock,
-      txid: candidateRecord.txid,
-      vout: candidateRecord.vout,
-      satoshis: candidateRecord.satoshis,
-      toScriptPubkey: releaseRequest.toScriptPubkey,
-      bitcoinNetworkFee: releaseRequest.bitcoinNetworkFee,
-    });
-    if (!vaultSignature) {
-      throw new Error('Failed to generate vault signature for orphan release.');
-    }
-    return vaultSignature;
-  }
-
-  private async syncOrphanReleaseProcessingOnBitcoin(args: {
-    oracleBitcoinBlockHeight: number;
-    getLockByUtxoId: (utxoId: number) => IBitcoinLockRecord | undefined;
-  }): Promise<void> {
-    const records = this.utxoTracking.getAllOrphanLifecycleUtxos();
-    const tasks = records
-      .filter(record => {
-        if (record.status !== BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin) return false;
-        const lock = args.getLockByUtxoId(record.lockUtxoId);
-        return record.id !== this.getAcceptedFundingState(lock).recordId;
-      })
-      .map(record => {
-        const lock = args.getLockByUtxoId(record.lockUtxoId);
-        const task = async () => {
-          if (!lock || !record.releaseTxid) return;
-          try {
-            await this.utxoTracking.updateReleaseLastConfirmationCheck(record);
-          } catch (err) {
-            console.warn(`[BitcoinLocks] Error updating orphan return confirmation check`, err);
-          }
-
-          const mempoolTxStatus = await this.#mempool
-            .getTxStatus(record.releaseTxid, args.oracleBitcoinBlockHeight)
-            .catch(() => undefined);
-          if (mempoolTxStatus?.isConfirmed) {
-            await this.utxoTracking.setReleaseComplete(record, mempoolTxStatus.transactionBlockHeight);
-          }
-        };
-        return task();
-      });
-    await Promise.allSettled(tasks);
-  }
-
-  private async ensureOrphanReleaseObservedAtTick(record: IBitcoinUtxoRecord, txInfo: TransactionInfo): Promise<void> {
-    if (record.requestedReleaseAtTick != null) return;
-    if (!record.releaseToDestinationAddress || record.releaseBitcoinNetworkFee == null) return;
-
-    const blockHash = txInfo.tx.blockHash ?? (await txInfo.txResult.waitForInFirstBlock);
-    const client = await getMainchainClient(false);
-    const api = await client.at(blockHash);
-    const requestedReleaseAtTick = await api.query.ticks.currentTick().then(x => x.toNumber());
-
-    await this.utxoTracking.setReleaseIsProcessingOnArgon(record, {
-      requestedReleaseAtTick,
-      releaseToDestinationAddress: record.releaseToDestinationAddress,
-      releaseBitcoinNetworkFee: record.releaseBitcoinNetworkFee,
-    });
-  }
-
-  private async syncOrphanReleaseRequestFromChain(
-    lock: IBitcoinLockRecord,
-    record: IBitcoinUtxoRecord,
-  ): Promise<boolean> {
-    if (record.requestedReleaseAtTick != null) return true;
-
-    const client = await getMainchainClient(true);
-    const orphanMaybe = await client.query.bitcoinLocks.orphanedUtxosByAccount(lock.lockDetails.ownerAccount, {
-      txid: record.txid,
-      outputIndex: record.vout,
-    });
-    if (!orphanMaybe.isSome) return false;
-
-    const orphan = orphanMaybe.unwrap();
-    if (orphan.utxoId.toNumber() !== lock.utxoId) return false;
-    if (orphan.cosignRequest.isNone) return false;
-
-    const request = orphan.cosignRequest.unwrap();
-    const blockHash = await client.rpc.chain.getBlockHash(request.createdAtArgonBlockNumber.toNumber());
-    const apiAt = await client.at(blockHash);
-    const requestedReleaseAtTick = await apiAt.query.ticks.currentTick().then(x => x.toNumber());
-
-    await this.utxoTracking.setReleaseIsProcessingOnArgon(record, {
-      requestedReleaseAtTick,
-      releaseToDestinationAddress: u8aToHex(request.toScriptPubkey, undefined, false),
-      releaseBitcoinNetworkFee: request.bitcoinNetworkFee.toBigInt(),
-    });
-    return true;
-  }
-
-  private async submitOrphanReleaseToBitcoin(
-    lock: IBitcoinLockRecord,
-    record: IBitcoinUtxoRecord,
-    args: { toScriptPubkey: string; bitcoinNetworkFee: bigint; vaultSignature?: Uint8Array },
-  ): Promise<void> {
-    try {
-      const vaultSignature =
-        args.vaultSignature ??
-        (record.releaseCosignVaultSignature && record.releaseCosignHeight != null
-          ? record.releaseCosignVaultSignature
-          : undefined) ??
-        (await this.createVaultSignatureForOrphanReturn(lock, record, {
-          toScriptPubkey: args.toScriptPubkey,
-          bitcoinNetworkFee: args.bitcoinNetworkFee,
-        }));
-      const ownerXpriv = await this.walletKeys.getBitcoinChildXpriv(lock.hdPath, this.bitcoinNetwork);
-      const utxoRef = this.getUtxoRef(record);
-      const cosign = new CosignScript({ ...lock.lockDetails, utxoSatoshis: record.satoshis }, this.bitcoinNetwork);
-      const tx = cosign.cosignAndGenerateTx({
-        releaseRequest: {
-          toScriptPubkey: args.toScriptPubkey,
-          bitcoinNetworkFee: args.bitcoinNetworkFee,
-        },
-        vaultCosignature: vaultSignature,
-        utxoRef,
-        ownerXpriv,
-      });
-      if (!tx || !tx.isFinal) {
-        throw new Error('Failed to generate orphan release transaction.');
-      }
-
-      const txid = tx.id;
-      const hexTx = u8aToHex(tx.toBytes(true, true), undefined, false);
-      const existingTxStatus = await this.#mempool
-        .getTxStatus(txid, this.oracleBitcoinBlockHeight)
-        .catch(() => undefined);
-      if (existingTxStatus?.isConfirmed) {
-        const mempoolTip = await this.#mempool.getTipHeight().catch(() => this.oracleBitcoinBlockHeight);
-        await this.utxoTracking.setReleaseSeenOnBitcoinAndProcessing(record, txid, mempoolTip);
-        return;
-      }
-
-      let bitcoinTxid: string;
-      try {
-        bitcoinTxid = await this.#mempool.broadcastTx(hexTx);
-      } catch (error) {
-        if (!this.isAlreadyBroadcastBitcoinTxError(error)) throw error;
-        bitcoinTxid = txid;
-      }
-      const mempoolTip = await this.#mempool.getTipHeight().catch(() => this.oracleBitcoinBlockHeight);
-      await this.utxoTracking.setReleaseSeenOnBitcoinAndProcessing(record, bitcoinTxid, mempoolTip);
-    } catch (error) {
-      await this.utxoTracking.setReleaseError(record, String(error));
-    }
-  }
-
-  private async continueOrphanReleaseAfterArgonInclusion(
-    lock: IBitcoinLockRecord,
-    record: IBitcoinUtxoRecord,
-    args: { toScriptPubkey: string; bitcoinNetworkFee: bigint; vaultSignature: Uint8Array },
-    txInfo: TransactionInfo,
-  ): Promise<void> {
-    try {
-      await txInfo.txResult.waitForInFirstBlock;
-      const txFailure = this.getTxFailureMessage(txInfo);
-      if (txFailure) {
-        await this.utxoTracking.setReleaseError(record, txFailure);
-        return;
-      }
-
-      await this.ensureOrphanReleaseObservedAtTick(record, txInfo);
-      await this.utxoTracking.setReleaseCosign(record, {
-        releaseCosignVaultSignature: args.vaultSignature,
-        releaseCosignHeight: txInfo.txResult.blockNumber!,
-      });
-      await this.submitOrphanReleaseToBitcoin(lock, record, args);
-    } catch (error) {
-      await this.utxoTracking.setReleaseError(record, String(error));
-    }
-  }
-
-  private getUtxoRef(record: Pick<IBitcoinUtxoRecord, 'txid' | 'vout'>): { txid: string; vout: number } {
-    return { txid: record.txid, vout: record.vout };
-  }
-
-  private isAlreadyBroadcastBitcoinTxError(error: unknown): boolean {
-    const message = String(error ?? '').toLowerCase();
-    return (
-      message.includes('txn-already-in-mempool') ||
-      message.includes('txn-already-known') ||
-      message.includes('already in mempool') ||
-      message.includes('already known') ||
-      message.includes('already have transaction')
-    );
-  }
-
   private async getReleaseCosignOnChain(
     lock: IBitcoinLockRecord,
     archiveClient?: ArgonClient,
@@ -3709,7 +3255,7 @@ export default class BitcoinLocks {
 
   private isTxFinalized(txInfo?: TransactionInfo): boolean {
     if (!txInfo) return false;
-    return txInfo.tx.status === TransactionStatus.Finalized && !this.getTxFailureMessage(txInfo);
+    return txInfo.tx.status === TransactionStatus.Finalized && !getTransactionFailureMessage(txInfo);
   }
 
   private isMismatchOrphanProcessingRecordActive(utxoId: number, record: IBitcoinUtxoRecord): boolean {
@@ -3717,26 +3263,10 @@ export default class BitcoinLocks {
       return !!record.releaseTxid;
     }
     if (record.status !== BitcoinUtxoStatus.ReleaseIsProcessingOnArgon) return false;
-    const txInfo = this.getOrphanedReturnTxInfoForRecord(utxoId, record);
+    const txInfo = this.orphanReleases.getTransactionInfo(utxoId, record);
     if (!txInfo) return true;
-    if (this.getTxFailureMessage(txInfo)) return false;
+    if (getTransactionFailureMessage(txInfo)) return false;
     return this.isTxInProgress(txInfo) || this.isTxFinalized(txInfo);
-  }
-
-  private getTxFailureMessage(txInfo?: TransactionInfo): string | undefined {
-    if (!txInfo) return undefined;
-    const submissionError = txInfo.txResult.submissionError;
-    if (submissionError) return submissionError.message || String(submissionError);
-    const extrinsicError = txInfo.txResult.extrinsicError;
-    if (extrinsicError) {
-      const details = (extrinsicError as { details?: string; message?: string }).details;
-      if (details) return details;
-      return extrinsicError.message || String(extrinsicError);
-    }
-    if ([TransactionStatus.Error, TransactionStatus.TimedOutWaitingForBlock].includes(txInfo.tx.status)) {
-      return `Transaction ended with status ${txInfo.tx.status}.`;
-    }
-    return undefined;
   }
 
   private setMismatchError(lockUtxoId: number, error: string): void {

--- a/src-vue/lib/BitcoinOrphanReleases.ts
+++ b/src-vue/lib/BitcoinOrphanReleases.ts
@@ -1,0 +1,712 @@
+import { addressBytesHex, CosignScript } from '@argonprotocol/bitcoin';
+import { ArgonClient, BitcoinLock, type SubmittableExtrinsic, TxSubmitter, u8aToHex } from '@argonprotocol/mainchain';
+import type { BlockWatch } from '@argonprotocol/apps-core';
+import { getMainchainClient } from '../stores/mainchain.ts';
+import type { IBitcoinLockRecord } from './db/BitcoinLocksTable.ts';
+import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from './db/BitcoinUtxosTable.ts';
+import { ExtrinsicType, TransactionStatus } from './db/TransactionsTable.ts';
+import type BitcoinLocks from './BitcoinLocks.ts';
+import type BitcoinMempool from './BitcoinMempool.ts';
+import { getTransactionFailureMessage, type TransactionInfo } from './TransactionInfo.ts';
+import type { TransactionTracker } from './TransactionTracker.ts';
+import type { WalletKeys } from './WalletKeys.ts';
+
+export default class BitcoinOrphanReleases {
+  #cosignCounterSubscriptions = new Map<string, () => void>();
+  #eventScanFromBlock?: number;
+  #eventScanThroughBlock?: number;
+
+  constructor(
+    private readonly bitcoinLocks: BitcoinLocks,
+    private readonly blockWatch: BlockWatch,
+    private readonly mempool: BitcoinMempool,
+    private readonly transactionTracker: TransactionTracker,
+    private readonly walletKeys: WalletKeys,
+  ) {}
+
+  public async requestCandidateReturn(args: {
+    lock: IBitcoinLockRecord;
+    candidateRecord: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<TransactionInfo | undefined> {
+    return await this.bitcoinLocks.runInQueueForUtxo(args.lock, 90e3, () => this.requestCandidateReturnUnqueued(args));
+  }
+
+  public async estimatedCandidateReturnArgonTxFee(args: {
+    lock: IBitcoinLockRecord;
+    candidateRecord: IBitcoinUtxoRecord;
+    liquidLockingAddress: string;
+    toScriptPubkey: string;
+    feeRatePerSatVb?: bigint;
+    tip?: bigint;
+  }): Promise<bigint> {
+    if (!args.lock.utxoId) return 0n;
+
+    const client = await getMainchainClient(false);
+    const request = await this.createRequest({
+      lock: args.lock,
+      record: args.candidateRecord,
+      toScriptPubkey: args.toScriptPubkey,
+      feeRatePerSatVb: args.feeRatePerSatVb ?? 5n,
+    });
+    const tx = await this.buildCandidateReturnTx({
+      client,
+      lock: args.lock,
+      request,
+      // Estimated fee only; signature bytes length needs to be valid, content is not used for weight estimation.
+      vaultSignature: new Uint8Array(71).fill(1),
+    });
+    const fee = await tx.paymentInfo(args.liquidLockingAddress, { tip: args.tip ?? 0n });
+    return fee.partialFee.toBigInt();
+  }
+
+  public async requestOrphanReturn(args: {
+    lock: IBitcoinLockRecord;
+    record: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<TransactionInfo | undefined> {
+    return await this.bitcoinLocks.runInQueueForUtxo(args.lock, 90e3, () => this.requestOrphanReturnUnqueued(args), {
+      allowOrphanRecovery: true,
+    });
+  }
+
+  public async getOrphanReturnFeeQuote(args: {
+    lock: IBitcoinLockRecord;
+    record: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<{ canAfford: boolean; availableBalance: bigint; txFee: bigint }> {
+    const client = await getMainchainClient(false);
+    const request = await this.createRequest(args);
+    const tx = await this.buildOrphanReturnRequestTx(client, request);
+    const txSigner = await this.walletKeys.getLiquidLockingKeypair();
+
+    return await new TxSubmitter(client, tx, txSigner).canAfford();
+  }
+
+  public getTransactionInfo(utxoId: number, record: Pick<IBitcoinUtxoRecord, 'id'>): TransactionInfo | undefined {
+    return this.transactionTracker.findLatestTxInfo(txInfo => {
+      if (txInfo.tx.extrinsicType !== ExtrinsicType.BitcoinOrphanedUtxoRelease) return false;
+      const metadata = txInfo.tx.metadataJson as { utxoId?: number; utxoRecordId?: number } | undefined;
+      if (metadata?.utxoId !== utxoId) return false;
+      return metadata.utxoRecordId === record.id;
+    });
+  }
+
+  public async reconcileCandidateReturns(lock: IBitcoinLockRecord): Promise<void> {
+    if (!lock.utxoId) return;
+
+    const fundingRecord = this.bitcoinLocks.utxoTracking.getAcceptedFundingRecordForLock(lock);
+    const fundingRecordId = fundingRecord?.id ?? lock.fundingUtxoRecordId ?? undefined;
+    const records = this.bitcoinLocks.utxoTracking
+      .getMismatchOrphanReleases(lock.utxoId, undefined, fundingRecordId)
+      .filter(record => record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnArgon);
+
+    for (const record of records) {
+      if (!record.releaseToDestinationAddress || record.releaseBitcoinNetworkFee == null) continue;
+
+      const txInfo = this.getTransactionInfo(record.lockUtxoId, record);
+      if (!txInfo) {
+        if (record.requestedReleaseAtTick == null) {
+          const recoveredFromChain = await this.syncReleaseRequestFromChain(lock, record);
+          if (!recoveredFromChain) {
+            await this.bitcoinLocks.utxoTracking.setReleaseError(
+              record,
+              'Mismatch return was interrupted before submission. Please retry return or collect the adjusted amount.',
+            );
+            continue;
+          }
+        }
+        await this.submitToBitcoin(lock, record, {
+          toScriptPubkey: record.releaseToDestinationAddress,
+          bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
+        });
+        continue;
+      }
+
+      const txFailure = getTransactionFailureMessage(txInfo);
+      if (txFailure) {
+        await this.bitcoinLocks.utxoTracking.setReleaseError(record, txFailure);
+        continue;
+      }
+      if (txInfo.tx.status !== TransactionStatus.Finalized) continue;
+
+      await this.ensureObservedAtTick(record, txInfo);
+      const vaultSignature =
+        record.releaseCosignVaultSignature && record.releaseCosignHeight != null
+          ? record.releaseCosignVaultSignature
+          : await this.createVaultSignature(lock, record, {
+              toScriptPubkey: record.releaseToDestinationAddress,
+              bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
+            });
+      if (!record.releaseCosignVaultSignature || record.releaseCosignHeight == null) {
+        await this.bitcoinLocks.utxoTracking.setReleaseCosign(record, {
+          releaseCosignVaultSignature: vaultSignature,
+          releaseCosignHeight: txInfo.txResult.blockNumber!,
+        });
+      }
+      await this.submitToBitcoin(lock, record, {
+        toScriptPubkey: record.releaseToDestinationAddress,
+        bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
+        vaultSignature,
+      });
+    }
+  }
+
+  public async reconcileOrphanReturns(lock: IBitcoinLockRecord): Promise<void> {
+    const records = this.bitcoinLocks.utxoTracking
+      .getUnresolvedOrphanRecords([lock])
+      .filter(record => record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnArgon);
+
+    for (const record of records) {
+      if (!record.releaseToDestinationAddress || record.releaseBitcoinNetworkFee == null) continue;
+
+      if (record.requestedReleaseAtTick == null) {
+        const txInfo = this.getTransactionInfo(record.lockUtxoId, record);
+        const txFailure = getTransactionFailureMessage(txInfo);
+
+        if (!txInfo || txFailure) {
+          const recoveredFromChain = await this.syncReleaseRequestFromChain(lock, record);
+          if (!recoveredFromChain) {
+            await this.bitcoinLocks.utxoTracking.setReleaseError(
+              record,
+              txFailure ?? 'Orphan return was interrupted before submission. Please retry the return.',
+            );
+            continue;
+          }
+        } else {
+          if (txInfo.tx.status !== TransactionStatus.Finalized) continue;
+          await this.ensureObservedAtTick(record, txInfo);
+        }
+      }
+
+      if (!record.releaseCosignVaultSignature || record.releaseCosignHeight == null) continue;
+      await this.submitToBitcoin(lock, record, {
+        toScriptPubkey: record.releaseToDestinationAddress,
+        bitcoinNetworkFee: record.releaseBitcoinNetworkFee,
+        vaultSignature: record.releaseCosignVaultSignature,
+      });
+    }
+  }
+
+  public async syncBitcoinProcessing(oracleBitcoinBlockHeight: number): Promise<void> {
+    const locksByUtxoId = this.bitcoinLocks.data.locksByUtxoId;
+    const tasks = this.bitcoinLocks.utxoTracking
+      .getAllOrphanLifecycleUtxos()
+      .filter(record => {
+        if (record.status !== BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin) return false;
+        const lock = locksByUtxoId[record.lockUtxoId];
+        const fundingRecord = lock ? this.bitcoinLocks.utxoTracking.getAcceptedFundingRecordForLock(lock) : undefined;
+        const fundingRecordId = fundingRecord?.id ?? lock?.fundingUtxoRecordId ?? undefined;
+        return record.id !== fundingRecordId;
+      })
+      .map(async record => {
+        const lock = locksByUtxoId[record.lockUtxoId];
+        if (!lock || !record.releaseTxid) return;
+
+        try {
+          await this.bitcoinLocks.utxoTracking.updateReleaseLastConfirmationCheck(record);
+        } catch (error) {
+          console.warn('[BitcoinOrphanReleases] Error updating return confirmation check', error);
+        }
+
+        const mempoolTxStatus = await this.mempool
+          .getTxStatus(record.releaseTxid, oracleBitcoinBlockHeight)
+          .catch(() => undefined);
+        if (mempoolTxStatus?.isConfirmed) {
+          await this.bitcoinLocks.utxoTracking.setReleaseComplete(record, mempoolTxStatus.transactionBlockHeight);
+        }
+      });
+
+    await Promise.allSettled(tasks);
+  }
+
+  public async syncCosignCounterSubscriptions(client: ArgonClient): Promise<void> {
+    const subscriptions = new Map<string, { vaultId: number; ownerAccount: string }>();
+    const locksByUtxoId = this.bitcoinLocks.data.locksByUtxoId;
+    const locks = Object.values(locksByUtxoId);
+
+    for (const record of this.bitcoinLocks.utxoTracking.getUnresolvedOrphanRecords(locks)) {
+      if (record.status !== BitcoinUtxoStatus.ReleaseIsProcessingOnArgon || record.releaseCosignVaultSignature) {
+        continue;
+      }
+      const lock = locksByUtxoId[record.lockUtxoId];
+      if (!lock) continue;
+
+      const ownerAccount = lock.lockDetails.ownerAccount;
+      subscriptions.set(`${lock.vaultId}:${ownerAccount}`, { vaultId: lock.vaultId, ownerAccount });
+    }
+
+    for (const [key, { vaultId, ownerAccount }] of subscriptions) {
+      if (this.#cosignCounterSubscriptions.has(key)) continue;
+
+      let previousCount: number | undefined;
+      const unsubscribe = await client.query.vaults.orphanedUtxoAccountsByVaultId(vaultId, ownerAccount, count => {
+        const nextCount = count.toNumber();
+        if (previousCount !== undefined && nextCount < previousCount) {
+          const bestBlockNumber = this.blockWatch.bestBlockHeader.blockNumber;
+          const scanThroughBlock = bestBlockNumber + 1;
+          const latestProcessedBlock = this.bitcoinLocks.data.latestArgonBlock?.blockNumber ?? bestBlockNumber - 1;
+          const scanFromBlock = Math.max(1, Math.min(latestProcessedBlock + 1, bestBlockNumber));
+
+          this.#eventScanFromBlock = Math.min(this.#eventScanFromBlock ?? scanFromBlock, scanFromBlock);
+          this.#eventScanThroughBlock = Math.max(this.#eventScanThroughBlock ?? scanThroughBlock, scanThroughBlock);
+        }
+        previousCount = nextCount;
+      });
+      this.#cosignCounterSubscriptions.set(key, unsubscribe);
+    }
+
+    for (const [key, unsubscribe] of this.#cosignCounterSubscriptions) {
+      if (subscriptions.has(key)) continue;
+      unsubscribe();
+      this.#cosignCounterSubscriptions.delete(key);
+    }
+  }
+
+  public async recoverPendingCosignEvents(settledThroughBlock: number): Promise<void> {
+    const requestedThroughBlock = this.#eventScanThroughBlock;
+    if (this.#eventScanFromBlock === undefined || requestedThroughBlock === undefined) return;
+
+    const scanThroughBlock = Math.min(requestedThroughBlock, settledThroughBlock);
+    if (this.#eventScanFromBlock > scanThroughBlock) return;
+
+    while (this.#eventScanFromBlock !== undefined && this.#eventScanFromBlock <= scanThroughBlock) {
+      const block = await this.blockWatch.getHeaderByBlockNumber(this.#eventScanFromBlock);
+      const events = (await this.blockWatch.getEvents(block)).filter(({ event }) => {
+        return event.section === 'bitcoinLocks' && event.method === 'OrphanedUtxoCosigned';
+      });
+      if (events.length) await this.bitcoinLocks.recovery.recoverBlock(block, events);
+      this.#eventScanFromBlock = block.blockNumber + 1;
+    }
+
+    if (this.#eventScanFromBlock > requestedThroughBlock) {
+      this.#eventScanFromBlock = undefined;
+      this.#eventScanThroughBlock = undefined;
+    }
+
+    const locksByUtxoId = this.bitcoinLocks.data.locksByUtxoId;
+    const locks = Object.values(locksByUtxoId);
+    const locksWithRecoveredCosigns = new Set(
+      this.bitcoinLocks.utxoTracking
+        .getUnresolvedOrphanRecords(locks)
+        .filter(record => record.releaseCosignVaultSignature)
+        .map(record => locksByUtxoId[record.lockUtxoId])
+        .filter((lock): lock is IBitcoinLockRecord => lock !== undefined),
+    );
+    for (const lock of locksWithRecoveredCosigns) {
+      await this.reconcileOrphanReturns(lock);
+    }
+  }
+
+  public shutdown(): void {
+    for (const unsubscribe of this.#cosignCounterSubscriptions.values()) unsubscribe();
+    this.#cosignCounterSubscriptions.clear();
+  }
+
+  private async requestCandidateReturnUnqueued(args: {
+    lock: IBitcoinLockRecord;
+    candidateRecord: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<TransactionInfo | undefined> {
+    const { lock } = args;
+    const candidateRecord =
+      this.bitcoinLocks.utxoTracking
+        .getUtxosForLock(lock)
+        .find(record => record.txid === args.candidateRecord.txid && record.vout === args.candidateRecord.vout) ??
+      args.candidateRecord;
+    if (!lock.utxoId) {
+      throw new Error('This lock has no Bitcoin funding ID yet.');
+    }
+    const candidate = this.bitcoinLocks
+      .getMismatchViewState(lock)
+      .candidates.find(x => x.record.txid === candidateRecord.txid && x.record.vout === candidateRecord.vout);
+    if (!candidate?.canReturn) {
+      throw new Error('This mismatch return is not currently available.');
+    }
+
+    const client = await getMainchainClient(false);
+    let record: IBitcoinUtxoRecord | undefined;
+
+    try {
+      const request = await this.createRequest({
+        lock,
+        record: candidateRecord,
+        toScriptPubkey: args.toScriptPubkey,
+        bitcoinNetworkFee: args.bitcoinNetworkFee,
+        feeRatePerSatVb: args.feeRatePerSatVb,
+      });
+      const vaultSignature = await this.createVaultSignature(lock, candidateRecord, {
+        toScriptPubkey: request.toScriptPubkeyHex,
+        bitcoinNetworkFee: request.bitcoinNetworkFee,
+      });
+      const tx = await this.buildCandidateReturnTx({
+        client,
+        lock,
+        request,
+        vaultSignature,
+      });
+
+      if (
+        [
+          BitcoinUtxoStatus.ReleaseIsProcessingOnArgon,
+          BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+          BitcoinUtxoStatus.ReleaseComplete,
+        ].includes(candidateRecord.status)
+      ) {
+        return this.getTransactionInfo(lock.utxoId, candidateRecord);
+      }
+
+      await this.bitcoinLocks.utxoTracking.setReleaseIsProcessingOnArgon(candidateRecord, {
+        releaseToDestinationAddress: request.toScriptPubkeyHex,
+        releaseBitcoinNetworkFee: request.bitcoinNetworkFee,
+      });
+      record = candidateRecord;
+
+      const txInfo = await this.transactionTracker.submitAndWatch({
+        tx,
+        txSigner: await this.walletKeys.getLiquidLockingKeypair(),
+        extrinsicType: ExtrinsicType.BitcoinOrphanedUtxoRelease,
+        metadata: {
+          releaseKind: 'Orphan',
+          utxoId: lock.utxoId,
+          utxoRecordId: candidateRecord.id,
+          utxoRef: request.utxoRef,
+        },
+      });
+
+      void this.continueAfterArgonInclusion(
+        lock,
+        record,
+        {
+          toScriptPubkey: request.toScriptPubkeyHex,
+          bitcoinNetworkFee: request.bitcoinNetworkFee,
+          vaultSignature,
+        },
+        txInfo,
+      );
+
+      return txInfo;
+    } catch (error) {
+      if (record) await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+      throw error;
+    }
+  }
+
+  private async requestOrphanReturnUnqueued(args: {
+    lock: IBitcoinLockRecord;
+    record: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<TransactionInfo | undefined> {
+    const { lock } = args;
+    const record =
+      this.bitcoinLocks.utxoTracking
+        .getUtxosForLock(lock)
+        .find(record => record.txid === args.record.txid && record.vout === args.record.vout) ?? args.record;
+    if (!lock.utxoId || record.lockUtxoId !== lock.utxoId) {
+      throw new Error('This orphan does not belong to the selected Bitcoin lock.');
+    }
+    if (this.bitcoinLocks.utxoTracking.isReleaseStatus(record.status)) {
+      return this.getTransactionInfo(lock.utxoId, record);
+    }
+    if (record.status !== BitcoinUtxoStatus.Orphaned) {
+      throw new Error('This orphan return is not currently available.');
+    }
+
+    const client = await getMainchainClient(false);
+    let releaseStarted = false;
+
+    try {
+      const request = await this.createRequest({
+        lock,
+        record,
+        toScriptPubkey: args.toScriptPubkey,
+        bitcoinNetworkFee: args.bitcoinNetworkFee,
+        feeRatePerSatVb: args.feeRatePerSatVb,
+      });
+      const tx = await this.buildOrphanReturnRequestTx(client, request);
+      const txSigner = await this.walletKeys.getLiquidLockingKeypair();
+      const affordability = await new TxSubmitter(client, tx, txSigner).canAfford();
+      if (!affordability.canAfford) {
+        throw new Error('The Internal App Wallet does not have enough ARGON to cover the transaction fee.');
+      }
+
+      await this.bitcoinLocks.utxoTracking.setReleaseIsProcessingOnArgon(record, {
+        releaseToDestinationAddress: request.toScriptPubkeyHex,
+        releaseBitcoinNetworkFee: request.bitcoinNetworkFee,
+      });
+      releaseStarted = true;
+      await this.syncCosignCounterSubscriptions(client).catch(error => {
+        console.warn('[BitcoinOrphanReleases] Unable to watch return counter', error);
+      });
+
+      const txInfo = await this.transactionTracker.submitAndWatch({
+        tx,
+        txSigner,
+        extrinsicType: ExtrinsicType.BitcoinOrphanedUtxoRelease,
+        metadata: {
+          releaseKind: 'Orphan',
+          utxoId: lock.utxoId,
+          utxoRecordId: record.id,
+          utxoRef: request.utxoRef,
+        },
+      });
+
+      void txInfo.txResult.waitForInFirstBlock
+        .then(async () => {
+          const txFailure = getTransactionFailureMessage(txInfo);
+          if (txFailure) {
+            await this.bitcoinLocks.utxoTracking.setReleaseError(record, txFailure);
+            return;
+          }
+          await this.ensureObservedAtTick(record, txInfo);
+        })
+        .catch(error => this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error)));
+
+      return txInfo;
+    } catch (error) {
+      if (releaseStarted) await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+      throw error;
+    }
+  }
+
+  private async createRequest(args: {
+    lock: IBitcoinLockRecord;
+    record: IBitcoinUtxoRecord;
+    toScriptPubkey: string;
+    bitcoinNetworkFee?: bigint;
+    feeRatePerSatVb?: bigint;
+  }): Promise<{ utxoRef: { txid: string; vout: number }; toScriptPubkeyHex: string; bitcoinNetworkFee: bigint }> {
+    const toScriptPubkeyHex = addressBytesHex(args.toScriptPubkey, this.bitcoinLocks.bitcoinNetwork);
+    const bitcoinNetworkFee =
+      args.bitcoinNetworkFee ??
+      (await this.bitcoinLocks.calculateBitcoinNetworkFee(args.lock, args.feeRatePerSatVb ?? 5n, args.toScriptPubkey));
+
+    return {
+      utxoRef: { txid: args.record.txid, vout: args.record.vout },
+      toScriptPubkeyHex,
+      bitcoinNetworkFee,
+    };
+  }
+
+  private async buildCandidateReturnTx(args: {
+    client: ArgonClient;
+    lock: IBitcoinLockRecord;
+    request: { utxoRef: { txid: string; vout: number }; toScriptPubkeyHex: string; bitcoinNetworkFee: bigint };
+    vaultSignature: Uint8Array;
+  }): Promise<SubmittableExtrinsic> {
+    if (!args.lock.lockDetails.ownerAccount) {
+      throw new Error('Missing lock owner account needed for orphan release.');
+    }
+
+    const txs: SubmittableExtrinsic[] = [];
+    const candidateRefs = await args.client.query.bitcoinUtxos.candidateUtxoRefsByUtxoId(args.lock.utxoId!);
+    const candidateStillOnChain = [...candidateRefs.entries()].some(([utxoRef]) => {
+      return (
+        utxoRef.txid.toHex() === args.request.utxoRef.txid &&
+        utxoRef.outputIndex.toNumber() === args.request.utxoRef.vout
+      );
+    });
+    if (candidateStillOnChain) {
+      txs.push(
+        args.client.tx.bitcoinUtxos.rejectUtxoCandidate(args.lock.utxoId!, {
+          txid: args.request.utxoRef.txid,
+          outputIndex: args.request.utxoRef.vout,
+        }),
+      );
+    }
+
+    const requestTx = await BitcoinLock.createOrphanedUtxoReleaseRequestTx({
+      client: args.client,
+      utxoRef: { txid: args.request.utxoRef.txid, outputIndex: args.request.utxoRef.vout },
+      releaseRequest: {
+        toScriptPubkey: args.request.toScriptPubkeyHex,
+        bitcoinNetworkFee: args.request.bitcoinNetworkFee,
+      },
+    });
+    if (!requestTx) throw new Error('Orphan release is not supported on this chain.');
+
+    const cosignTx = await BitcoinLock.createOrphanedUtxoCosignTx({
+      client: args.client,
+      orphanOwner: args.lock.lockDetails.ownerAccount,
+      utxoRef: { txid: args.request.utxoRef.txid, outputIndex: args.request.utxoRef.vout },
+      vaultSignature: args.vaultSignature,
+    });
+    if (!cosignTx) throw new Error('Orphan release is not supported on this chain.');
+
+    txs.push(requestTx, cosignTx);
+    return args.client.tx.utility.batchAll(txs);
+  }
+
+  private async buildOrphanReturnRequestTx(
+    client: ArgonClient,
+    request: { utxoRef: { txid: string; vout: number }; toScriptPubkeyHex: string; bitcoinNetworkFee: bigint },
+  ): Promise<SubmittableExtrinsic> {
+    const tx = await BitcoinLock.createOrphanedUtxoReleaseRequestTx({
+      client,
+      utxoRef: { txid: request.utxoRef.txid, outputIndex: request.utxoRef.vout },
+      releaseRequest: {
+        toScriptPubkey: request.toScriptPubkeyHex,
+        bitcoinNetworkFee: request.bitcoinNetworkFee,
+      },
+    });
+    if (!tx) throw new Error('Orphan release is not supported on this chain.');
+    return tx;
+  }
+
+  private async createVaultSignature(
+    lock: IBitcoinLockRecord,
+    record: Pick<IBitcoinUtxoRecord, 'txid' | 'vout' | 'satoshis'>,
+    releaseRequest: { toScriptPubkey: string; bitcoinNetworkFee: bigint },
+  ): Promise<Uint8Array> {
+    const vault = this.bitcoinLocks.myVault;
+    if (!vault) throw new Error('No vault available to cosign this release.');
+
+    const vaultSignature = await vault.createVaultSignatureForMyOrphanedUtxoRelease({
+      lock,
+      txid: record.txid,
+      vout: record.vout,
+      satoshis: record.satoshis,
+      toScriptPubkey: releaseRequest.toScriptPubkey,
+      bitcoinNetworkFee: releaseRequest.bitcoinNetworkFee,
+    });
+    if (!vaultSignature) throw new Error('Failed to generate vault signature for orphan release.');
+    return vaultSignature;
+  }
+
+  private async ensureObservedAtTick(record: IBitcoinUtxoRecord, txInfo: TransactionInfo): Promise<void> {
+    if (record.requestedReleaseAtTick != null) return;
+    if (!record.releaseToDestinationAddress || record.releaseBitcoinNetworkFee == null) return;
+
+    const blockHash = txInfo.tx.blockHash ?? (await txInfo.txResult.waitForInFirstBlock);
+    const client = await getMainchainClient(false);
+    const api = await client.at(blockHash);
+    const requestedReleaseAtTick = await api.query.ticks.currentTick().then(x => x.toNumber());
+
+    await this.bitcoinLocks.utxoTracking.setReleaseIsProcessingOnArgon(record, {
+      requestedReleaseAtTick,
+      releaseToDestinationAddress: record.releaseToDestinationAddress,
+      releaseBitcoinNetworkFee: record.releaseBitcoinNetworkFee,
+    });
+  }
+
+  private async syncReleaseRequestFromChain(lock: IBitcoinLockRecord, record: IBitcoinUtxoRecord): Promise<boolean> {
+    if (record.requestedReleaseAtTick != null) return true;
+
+    const client = await getMainchainClient(true);
+    const orphanMaybe = await client.query.bitcoinLocks.orphanedUtxosByAccount(lock.lockDetails.ownerAccount, {
+      txid: record.txid,
+      outputIndex: record.vout,
+    });
+    if (!orphanMaybe.isSome) return false;
+
+    const orphan = orphanMaybe.unwrap();
+    if (orphan.utxoId.toNumber() !== lock.utxoId || orphan.cosignRequest.isNone) return false;
+
+    const request = orphan.cosignRequest.unwrap();
+    const blockHash = await client.rpc.chain.getBlockHash(request.createdAtArgonBlockNumber.toNumber());
+    const apiAt = await client.at(blockHash);
+    const requestedReleaseAtTick = await apiAt.query.ticks.currentTick().then(x => x.toNumber());
+
+    await this.bitcoinLocks.utxoTracking.setReleaseIsProcessingOnArgon(record, {
+      requestedReleaseAtTick,
+      releaseToDestinationAddress: u8aToHex(request.toScriptPubkey, undefined, false),
+      releaseBitcoinNetworkFee: request.bitcoinNetworkFee.toBigInt(),
+    });
+    return true;
+  }
+
+  private async submitToBitcoin(
+    lock: IBitcoinLockRecord,
+    record: IBitcoinUtxoRecord,
+    args: { toScriptPubkey: string; bitcoinNetworkFee: bigint; vaultSignature?: Uint8Array },
+  ): Promise<void> {
+    try {
+      const vaultSignature =
+        args.vaultSignature ??
+        (record.releaseCosignVaultSignature && record.releaseCosignHeight != null
+          ? record.releaseCosignVaultSignature
+          : undefined) ??
+        (await this.createVaultSignature(lock, record, {
+          toScriptPubkey: args.toScriptPubkey,
+          bitcoinNetworkFee: args.bitcoinNetworkFee,
+        }));
+      const bitcoinNetwork = this.bitcoinLocks.bitcoinNetwork;
+      const ownerXpriv = await this.walletKeys.getBitcoinChildXpriv(lock.hdPath, bitcoinNetwork);
+      const cosign = new CosignScript({ ...lock.lockDetails, utxoSatoshis: record.satoshis }, bitcoinNetwork);
+      const tx = cosign.cosignAndGenerateTx({
+        releaseRequest: {
+          toScriptPubkey: args.toScriptPubkey,
+          bitcoinNetworkFee: args.bitcoinNetworkFee,
+        },
+        vaultCosignature: vaultSignature,
+        utxoRef: { txid: record.txid, vout: record.vout },
+        ownerXpriv,
+      });
+      if (!tx || !tx.isFinal) throw new Error('Failed to generate orphan release transaction.');
+
+      const txid = tx.id;
+      const hexTx = u8aToHex(tx.toBytes(true, true), undefined, false);
+      const oracleBitcoinBlockHeight = this.bitcoinLocks.data.oracleBitcoinBlockHeight;
+      const existingTxStatus = await this.mempool.getTxStatus(txid, oracleBitcoinBlockHeight).catch(() => undefined);
+      if (existingTxStatus?.isConfirmed) {
+        const mempoolTip = await this.mempool.getTipHeight().catch(() => oracleBitcoinBlockHeight);
+        await this.bitcoinLocks.utxoTracking.setReleaseSeenOnBitcoinAndProcessing(record, txid, mempoolTip);
+        return;
+      }
+
+      let bitcoinTxid: string;
+      try {
+        bitcoinTxid = await this.mempool.broadcastTx(hexTx);
+      } catch (error) {
+        const message = String(error ?? '').toLowerCase();
+        const wasAlreadyBroadcast =
+          message.includes('txn-already-in-mempool') ||
+          message.includes('txn-already-known') ||
+          message.includes('already in mempool') ||
+          message.includes('already known') ||
+          message.includes('already have transaction');
+        if (!wasAlreadyBroadcast) throw error;
+        bitcoinTxid = txid;
+      }
+      const mempoolTip = await this.mempool.getTipHeight().catch(() => oracleBitcoinBlockHeight);
+      await this.bitcoinLocks.utxoTracking.setReleaseSeenOnBitcoinAndProcessing(record, bitcoinTxid, mempoolTip);
+    } catch (error) {
+      await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+    }
+  }
+
+  private async continueAfterArgonInclusion(
+    lock: IBitcoinLockRecord,
+    record: IBitcoinUtxoRecord,
+    args: { toScriptPubkey: string; bitcoinNetworkFee: bigint; vaultSignature: Uint8Array },
+    txInfo: TransactionInfo,
+  ): Promise<void> {
+    try {
+      await txInfo.txResult.waitForInFirstBlock;
+      const txFailure = getTransactionFailureMessage(txInfo);
+      if (txFailure) {
+        await this.bitcoinLocks.utxoTracking.setReleaseError(record, txFailure);
+        return;
+      }
+
+      await this.ensureObservedAtTick(record, txInfo);
+      await this.bitcoinLocks.utxoTracking.setReleaseCosign(record, {
+        releaseCosignVaultSignature: args.vaultSignature,
+        releaseCosignHeight: txInfo.txResult.blockNumber!,
+      });
+      await this.submitToBitcoin(lock, record, args);
+    } catch (error) {
+      await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+    }
+  }
+}

--- a/src-vue/lib/BitcoinOrphanReleases.ts
+++ b/src-vue/lib/BitcoinOrphanReleases.ts
@@ -694,7 +694,7 @@ export default class BitcoinOrphanReleases {
       const mempoolTip = await this.mempool.getTipHeight().catch(() => oracleBitcoinBlockHeight);
       await this.bitcoinLocks.utxoTracking.setReleaseSeenOnBitcoinAndProcessing(record, bitcoinTxid, mempoolTip);
     } catch (error) {
-      await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+      await this.bitcoinLocks.utxoTracking.setStatusError(record, String(error));
     }
   }
 

--- a/src-vue/lib/BitcoinOrphanReleases.ts
+++ b/src-vue/lib/BitcoinOrphanReleases.ts
@@ -98,6 +98,26 @@ export default class BitcoinOrphanReleases {
     });
   }
 
+  public async onRequestedReleaseInBlock(record: IBitcoinUtxoRecord, txInfo: TransactionInfo): Promise<void> {
+    const { txResult } = txInfo;
+    const postProcessor = txInfo.createPostProcessor();
+    try {
+      await txResult.waitForInFirstBlock;
+      const txFailure = getTransactionFailureMessage(txInfo);
+      if (txFailure) {
+        await this.bitcoinLocks.utxoTracking.setReleaseError(record, txFailure);
+        return;
+      }
+
+      await this.ensureObservedAtTick(record, txInfo);
+    } catch (error) {
+      await this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error));
+      throw error;
+    } finally {
+      postProcessor.resolve();
+    }
+  }
+
   public async reconcileCandidateReturns(lock: IBitcoinLockRecord): Promise<void> {
     if (!lock.utxoId) return;
 
@@ -461,16 +481,9 @@ export default class BitcoinOrphanReleases {
         },
       });
 
-      void txInfo.txResult.waitForInFirstBlock
-        .then(async () => {
-          const txFailure = getTransactionFailureMessage(txInfo);
-          if (txFailure) {
-            await this.bitcoinLocks.utxoTracking.setReleaseError(record, txFailure);
-            return;
-          }
-          await this.ensureObservedAtTick(record, txInfo);
-        })
-        .catch(error => this.bitcoinLocks.utxoTracking.setReleaseError(record, String(error)));
+      void this.onRequestedReleaseInBlock(record, txInfo).catch(error => {
+        console.warn(`[BitcoinOrphanReleases] Unable to process return request #${txInfo.tx.id}`, error);
+      });
 
       return txInfo;
     } catch (error) {

--- a/src-vue/lib/BitcoinUtxoTracking.ts
+++ b/src-vue/lib/BitcoinUtxoTracking.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import { BitcoinNetwork } from '@argonprotocol/bitcoin';
 import { getPercent, MiningFrames, NetworkConfig } from '@argonprotocol/apps-core';
-import { type ApiDecoration, type ArgonClient, type IBitcoinLockConfig } from '@argonprotocol/mainchain';
+import { type ApiDecoration, type ArgonClient, type IBitcoinLockConfig, u8aToHex } from '@argonprotocol/mainchain';
 import {
   BitcoinUtxosTable,
   BitcoinUtxoStatus,
@@ -227,7 +227,7 @@ export default class BitcoinUtxoTracking {
         if (orphan.cosignRequest.isSome) {
           const request = orphan.cosignRequest.unwrap();
           await this.setReleaseIsProcessingOnArgon(record, {
-            releaseToDestinationAddress: request.toScriptPubkey.toHex(),
+            releaseToDestinationAddress: u8aToHex(request.toScriptPubkey, undefined, false),
             releaseBitcoinNetworkFee: request.bitcoinNetworkFee.toBigInt(),
           });
         }

--- a/src-vue/lib/BitcoinUtxoTracking.ts
+++ b/src-vue/lib/BitcoinUtxoTracking.ts
@@ -29,6 +29,8 @@ export interface IUtxoTrackingDeps {
 }
 
 export default class BitcoinUtxoTracking {
+  readonly #orphanedUtxoRecordIds = new Set<number>();
+
   public data: {
     utxosByLockUtxoId: { [utxoId: number]: IBitcoinUtxoRecord[] };
     utxosByKey: { [key: string]: IBitcoinUtxoRecord };
@@ -45,10 +47,12 @@ export default class BitcoinUtxoTracking {
 
   public async load(): Promise<void> {
     const table = await this.getTable();
-    const records = await table.fetchAll();
+    const [records, orphanedRecordIds] = await Promise.all([table.fetchAll(), table.fetchOrphanedRecordIds()]);
     this.data.utxosByLockUtxoId = {};
     this.data.utxosByKey = {};
     this.data.utxosById = {};
+    this.#orphanedUtxoRecordIds.clear();
+    for (const id of orphanedRecordIds) this.#orphanedUtxoRecordIds.add(id);
     for (const record of records) {
       this.recordUtxo(record);
     }
@@ -126,6 +130,7 @@ export default class BitcoinUtxoTracking {
       if (siblingRecord.id === record.id) continue;
       if (siblingRecord.status !== BitcoinUtxoStatus.FundingCandidate) continue;
       await table.setOrphaned(siblingRecord);
+      this.#orphanedUtxoRecordIds.add(siblingRecord.id);
     }
 
     lock.fundingUtxoRecordId = record.id;
@@ -144,7 +149,7 @@ export default class BitcoinUtxoTracking {
       seenClients.add(client);
 
       const candidates = await this.syncArgonFundingCandidates(lock, client);
-      const orphans = await this.syncArgonOrphanedCandidates(lock, client);
+      const orphans = await this.syncArgonOrphans([lock], client);
       if (candidates.length || orphans.length) return;
     }
 
@@ -152,7 +157,7 @@ export default class BitcoinUtxoTracking {
     const latestClient = await this.deps.getMainchainClient(false).catch(() => undefined);
     if (!latestClient) return;
     await this.syncArgonFundingCandidates(lock, latestClient);
-    await this.syncArgonOrphanedCandidates(lock, latestClient);
+    await this.syncArgonOrphans([lock], latestClient);
   }
 
   public async syncArgonFundingCandidates(
@@ -183,32 +188,50 @@ export default class BitcoinUtxoTracking {
     return records;
   }
 
-  public async syncArgonOrphanedCandidates(
-    lock: IBitcoinLockRecord,
+  public async syncArgonOrphans(
+    locks: IBitcoinLockRecord[],
     apiClient: ApiDecoration<'promise'>,
   ): Promise<IBitcoinUtxoRecord[]> {
-    if (!lock.utxoId) return [];
-
-    const entries = await apiClient.query.bitcoinLocks.orphanedUtxosByAccount.entries(lock.lockDetails.ownerAccount);
-    if (!entries.length) return [];
-
+    const locksByOwner = new Map<string, IBitcoinLockRecord[]>();
     const records: IBitcoinUtxoRecord[] = [];
-    for (const [orphanKey, orphanMaybe] of entries) {
-      if (orphanMaybe.isNone) continue;
-      const orphan = orphanMaybe.unwrap();
-      if (orphan.utxoId.toNumber() !== lock.utxoId) continue;
 
-      const utxoRef = orphanKey.args[1];
-      const record = await this.upsertUtxoRecord(
-        lock,
-        {
-          txid: utxoRef.txid.toHex(),
-          vout: utxoRef.outputIndex.toNumber(),
-          satoshis: orphan.satoshis.toBigInt(),
-        },
-        { markOrphaned: true },
-      );
-      records.push(record);
+    for (const lock of locks) {
+      if (!lock.utxoId) continue;
+      const ownerLocks = locksByOwner.get(lock.lockDetails.ownerAccount) ?? [];
+      ownerLocks.push(lock);
+      locksByOwner.set(lock.lockDetails.ownerAccount, ownerLocks);
+    }
+
+    for (const [ownerAccount, ownerLocks] of locksByOwner) {
+      const locksByUtxoId = new Map(ownerLocks.map(lock => [lock.utxoId, lock]));
+      const entries = await apiClient.query.bitcoinLocks.orphanedUtxosByAccount.entries(ownerAccount);
+
+      for (const [orphanKey, orphanMaybe] of entries) {
+        if (orphanMaybe.isNone) continue;
+        const orphan = orphanMaybe.unwrap();
+        const lock = locksByUtxoId.get(orphan.utxoId.toNumber());
+        if (!lock) continue;
+
+        const utxoRef = orphanKey.args[1];
+        const record = await this.upsertUtxoRecord(
+          lock,
+          {
+            txid: utxoRef.txid.toHex(),
+            vout: utxoRef.outputIndex.toNumber(),
+            satoshis: orphan.satoshis.toBigInt(),
+          },
+          { markOrphaned: true },
+        );
+        records.push(record);
+
+        if (orphan.cosignRequest.isSome) {
+          const request = orphan.cosignRequest.unwrap();
+          await this.setReleaseIsProcessingOnArgon(record, {
+            releaseToDestinationAddress: request.toScriptPubkey.toHex(),
+            releaseBitcoinNetworkFee: request.bitcoinNetworkFee.toBigInt(),
+          });
+        }
+      }
     }
     return records;
   }
@@ -398,6 +421,7 @@ export default class BitcoinUtxoTracking {
   ): IBitcoinUtxoRecord[] {
     const records = (this.data.utxosByLockUtxoId[lockUtxoId] ?? []).filter(record => {
       if (!this.isMismatchOrphanLifecycleRecord(record, fundingUtxoRecordId)) return false;
+      if (this.#orphanedUtxoRecordIds.has(record.id)) return false;
       if (!candidateRecord) return true;
       return this.isSameCandidate(record, candidateRecord);
     });
@@ -407,7 +431,23 @@ export default class BitcoinUtxoTracking {
   public getAllOrphanLifecycleUtxos(): IBitcoinUtxoRecord[] {
     return Object.values(this.data.utxosByLockUtxoId)
       .flat()
-      .filter(record => this.isMismatchOrphanLifecycleRecord(record));
+      .filter(record => {
+        const hasOrphanLifecycleStatus =
+          record.status === BitcoinUtxoStatus.Orphaned ||
+          this.isReleaseProcessingStatus(record.status) ||
+          this.isReleaseCompleteStatus(record.status);
+        return hasOrphanLifecycleStatus && this.#orphanedUtxoRecordIds.has(record.id);
+      });
+  }
+
+  public getUnresolvedOrphanRecords(locks: IBitcoinLockRecord[]): IBitcoinUtxoRecord[] {
+    const fundingRecordIds = new Set(
+      locks.map(lock => this.getAcceptedFundingRecordForLock(lock)?.id).filter((id): id is number => id !== undefined),
+    );
+
+    return this.getAllOrphanLifecycleUtxos()
+      .filter(record => !fundingRecordIds.has(record.id) && !this.isReleaseCompleteStatus(record.status))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
   }
 
   public getRequestReleaseByVaultProgress(
@@ -616,6 +656,7 @@ export default class BitcoinUtxoTracking {
         );
       }
       this.recordUtxo(record);
+      if (options?.markOrphaned) this.#orphanedUtxoRecordIds.add(record.id);
       if (options?.markFundingUtxo) {
         lock.fundingUtxoRecordId = record.id;
         lock.fundingUtxoRecord = record;
@@ -643,6 +684,7 @@ export default class BitcoinUtxoTracking {
       await table.updateMempoolObservation(record, options.mempoolObservation, this.deps.getOracleBitcoinBlockHeight());
     }
     this.recordUtxo(record);
+    if (options?.markOrphaned) this.#orphanedUtxoRecordIds.add(record.id);
     if (options?.markFundingUtxo) {
       lock.fundingUtxoRecordId = record.id;
       lock.fundingUtxoRecord = record;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -147,6 +147,7 @@ export class MyVault {
     };
     pendingCollectRevenue: bigint;
     pendingCosignUtxosById: Map<number, IPendingCosignUtxo>;
+    pendingOrphanCosignCount: number;
     releasedExternalUtxoIds: Set<number>;
     myPendingBitcoinCosignTxInfosByUtxoId: Map<number, TransactionInfo<{ utxoId: number }>>;
     nextCollectDueDate: number;
@@ -186,6 +187,7 @@ export class MyVault {
   #cosignQueue = new SingleFileQueue();
   #collectFrames: { frameId: number; uncollectedEarnings: bigint }[] = [];
   #pendingCosignUpdateSeq = 0;
+  #pendingOrphanCosignUpdateSeq = 0;
   #externalLocksUpdateSeq = 0;
   public readonly collectBuilder: VaultCollectBuilder;
   public readonly history: VaultHistory;
@@ -213,6 +215,7 @@ export class MyVault {
       pendingCollectTxInfo: null,
       pendingAllocateTxInfo: null,
       pendingCosignUtxosById: new Map(),
+      pendingOrphanCosignCount: 0,
       myPendingBitcoinCosignTxInfosByUtxoId: new Map(),
       nextCollectDueDate: 0,
       nextCosignDueDate: 0,
@@ -305,7 +308,9 @@ export class MyVault {
           tx.extrinsicType === ExtrinsicType.VaultCollect ||
           tx.extrinsicType === ExtrinsicType.CrosschainTransferApproveCouncil
         ) {
-          void this.onVaultCollect(txInfo);
+          void this.onVaultCollect(txInfo).catch(error => {
+            console.warn(`[MyVault] Unable to finish vault collect transaction #${txInfo.tx.id}`, error);
+          });
         }
       }
       if (!this.#singleRunTransactions.has(ExtrinsicType.VaultInitialAllocate)) {
@@ -379,6 +384,7 @@ export class MyVault {
       const vaultId = this.createdVault.vaultId;
       const clients = getMainchainClients();
       const client = await clients.get(false);
+      await this.refreshPendingOrphanCosignCount(client, vaultId);
 
       // update stats live
       const sub = await client.query.vaults.vaultsById(vaultId, vault => {
@@ -409,11 +415,14 @@ export class MyVault {
       const { unsubscribe: sub6 } = this.miningFrames.onFrameId(frameId => {
         this.data.currentFrameId = frameId;
         this.updateCollectDeadlines();
+        void this.refreshPendingOrphanCosignCount(client, vaultId).catch(x =>
+          console.error('Error updating pending orphaned Bitcoin signatures', x),
+        );
       });
 
       const sub7 = this.miningFrames.blockWatch.events.on('best-blocks', headers => {
-        void this.refreshExternalLocksFromBlockEvents(headers).catch(x =>
-          console.error(`Error updating external locks from block events`, x),
+        void this.refreshVaultBitcoinStateFromBlockEvents(headers).catch(x =>
+          console.error(`Error updating vault Bitcoin state from block events`, x),
         );
       });
 
@@ -454,15 +463,37 @@ export class MyVault {
     };
   }
 
-  private async refreshExternalLocksFromBlockEvents(headers: IBlockHeaderInfo[]): Promise<void> {
+  private async refreshPendingOrphanCosignCount(client: ArgonQueryClient, vaultId: number): Promise<void> {
+    const updateSeq = ++this.#pendingOrphanCosignUpdateSeq;
+    const entries = await client.query.vaults.orphanedUtxoAccountsByVaultId.entries(vaultId);
+    if (updateSeq !== this.#pendingOrphanCosignUpdateSeq) return;
+
+    this.data.pendingOrphanCosignCount = entries.reduce((total, [, count]) => total + count.toNumber(), 0);
+  }
+
+  private async refreshVaultBitcoinStateFromBlockEvents(headers: IBlockHeaderInfo[]): Promise<void> {
     const vaultId = this.vaultId;
     if (vaultId == null) return;
 
     const typeClient = await getMainchainClient(false);
     let latestApiClient: ApiDecoration<'promise'> | undefined;
+    let shouldRefreshOrphanCosigns = false;
     for (const header of headers) {
       const events = await this.miningFrames.blockWatch.getEvents(header);
+      let shouldRefreshExternalLocks = false;
       for (const { event } of events) {
+        if (typeClient.events.bitcoinLocks.OrphanedUtxoReleaseRequested.is(event)) {
+          if (vaultId === event.data.vaultId.toNumber()) {
+            shouldRefreshOrphanCosigns = true;
+          }
+          continue;
+        }
+        if (typeClient.events.bitcoinLocks.OrphanedUtxoCosigned.is(event)) {
+          if (vaultId === event.data.vaultId.toNumber()) {
+            shouldRefreshOrphanCosigns = true;
+          }
+          continue;
+        }
         if (
           typeClient.events.bitcoinLocks.BitcoinLockCreated.is(event) ||
           typeClient.events.bitcoinLocks.BitcoinLockRatcheted.is(event) ||
@@ -472,14 +503,19 @@ export class MyVault {
           typeClient.events.bitcoinLocks.BitcoinLockBurned.is(event)
         ) {
           if (vaultId === event.data.vaultId.toNumber()) {
-            latestApiClient = await this.miningFrames.clientAt(header);
-            break;
+            shouldRefreshExternalLocks = true;
           }
         }
+      }
+      if (shouldRefreshExternalLocks) {
+        latestApiClient = await this.miningFrames.clientAt(header);
       }
     }
     if (latestApiClient) {
       await this.refreshExternalLocks(latestApiClient);
+    }
+    if (shouldRefreshOrphanCosigns) {
+      await this.refreshPendingOrphanCosignCount(typeClient, vaultId);
     }
   }
 
@@ -1046,7 +1082,7 @@ export class MyVault {
     }
   }
 
-  public async collect(afterCollect: { moveTo: MoveTo }): Promise<TransactionInfo> {
+  public async collect(afterCollect: { moveTo: MoveTo }): Promise<TransactionInfo | undefined> {
     return await this.#cosignQueue.add(async () => {
       if (this.data.pendingCollectTxInfo) {
         if (!this.data.pendingCollectTxInfo.isPostProcessed) {
@@ -1069,7 +1105,7 @@ export class MyVault {
       });
 
       if (!submission) {
-        throw new Error('No vault actions are currently available to submit.');
+        return;
       }
 
       const txSigner = await this.walletKeys.getVaultingKeypair();
@@ -1088,7 +1124,7 @@ export class MyVault {
         this.data.releasedExternalUtxoIds.add(utxoId);
       }
 
-      void this.onVaultCollect(txInfo);
+      void this.onVaultCollect(txInfo).catch(() => undefined);
 
       return txInfo;
     }).promise;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -186,8 +186,8 @@ export class MyVault {
   // Serialize cosign submissions (collect + individual cosign) and track in-flight intent per UTXO.
   #cosignQueue = new SingleFileQueue();
   #collectFrames: { frameId: number; uncollectedEarnings: bigint }[] = [];
+  #finalizedBitcoinCosignUpdateSeq = 0;
   #pendingCosignUpdateSeq = 0;
-  #pendingOrphanCosignUpdateSeq = 0;
   #externalLocksUpdateSeq = 0;
   public readonly collectBuilder: VaultCollectBuilder;
   public readonly history: VaultHistory;
@@ -384,7 +384,11 @@ export class MyVault {
       const vaultId = this.createdVault.vaultId;
       const clients = getMainchainClients();
       const client = await clients.get(false);
-      await this.refreshPendingOrphanCosignCount(client, vaultId);
+      const finalizedClient = await this.miningFrames.blockWatch.getFinalizedApi();
+      await Promise.all([
+        this.refreshFinalizedRevenueState(finalizedClient, vaultId),
+        this.refreshFinalizedBitcoinCosignState(finalizedClient, vaultId),
+      ]);
 
       // update stats live
       const sub = await client.query.vaults.vaultsById(vaultId, vault => {
@@ -396,37 +400,68 @@ export class MyVault {
         this.data.createdVault = nextVault;
       });
 
-      const sub2 = await client.query.vaults.revenuePerFrameByVault(vaultId, async x => {
-        await this.updateRevenueStats(x);
+      const sub2 = await client.query.vaults.lastCollectFrameByVaultId(vaultId, () => {
         this.updateCollectDeadlines();
       });
-
-      const sub3 = await client.query.vaults.pendingCosignByVaultId(vaultId, async x => {
-        const updateSeq = ++this.#pendingCosignUpdateSeq;
-        await this.recordPendingCosignUtxos(x, updateSeq, client);
-      });
-      const sub4 = await client.query.vaults.lastCollectFrameByVaultId(vaultId, () => {
-        this.updateCollectDeadlines();
-      });
-      const sub5 = await client.query.vaults.argonotCommitmentByVaultId(vaultId, commitment => {
+      const sub3 = await client.query.vaults.argonotCommitmentByVaultId(vaultId, commitment => {
         this.updateArgonotCommitment(commitment);
       });
 
-      const { unsubscribe: sub6 } = this.miningFrames.onFrameId(frameId => {
+      const { unsubscribe: sub4 } = this.miningFrames.onFrameId(frameId => {
         this.data.currentFrameId = frameId;
         this.updateCollectDeadlines();
-        void this.refreshPendingOrphanCosignCount(client, vaultId).catch(x =>
-          console.error('Error updating pending orphaned Bitcoin signatures', x),
-        );
       });
 
-      const sub7 = this.miningFrames.blockWatch.events.on('best-blocks', headers => {
+      const sub5 = this.miningFrames.blockWatch.events.on('best-blocks', headers => {
         void this.refreshVaultBitcoinStateFromBlockEvents(headers).catch(x =>
           console.error(`Error updating vault Bitcoin state from block events`, x),
         );
       });
 
-      const sub8 = clients.events.on('on-pruned-client', () => {
+      const sub6 = this.miningFrames.blockWatch.events.on('finalized', async headers => {
+        try {
+          let latestBitcoinClient: ApiDecoration<'promise'> | undefined;
+          let latestRevenueClient: ApiDecoration<'promise'> | undefined;
+          for (const header of headers) {
+            const { api, events } = await this.miningFrames.blockWatch.getEventsWithSpec(header);
+            if (header.isNewFrame) latestRevenueClient = api;
+
+            for (const { event } of events) {
+              if (
+                api.events.bitcoinLocks.BitcoinUtxoCosignRequested.is(event) ||
+                api.events.bitcoinLocks.BitcoinUtxoCosigned.is(event) ||
+                api.events.bitcoinLocks.BitcoinCosignPastDue.is(event) ||
+                api.events.bitcoinLocks.OrphanedUtxoReleaseRequested.is(event) ||
+                api.events.bitcoinLocks.OrphanedUtxoCosigned.is(event)
+              ) {
+                if (event.data.vaultId.toNumber() === vaultId) latestBitcoinClient = api;
+                continue;
+              }
+
+              if (
+                api.events.vaults.FundsLocked.is(event) ||
+                api.events.vaults.VaultCollected.is(event) ||
+                api.events.vaults.VaultRevenueUncollected.is(event)
+              ) {
+                if (event.data.vaultId.toNumber() === vaultId) latestRevenueClient = api;
+              }
+            }
+          }
+
+          const refreshes: Promise<void>[] = [];
+          if (latestBitcoinClient) {
+            refreshes.push(this.refreshFinalizedBitcoinCosignState(latestBitcoinClient, vaultId));
+          }
+          if (latestRevenueClient) {
+            refreshes.push(this.refreshFinalizedRevenueState(latestRevenueClient, vaultId));
+          }
+          await Promise.all(refreshes);
+        } catch (error) {
+          console.error('Error updating finalized vault collect state', error);
+        }
+      });
+
+      const sub7 = clients.events.on('on-pruned-client', () => {
         if (client.clientType === 'archive') {
           this.unsubscribe();
           void this.subscribe();
@@ -441,10 +476,28 @@ export class MyVault {
 
       await Promise.all([this.globalCouncil.subscribe(), this.mintingAuthorities.subscribe()]);
 
-      this.#subscriptions.push(sub, sub2, sub3, sub4, sub5, sub6, sub7, sub8);
+      this.#subscriptions.push(sub, sub2, sub3, sub4, sub5, sub6, sub7);
     } finally {
       this.#isSubscribing = false;
     }
+  }
+
+  public async refreshFinalizedState(args: { client: ArgonQueryClient; currentFrameId: number }): Promise<void> {
+    const vaultId = this.vaultId;
+    const refreshes: Promise<unknown>[] = [];
+
+    if (this.data.isReady && vaultId != null) {
+      this.data.currentFrameId = args.currentFrameId;
+      refreshes.push(
+        this.refreshFinalizedBitcoinCosignState(args.client, vaultId),
+        this.refreshFinalizedRevenueState(args.client, vaultId),
+        this.refreshExternalLocks(args.client),
+      );
+    }
+    if (this.globalCouncil.data.isReady) refreshes.push(this.globalCouncil.refresh(args.client));
+    if (this.mintingAuthorities.data.isReady) refreshes.push(this.mintingAuthorities.refresh(args.client));
+
+    await Promise.all(refreshes);
   }
 
   private updateArgonotCommitment(commitment: Option<ArgonPrimitivesVaultVaultArgonotCommitment>): void {
@@ -463,12 +516,23 @@ export class MyVault {
     };
   }
 
-  private async refreshPendingOrphanCosignCount(client: ArgonQueryClient, vaultId: number): Promise<void> {
-    const updateSeq = ++this.#pendingOrphanCosignUpdateSeq;
-    const entries = await client.query.vaults.orphanedUtxoAccountsByVaultId.entries(vaultId);
-    if (updateSeq !== this.#pendingOrphanCosignUpdateSeq) return;
+  private async refreshFinalizedBitcoinCosignState(client: ArgonQueryClient, vaultId: number): Promise<void> {
+    const updateSeq = ++this.#finalizedBitcoinCosignUpdateSeq;
+    const [pendingCosignUtxos, orphanCosignEntries] = await Promise.all([
+      client.query.vaults.pendingCosignByVaultId(vaultId),
+      client.query.vaults.orphanedUtxoAccountsByVaultId.entries(vaultId),
+    ]);
+    if (updateSeq !== this.#finalizedBitcoinCosignUpdateSeq) return;
 
-    this.data.pendingOrphanCosignCount = entries.reduce((total, [, count]) => total + count.toNumber(), 0);
+    await this.recordPendingCosignUtxos(pendingCosignUtxos, ++this.#pendingCosignUpdateSeq, client);
+    if (updateSeq !== this.#finalizedBitcoinCosignUpdateSeq) return;
+
+    this.data.pendingOrphanCosignCount = orphanCosignEntries.reduce((total, [, count]) => total + count.toNumber(), 0);
+  }
+
+  private async refreshFinalizedRevenueState(client: ArgonQueryClient, vaultId: number): Promise<void> {
+    await this.updateRevenueStats(await client.query.vaults.revenuePerFrameByVault(vaultId));
+    this.updateCollectDeadlines();
   }
 
   private async refreshVaultBitcoinStateFromBlockEvents(headers: IBlockHeaderInfo[]): Promise<void> {
@@ -477,23 +541,10 @@ export class MyVault {
 
     const typeClient = await getMainchainClient(false);
     let latestApiClient: ApiDecoration<'promise'> | undefined;
-    let shouldRefreshOrphanCosigns = false;
     for (const header of headers) {
       const events = await this.miningFrames.blockWatch.getEvents(header);
       let shouldRefreshExternalLocks = false;
       for (const { event } of events) {
-        if (typeClient.events.bitcoinLocks.OrphanedUtxoReleaseRequested.is(event)) {
-          if (vaultId === event.data.vaultId.toNumber()) {
-            shouldRefreshOrphanCosigns = true;
-          }
-          continue;
-        }
-        if (typeClient.events.bitcoinLocks.OrphanedUtxoCosigned.is(event)) {
-          if (vaultId === event.data.vaultId.toNumber()) {
-            shouldRefreshOrphanCosigns = true;
-          }
-          continue;
-        }
         if (
           typeClient.events.bitcoinLocks.BitcoinLockCreated.is(event) ||
           typeClient.events.bitcoinLocks.BitcoinLockRatcheted.is(event) ||
@@ -514,9 +565,6 @@ export class MyVault {
     if (latestApiClient) {
       await this.refreshExternalLocks(latestApiClient);
     }
-    if (shouldRefreshOrphanCosigns) {
-      await this.refreshPendingOrphanCosignCount(typeClient, vaultId);
-    }
   }
 
   private updateCollectDeadlines() {
@@ -532,7 +580,7 @@ export class MyVault {
     this.data.nextCosignDueDate = nextCosignFrame ? this.miningFrames.getFrameDate(nextCosignFrame).getTime() : 0;
   }
 
-  private async recordPendingCosignUtxos(rawUtxoIds: Iterable<u64>, updateSeq: number, client: ArgonClient) {
+  private async recordPendingCosignUtxos(rawUtxoIds: Iterable<u64>, updateSeq: number, client: ArgonQueryClient) {
     const previousPendingCosignsById = new Map(this.data.pendingCosignUtxosById);
     const pendingCosignUtxosById = new Map<number, IPendingCosignUtxo>();
     for (const utxoId of rawUtxoIds) {

--- a/src-vue/lib/TransactionInfo.ts
+++ b/src-vue/lib/TransactionInfo.ts
@@ -261,7 +261,8 @@ export function getTransactionFailureMessage(txInfo?: TransactionInfo): string |
 
   const extrinsicError = txInfo.txResult.extrinsicError;
   if (extrinsicError) {
-    if (extrinsicError instanceof ExtrinsicError && extrinsicError.details) return extrinsicError.details;
+    const details = (extrinsicError as ExtrinsicError).details;
+    if (details) return details;
     return extrinsicError.message || String(extrinsicError);
   }
 

--- a/src-vue/lib/TransactionInfo.ts
+++ b/src-vue/lib/TransactionInfo.ts
@@ -252,3 +252,22 @@ export class TransactionInfo<MetadataType = unknown> {
     }
   }
 }
+
+export function getTransactionFailureMessage(txInfo?: TransactionInfo): string | undefined {
+  if (!txInfo) return undefined;
+
+  const submissionError = txInfo.txResult.submissionError;
+  if (submissionError) return submissionError.message || String(submissionError);
+
+  const extrinsicError = txInfo.txResult.extrinsicError;
+  if (extrinsicError) {
+    if (extrinsicError instanceof ExtrinsicError && extrinsicError.details) return extrinsicError.details;
+    return extrinsicError.message || String(extrinsicError);
+  }
+
+  if ([TransactionStatus.Error, TransactionStatus.TimedOutWaitingForBlock].includes(txInfo.tx.status)) {
+    return `Transaction ended with status ${txInfo.tx.status}.`;
+  }
+
+  return undefined;
+}

--- a/src-vue/lib/VaultCollectBuilder.ts
+++ b/src-vue/lib/VaultCollectBuilder.ts
@@ -157,13 +157,15 @@ export class VaultCollectBuilder {
       vaultId,
     });
 
-    const frameRevenues = await client.query.vaults.revenuePerFrameByVault(vaultId);
+    const frameRevenues = await finalizedClient.query.vaults.revenuePerFrameByVault(vaultId);
     const expectedCollectRevenue = frameRevenues.reduce(
       (total, frameRevenue) => total + frameRevenue.uncollectedRevenue.toBigInt(),
       0n,
     );
     const pendingCouncilApprovals = await myVault.globalCouncil.refresh(finalizedClient);
-    const hasUnsubmittedOrphanCosigns = myVault.data.pendingOrphanCosignCount > cosignedOrphanUtxos.length;
+    const orphanCosignEntries = await finalizedClient.query.vaults.orphanedUtxoAccountsByVaultId.entries(vaultId);
+    const pendingOrphanCosignCount = orphanCosignEntries.reduce((total, [, count]) => total + count.toNumber(), 0);
+    const hasUnsubmittedOrphanCosigns = pendingOrphanCosignCount > cosignedOrphanUtxos.length;
     const shouldCollectRevenue = expectedCollectRevenue > 0n && !hasUnsubmittedOrphanCosigns;
     const hasCollectWork = shouldCollectRevenue || bitcoinTxs.length > 0;
     const metadata = {
@@ -244,7 +246,7 @@ async function buildCollectBitcoinTxs(args: {
   vaultId: number;
 }) {
   const { myVault, client, finalizedClient, vaultId } = args;
-  const pendingCosignUtxos = await client.query.vaults.pendingCosignByVaultId(vaultId);
+  const pendingCosignUtxos = await finalizedClient.query.vaults.pendingCosignByVaultId(vaultId);
   const bitcoinTxs: SubmittableExtrinsic[] = [];
   const cosignedUtxoIds: number[] = [];
 

--- a/src-vue/lib/VaultCollectBuilder.ts
+++ b/src-vue/lib/VaultCollectBuilder.ts
@@ -34,6 +34,7 @@ export type IVaultCollectNotice = {
   expiringCollectAmount: bigint;
   nextCollectDueDate: number;
   signatureCount: number;
+  orphanSignatureCount: number;
   nextCosignDueDate: number;
   councilApprovalCount: number;
   authorizedTransferCount: number;
@@ -75,7 +76,7 @@ export class VaultCollectBuilder {
     );
 
     const collectRevenue = myVault.data.pendingCollectRevenue;
-    const signatureCount = manualPendingCosignEntries.length;
+    const signatureCount = manualPendingCosignEntries.length + myVault.data.pendingOrphanCosignCount;
     const councilApprovalCount = myVault.globalCouncil.data.pendingApprovals.length;
 
     const pendingMintingAuthorizations = myVault.mintingAuthorities.data.pendingMintingAuthorizations;
@@ -122,6 +123,7 @@ export class VaultCollectBuilder {
       expiringCollectAmount: myVault.data.expiringCollectAmount,
       nextCollectDueDate: myVault.data.nextCollectDueDate,
       signatureCount,
+      orphanSignatureCount: myVault.data.pendingOrphanCosignCount,
       nextCosignDueDate: myVault.data.nextCosignDueDate,
       councilApprovalCount,
       authorizedTransferCount,
@@ -161,7 +163,9 @@ export class VaultCollectBuilder {
       0n,
     );
     const pendingCouncilApprovals = await myVault.globalCouncil.refresh(finalizedClient);
-    const hasCollectWork = expectedCollectRevenue > 0n || bitcoinTxs.length > 0;
+    const hasUnsubmittedOrphanCosigns = myVault.data.pendingOrphanCosignCount > cosignedOrphanUtxos.length;
+    const shouldCollectRevenue = expectedCollectRevenue > 0n && !hasUnsubmittedOrphanCosigns;
+    const hasCollectWork = shouldCollectRevenue || bitcoinTxs.length > 0;
     const metadata = {
       vaultId,
       actionType: 'cosignBitcoin',
@@ -176,14 +180,14 @@ export class VaultCollectBuilder {
         ...(await myVault.globalCouncil.buildApprovePendingGatewayUpdateTxs(client, pendingCouncilApprovals)),
         ...bitcoinTxs,
       ];
-      if (expectedCollectRevenue > 0n) {
+      if (shouldCollectRevenue) {
         txs.push(client.tx.vaults.collect(vaultId));
       }
       return {
         tx: txs.length === 1 ? txs[0] : client.tx.utility.batchAll(txs),
         metadata: {
           ...metadata,
-          actionType: expectedCollectRevenue > 0n ? 'collectRevenue' : 'cosignBitcoin',
+          actionType: shouldCollectRevenue ? 'collectRevenue' : 'cosignBitcoin',
           councilApprovalCount: pendingCouncilApprovals.length,
         },
         submittedCosignUtxoIds: cosignedUtxoIds,

--- a/src-vue/lib/db/BitcoinUtxosTable.ts
+++ b/src-vue/lib/db/BitcoinUtxosTable.ts
@@ -59,6 +59,16 @@ export class BitcoinUtxosTable extends BaseTable {
     return convertFromSqliteFields<IBitcoinUtxoStatusHistoryRecord[]>(rawRecords, { date: ['createdAt'] });
   }
 
+  public async fetchOrphanedRecordIds(): Promise<number[]> {
+    const records = await this.db.select<{ utxoRecordId: number }[]>(
+      `SELECT DISTINCT utxoRecordId
+       FROM BitcoinUtxoStatusHistory
+       WHERE newStatus = ?`,
+      toSqlParams([BitcoinUtxoStatus.Orphaned]),
+    );
+    return records.map(record => record.utxoRecordId);
+  }
+
   public async getByLockOutpoint(
     lockUtxoId: number,
     txid: string,

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -1,7 +1,10 @@
 import {
   BitcoinLock,
   u8aEq,
+  u8aToHex,
   type ApiDecoration,
+  type ArgonPrimitivesBitcoinUtxoRef,
+  type Bytes,
   type FrameSystemEventRecord,
   type GenericEvent,
 } from '@argonprotocol/mainchain';
@@ -31,9 +34,12 @@ export class BitcoinLockRecovery {
   private readonly utxoTracking: Pick<
     BitcoinUtxoTracking,
     | 'getAcceptedFundingRecordForLock'
+    | 'getUtxoRecord'
     | 'isReleaseCompleteStatus'
     | 'isReleaseStatus'
     | 'setAcceptedFundingRecordForLock'
+    | 'setReleaseCosign'
+    | 'setReleaseIsProcessingOnArgon'
     | 'setReleaseRequest'
     | 'upsertUtxoRecord'
   >;
@@ -336,7 +342,56 @@ export class BitcoinLockRecovery {
         if (!isBitcoinMint && event.method !== 'BitcoinLockRatcheted') continue;
         throw new Error(`Bitcoin lock ${utxoId} history is missing its creation record`);
       }
-      if (isBitcoinUtxoVerified) {
+      if (event.method === 'OrphanedUtxoReceived') {
+        const utxoRef = readRequiredEventField(event, 'utxoRef', block) as ArgonPrimitivesBitcoinUtxoRef;
+        await this.utxoTracking.upsertUtxoRecord(
+          record,
+          {
+            txid: utxoRef.txid.toHex(),
+            vout: utxoRef.outputIndex.toNumber(),
+            satoshis: readRequiredEventBigInt(event, ['satoshis'], block),
+          },
+          { markOrphaned: true },
+        );
+      } else if (event.method === 'OrphanedUtxoReleaseRequested') {
+        const ownerAccount = readRequiredEventField(event, 'accountId', block).toString();
+        if (ownerAccount !== record.lockDetails.ownerAccount) continue;
+        const utxoRef = readRequiredEventField(event, 'utxoRef', block) as ArgonPrimitivesBitcoinUtxoRef;
+        const orphanMaybe = await api.query.bitcoinLocks.orphanedUtxosByAccount(ownerAccount, utxoRef);
+        if (orphanMaybe.isNone) continue;
+        const orphan = orphanMaybe.unwrap();
+        if (orphan.cosignRequest.isNone) continue;
+        const request = orphan.cosignRequest.unwrap();
+        const orphanRecord = await this.utxoTracking.upsertUtxoRecord(
+          record,
+          {
+            txid: utxoRef.txid.toHex(),
+            vout: utxoRef.outputIndex.toNumber(),
+            satoshis: orphan.satoshis.toBigInt(),
+          },
+          { markOrphaned: true },
+        );
+        await this.utxoTracking.setReleaseIsProcessingOnArgon(orphanRecord, {
+          requestedReleaseAtTick: await api.query.ticks.currentTick().then(tick => tick.toNumber()),
+          releaseToDestinationAddress: u8aToHex(request.toScriptPubkey, undefined, false),
+          releaseBitcoinNetworkFee: request.bitcoinNetworkFee.toBigInt(),
+        });
+      } else if (event.method === 'OrphanedUtxoCosigned') {
+        const ownerAccount = readRequiredEventField(event, 'accountId', block).toString();
+        if (ownerAccount !== record.lockDetails.ownerAccount) continue;
+        const utxoRef = readRequiredEventField(event, 'utxoRef', block) as ArgonPrimitivesBitcoinUtxoRef;
+        const orphanRecord = this.utxoTracking.getUtxoRecord(
+          utxoId,
+          utxoRef.txid.toHex(),
+          utxoRef.outputIndex.toNumber(),
+        );
+        if (!orphanRecord) continue;
+        const signature = readRequiredEventField(event, 'signature', block) as Bytes;
+        await this.utxoTracking.setReleaseCosign(orphanRecord, {
+          releaseCosignVaultSignature: signature.toU8a(true),
+          releaseCosignHeight: block.blockNumber,
+        });
+      } else if (isBitcoinUtxoVerified) {
         const chainLock = await BitcoinLock.get(api, utxoId);
         if (!chainLock) throw new Error(`Bitcoin lock ${utxoId} is unavailable after funding verification`);
 
@@ -1096,4 +1151,7 @@ const bitcoinRecoveryEventMethods = new Set([
   'BitcoinSpentAfterRelease',
   'BitcoinUtxoCosignRequested',
   'BitcoinUtxoCosigned',
+  'OrphanedUtxoCosigned',
+  'OrphanedUtxoReceived',
+  'OrphanedUtxoReleaseRequested',
 ]);

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -80,7 +80,7 @@ const earliestSupportedSpecVersions: Record<IFinancialHistoryDomain, number> = {
   vaulting: 116,
 };
 const historyRecoveryVersions: Partial<Record<IFinancialHistoryDomain, number>> = {
-  bitcoin: 6,
+  bitcoin: 7,
   bonds: 1,
 };
 

--- a/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
+++ b/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
@@ -32,6 +32,7 @@
           <a
             :href="mempool.txUrl(record.txid)"
             target="_blank"
+            rel="noopener noreferrer"
             class="text-argon-600 inline-flex items-center gap-1 hover:underline"
           >
             View transaction
@@ -89,7 +90,19 @@
       </div>
 
       <div v-else class="space-y-4">
-        <div class="border-argon-100 bg-argon-50 space-y-2 rounded-lg border px-4 py-3">
+        <template v-if="isArgonRequestInProgress">
+          <div class="mt-6">
+            <div class="fade-progress text-center text-5xl font-bold">
+              {{ numeral(argonRequestProgressPct).format('0.00') }}%
+            </div>
+          </div>
+
+          <ProgressBar :progress="argonRequestProgressPct" :showLabel="false" class="h-4" />
+
+          <div class="mt-1 text-center font-light text-gray-500">{{ argonRequestProgressLabel }}</div>
+        </template>
+
+        <div v-else class="border-argon-100 bg-argon-50 space-y-2 rounded-lg border px-4 py-3">
           <template
             v-if="
               record.status === BitcoinUtxoStatus.ReleaseComplete ||
@@ -148,6 +161,7 @@
             v-if="record.releaseTxid"
             :href="mempool.txUrl(record.releaseTxid)"
             target="_blank"
+            rel="noopener noreferrer"
             class="text-argon-600 inline-flex items-center gap-1 text-sm hover:underline"
           >
             View return transaction
@@ -180,9 +194,11 @@ import { getCurrency } from '../stores/currency.ts';
 import { useWallets } from '../stores/wallets.ts';
 import type { IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
+import { TransactionStatus } from '../lib/db/TransactionsTable.ts';
 import BitcoinLocks from '../lib/BitcoinLocks.ts';
 import BitcoinMempool from '../lib/BitcoinMempool.ts';
 import { ESPLORA_HOST } from '../lib/Env.ts';
+import { generateProgressLabel } from '../lib/Utils.ts';
 
 dayjs.extend(utc);
 
@@ -204,6 +220,10 @@ const requestError = Vue.ref('');
 const argonFeeQuote = Vue.ref<{ canAfford: boolean; availableBalance: bigint; txFee: bigint }>();
 const argonFeeQuoteError = Vue.ref('');
 const isCheckingArgonFee = Vue.ref(false);
+const argonRequestProgressPct = Vue.ref(0);
+const argonRequestConfirmations = Vue.ref(-1);
+const argonRequestExpectedConfirmations = Vue.ref(0);
+const isArgonRequestInProgress = Vue.ref(false);
 
 const bitcoinAmount = Vue.computed(() =>
   numeral(currency.convertSatToBtc(props.record.satoshis)).format('0,0.[00000000]'),
@@ -291,9 +311,15 @@ const argonFeeShortfall = Vue.computed(() => {
   return shortfall > 0n ? shortfall : 0n;
 });
 const releaseProgress = Vue.computed(() => bitcoinLocks.utxoTracking.getReleaseLifecycleProgress(props.record));
+const argonRequestProgressLabel = Vue.computed(() => {
+  return generateProgressLabel(argonRequestConfirmations.value, argonRequestExpectedConfirmations.value, {
+    blockType: 'Argon',
+  });
+});
 
 let feeQuoteTimeout: ReturnType<typeof setTimeout> | undefined;
 let feeQuoteRunId = 0;
+let stopArgonRequestProgress: (() => void) | undefined;
 
 Vue.watch(
   [trimmedDestination, feeRatePerSatVb, () => wallets.liquidLockingWallet.availableMicrogons],
@@ -316,25 +342,47 @@ Vue.watch(
 
 Vue.onUnmounted(() => {
   if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
+  stopArgonRequestProgress?.();
 });
+
+Vue.onMounted(() => trackArgonRequestProgress());
 
 async function requestReturn(): Promise<void> {
   if (!canSubmit.value) return;
   isSubmitting.value = true;
+  isArgonRequestInProgress.value = true;
   requestError.value = '';
 
   try {
-    await bitcoinLocks.orphanReleases.requestOrphanReturn({
+    const txInfo = await bitcoinLocks.orphanReleases.requestOrphanReturn({
       lock: props.lock,
       record: props.record,
       toScriptPubkey: trimmedDestination.value,
       feeRatePerSatVb: feeRatePerSatVb.value,
     });
+    trackArgonRequestProgress(txInfo);
   } catch (error) {
+    isArgonRequestInProgress.value = false;
     requestError.value = error instanceof Error ? error.message : String(error);
   } finally {
     isSubmitting.value = false;
   }
+}
+
+function trackArgonRequestProgress(
+  txInfo = bitcoinLocks.orphanReleases.getTransactionInfo(props.record.lockUtxoId, props.record),
+): void {
+  if (!txInfo) return;
+
+  isArgonRequestInProgress.value = [TransactionStatus.Submitted, TransactionStatus.InBlock].includes(txInfo.tx.status);
+  stopArgonRequestProgress?.();
+  stopArgonRequestProgress = txInfo.subscribeToProgress((progress, error) => {
+    argonRequestProgressPct.value = progress.progressPct;
+    argonRequestConfirmations.value = progress.confirmations;
+    argonRequestExpectedConfirmations.value = progress.expectedConfirmations;
+    isArgonRequestInProgress.value = progress.progressPct < 100 && !error;
+    if (error) requestError.value = error.message;
+  });
 }
 
 async function refreshArgonFeeQuote(runId: number): Promise<void> {

--- a/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
+++ b/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
@@ -1,0 +1,362 @@
+<template>
+  <OverlayBase
+    :isOpen="true"
+    data-testid="BitcoinOrphanRecoveryOverlay"
+    @close="emit('close')"
+    @pressEsc="emit('close')"
+    class="w-5/12"
+  >
+    <template #title>
+      <div class="text-xl font-bold text-slate-800/80">Return Orphaned Bitcoin</div>
+    </template>
+
+    <div class="space-y-5 px-7 py-6">
+      <div class="rounded-lg bg-slate-50 px-4 py-4 ring-1 ring-slate-200">
+        <div class="text-sm font-semibold tracking-wide text-slate-500 uppercase">
+          {{ isAdditionalDeposit ? 'Additional Bitcoin received' : 'Deposit mismatch' }}
+        </div>
+        <div class="mt-3 grid grid-cols-2 divide-x divide-slate-200">
+          <div class="pr-4">
+            <div class="text-sm text-slate-500">Received</div>
+            <div class="mt-0.5 text-lg font-semibold text-slate-900">{{ bitcoinAmount }} BTC</div>
+          </div>
+          <div class="pl-4">
+            <div class="text-sm text-slate-500">
+              {{ isAdditionalDeposit ? 'Already funded with' : 'Expected for lock' }}
+            </div>
+            <div class="mt-0.5 text-lg font-semibold text-slate-900">{{ comparisonBitcoinAmount }} BTC</div>
+          </div>
+        </div>
+        <div class="mt-3 flex items-center justify-between border-t border-slate-200 pt-3 text-sm">
+          <span class="text-slate-500">Received {{ receivedAt }}</span>
+          <a
+            :href="mempool.txUrl(record.txid)"
+            target="_blank"
+            class="text-argon-600 inline-flex items-center gap-1 hover:underline"
+          >
+            View transaction
+            <ArrowTopRightOnSquareIcon class="h-4 w-4" />
+          </a>
+        </div>
+      </div>
+
+      <div v-if="record.status === BitcoinUtxoStatus.Orphaned" class="space-y-5">
+        <p v-if="isAdditionalDeposit" class="text-sm text-slate-700">
+          This lock was already funded before this Bitcoin arrived. Choose an address you control and return the
+          additional payment.
+        </p>
+        <p v-else class="text-sm text-slate-700">
+          This Bitcoin cannot fund a lock. Choose an address you control and request its return.
+        </p>
+
+        <div>
+          <label class="mb-2 block font-medium text-gray-700">Return destination address</label>
+          <input
+            v-model="destinationAddress"
+            data-testid="BitcoinOrphanRecoveryOverlay.returnDestination"
+            type="text"
+            placeholder="bc1q..."
+            :class="destinationError ? 'border-red-400 text-red-900' : 'border-slate-700/50'"
+            class="focus:ring-argon-500 w-full rounded-md border px-3 py-3 focus:border-transparent focus:ring-2"
+          />
+          <p class="mt-2 text-sm" :class="destinationError ? 'font-semibold text-red-700' : 'text-slate-500'">
+            {{ destinationError || `Use a ${bitcoinNetworkName} address you control.` }}
+          </p>
+        </div>
+
+        <BitcoinFeeRateInput v-model="feeRatePerSatVb" dataTestid="BitcoinOrphanRecoveryOverlay.feeRate" />
+
+        <button
+          data-testid="BitcoinOrphanRecoveryOverlay.requestReturn()"
+          :disabled="!canSubmit"
+          @click="requestReturn"
+          class="bg-argon-600 hover:bg-argon-700 w-full cursor-pointer rounded-lg px-6 py-2.5 font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ isSubmitting ? 'Requesting Return...' : 'Return Bitcoin' }}
+        </button>
+        <p v-if="isCheckingArgonFee" class="text-sm text-slate-500">
+          Checking the Internal App Wallet transaction fee...
+        </p>
+        <p v-else-if="argonFeeQuote && !argonFeeQuote.canAfford" class="text-sm text-red-700">
+          Add
+          <span class="font-mono font-semibold">{{ formatArgon(argonFeeShortfall) }}</span>
+          to the Internal App Wallet to cover the Argon transaction fee.
+        </p>
+        <p v-else-if="argonFeeQuote" class="text-sm text-slate-500">
+          Argon transaction fee: approximately {{ formatArgon(argonFeeQuote.txFee) }}.
+        </p>
+        <p v-else-if="argonFeeQuoteError" class="text-sm text-red-700">{{ argonFeeQuoteError }}</p>
+      </div>
+
+      <div v-else class="space-y-4">
+        <div class="border-argon-100 bg-argon-50 space-y-2 rounded-lg border px-4 py-3">
+          <template
+            v-if="
+              record.status === BitcoinUtxoStatus.ReleaseComplete ||
+              record.status === BitcoinUtxoStatus.ReleaseCompleteAcknowledged
+            "
+          >
+            <div class="font-semibold text-slate-800">Bitcoin returned</div>
+            <p class="text-sm text-slate-600">The Bitcoin was returned to the requested destination.</p>
+          </template>
+          <template v-else-if="record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin">
+            <div class="font-semibold text-slate-800">Returning on Bitcoin</div>
+            <p class="text-sm text-slate-600">
+              The return transaction was broadcast and is waiting for Bitcoin confirmations.
+            </p>
+          </template>
+          <template v-else-if="record.releaseCosignVaultSignature">
+            <div class="font-semibold text-slate-800">Preparing Bitcoin return</div>
+            <p class="text-sm text-slate-600">The vault signed the return. Preparing the Bitcoin transaction.</p>
+          </template>
+          <template v-else>
+            <div class="font-semibold text-slate-800">Awaiting vault signature</div>
+            <p class="text-sm text-slate-600">
+              The vault operator has been asked to sign this return. You can close this screen and come back later.
+            </p>
+          </template>
+          <ProgressBar
+            v-if="record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin"
+            :progress="releaseProgress.progressPct"
+            :showLabel="false"
+            class="h-4"
+          />
+        </div>
+
+        <div class="space-y-3 rounded-lg border border-slate-200 px-4 py-4">
+          <div class="text-sm font-semibold tracking-wide text-slate-500 uppercase">Return request details</div>
+          <dl class="space-y-3 text-sm">
+            <div>
+              <dt class="text-slate-500">Destination</dt>
+              <dd class="mt-0.5 font-mono text-sm break-all text-slate-800">{{ releaseDestinationAddress }}</dd>
+            </div>
+            <div v-if="record.releaseBitcoinNetworkFee != null">
+              <dt class="text-slate-500">Bitcoin network fee</dt>
+              <dd class="mt-0.5 text-slate-800">
+                <span v-if="releaseFeeRate != null">{{ releaseFeeRate }} sats/vbyte ·</span>
+                {{ numeral(record.releaseBitcoinNetworkFee).format('0,0') }} sats total
+              </dd>
+            </div>
+            <div>
+              <dt class="text-slate-500">Request sent</dt>
+              <dd class="mt-0.5 text-slate-800">
+                {{ releaseRequestedAt || 'Waiting for Argon confirmation' }}
+              </dd>
+            </div>
+          </dl>
+          <a
+            v-if="record.releaseTxid"
+            :href="mempool.txUrl(record.releaseTxid)"
+            target="_blank"
+            class="text-argon-600 inline-flex items-center gap-1 text-sm hover:underline"
+          >
+            View return transaction
+            <ArrowTopRightOnSquareIcon class="h-4 w-4" />
+          </a>
+        </div>
+      </div>
+
+      <p v-if="record.statusError || requestError" class="text-sm font-semibold text-red-700">
+        {{ requestError || record.statusError }}
+      </p>
+    </div>
+  </OverlayBase>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { CosignScript } from '@argonprotocol/bitcoin';
+import { MiningFrames } from '@argonprotocol/apps-core';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/outline';
+import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
+import OverlayBase from './OverlayBase.vue';
+import ProgressBar from '../components/ProgressBar.vue';
+import BitcoinFeeRateInput from './bitcoin-locking/components/BitcoinFeeRateInput.vue';
+import { getBitcoinNetworkName, validateBitcoinAddressForNetwork } from '../lib/BitcoinAddressValidation.ts';
+import { getBitcoinLocks } from '../stores/bitcoin.ts';
+import { getCurrency } from '../stores/currency.ts';
+import { useWallets } from '../stores/wallets.ts';
+import type { IBitcoinLockRecord } from '../lib/db/BitcoinLocksTable.ts';
+import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../lib/db/BitcoinUtxosTable.ts';
+import BitcoinLocks from '../lib/BitcoinLocks.ts';
+import BitcoinMempool from '../lib/BitcoinMempool.ts';
+import { ESPLORA_HOST } from '../lib/Env.ts';
+
+dayjs.extend(utc);
+
+const props = defineProps<{
+  lock: IBitcoinLockRecord;
+  record: IBitcoinUtxoRecord;
+}>();
+const emit = defineEmits<{ close: [] }>();
+const bitcoinLocks = getBitcoinLocks();
+const currency = getCurrency();
+const wallets = useWallets();
+const { microgonToArgonNm } = createNumeralHelpers(currency);
+const mempool = new BitcoinMempool(ESPLORA_HOST);
+
+const destinationAddress = Vue.ref('');
+const feeRatePerSatVb = Vue.ref(5n);
+const isSubmitting = Vue.ref(false);
+const requestError = Vue.ref('');
+const argonFeeQuote = Vue.ref<{ canAfford: boolean; availableBalance: bigint; txFee: bigint }>();
+const argonFeeQuoteError = Vue.ref('');
+const isCheckingArgonFee = Vue.ref(false);
+
+const bitcoinAmount = Vue.computed(() =>
+  numeral(currency.convertSatToBtc(props.record.satoshis)).format('0,0.[00000000]'),
+);
+const acceptedFundingRecord = Vue.computed(() => bitcoinLocks.getAcceptedFundingRecord(props.lock));
+const isAdditionalDeposit = Vue.computed(() => {
+  const fundingRecord = acceptedFundingRecord.value;
+  if (!fundingRecord || fundingRecord.id === props.record.id) return false;
+
+  const fundingHeight = fundingRecord.firstSeenBitcoinHeight;
+  const receivedHeight = props.record.firstSeenBitcoinHeight;
+  if (fundingHeight > 0 && receivedHeight > 0 && fundingHeight !== receivedHeight) {
+    return fundingHeight < receivedHeight;
+  }
+
+  return fundingRecord.firstSeenAt.getTime() < props.record.firstSeenAt.getTime();
+});
+const comparisonBitcoinAmount = Vue.computed(() => {
+  const satoshis = isAdditionalDeposit.value
+    ? (acceptedFundingRecord.value?.satoshis ?? props.lock.satoshis)
+    : props.lock.satoshis;
+  return numeral(currency.convertSatToBtc(satoshis)).format('0,0.[00000000]');
+});
+const receivedAt = Vue.computed(() => {
+  const transactionBlockTime = props.record.mempoolObservation?.transactionBlockTime;
+  const receivedDate = transactionBlockTime ? dayjs.unix(transactionBlockTime) : dayjs(props.record.firstSeenAt);
+  return receivedDate.local().format('MMM D, YYYY [at] h:mm A');
+});
+
+const trimmedDestination = Vue.computed(() => destinationAddress.value.trim());
+const currentLockAddress = Vue.computed(() => {
+  try {
+    return bitcoinLocks.formatP2wshAddress(props.lock.lockDetails.p2wshScriptHashHex);
+  } catch {
+    return '';
+  }
+});
+const destinationError = Vue.computed(() =>
+  validateBitcoinAddressForNetwork(trimmedDestination.value, bitcoinLocks.bitcoinNetwork, {
+    disallowAddress: currentLockAddress.value,
+  }),
+);
+const bitcoinNetworkName = Vue.computed(() => getBitcoinNetworkName(bitcoinLocks.bitcoinNetwork));
+
+const releaseDestinationAddress = Vue.computed(() => {
+  if (!props.record.releaseToDestinationAddress) return '';
+  try {
+    return BitcoinLocks.formatAddressBytes(props.record.releaseToDestinationAddress, bitcoinLocks.bitcoinNetwork);
+  } catch {
+    return props.record.releaseToDestinationAddress;
+  }
+});
+const releaseRequestedAt = Vue.computed(() => {
+  if (props.record.requestedReleaseAtTick == null) return '';
+  return dayjs
+    .utc(MiningFrames.getTickDate(props.record.requestedReleaseAtTick))
+    .local()
+    .format('MMM D, YYYY [at] h:mm A');
+});
+const releaseFeeRate = Vue.computed(() => {
+  const networkFee = props.record.releaseBitcoinNetworkFee;
+  const destination = props.record.releaseToDestinationAddress;
+  if (networkFee == null || !destination) return;
+
+  try {
+    const cosignScript = new CosignScript(props.lock.lockDetails, bitcoinLocks.bitcoinNetwork);
+    const oneSatFee = cosignScript.calculateFee(1n, destination);
+    const feeRate = (networkFee + oneSatFee / 2n) / oneSatFee;
+    if (cosignScript.calculateFee(feeRate, destination) === networkFee) return feeRate;
+  } catch {
+    return;
+  }
+});
+
+const canSubmit = Vue.computed(
+  () =>
+    trimmedDestination.value.length > 0 &&
+    !destinationError.value &&
+    argonFeeQuote.value?.canAfford === true &&
+    !isSubmitting.value,
+);
+const argonFeeShortfall = Vue.computed(() => {
+  if (!argonFeeQuote.value) return 0n;
+  const shortfall = argonFeeQuote.value.txFee - argonFeeQuote.value.availableBalance;
+  return shortfall > 0n ? shortfall : 0n;
+});
+const releaseProgress = Vue.computed(() => bitcoinLocks.utxoTracking.getReleaseLifecycleProgress(props.record));
+
+let feeQuoteTimeout: ReturnType<typeof setTimeout> | undefined;
+let feeQuoteRunId = 0;
+
+Vue.watch(
+  [trimmedDestination, feeRatePerSatVb, () => wallets.liquidLockingWallet.availableMicrogons],
+  () => {
+    if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
+    const runId = ++feeQuoteRunId;
+    argonFeeQuote.value = undefined;
+    argonFeeQuoteError.value = '';
+    requestError.value = '';
+    if (!trimmedDestination.value || destinationError.value) {
+      isCheckingArgonFee.value = false;
+      return;
+    }
+
+    isCheckingArgonFee.value = true;
+    feeQuoteTimeout = setTimeout(() => void refreshArgonFeeQuote(runId), 200);
+  },
+  { immediate: true },
+);
+
+Vue.onUnmounted(() => {
+  if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
+});
+
+async function requestReturn(): Promise<void> {
+  if (!canSubmit.value) return;
+  isSubmitting.value = true;
+  requestError.value = '';
+
+  try {
+    await bitcoinLocks.orphanReleases.requestOrphanReturn({
+      lock: props.lock,
+      record: props.record,
+      toScriptPubkey: trimmedDestination.value,
+      feeRatePerSatVb: feeRatePerSatVb.value,
+    });
+  } catch (error) {
+    requestError.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function refreshArgonFeeQuote(runId: number): Promise<void> {
+  try {
+    const quote = await bitcoinLocks.orphanReleases.getOrphanReturnFeeQuote({
+      lock: props.lock,
+      record: props.record,
+      toScriptPubkey: trimmedDestination.value,
+      feeRatePerSatVb: feeRatePerSatVb.value,
+    });
+    if (runId !== feeQuoteRunId) return;
+    argonFeeQuote.value = quote;
+  } catch {
+    if (runId !== feeQuoteRunId) return;
+    argonFeeQuoteError.value = 'Unable to check the Argon transaction fee. Please try again.';
+  } finally {
+    if (runId === feeQuoteRunId) isCheckingArgonFee.value = false;
+  }
+}
+
+function formatArgon(microgons: bigint): string {
+  const value = Math.abs(microgonToArgonNm(microgons)._value);
+  return `${currency.symbol}${microgonToArgonNm(microgons).format(value > 0 && value < 0.01 ? '0,0.[000000]' : '0,0.00')}`;
+}
+</script>

--- a/src-vue/overlays/VaultCollectOverlay.vue
+++ b/src-vue/overlays/VaultCollectOverlay.vue
@@ -403,7 +403,12 @@ async function submitCollect() {
   collectProgressLabel.value = 'Preparing transaction...';
 
   try {
-    await myVault.collect({ moveTo: MoveTo.DefaultArgon });
+    const txInfo = await myVault.collect({ moveTo: MoveTo.DefaultArgon });
+    if (!txInfo) {
+      isSubmittingCollect.value = false;
+      collectProgressPct.value = 0;
+      collectProgressLabel.value = '';
+    }
   } catch (error) {
     collectError.value = error instanceof Error ? error.message : `${error}`;
     isSubmittingCollect.value = false;

--- a/src-vue/overlays/VaultCollectOverlay.vue
+++ b/src-vue/overlays/VaultCollectOverlay.vue
@@ -49,19 +49,23 @@
           <strong>
             {{ manualPendingCosignCount }} transaction{{ manualPendingCosignCount === 1 ? '' : 's' }}
           </strong>
-          that must be signed. Failure to do so within
-          <CountdownClock :time="nextCosignDueDate" v-slot="{ hours, minutes, days }">
-            <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
-            <template v-else>
-              <span class="mr-2" v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
-              <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
-            </template>
-          </CountdownClock>
-          will result in your vault forfeiting
-          <strong>
-            {{ currency.symbol }}{{ microgonToMoneyNm(manualPendingCosignSum).formatIfElse('< 1_000', '0,0.00', '0,0') }}
-          </strong>
-          in securitization.
+          that must be signed.
+          <template v-if="manualPendingCosignSum > 0n">
+            Failure to do so within
+            <CountdownClock :time="nextCosignDueDate" v-slot="{ hours, minutes, days }">
+              <span v-if="days > 0">{{ days }} day{{ days === 1 ? '' : 's' }}</span>
+              <template v-else>
+                <span class="mr-2" v-if="hours">{{ hours }} hour{{ hours === 1 ? '' : 's' }}</span>
+                <span v-if="minutes">{{ minutes }} minute{{ minutes === 1 ? '' : 's' }}</span>
+              </template>
+            </CountdownClock>
+            will result in your vault forfeiting
+            <strong>
+              {{ currency.symbol
+              }}{{ microgonToMoneyNm(manualPendingCosignSum).formatIfElse('< 1_000', '0,0.00', '0,0') }}
+            </strong>
+            in securitization.
+          </template>
         </p>
 
         <div
@@ -385,6 +389,7 @@ Vue.watch(
     myVault.mintingAuthorities.data.pendingMintingAuthorizations.length,
     myVault.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.size,
     myVault.data.pendingCosignUtxosById.size,
+    myVault.data.pendingOrphanCosignCount,
     myVault.data.myPendingBitcoinCosignTxInfosByUtxoId.size,
   ],
   () => {

--- a/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
+++ b/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
@@ -806,8 +806,8 @@ async function refreshEstimatedOptionFees() {
   let returnFee: bigint | null = null;
   const destination = returnFeeEstimateDestination.value;
   if (destination && canReturnMismatch.value) {
-    returnFee = await bitcoinLocks
-      .estimatedMismatchReturnArgonTxFee({
+    returnFee = await bitcoinLocks.orphanReleases
+      .estimatedCandidateReturnArgonTxFee({
         lock: currentLock.value,
         candidateRecord: candidate,
         liquidLockingAddress,
@@ -904,7 +904,7 @@ async function returnMismatch() {
 
   isSubmitting.value = true;
   try {
-    await bitcoinLocks.requestMismatchOrphanReturnOnArgon({
+    await bitcoinLocks.orphanReleases.requestCandidateReturn({
       lock: currentLock.value,
       candidateRecord: candidate,
       toScriptPubkey: destination,

--- a/src-vue/screens/BitcoinLocks.vue
+++ b/src-vue/screens/BitcoinLocks.vue
@@ -23,7 +23,10 @@ const currency = getCurrency();
 const financials = useFinancials();
 const isLoaded = Vue.ref(false);
 const hasBitcoinRecords = Vue.computed(
-  () => financials.bitcoinLockDisplayRecords.length > 0 || financials.liquidInvisibleRecords.length > 0,
+  () =>
+    financials.bitcoinLockDisplayRecords.length > 0 ||
+    financials.liquidInvisibleRecords.length > 0 ||
+    bitcoinLocks.utxoTracking.getAllOrphanLifecycleUtxos().length > 0,
 );
 
 Vue.onMounted(async () => {

--- a/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
+++ b/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
@@ -86,22 +86,12 @@
           <section
             v-if="actionableOrphanRecords.length || showReturnedOrphans"
             data-testid="BitcoinOrphans"
-            class="mt-2 space-y-2 border-y border-slate-300/70 py-4"
+            :class="financials.liquidInvisibleRecords.length ? 'border-b' : ''"
+            class="mt-2 space-y-2 border-t border-slate-300/70 py-4"
           >
-            <div class="flex items-start justify-between gap-4">
-              <div>
-                <h2 class="font-semibold text-slate-800">Orphaned Bitcoin</h2>
-                <p class="text-sm text-slate-500">Bitcoin deposits handled outside a lock.</p>
-              </div>
-              <button
-                v-if="returnedOrphanCount"
-                type="button"
-                data-testid="BitcoinOrphans.toggleReturned()"
-                @click="showReturnedOrphans = !showReturnedOrphans"
-                class="text-argon-600 cursor-pointer text-sm whitespace-nowrap hover:underline"
-              >
-                {{ showReturnedOrphans ? 'Hide returned' : `Show returned (${returnedOrphanCount})` }}
-              </button>
+            <div>
+              <h2 class="font-semibold text-slate-800">Orphaned Bitcoin</h2>
+              <p class="text-sm text-slate-500">Bitcoin deposits handled outside a lock.</p>
             </div>
             <button
               v-for="record in visibleOrphanRecords"
@@ -132,6 +122,15 @@
                 <div class="text-sm text-slate-500">{{ orphanAction(record) }}</div>
               </div>
             </button>
+            <button
+              v-if="returnedOrphanCount"
+              type="button"
+              data-testid="BitcoinOrphans.toggleReturned()"
+              @click="showReturnedOrphans = !showReturnedOrphans"
+              class="text-argon-600 ml-auto block cursor-pointer text-sm whitespace-nowrap hover:underline"
+            >
+              {{ showReturnedOrphans ? 'Hide returned' : `Show returned (${returnedOrphanCount})` }}
+            </button>
           </section>
           <button
             v-else-if="returnedOrphanCount"
@@ -140,7 +139,7 @@
             @click="showReturnedOrphans = true"
             class="hover:text-argon-600 cursor-pointer self-end text-sm text-slate-500 hover:underline"
           >
-            View returned Bitcoin ({{ returnedOrphanCount }})
+            Show orphaned Bitcoin ({{ returnedOrphanCount }})
           </button>
           <BitcoinsReleasedOverlay v-if="financials.liquidInvisibleRecords.length" @open-detail="openDetail" />
         </section>
@@ -189,6 +188,7 @@ import { getBitcoinLockCoupons, getBitcoinLocks } from '../../stores/bitcoin.ts'
 import { getMiningFrames } from '../../stores/mainchain.ts';
 import { type IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
 import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../../lib/db/BitcoinUtxosTable.ts';
+import { TransactionStatus } from '../../lib/db/TransactionsTable.ts';
 import BitcoinLockDetailOverlay from '../../overlays/BitcoinLockDetailOverlay.vue';
 import BitcoinUnlockingOverlay from '../../overlays/BitcoinUnlockingOverlay.vue';
 import basicEmitter from '../../emitters/basicEmitter.ts';
@@ -254,6 +254,10 @@ function orphanStatus(record: IBitcoinUtxoRecord): string {
   if (record.status === BitcoinUtxoStatus.Orphaned) return 'Return required';
   if (record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin) return 'Returning on Bitcoin';
   if (record.releaseCosignVaultSignature) return 'Preparing return';
+  const txStatus = bitcoinLocks.orphanReleases.getTransactionInfo(record.lockUtxoId, record)?.tx.status;
+  if (txStatus && [TransactionStatus.Submitted, TransactionStatus.InBlock].includes(txStatus)) {
+    return 'Submitting return request';
+  }
   return 'Awaiting vault signature';
 }
 

--- a/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
+++ b/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
@@ -83,6 +83,65 @@
             @ratchet="openRatchetingOverlay"
             @unlock="openUnlockingOverlay"
           />
+          <section
+            v-if="actionableOrphanRecords.length || showReturnedOrphans"
+            data-testid="BitcoinOrphans"
+            class="mt-2 space-y-2 border-y border-slate-300/70 py-4"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="font-semibold text-slate-800">Orphaned Bitcoin</h2>
+                <p class="text-sm text-slate-500">Bitcoin deposits handled outside a lock.</p>
+              </div>
+              <button
+                v-if="returnedOrphanCount"
+                type="button"
+                data-testid="BitcoinOrphans.toggleReturned()"
+                @click="showReturnedOrphans = !showReturnedOrphans"
+                class="text-argon-600 cursor-pointer text-sm whitespace-nowrap hover:underline"
+              >
+                {{ showReturnedOrphans ? 'Hide returned' : `Show returned (${returnedOrphanCount})` }}
+              </button>
+            </div>
+            <button
+              v-for="record in visibleOrphanRecords"
+              :key="record.id"
+              :data-testid="`BitcoinOrphans.record.${record.id}`"
+              type="button"
+              @click="selectedOrphan = record"
+              class="hover:border-argon-400 flex w-full cursor-pointer items-center rounded-lg border border-slate-300 bg-white px-4 py-3 text-left"
+            >
+              <div class="grow">
+                <div class="font-semibold text-slate-800">
+                  {{ numeral(currency.convertSatToBtc(record.satoshis)).format('0,0.[00000000]') }} BTC received
+                </div>
+                <div class="text-sm text-slate-500">
+                  {{ dayjs(record.firstSeenAt).format('MMM D, YYYY') }} · Lock expected
+                  {{
+                    numeral(
+                      currency.convertSatToBtc(bitcoinLocks.getLockByUtxoId(record.lockUtxoId)?.satoshis ?? 0n),
+                    ).format('0,0.[00000000]')
+                  }}
+                  BTC
+                </div>
+              </div>
+              <div class="text-right">
+                <div class="text-sm font-semibold" :class="record.statusError ? 'text-red-700' : 'text-argon-700'">
+                  {{ orphanStatus(record) }}
+                </div>
+                <div class="text-sm text-slate-500">{{ orphanAction(record) }}</div>
+              </div>
+            </button>
+          </section>
+          <button
+            v-else-if="returnedOrphanCount"
+            type="button"
+            data-testid="BitcoinOrphans.showReturned()"
+            @click="showReturnedOrphans = true"
+            class="hover:text-argon-600 cursor-pointer self-end text-sm text-slate-500 hover:underline"
+          >
+            View returned Bitcoin ({{ returnedOrphanCount }})
+          </button>
           <BitcoinsReleasedOverlay v-if="financials.liquidInvisibleRecords.length" @open-detail="openDetail" />
         </section>
         <div class="relative px-0.5 pb-0.5">
@@ -112,19 +171,29 @@
     @close="showRatchetingOverlay = false"
     @completed="onRatchetCompleted"
   />
+
+  <BitcoinOrphanRecoveryOverlay
+    v-if="selectedOrphan && selectedOrphanLock"
+    :record="selectedOrphan"
+    :lock="selectedOrphanLock"
+    @close="selectedOrphan = undefined"
+  />
 </template>
 
 <script setup lang="ts">
 import * as Vue from 'vue';
+import dayjs from 'dayjs';
 import numeral from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { getBitcoinLockCoupons, getBitcoinLocks } from '../../stores/bitcoin.ts';
 import { getMiningFrames } from '../../stores/mainchain.ts';
 import { type IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
+import { BitcoinUtxoStatus, type IBitcoinUtxoRecord } from '../../lib/db/BitcoinUtxosTable.ts';
 import BitcoinLockDetailOverlay from '../../overlays/BitcoinLockDetailOverlay.vue';
 import BitcoinUnlockingOverlay from '../../overlays/BitcoinUnlockingOverlay.vue';
 import basicEmitter from '../../emitters/basicEmitter.ts';
 import BitcoinRatchetingOverlay from '../../overlays/BitcoinRatchetingOverlay.vue';
+import BitcoinOrphanRecoveryOverlay from '../../overlays/BitcoinOrphanRecoveryOverlay.vue';
 import FormattedMoney from '../../components/FormattedMoney.vue';
 import { NetworkConfig, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import type { IBitcoinLockSummary } from '../../interfaces/IBitcoinLockSummary.ts';
@@ -146,7 +215,59 @@ const pageSourcesAreLoaded = Vue.ref(false);
 const showDetailOverlay = Vue.ref(false);
 const showUnlockingOverlay = Vue.ref(false);
 const showRatchetingOverlay = Vue.ref(false);
+const showReturnedOrphans = Vue.ref(false);
 const selectedLock = Vue.ref<IBitcoinLockSummary>();
+const selectedOrphan = Vue.ref<IBitcoinUtxoRecord>();
+
+const orphanRecords = Vue.computed(() => {
+  const locks = bitcoinLocks.getAllLocks();
+  const fundingRecordIds = new Set(
+    locks
+      .map(lock => bitcoinLocks.utxoTracking.getAcceptedFundingRecordForLock(lock)?.id)
+      .filter((id): id is number => id !== undefined),
+  );
+
+  return bitcoinLocks.utxoTracking
+    .getAllOrphanLifecycleUtxos()
+    .filter(record => !fundingRecordIds.has(record.id))
+    .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+});
+const actionableOrphanRecords = Vue.computed(() =>
+  orphanRecords.value.filter(record => !bitcoinLocks.utxoTracking.isReleaseCompleteStatus(record.status)),
+);
+const visibleOrphanRecords = Vue.computed(() => {
+  if (showReturnedOrphans.value) return orphanRecords.value;
+  return actionableOrphanRecords.value;
+});
+const returnedOrphanCount = Vue.computed(
+  () => orphanRecords.value.filter(record => bitcoinLocks.utxoTracking.isReleaseCompleteStatus(record.status)).length,
+);
+
+const selectedOrphanLock = Vue.computed(() => {
+  if (!selectedOrphan.value) return undefined;
+  return bitcoinLocks.getLockByUtxoId(selectedOrphan.value.lockUtxoId);
+});
+
+function orphanStatus(record: IBitcoinUtxoRecord): string {
+  if (record.statusError) return 'Recovery needs attention';
+  if (bitcoinLocks.utxoTracking.isReleaseCompleteStatus(record.status)) return 'Returned';
+  if (record.status === BitcoinUtxoStatus.Orphaned) return 'Return required';
+  if (record.status === BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin) return 'Returning on Bitcoin';
+  if (record.releaseCosignVaultSignature) return 'Preparing return';
+  return 'Awaiting vault signature';
+}
+
+function orphanAction(record: IBitcoinUtxoRecord): string {
+  if (record.statusError || record.status === BitcoinUtxoStatus.Orphaned) return 'Return Bitcoin';
+  if (bitcoinLocks.utxoTracking.isReleaseCompleteStatus(record.status)) return 'View details';
+  return 'View progress';
+}
+
+Vue.watch(visibleOrphanRecords, records => {
+  if (selectedOrphan.value && !records.some(record => record.id === selectedOrphan.value?.id)) {
+    selectedOrphan.value = undefined;
+  }
+});
 
 function openDetail(lock: IBitcoinLockSummary) {
   if (lock.record.isHistoryRecoveryPending) return;

--- a/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecord.vue
@@ -178,7 +178,7 @@
             <button
               @click.stop="openRatchetingOverlay($event, lockSummary)"
               :class="[
-                lockSummary.ratchetPercent || isRatchetPending
+                displayedRatchetPercent || isRatchetPending
                   ? 'bg-argon-600 border-argon-800 hover:bg-argon-700 text-white hover:shadow-lg'
                   : 'cursor-default border-slate-800/20 text-slate-600/40',
               ]"
@@ -188,9 +188,9 @@
                 <Spinner class="Inverse mr-1.5 h-3 min-h-3 w-3 min-w-3" />
                 Ratcheting...
               </template>
-              <span v-else-if="lockSummary.ratchetPercent">
-                Ratchet {{ lockSummary.ratchetPercent > 0 ? '+' : ''
-                }}{{ numeral(lockSummary.ratchetPercent).format('0,0.[00]') }}%
+              <span v-else-if="displayedRatchetPercent">
+                Ratchet {{ displayedRatchetPercent > 0 ? '+' : ''
+                }}{{ numeral(displayedRatchetPercent).format('0,0.[00]') }}%
               </span>
               <template v-else>Price Is at Par</template>
             </button>
@@ -219,7 +219,9 @@
           <div class="flex grow flex-row items-stretch justify-center">
             <span class="h-full w-px bg-slate-400/50"></span>
           </div>
-          <span class="pr-1">{{ numeral(lockSummary.totalReturn).format('0,0.[00]') }}% return</span>
+          <span class="pr-1">
+            {{ numeral(Math.round(lockSummary.totalReturn * 100) / 100).format('0,0.[00]') }}% return
+          </span>
         </div>
       </div>
     </section>
@@ -265,6 +267,7 @@ const lockRecord = Vue.computed(() => props.lockSummary.record);
 const fundingExpirationTime = Vue.computed(() => dayjs.utc(bitcoinLocks.verifyExpirationTime(lockRecord.value)));
 const isHistoryRecoveryPaused = Vue.computed(() => financials.historyRecovery.state === 'error');
 const isRatchetPending = Vue.computed(() => !!bitcoinLocks.getPendingRatchetTxInfo(lockRecord.value));
+const displayedRatchetPercent = Vue.computed(() => Math.round(props.lockSummary.ratchetPercent * 100) / 100);
 const mismatchAcceptProgress = Vue.computed(() => {
   if (!lockRecord.value.utxoId) {
     return { progressPct: 0, error: '' };
@@ -288,7 +291,7 @@ function formatTimeRemaining(days: number, hours: number, minutes: number, secon
 }
 
 function openRatchetingOverlay(event: MouseEvent, lock: IBitcoinLockSummary) {
-  if (!props.lockSummary.ratchetPercent && !isRatchetPending.value) return;
+  if (!displayedRatchetPercent.value && !isRatchetPending.value) return;
   emit('ratchet', event, lock);
 }
 

--- a/src-vue/screens/treasury-screens/components/BitcoinRecordMismatch.vue
+++ b/src-vue/screens/treasury-screens/components/BitcoinRecordMismatch.vue
@@ -119,7 +119,7 @@ const showMismatchReturnProgress = Vue.computed(() => {
 const mismatchReturnProgress = Vue.computed(() => {
   const returnRecord = nextMismatchCandidate.value?.returnRecord;
   if (isMismatchReturningOnArgon.value && lockRecord.value.utxoId && returnRecord) {
-    const txStatus = bitcoinLocks.getOrphanedReturnTxInfoForRecord(lockRecord.value.utxoId, returnRecord)?.getStatus();
+    const txStatus = bitcoinLocks.orphanReleases.getTransactionInfo(lockRecord.value.utxoId, returnRecord)?.getStatus();
     return {
       progressPct: txStatus?.progressPct ?? 0,
       label: generateProgressLabel(txStatus?.confirmations ?? -1, txStatus?.expectedConfirmations ?? 0, {

--- a/src-vue/stores/bitcoinLockProgress.ts
+++ b/src-vue/stores/bitcoinLockProgress.ts
@@ -345,7 +345,7 @@ export function createBitcoinLockProgressStore(deps: BitcoinLockProgressDeps) {
       clearOrphanedReturnArgonProgress();
       return;
     }
-    const txInfo = bitcoinLocks.getOrphanedReturnTxInfoForRecord(utxoId, record);
+    const txInfo = bitcoinLocks.orphanReleases.getTransactionInfo(utxoId, record);
     if (!txInfo) {
       clearOrphanedReturnArgonProgress();
       return;


### PR DESCRIPTION
## Summary

Bitcoin sent after a lock is funded, expired, or otherwise unable to accept the deposit now stays visible and recoverable instead of appearing lost.

- Show only orphaned deposits that still need action by default, with completed returns available through a secondary history link.
- Let the owner request a return to a chosen Bitcoin address and restore the same request, signature, and broadcast state after an app restart.
- Route vault cosigning through the existing vault alert and collect flow. Normal vault signatures remain finalized-chain only, while pending orphan cosigns block revenue collection until they are cleared.
- Keep orphan return orchestration separate from the already large Bitcoin lock class while reusing the existing lock, UTXO, transaction, recovery, and alert stores.

## Validation

- Recovered three orphan deposits through vault cosigning and Bitcoin confirmation in the local stack, including restarting the upstream actor before it processed the pending requests.
- Verified vault and alert behavior with 41 focused tests.
- Verified the Vue TypeScript build and repository formatting checks.
