### PR TITLE
fix: complete bitcoin mismatch returns

### DIFF
--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -388,7 +388,6 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
         const firstRelease = await releaseLockAndWaitForChainRestore(
           harness,
-          harness.myVault,
           fundedFirst.lock,
           progress,
           initialAvailableBitcoinSpace,
@@ -442,7 +441,6 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
         const thirdRelease = await releaseLockAndWaitForChainRestore(
           harness,
-          harness.myVault,
           fundedThird.lock,
           progress,
           initialAvailableBitcoinSpace,
@@ -1072,8 +1070,7 @@ async function returnExpiredMismatchAndWaitForChainRestore(
 }
 
 async function releaseLockAndWaitForChainRestore(
-  harness: ClientHarness,
-  operatorVault: MyVault,
+  harness: TestHarness,
   lock: IBitcoinLockRecord,
   progress: ReturnType<typeof createBitcoinLockProgressStore>,
   expectedAvailableBitcoinSpace: bigint,
@@ -1087,9 +1084,7 @@ async function releaseLockAndWaitForChainRestore(
     toScriptPubkey: releaseAddress,
   });
   expect(releaseTx).toBeTruthy();
-  await releaseTx!.txResult.waitForFinalizedBlock;
-
-  await collectVaultSignatureFromAlert(operatorVault, 0);
+  await releaseTx!.txResult.waitForInFirstBlock;
 
   await waitFor(30e3, 'release request tracked on argon', () => {
     const refreshed = getCurrentLock(harness, currentLock.utxoId!);
@@ -1150,7 +1145,7 @@ async function releaseLockAndWaitForChainRestore(
     if (!vault.isSome) return;
     if (vault.unwrap().securitizationLocked.toBigInt() !== 0n) return;
     if (JSON.stringify(pendingCosign.toJSON()) !== '[]') return;
-    if (operatorVault.createdVault?.availableBitcoinSpace() !== expectedAvailableBitcoinSpace) return;
+    if (harness.myVault.createdVault?.availableBitcoinSpace() !== expectedAvailableBitcoinSpace) return;
     return true;
   });
 

--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -306,15 +306,23 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
 
           await collectVaultSignatureFromAlert(operator.myVault, 1);
 
-          const returningOrphan = await waitFor(120e3, 'orphan return seen on bitcoin', () => {
-            const current = owner.bitcoinLocks.utxoTracking.getUtxoRecord(
-              currentLock.utxoId!,
-              orphan.txid,
-              orphan.vout,
-            );
-            if (!current?.releaseTxid) return;
-            return current;
-          });
+          const returningOrphan = await waitFor(
+            120e3,
+            'orphan return seen on bitcoin',
+            async () => {
+              await owner.bitcoinLocks.orphanReleases.recoverPendingCosignEvents(
+                owner.miningFrames.blockWatch.bestBlockHeader.blockNumber,
+              );
+              const current = owner.bitcoinLocks.utxoTracking.getUtxoRecord(
+                currentLock.utxoId!,
+                orphan.txid,
+                orphan.vout,
+              );
+              if (!current?.releaseTxid) return;
+              return current;
+            },
+            { pollMs: 1e3 },
+          );
           await waitForBitcoinTransactionOutputSatoshis({
             flowName: 'BitcoinLocks.integration.orphanReturn',
             txid: returningOrphan.releaseTxid!,

--- a/src-vue/__test__/BitcoinReleaseFlow.test.ts
+++ b/src-vue/__test__/BitcoinReleaseFlow.test.ts
@@ -471,6 +471,54 @@ describe('BitcoinLocks release status sync', () => {
     expect(submitToBitcoin).not.toHaveBeenCalled();
   });
 
+  it('syncBitcoinProcessing completes mismatch and orphan returns without treating the funding UTXO as a return', async () => {
+    const lock = createLockRecord({ utxoId: 11 });
+    const fundingRecord = createFundingRecord({
+      id: 12,
+      lockUtxoId: 11,
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+      releaseTxid: 'a'.repeat(64),
+    });
+    const mismatchReturn = createFundingRecord({
+      id: 13,
+      lockUtxoId: 11,
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+      releaseTxid: 'b'.repeat(64),
+    });
+    const orphanReturn = createFundingRecord({
+      id: 14,
+      lockUtxoId: 11,
+      status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
+      releaseTxid: 'c'.repeat(64),
+    });
+    const updateReleaseLastConfirmationCheck = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue();
+    const setReleaseComplete = vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue();
+    const getTxStatus = vi.fn().mockResolvedValue({ isConfirmed: true, transactionBlockHeight: 321 });
+    const orphanReleases = createOrphanReleasesStub({
+      bitcoinLocks: {
+        data: { locksByUtxoId: { 11: lock } },
+        utxoTracking: {
+          getUtxosForLock: vi.fn().mockReturnValue([fundingRecord, mismatchReturn, orphanReturn]),
+          getAllOrphanLifecycleUtxos: vi.fn().mockReturnValue([orphanReturn]),
+          getAcceptedFundingRecordForLock: vi.fn().mockReturnValue(fundingRecord),
+          updateReleaseLastConfirmationCheck,
+          setReleaseComplete,
+        },
+      },
+      mempool: { getTxStatus },
+    });
+
+    await orphanReleases.syncBitcoinProcessing(300);
+
+    expect(getTxStatus).toHaveBeenCalledTimes(2);
+    expect(getTxStatus).toHaveBeenCalledWith(mismatchReturn.releaseTxid, 300);
+    expect(getTxStatus).toHaveBeenCalledWith(orphanReturn.releaseTxid, 300);
+    expect(updateReleaseLastConfirmationCheck).toHaveBeenCalledWith(mismatchReturn);
+    expect(updateReleaseLastConfirmationCheck).toHaveBeenCalledWith(orphanReturn);
+    expect(setReleaseComplete).toHaveBeenCalledWith(mismatchReturn, 321);
+    expect(setReleaseComplete).toHaveBeenCalledWith(orphanReturn, 321);
+  });
+
   it('submitToBitcoin keeps failed orphan broadcasts retryable and treats duplicates as submitted', async () => {
     const db = await createTestDb();
     const orphanReturnTxid = 'b'.repeat(64);

--- a/src-vue/lib/BitcoinOrphanReleases.ts
+++ b/src-vue/lib/BitcoinOrphanReleases.ts
@@ -216,8 +216,8 @@ export default class BitcoinOrphanReleases {
 
   public async syncBitcoinProcessing(oracleBitcoinBlockHeight: number): Promise<void> {
     const locksByUtxoId = this.bitcoinLocks.data.locksByUtxoId;
-    const tasks = this.bitcoinLocks.utxoTracking
-      .getAllOrphanLifecycleUtxos()
+    const tasks = Object.values(locksByUtxoId)
+      .flatMap(lock => this.bitcoinLocks.utxoTracking.getUtxosForLock(lock))
       .filter(record => {
         if (record.status !== BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin) return false;
         const lock = locksByUtxoId[record.lockUtxoId];


### PR DESCRIPTION
Bitcoin mismatch returns can now move from Bitcoin processing to complete after their return transaction confirms. Confirmation sync considers all return-processing UTXOs for loaded locks while preserving the accepted funding UTXO exclusion, so existing orphan-return behavior remains intact.

Owner releases also remain on their automatic cosign path after first-block inclusion, while manual vault signature alerts stay reserved for separate operators. The release coverage exercises mismatch, orphan, and owner return behavior together.