### PR TITLE
Restore Operations request retry for stale invites

### DIFF
--- a/src-vue/overlays/UpgradeToOperationsOverlay.vue
+++ b/src-vue/overlays/UpgradeToOperationsOverlay.vue
@@ -79,6 +79,12 @@
   </OverlayBase>
 </template>
 
+<script lang="ts">
+import { ref } from 'vue';
+
+const hasRequestedUpgradeThisSession = ref(false);
+</script>
+
 <script setup lang="ts">
 import * as Vue from 'vue';
 import type { IMemberInvite } from '@argonprotocol/apps-router';
@@ -132,6 +138,10 @@ const canRequestUpgrade = Vue.computed(() => {
     return false;
   }
 
+  if (hasRequestedUpgradeThisSession.value) {
+    return false;
+  }
+
   if (invite.value?.operationsUpgradeRequestedAt && controller.chainProgress.hasOperationalAccount) {
     return false;
   }
@@ -163,6 +173,8 @@ async function requestUpgrade() {
       operationalAccountId: walletKeys.operationalAddress,
       authKeypair,
     });
+
+    hasRequestedUpgradeThisSession.value = true;
 
     config.setCertificationDetails({ dismissedOperationsUpgradeOverlay: true });
     void config.save();

--- a/src-vue/overlays/UpgradeToOperationsOverlay.vue
+++ b/src-vue/overlays/UpgradeToOperationsOverlay.vue
@@ -58,7 +58,7 @@
       </div>
 
       <div
-        v-else-if="invite?.operationsUpgradeRequestedAt"
+        v-else-if="invite?.operationsUpgradeRequestedAt && !canRequestUpgrade"
         class="border-argon-300 mt-5 border-l-2 pl-3 text-sm text-slate-600"
       >
         Upgrade requested on {{ requestedAtLabel }}. We're waiting for your sponsor to approve.
@@ -128,7 +128,11 @@ const canRequestUpgrade = Vue.computed(() => {
     return false;
   }
 
-  if (invite.value?.operationsUpgradeRequestedAt || invite.value?.accessProof || invite.value?.operationsUpgradedAt) {
+  if (invite.value?.accessProof || invite.value?.operationsUpgradedAt) {
+    return false;
+  }
+
+  if (invite.value?.operationsUpgradeRequestedAt && controller.chainProgress.hasOperationalAccount) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Restore the Request Operations prompt when an invite has a stale request timestamp but no operational account registered
- Keep approved and registered Operations upgrades in their existing waiting or completed states