### PR TITLE
fix: allow expired orphan Bitcoin returns

### DIFF
--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -224,7 +224,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
     }
   });
 
-  it('alerts a separate vault operator to return an orphaned deposit', async () => {
+  it('returns a mismatched deposit received before expiry through a separate vault operator', async () => {
     const operator = await createHarness({
       archiveUrl: network.archiveUrl,
       esploraHost: network.networkConfigOverride.esploraHost,
@@ -263,20 +263,51 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
             getMismatchFundingSatoshis(lock.satoshis),
             progress,
           );
-          const client = await clients.get(false);
-          await client.tx.bitcoinUtxos
-            .rejectUtxoCandidate(lock.utxoId!, {
-              txid: observed.candidate.txid,
-              outputIndex: observed.candidate.vout,
-            })
-            .signAndSend(await owner.walletKeys.getLiquidLockingKeypair());
+
+          const expirationConfig = await BitcoinLock.getConfig(await clients.get(false));
+          const expirationBitcoinHeight =
+            observed.lock.lockDetails.createdAtHeight + expirationConfig.pendingConfirmationExpirationBlocks;
+
+          const preExpiryClient = await clients.get(false);
+          const preExpiryBitcoinHeight = await BitcoinLock.getBitcoinConfirmedBlockHeight(preExpiryClient);
+          const preExpiryChainLock = await BitcoinLock.get(preExpiryClient, observed.lock.utxoId!);
+          const preExpiryCandidates = await preExpiryClient.query.bitcoinUtxos.candidateUtxoRefsByUtxoId(
+            observed.lock.utxoId!,
+          );
+          const candidateWasRecordedBeforeExpiry = [...preExpiryCandidates.entries()].some(([utxoRef]) => {
+            return (
+              utxoRef.txid.toHex() === observed.candidate.txid &&
+              utxoRef.outputIndex.toNumber() === observed.candidate.vout
+            );
+          });
+
+          expect(preExpiryBitcoinHeight).toBeLessThan(expirationBitcoinHeight);
+          expect(preExpiryChainLock).toBeTruthy();
+          expect(candidateWasRecordedBeforeExpiry).toBe(true);
+
+          await waitFor(
+            60e3,
+            'separate operator lock expiration height',
+            async () => {
+              const chainClient = await clients.get(false);
+              const currentBitcoinHeight = await BitcoinLock.getBitcoinConfirmedBlockHeight(chainClient);
+              if (currentBitcoinHeight >= expirationBitcoinHeight) return true;
+              mineBitcoinBlocks(expirationBitcoinHeight - currentBitcoinHeight, minerAddress);
+              return;
+            },
+            { pollMs: 1e3 },
+          );
 
           const orphan = await waitFor(
-            60e3,
-            'rejected deposit recorded as orphan',
+            90e3,
+            'expired late deposit recorded as orphan',
             async () => {
               const currentLock = getCurrentLock(owner, lock.utxoId!);
-              await owner.bitcoinLocks.utxoTracking.syncArgonOrphans([currentLock], await clients.get(false));
+              const chainClient = await clients.get(false);
+              await owner.bitcoinLocks.utxoTracking.syncPendingFundingSignals(currentLock);
+              progress.updateLock(currentLock);
+              if (await BitcoinLock.get(chainClient, currentLock.utxoId!)) return;
+              await owner.bitcoinLocks.utxoTracking.syncArgonOrphans([currentLock], chainClient);
               return owner.bitcoinLocks.utxoTracking
                 .getUnresolvedOrphanRecords([currentLock])
                 .find(record => record.txid === observed.candidate.txid);

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -1299,10 +1299,11 @@ export class MyVault {
         }
         queued.add(key);
 
-        const blockNumber = orphan.recordedArgonBlockNumber.toNumber();
+        // The orphan is written during this block, so recover its lock from the pre-orphan state.
+        const blockNumber = orphan.recordedArgonBlockNumber.toNumber() - 1;
         const apiNode = await this.miningFrames.blockWatch.getRpcClient(blockNumber);
         const blockHash = await apiNode.rpc.chain.getBlockHash(blockNumber);
-        const apiClient = await submitClient.at(blockHash);
+        const apiClient = await apiNode.at(blockHash);
 
         const lock = await BitcoinLock.get(apiClient, lockUtxoId);
         if (!lock) {


### PR DESCRIPTION
Bitcoin deposits observed before the funding deadline but left mismatched until timeout can now complete the orphan return flow. A separate vault operator can recover the original lock signing data from the pre-orphan block, cosign the return, and let the owner broadcast it on Bitcoin.

The integration regression covers the full transition from a pre-expiry mismatch through timeout, owner release request, operator cosign, and final Bitcoin return. Type checking, focused unit tests, linting, formatting, and the complete integration scenario pass.
