### PR TITLE
fix(bot): prevent delegate transaction queue stalls

### DIFF
--- a/bot/__test__/BitcoinLockRelayService.integration.test.ts
+++ b/bot/__test__/BitcoinLockRelayService.integration.test.ts
@@ -505,7 +505,22 @@ async function createRelayServiceHarness(args?: { bestBlockNumber?: number; fina
     get: vi.fn(async () => ({})),
   } as unknown as MainchainClients;
   const laneClient = {
+    at: vi.fn(async () => ({
+      query: {
+        system: {
+          account: vi.fn(async () => ({
+            nonce: { toNumber: () => 1 },
+          })),
+        },
+      },
+    })),
     rpc: {
+      chain: {
+        getHeader: vi.fn(async () => ({
+          number: { toNumber: () => 100 },
+        })),
+        getBlockHash: vi.fn(async () => '0xstable'),
+      },
       system: {
         accountNextIndex: vi.fn(async () => ({
           toNumber: () => 1,

--- a/bot/__test__/DelegateSubmitLane.test.ts
+++ b/bot/__test__/DelegateSubmitLane.test.ts
@@ -136,8 +136,7 @@ describe('DelegateSubmitLane', () => {
     void submission.then(settled, settled);
     const accountNextIndex = vi.mocked(lane.client.rpc.system.accountNextIndex);
     await vi.waitFor(() => expect(accountNextIndex).toHaveBeenCalledOnce());
-    vi.setSystemTime(Date.now() + 600_000);
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(600_000);
 
     await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce());
     await expect(submission).rejects.toThrow(

--- a/bot/__test__/DelegateSubmitLane.test.ts
+++ b/bot/__test__/DelegateSubmitLane.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ArgonClient } from '@argonprotocol/mainchain';
+import { DelegateSubmitLane } from '../src/DelegateSubmitLane.ts';
+
+const keypair = { address: 'delegate-account' } as any;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('DelegateSubmitLane', () => {
+  it('keeps the next submission queued until the previous nonce is two blocks deep', async () => {
+    vi.useFakeTimers();
+    const waitStartedAt = Date.now();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 5,
+      nonceByBlock: new Map([
+        [100, 4],
+        [101, 4],
+        [102, 4],
+        [103, 5],
+      ]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+
+    const nonceAssigned = vi.fn();
+    const submission = lane.runExclusive(async (_client, getNonce) => {
+      const nonce = await getNonce();
+      nonceAssigned(nonce);
+      return nonce;
+    });
+    void submission.catch(() => undefined);
+    const accountNextIndex = vi.mocked(lane.client.rpc.system.accountNextIndex);
+    await vi.waitFor(() => expect(accountNextIndex).toHaveBeenCalledOnce());
+
+    nonceState.bestBlock = 103;
+    vi.setSystemTime(waitStartedAt + 60_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(nonceAssigned).not.toHaveBeenCalled();
+
+    nonceState.bestBlock = 104;
+    vi.setSystemTime(waitStartedAt + 120_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(nonceAssigned).not.toHaveBeenCalled();
+
+    nonceState.bestBlock = 105;
+    vi.setSystemTime(waitStartedAt + 180_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(submission).resolves.toBe(5);
+  });
+
+  it('reuses the stable nonce when an early reorg removes the previous transaction', async () => {
+    vi.useFakeTimers();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 5,
+      nonceByBlock: new Map([[100, 4]]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+
+    const nonceAssigned = vi.fn();
+    const submission = lane.runExclusive(async (_client, getNonce) => {
+      const nonce = await getNonce();
+      nonceAssigned(nonce);
+      return nonce;
+    });
+    const accountNextIndex = vi.mocked(lane.client.rpc.system.accountNextIndex);
+    await vi.waitFor(() => expect(accountNextIndex).toHaveBeenCalledOnce());
+    expect(nonceAssigned).not.toHaveBeenCalled();
+
+    nonceState.pool = 4;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(submission).resolves.toBe(4);
+  });
+
+  it('retries when stable block state is discarded during a reorg', async () => {
+    vi.useFakeTimers();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 4,
+      nonceByBlock: new Map([[100, 4]]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+    const at = vi.spyOn(lane.client, 'at').mockRejectedValueOnce(new Error('4003: State already discarded'));
+
+    const submission = lane.runExclusive(async (_client, getNonce) => await getNonce());
+    void submission.catch(() => undefined);
+    await vi.waitFor(() => expect(at).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(submission).resolves.toBe(4);
+  });
+
+  it('logs and rejects unexpected stable-state read failures', async () => {
+    vi.useFakeTimers();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 4,
+      nonceByBlock: new Map([[100, 4]]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+    const error = new Error('Unexpected codec failure');
+    const at = vi.spyOn(lane.client, 'at').mockRejectedValueOnce(error);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const submission = lane.runExclusive(async (_client, getNonce) => await getNonce());
+    void submission.catch(() => undefined);
+    await vi.waitFor(() => expect(at).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(submission).rejects.toBe(error);
+    expect(consoleError).toHaveBeenCalledWith('[DelegateSubmitLane] Failed to read delegate nonce state', error);
+  });
+
+  it('stops waiting and reports the last mismatched nonce snapshot', async () => {
+    vi.useFakeTimers();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 5,
+      nonceByBlock: new Map([[100, 4]]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const submission = lane.runExclusive(async (_client, getNonce) => await getNonce());
+    const settled = vi.fn();
+    void submission.then(settled, settled);
+    const accountNextIndex = vi.mocked(lane.client.rpc.system.accountNextIndex);
+    await vi.waitFor(() => expect(accountNextIndex).toHaveBeenCalledOnce());
+    vi.setSystemTime(Date.now() + 600_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce());
+    await expect(submission).rejects.toThrow(
+      'Timed out after 600s waiting for delegate nonce to stabilize. ' +
+        'Last observation: stable block 100 nonce 4, transaction pool next index 5.',
+    );
+  });
+
+  it('times out a stalled state read and releases the next submission', async () => {
+    vi.useFakeTimers();
+    const nonceState = {
+      bestBlock: 102,
+      pool: 4,
+      nonceByBlock: new Map([[100, 4]]),
+    };
+    const lane = new DelegateSubmitLane(keypair);
+    lane.client = createClient(nonceState);
+    const getHeader = vi.mocked(lane.client.rpc.chain.getHeader);
+    getHeader.mockReturnValueOnce(new Promise<never>(() => undefined));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const stalledSubmission = lane.runExclusive(async (_client, getNonce) => await getNonce());
+    const settled = vi.fn();
+    void stalledSubmission.then(settled, settled);
+    const nextSubmission = lane.runExclusive(async (_client, getNonce) => await getNonce());
+    await vi.waitFor(() => expect(getHeader).toHaveBeenCalledOnce());
+
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce());
+    await expect(stalledSubmission).rejects.toThrow(
+      'Timed out after 600s waiting for delegate nonce to stabilize. ' +
+        'Last observation: no nonce snapshot was available.',
+    );
+    await expect(nextSubmission).resolves.toBe(4);
+  });
+});
+
+function createClient(nonceState: { bestBlock: number; pool: number; nonceByBlock: Map<number, number> }): ArgonClient {
+  return {
+    at: vi.fn(async (blockHash: string) => {
+      const blockNumber = Number(blockHash.slice(2));
+      return {
+        query: {
+          system: {
+            account: vi.fn(async () => ({
+              nonce: { toNumber: () => nonceState.nonceByBlock.get(blockNumber) ?? 0 },
+            })),
+          },
+        },
+      };
+    }),
+    rpc: {
+      chain: {
+        getHeader: vi.fn(async () => ({
+          number: { toNumber: () => nonceState.bestBlock },
+        })),
+        getBlockHash: vi.fn(async (blockNumber: number) => `0x${blockNumber}`),
+      },
+      system: {
+        accountNextIndex: vi.fn(async () => ({
+          toNumber: () => nonceState.pool,
+        })),
+      },
+    },
+  } as unknown as ArgonClient;
+}

--- a/bot/__test__/EthereumBeaconSyncService.test.ts
+++ b/bot/__test__/EthereumBeaconSyncService.test.ts
@@ -99,15 +99,26 @@ const syncKeypair = { address: 'sync-account' } as any;
 describe('EthereumBeaconSyncService', () => {
   const createClient = ({
     startingNonce = 4,
+    nonceState = { stable: startingNonce, pool: startingNonce },
     hasEthereumChainConfig = true,
     getDelegateBalance = () => minimumVaultDelegateBalance,
   }: {
     startingNonce?: number;
+    nonceState?: { stable: number; pool: number };
     hasEthereumChainConfig?: boolean;
     getDelegateBalance?: () => bigint;
   } = {}): ArgonClient =>
     ({
       isConnected: true,
+      at: vi.fn(async () => ({
+        query: {
+          system: {
+            account: vi.fn(async () => ({
+              nonce: { toNumber: () => nonceState.stable },
+            })),
+          },
+        },
+      })),
       query: {
         system: {
           account: vi.fn(async () => ({
@@ -132,12 +143,18 @@ describe('EthereumBeaconSyncService', () => {
         },
       },
       rpc: {
+        chain: {
+          getHeader: vi.fn(async () => ({
+            number: { toNumber: () => 100 },
+          })),
+          getBlockHash: vi.fn(async () => '0xstable'),
+        },
         author: {
           pendingExtrinsics: vi.fn(async () => []),
         },
         system: {
           accountNextIndex: vi.fn(async () => ({
-            toNumber: () => startingNonce,
+            toNumber: () => nonceState.pool,
           })),
         },
       },
@@ -255,7 +272,6 @@ describe('EthereumBeaconSyncService', () => {
     releaseLane();
     await runOncePromise;
 
-    expect(client.query.system.account).toHaveBeenCalledTimes(3);
     expect(submissionMock.submitWithTerminalStatusWatch).not.toHaveBeenCalled();
     expect(service.state()).toMatchObject({
       mode: 'idle',
@@ -269,7 +285,8 @@ describe('EthereumBeaconSyncService', () => {
       resolveFirstInBlock = resolve;
     });
     const txs: IMockTx[] = [{ id: 'tx-1' }, { id: 'tx-2' }];
-    const client = createClient({ startingNonce: 12 });
+    const nonceState = { stable: 12, pool: 12 };
+    const client = createClient({ nonceState });
 
     mainchainMock.getEthereumBeaconSyncState
       .mockResolvedValueOnce({
@@ -321,6 +338,8 @@ describe('EthereumBeaconSyncService', () => {
       { nonce: 12 },
     );
 
+    nonceState.stable = 13;
+    nonceState.pool = 13;
     resolveFirstInBlock();
     await vi.waitFor(() => {
       expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);

--- a/bot/__test__/EthereumGatewayProverService.test.ts
+++ b/bot/__test__/EthereumGatewayProverService.test.ts
@@ -241,13 +241,11 @@ describe('EthereumGatewayProverService', () => {
     expect(submissionMock.submitWithTerminalStatusWatch).toHaveBeenCalledTimes(2);
   });
 
-  it('retries with a refreshed nonce when the node drops the delegate submission', async () => {
+  it('retries a dropped delegate submission with the still-available nonce', async () => {
     const client = createClient();
     const service = new EthereumGatewayProverService(createSubmitLane(client), {
       shouldApplySharedRelayStagger: true,
     });
-    const accountNextIndex = client.rpc.system.accountNextIndex as ReturnType<typeof vi.fn>;
-    accountNextIndex.mockResolvedValueOnce({ toNumber: () => 4 }).mockResolvedValueOnce({ toNumber: () => 5 });
 
     gatewayProofMock.buildGatewayActivityProofPayload
       .mockResolvedValueOnce({
@@ -315,7 +313,7 @@ describe('EthereumGatewayProverService', () => {
       delegateAddress: '5RelayDelegate',
       argonTxHash: '0xrelaytx',
       extrinsicMethodJson: { section: 'crosschainTransfer', method: 'proveGatewayActivity' },
-      txNonce: 5,
+      txNonce: 4,
       txSubmittedAtBlockHeight: 322,
       txSubmittedAtTime: new Date('2026-05-13T16:00:01.000Z'),
       estimatedFee: 7n,
@@ -327,7 +325,8 @@ describe('EthereumGatewayProverService', () => {
   it('releases a timed-out first-block wait so a later catch-up can run', async () => {
     vi.useFakeTimers();
 
-    const client = createClient();
+    const nonceState = { stable: 4, pool: 4 };
+    const client = createClient({ nonceState });
     const service = new EthereumGatewayProverService(createSubmitLane(client), {
       shouldApplySharedRelayStagger: true,
     });
@@ -339,21 +338,24 @@ describe('EthereumGatewayProverService', () => {
       activities: [{ gatewayState: { gatewayActivityNonce: 7n } }],
     });
     submissionMock.submitWithTerminalStatusWatch
-      .mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
-        signedTx: {
-          method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
-          nonce: { toNumber: () => options?.nonce ?? 0 },
-        },
-        result: {
-          extrinsic: {
-            signedHash: '0xtimeout',
-            submittedAtBlockNumber: 321,
-            submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+      .mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => {
+        nonceState.pool = 5;
+        return {
+          signedTx: {
+            method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
+            nonce: { toNumber: () => options?.nonce ?? 0 },
           },
-          blockNumber: 321,
-          waitForInFirstBlock: new Promise(() => undefined),
-        },
-      }))
+          result: {
+            extrinsic: {
+              signedHash: '0xtimeout',
+              submittedAtBlockNumber: 321,
+              submittedTime: new Date('2026-05-13T16:00:00.000Z'),
+            },
+            blockNumber: 321,
+            waitForInFirstBlock: new Promise(() => undefined),
+          },
+        };
+      })
       .mockImplementationOnce(async (_submitter, options?: { nonce?: number }) => ({
         signedTx: {
           method: { toHuman: () => ({ section: 'crosschainTransfer', method: 'proveGatewayActivity' }) },
@@ -387,6 +389,8 @@ describe('EthereumGatewayProverService', () => {
       estimatedFee: 7n,
       throughGatewayActivityNonce: 7n,
     });
+    nonceState.stable = 5;
+    nonceState.pool = 5;
     await expect(
       service.runToCheckpoint({ sourceChain: 'Ethereum', throughGatewayActivityNonce: 7n }),
     ).resolves.toEqual({
@@ -985,6 +989,7 @@ function createClient(
   args: {
     tx?: { paymentInfo: ReturnType<typeof vi.fn> };
     accountNextNonce?: number;
+    nonceState?: { stable: number; pool: number };
     balance?: bigint;
     existentialDeposit?: bigint;
     hasEthereumChainConfig?: boolean;
@@ -1017,6 +1022,17 @@ function createClient(
     } as const);
 
   return {
+    at: vi.fn(async () => ({
+      query: {
+        system: {
+          account: vi.fn(async () => ({
+            nonce: {
+              toNumber: () => args.nonceState?.stable ?? args.accountNextNonce ?? 4,
+            },
+          })),
+        },
+      },
+    })),
     tx: {
       crosschainTransfer: {
         proveGatewayActivity: vi.fn(() => tx),
@@ -1101,9 +1117,15 @@ function createClient(
       },
     },
     rpc: {
+      chain: {
+        getHeader: vi.fn(async () => ({
+          number: { toNumber: () => 100 },
+        })),
+        getBlockHash: vi.fn(async () => '0xstable'),
+      },
       system: {
         accountNextIndex: vi.fn(async () => ({
-          toNumber: () => args.accountNextNonce ?? 4,
+          toNumber: () => args.nonceState?.pool ?? args.accountNextNonce ?? 4,
         })),
       },
     },

--- a/bot/src/BitcoinLockRelayService.ts
+++ b/bot/src/BitcoinLockRelayService.ts
@@ -447,25 +447,21 @@ export class BitcoinLockRelayService {
         this.db.bitcoinLockRelaysTable.revertToSubmitted(relayId);
         return;
       }
-      this.submitLane.invalidateNonce();
       this.failRelay(relayId, 'Relay was retracted before it was included in a block.');
       return;
     }
 
     if (status.isUsurped) {
-      this.submitLane.invalidateNonce();
       this.failRelay(relayId, `Relay was usurped by ${status.asUsurped.toHex()}.`);
       return;
     }
 
     if (status.isDropped) {
-      this.submitLane.invalidateNonce();
       this.failRelay(relayId, 'Relay was dropped before it was included in a block.');
       return;
     }
 
     if (status.isInvalid) {
-      this.submitLane.invalidateNonce();
       this.failRelay(relayId, 'Relay was rejected as invalid by the node.');
       return;
     }

--- a/bot/src/DelegateSubmitLane.ts
+++ b/bot/src/DelegateSubmitLane.ts
@@ -1,9 +1,12 @@
-import { SingleFileQueue } from '@argonprotocol/apps-core';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { isUnreadableBlockError, raceWithTimeout, SingleFileQueue } from '@argonprotocol/apps-core';
 import { type ArgonClient, type KeyringPair } from '@argonprotocol/mainchain';
+
+const NONCE_STABILITY_BLOCKS = 2;
+const NONCE_WAIT_TIMEOUT_MS = 10 * 60_000;
 
 export class DelegateSubmitLane {
   public client!: ArgonClient;
-  private nextNonce?: number;
   private readonly queue: SingleFileQueue;
 
   constructor(
@@ -17,10 +20,6 @@ export class DelegateSubmitLane {
     return this.keypair.address;
   }
 
-  public invalidateNonce(): void {
-    this.nextNonce = undefined;
-  }
-
   public async runExclusive<T>(fn: (client: ArgonClient, getNonce: () => Promise<number>) => Promise<T>): Promise<T> {
     return await this.queue.add(async () => {
       const client = this.client;
@@ -30,19 +29,66 @@ export class DelegateSubmitLane {
 
       let nonce: number | undefined;
       const getNonce = async (): Promise<number> => {
-        nonce ??= this.nextNonce ?? (await client.rpc.system.accountNextIndex(this.address)).toNumber();
-        this.nextNonce = nonce + 1;
+        const waitDeadline = Date.now() + NONCE_WAIT_TIMEOUT_MS;
+        let lastObservation = 'no nonce snapshot was available';
+
+        while (nonce === undefined && Date.now() < waitDeadline) {
+          const remainingWaitMs = waitDeadline - Date.now();
+          if (remainingWaitMs <= 0) break;
+
+          try {
+            const snapshot = await raceWithTimeout(
+              (async () => {
+                const bestBlockHeader = await client.rpc.chain.getHeader();
+                const stableBlockNumber = Math.max(0, bestBlockHeader.number.toNumber() - NONCE_STABILITY_BLOCKS);
+                const stableBlockHash = await client.rpc.chain.getBlockHash(stableBlockNumber);
+                const stableClient = await client.at(stableBlockHash);
+                const [account, nextIndex] = await Promise.all([
+                  stableClient.query.system.account(this.address),
+                  client.rpc.system.accountNextIndex(this.address),
+                ]);
+                return {
+                  stableBlockNumber,
+                  stableNonce: account.nonce.toNumber(),
+                  poolNextIndex: nextIndex.toNumber(),
+                };
+              })(),
+              remainingWaitMs,
+              () => undefined,
+            );
+            if (!snapshot) break;
+
+            const { stableBlockNumber, stableNonce, poolNextIndex } = snapshot;
+            if (poolNextIndex === stableNonce) {
+              nonce = stableNonce;
+              break;
+            }
+            lastObservation =
+              `stable block ${stableBlockNumber} nonce ${stableNonce}, ` +
+              `transaction pool next index ${poolNextIndex}`;
+          } catch (error) {
+            if (!isUnreadableBlockError(error)) {
+              console.error('[DelegateSubmitLane] Failed to read delegate nonce state', error);
+              throw error;
+            }
+            lastObservation = `stable block state was unreadable: ${String(error)}`;
+          }
+
+          const remainingSleepMs = waitDeadline - Date.now();
+          if (remainingSleepMs <= 0) break;
+          await sleep(Math.min(1_000, remainingSleepMs));
+        }
+
+        if (nonce === undefined) {
+          throw new Error(
+            `Timed out after ${NONCE_WAIT_TIMEOUT_MS / 1_000}s waiting for delegate nonce to stabilize. ` +
+              `Last observation: ${lastObservation}.`,
+          );
+        }
         return nonce;
       };
 
-      try {
-        return await fn(client, getNonce);
-      } catch (error) {
-        if (nonce !== undefined) {
-          this.invalidateNonce();
-        }
-        throw error;
-      }
+      return await fn(client, getNonce);
     }).promise;
   }
 }

--- a/bot/src/EthereumBeaconSyncService.ts
+++ b/bot/src/EthereumBeaconSyncService.ts
@@ -132,7 +132,6 @@ export class EthereumBeaconSyncService {
         `[EthereumBeaconSyncService] Submitted beacon sync tx ${this.stateData.lastSubmittedTxHash} ` +
           'is no longer pending before inclusion was observed; retrying',
       );
-      submitLane.invalidateNonce();
       this.stateData.mode = 'idle';
       delete this.stateData.lastSubmittedTxHash;
     }
@@ -201,7 +200,6 @@ export class EthereumBeaconSyncService {
               console.warn(
                 `[EthereumBeaconSyncService] Beacon sync tx already pending in pool; waiting for next sweep: ${message}`,
               );
-              submitLane.invalidateNonce();
               return;
             }
             throw error;
@@ -228,7 +226,6 @@ export class EthereumBeaconSyncService {
         }
       } catch (error) {
         if (isRetryableBeaconSyncSubmitError(error)) {
-          submitLane.invalidateNonce();
           continue;
         }
         if (

--- a/bot/src/EthereumGatewayProverService.ts
+++ b/bot/src/EthereumGatewayProverService.ts
@@ -528,7 +528,6 @@ export class EthereumGatewayProverService {
           console.log(
             `[EthereumGatewayProverService] Gateway relay submission went stale for target ${throughGatewayActivityNonce}; retrying`,
           );
-          this.submitLane.invalidateNonce();
           continue;
         }
         if (isRedundantCatchUpError(reason)) {

--- a/server/scripts/create_troubleshooting_gz.sh
+++ b/server/scripts/create_troubleshooting_gz.sh
@@ -228,7 +228,7 @@ SINCE="$(date -u -d '48 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -v -4
 # Data folders
 echo "[*] Copying data folders"
 shopt -s nullglob
-bot_data_paths=("$ROOT_DIR"/data/argon/bot*)
+bot_data_paths=("$ROOT_DIR"/data/argon/bot* "$ROOT_DIR"/data/argon/vault.sqlite*)
 shopt -u nullglob
 
 if (( ${#bot_data_paths[@]} )); then
@@ -236,7 +236,8 @@ if (( ${#bot_data_paths[@]} )); then
     record_collection_error "Some bot data files could not be copied. Continuing with a partial bundle."
   fi
 else
-  record_collection_error "No bot data paths matched $ROOT_DIR/data/argon/bot*. Continuing without bot data."
+  record_collection_error \
+    "No bot data paths matched $ROOT_DIR/data/argon/bot* or $ROOT_DIR/data/argon/vault.sqlite*. Continuing without bot data."
 fi
 
 exec 2>&3


### PR DESCRIPTION
## Summary

Prevents vault delegate transactions from stalling behind a nonce that was only present in the transaction pool or lost during a short chain reorganization.

- waits for pool and stable chain state to agree before the shared delegate lane assigns a nonce
- bounds reorganization and RPC recovery at ten minutes so one submission cannot hold the lane forever
- includes the vault database in operator troubleshooting bundles so stalled submissions can be diagnosed

## Validation

- bot test suite: 53 passed
- Bitcoin lock relay integration suite: 13 passed
- TypeScript, ESLint, Prettier, and troubleshooting script syntax checks passed
