### PR TITLE
fix: refresh bitcoin vault availability immediately

### DIFF
--- a/src-vue/overlays/BitcoinLockingOverlay.vue
+++ b/src-vue/overlays/BitcoinLockingOverlay.vue
@@ -453,7 +453,7 @@ async function refreshVaultAvailability() {
   }
 }
 
-async function openOverlay(args?: { lock?: IBitcoinLockRecord }) {
+function openOverlay(args?: { lock?: IBitcoinLockRecord }) {
   stopSessionRefresh();
   resetLockingSession();
 
@@ -465,9 +465,6 @@ async function openOverlay(args?: { lock?: IBitcoinLockRecord }) {
     vault.value = defaultVault.value;
     startSessionRefresh();
   } else {
-    const openKey = vaultRefreshKey;
-    await new Promise(resolve => setTimeout(resolve, 5_000));
-    if (openKey !== vaultRefreshKey || !isOpen.value) return;
     void refreshVaultAvailability();
   }
 }


### PR DESCRIPTION
Opening the Bitcoin locking flow now starts vault availability refresh immediately instead of leaving the overlay in a deliberate five-second loading delay. Existing refresh-key and overlay-open checks still ignore stale completions after a close, reset, or newer refresh.

Validated with the workspace typecheck and a focused Prettier check for the overlay.
