### PR TITLE
fix: show missing mnemonic backup in operations checklist

### DIFF
--- a/src-vue/navigation/CertificationMenu.vue
+++ b/src-vue/navigation/CertificationMenu.vue
@@ -258,7 +258,6 @@ import Arrow from '../components/Arrow.vue';
 import { createNumeralHelpers } from '../lib/numeral.ts';
 import {
   OperationalStepId,
-  operationsCertificationStepIds,
   operationalSteps,
   treasuryCertificationStepIds,
   useCertificationController,
@@ -296,7 +295,7 @@ const hasRequestedOperationsUpgrade = Vue.computed(() => {
 });
 
 const currentStepIds = Vue.computed(() => {
-  return isUnlockTrack.value ? treasuryCertificationStepIds : operationsCertificationStepIds;
+  return isUnlockTrack.value ? treasuryCertificationStepIds : controller.visibleOperationsCertificationStepIds;
 });
 
 const completedStepCount = Vue.computed(() => {

--- a/src-vue/overlays/CertificationOverlay.vue
+++ b/src-vue/overlays/CertificationOverlay.vue
@@ -144,7 +144,6 @@ import {
   useCertificationController,
   OperationalStepId,
   operationalSteps,
-  operationsCertificationStepIds,
   treasuryCertificationStepIds,
 } from '../stores/certificationController.ts';
 import { useBasics } from '../stores/basics.ts';
@@ -161,7 +160,9 @@ const isOpen = Vue.ref(false);
 const currentStepId = Vue.ref<OperationalStepId | null>(null);
 const currentTrack = Vue.ref<'treasury' | 'operations'>('treasury');
 const currentStepIds = Vue.computed(() => {
-  return currentTrack.value === 'treasury' ? treasuryCertificationStepIds : operationsCertificationStepIds;
+  return currentTrack.value === 'treasury'
+    ? treasuryCertificationStepIds
+    : controller.visibleOperationsCertificationStepIds;
 });
 const currentBlockingStep = Vue.computed(() => {
   return currentStepId.value ? controller.getCertificationBlocker(currentStepId.value) : null;
@@ -272,7 +273,11 @@ basicEmitter.on('openOperationalOverlay', (stepId: OperationalStepId) => {
     return;
   }
 
-  currentTrack.value = treasuryCertificationStepIds.some(id => id === stepId) ? 'treasury' : 'operations';
+  if (stepId === OperationalStepId.BackupMnemonic && controller.chainProgress.isUpgradedToOperations) {
+    currentTrack.value = 'operations';
+  } else {
+    currentTrack.value = treasuryCertificationStepIds.some(id => id === stepId) ? 'treasury' : 'operations';
+  }
   isOpen.value = true;
   currentStepId.value = stepId;
   basics.overlayIsOpen = true;

--- a/src-vue/stores/certificationController.ts
+++ b/src-vue/stores/certificationController.ts
@@ -331,6 +331,14 @@ export const useCertificationController = defineStore('certificationController',
     };
   });
 
+  const visibleOperationsCertificationStepIds = Vue.computed(() => {
+    if (isCertificationStepComplete(OperationalStepId.BackupMnemonic)) {
+      return operationsCertificationStepIds;
+    }
+
+    return [OperationalStepId.BackupMnemonic, ...operationsCertificationStepIds];
+  });
+
   const completedCertificationStepCount = Vue.computed(() => {
     return allCertificationStepIds.filter(stepId => isCertificationStepComplete(stepId)).length;
   });
@@ -852,6 +860,7 @@ export const useCertificationController = defineStore('certificationController',
     isTreasuryCertificationChecklistComplete,
     isCertificationChecklistComplete,
     isTreasuryCertificationFlowActive,
+    visibleOperationsCertificationStepIds,
     chainProgress,
     rewardConfig,
     inviteSlotProgress,


### PR DESCRIPTION
Upgraded accounts now see an incomplete mnemonic backup in the Operations certification checklist instead of appearing complete while activation remains blocked. The requirement appears in both the header menu and certification overlay, stays within the Operations flow when opened, and disappears after the backup is recorded.

Validated with Vue typechecking, focused operational tests, formatting, operation-rule enforcement, and diff checks. A manual account-state walkthrough was not run.
