### PR TITLE
fix: make orphan recovery follow-up resilient

### DIFF
--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -304,10 +304,8 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
             async () => {
               const currentLock = getCurrentLock(owner, lock.utxoId!);
               const chainClient = await clients.get(false);
-              await owner.bitcoinLocks.utxoTracking.syncPendingFundingSignals(currentLock);
+              await owner.bitcoinLocks.utxoTracking.syncPendingFundingSignals(currentLock, chainClient);
               progress.updateLock(currentLock);
-              if (await BitcoinLock.get(chainClient, currentLock.utxoId!)) return;
-              await owner.bitcoinLocks.utxoTracking.syncArgonOrphans([currentLock], chainClient);
               return owner.bitcoinLocks.utxoTracking
                 .getUnresolvedOrphanRecords([currentLock])
                 .find(record => record.txid === observed.candidate.txid);
@@ -318,6 +316,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
           expect(orphan.satoshis).toBe(observed.candidate.satoshis);
 
           const currentLock = getCurrentLock(owner, lock.utxoId!);
+          expect(await BitcoinLock.get(await clients.get(false), currentLock.utxoId!)).toBeFalsy();
           expect(owner.bitcoinLocks.utxoTracking.getUnresolvedOrphanRecords([currentLock])).toContain(orphan);
 
           const returnDestination = createBitcoinAddress();

--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -316,7 +316,10 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
           expect(orphan.satoshis).toBe(observed.candidate.satoshis);
 
           const currentLock = getCurrentLock(owner, lock.utxoId!);
-          expect(await BitcoinLock.get(await clients.get(false), currentLock.utxoId!)).toBeFalsy();
+          await waitFor(90e3, 'expired chain lock removed', async () => {
+            const chainClient = await clients.get(false);
+            return !(await BitcoinLock.get(chainClient, currentLock.utxoId!));
+          });
           expect(owner.bitcoinLocks.utxoTracking.getUnresolvedOrphanRecords([currentLock])).toContain(orphan);
 
           const returnDestination = createBitcoinAddress();

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -1154,10 +1154,21 @@ export class MyVault {
 
       if (!submission) {
         const vaultId = this.createdVault.vaultId;
-        await Promise.all([
+        const [bitcoinCosignResult, revenueResult] = await Promise.allSettled([
           this.refreshFinalizedBitcoinCosignState(finalizedClient, vaultId),
           this.refreshFinalizedRevenueState(finalizedClient, vaultId),
         ]);
+
+        if (bitcoinCosignResult.status === 'rejected') {
+          console.warn(
+            '[MyVault] Unable to refresh finalized Bitcoin cosign state after no-op collect',
+            bitcoinCosignResult.reason,
+          );
+        }
+
+        if (revenueResult.status === 'rejected') {
+          console.warn('[MyVault] Unable to refresh finalized revenue state after no-op collect', revenueResult.reason);
+        }
         return;
       }
 


### PR DESCRIPTION
When vault collection has nothing to submit, both finalized alert refreshes now run as best-effort reconciliation. A transient failure is logged without surfacing a failed collection for a transaction that does not exist.

The expired-mismatch integration scenario now observes the orphan through the normal funding-signal synchronization path, then waits separately for chain lock cleanup. This keeps orphan discovery independent from asynchronous cleanup while still verifying that cleanup completes.

Related: #551, #552
