### PR TITLE
fix: synchronize Ethereum minting authority startup

### DIFF
--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -522,16 +522,13 @@ export class AppVaultOperator {
     throw new Error(`Minting authority registration for ${signingKey} never appeared on chain.`);
   }
 
-  public async approvePendingGatewayUpdates(args: { client: ArgonClient }): Promise<boolean> {
-    const txs = await this.globalCouncil.buildApprovePendingGatewayUpdateTxs(args.client);
-    if (!txs.length) {
+  public async approvePendingGatewayUpdates(): Promise<boolean> {
+    const txInfo = await this.myVault.collect({ moveTo: MoveTo.DefaultArgon });
+    if (!txInfo) {
       return false;
     }
 
-    await this.submitVaultingTx({
-      client: args.client,
-      tx: txs.length === 1 ? txs[0] : args.client.tx.utility.batchAll(txs),
-    });
+    await txInfo.waitForPostProcessing;
     return true;
   }
 

--- a/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.flow.transferOutToEthereum.ts
@@ -126,6 +126,7 @@ export default new OperationalFlow<IVaultingFlowContext, ITransferOutToEthereumS
 
     await clickIfVisible(flow, 'WalletOverlay.closeLeft()', { timeoutMs: 5_000 });
     await clickIfVisible(flow, 'WalletOverlay.closeRight()', { timeoutMs: 5_000 });
+    await flow.waitFor('WalletOverlay', { state: 'missing', timeoutMs: 10_000 });
 
     if (!(await flow.isVisible('VaultingScreen')).visible) {
       await flow.run(vaultingActivateTab);

--- a/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
@@ -105,7 +105,7 @@ export default new Operation<IVaultingFlowContext, ITransferOutToEthereumState>(
       await pollEvery(
         1_000,
         async () => {
-          if ((await flow.isVisible(moveToEthereumTarget)).visible) return true;
+          if ((await flow.isVisible(moveToEthereumTarget)).clickable) return true;
           await clickIfVisible(flow, 'WalletOverlay.chooseEthereumWallet()', { timeoutMs: 1_500 });
           return false;
         },

--- a/e2e/helpers/startDevEthereumMintingAuthority.ts
+++ b/e2e/helpers/startDevEthereumMintingAuthority.ts
@@ -72,7 +72,7 @@ export async function startDevEthereumMintingAuthority(args: {
       executionRpcUrl,
       logPrefix,
     });
-    await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+    let runtimeStateReady = false;
 
     authorizeTransfersPromise = (async () => {
       while (!shouldStopAuthorizing) {
@@ -86,6 +86,10 @@ export async function startDevEthereumMintingAuthority(args: {
             });
             if (activationStatus.authorityActive) {
               console.info(`[${logPrefix}] minting authority activation is finalized`);
+              if (!runtimeStateReady) {
+                await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+                runtimeStateReady = true;
+              }
             } else if (Date.now() - lastActivationProgressLogAt >= 10_000) {
               lastActivationProgressLogAt = Date.now();
               console.info(
@@ -94,6 +98,11 @@ export async function startDevEthereumMintingAuthority(args: {
             }
             await new Promise(resolve => setTimeout(resolve, 1_000));
             continue;
+          }
+
+          if (!runtimeStateReady) {
+            await updateMintingAuthorityRuntimeState(executionRpcUrl, 'ready');
+            runtimeStateReady = true;
           }
 
           const didAuthorize = await actor.authorizeNextPendingTransfer(client);
@@ -295,7 +304,7 @@ async function activateDevEthereumMintingAuthority(args: {
   });
 
   console.info(`[${logPrefix}] approving pending council updates`);
-  if (!(await actor.approvePendingGatewayUpdates({ client }))) {
+  if (!(await actor.approvePendingGatewayUpdates())) {
     throw new Error(`${logPrefix}: minting authority activation approval disappeared before it could be signed.`);
   }
 
@@ -354,9 +363,7 @@ async function refreshMintingAuthorityActivation(args: {
 
   if (status.pendingApprovals > 0) {
     console.info(`[${args.logPrefix}] approving pending council updates`);
-    await args.actor.approvePendingGatewayUpdates({
-      client: args.client,
-    });
+    await args.actor.approvePendingGatewayUpdates();
     status = await args.actor.getEthereumMintingAuthorityStatus({
       client: args.client,
       priorStatus: status,

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -291,7 +291,7 @@ async function main(): Promise<void> {
           serverEnvVars: tauriEnv,
         },
       });
-      console.log('[tauri-dev][ethereum-ready] local Ethereum minting authority is ready');
+      console.log('[tauri-dev] local Ethereum minting authority activation is running');
 
       if (isShuttingDown) {
         await devEthereumMintingAuthorityRuntime.shutdown().catch(() => undefined);


### PR DESCRIPTION

## Summary

Synchronize local Ethereum minting-authority startup with the authority's active state and make the transfer-out flow wait for actionable UI state.

The startup helper now reuses the vault collection flow for pending gateway approvals and reports readiness only after activation succeeds. The Ethereum transfer E2E flow also waits for the move action and setup overlay to reach their required states.

## Validation

- Focused TypeScript, Vue typecheck, lint, formatting, and Ethereum integration checks passed.
- The full local Ethereum E2E exposed the false-ready startup state during diagnosis; the final post-fix E2E run was not completed.
