### PR TITLE
fix(dev): hand off upstream operator to visible app

### DIFF
--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -404,6 +404,7 @@ export class AppVaultOperator {
     const { client, routerHost } = args;
     const pollMs = args.pollMs ?? 5_000;
     const serverAuthClient = new ServerAuthClient(() => this.walletKeys);
+    const abortController = new AbortController();
     let isStopped = false;
 
     const runPromise = (async () => {
@@ -452,7 +453,11 @@ export class AppVaultOperator {
         }
 
         if (!isStopped) {
-          await new Promise(resolve => setTimeout(resolve, pollMs));
+          try {
+            await delay(pollMs, undefined, { signal: abortController.signal });
+          } catch (error) {
+            if (!isStopped) throw error;
+          }
         }
       }
     })();
@@ -460,7 +465,8 @@ export class AppVaultOperator {
     return {
       shutdown: async () => {
         isStopped = true;
-        await runPromise.catch(() => undefined);
+        abortController.abort();
+        await runPromise;
       },
     };
   }

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -414,6 +414,7 @@ export class AppVaultOperator {
             serverAuthClient,
             routerHost,
             path: '/invites',
+            init: { signal: abortController.signal },
           });
 
           for (const invite of invites.invites) {
@@ -437,6 +438,7 @@ export class AppVaultOperator {
               path: `/invites/${encodeURIComponent(invite.inviteCode)}/mark-operations-upgraded`,
               init: {
                 method: 'POST',
+                signal: abortController.signal,
                 headers: {
                   'Content-Type': 'application/json',
                 },
@@ -449,7 +451,9 @@ export class AppVaultOperator {
             break;
           }
         } catch (error) {
-          console.warn('[dev-upstream] Unable to process requested operations upgrades.', error);
+          if (!isStopped) {
+            console.warn('[dev-upstream] Unable to process requested operations upgrades.', error);
+          }
         }
 
         if (!isStopped) {

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -57,7 +57,7 @@ export interface IDevUpstreamServerRuntime {
   botPort: string;
   gatewayPort: string;
   routerPort: string;
-  stopVaultAlertPoller(): Promise<void>;
+  detachOperator(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -264,10 +264,18 @@ export async function startDevUpstreamServer(args: {
   let endpointMonitor: NodeJS.Timeout | undefined;
   let isEndpointRefreshRunning = false;
   let publishedGatewayPort: string | undefined;
-  const stopVaultAlertPoller = async () => {
-    vaultAlertAbortController.abort();
-    await vaultAlertPoller?.catch(() => undefined);
+  const detachOperator = async () => {
+    const upgradePoller = operationsUpgradePoller;
+    const alertPoller = vaultAlertPoller;
+    operationsUpgradePoller = undefined;
     vaultAlertPoller = undefined;
+
+    vaultAlertAbortController.abort();
+    try {
+      await Promise.all([upgradePoller?.shutdown(), alertPoller]);
+    } finally {
+      actor.myVault.unsubscribe();
+    }
   };
   const shutdown = async () => {
     if (isShutdown) {
@@ -275,7 +283,7 @@ export async function startDevUpstreamServer(args: {
     }
     isShutdown = true;
     clearInterval(endpointMonitor);
-    await Promise.all([operationsUpgradePoller?.shutdown().catch(() => undefined), stopVaultAlertPoller()]);
+    await detachOperator().catch(() => undefined);
     await actor.dispose().catch(() => undefined);
     await clients.disconnect().catch(() => undefined);
   };
@@ -346,7 +354,7 @@ export async function startDevUpstreamServer(args: {
       botPort,
       gatewayPort,
       routerPort,
-      stopVaultAlertPoller,
+      detachOperator,
       shutdown,
     };
   } catch (error) {
@@ -489,7 +497,7 @@ export async function waitForDevUpstreamEthereumRelayReady(args: {
   throw new Error(`Upstream Ethereum relay did not become ready within ${timeoutMs}ms: ${lastReason}`);
 }
 
-function resolveDevUpstreamRootDir(): string {
+export function resolveDevUpstreamRootDir(): string {
   const configuredRootDir = process.env.ARGON_DEV_UPSTREAM_ROOT_DIR?.trim() || defaultUpstreamRootDir;
   return path.resolve(configuredRootDir);
 }

--- a/e2e/scripts/prepareDevUpstreamApp.ts
+++ b/e2e/scripts/prepareDevUpstreamApp.ts
@@ -7,12 +7,14 @@ import process from 'node:process';
 import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
 import { DEV_UPSTREAM_MASTER_MNEMONIC, resolveDevUpstreamRootDir } from './devUpstreamServer.ts';
 
+if (process.platform === 'win32') {
+  throw new Error('The visible dev upstream handoff is not supported on Windows because it requires SIGUSR2.');
+}
+
 const actorPidPath = Path.join(resolveDevUpstreamRootDir(), 'config', 'operator-actor.pid');
 let appConfigDir: string;
 if (process.platform === 'darwin') {
   appConfigDir = Path.join(Os.homedir(), 'Library', 'Application Support');
-} else if (process.platform === 'win32') {
-  appConfigDir = process.env.APPDATA || Path.join(Os.homedir(), 'AppData', 'Roaming');
 } else {
   appConfigDir = process.env.XDG_CONFIG_HOME || Path.join(Os.homedir(), '.config');
 }

--- a/e2e/scripts/prepareDevUpstreamApp.ts
+++ b/e2e/scripts/prepareDevUpstreamApp.ts
@@ -3,16 +3,47 @@
 import Fs from 'node:fs';
 import Os from 'node:os';
 import Path from 'node:path';
-import { DEV_UPSTREAM_MASTER_MNEMONIC } from './devUpstreamServer.ts';
+import process from 'node:process';
+import { waitFor } from '@argonprotocol/apps-core/__test__/helpers/waitFor.ts';
+import { DEV_UPSTREAM_MASTER_MNEMONIC, resolveDevUpstreamRootDir } from './devUpstreamServer.ts';
 
-const appDir = Path.join(
-  Os.homedir(),
-  'Library',
-  'Application Support',
-  'com.argon.desktop.local',
-  'dev-docker',
-  'app2',
-);
+const actorPidPath = Path.join(resolveDevUpstreamRootDir(), 'config', 'operator-actor.pid');
+let appConfigDir: string;
+if (process.platform === 'darwin') {
+  appConfigDir = Path.join(Os.homedir(), 'Library', 'Application Support');
+} else if (process.platform === 'win32') {
+  appConfigDir = process.env.APPDATA || Path.join(Os.homedir(), 'AppData', 'Roaming');
+} else {
+  appConfigDir = process.env.XDG_CONFIG_HOME || Path.join(Os.homedir(), '.config');
+}
+const appDir = Path.join(appConfigDir, 'com.argon.desktop.local', 'dev-docker', 'app2');
 
 Fs.mkdirSync(appDir, { recursive: true });
 Fs.writeFileSync(Path.join(appDir, 'mnemonic'), `${DEV_UPSTREAM_MASTER_MNEMONIC}\n`);
+
+let actorPid: number;
+try {
+  actorPid = Number.parseInt(Fs.readFileSync(actorPidPath, 'utf8').trim(), 10);
+} catch (error) {
+  if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    throw new Error("Keep 'yarn dev:docker' running and wait for '[tauri-dev][upstream-ready]' before continuing.");
+  }
+  throw error;
+}
+if (!Number.isSafeInteger(actorPid) || actorPid <= 0) {
+  throw new Error(`Invalid embedded upstream operator PID in ${actorPidPath}.`);
+}
+
+try {
+  process.kill(actorPid, 'SIGUSR2');
+} catch (error) {
+  throw new Error(`The embedded upstream operator is not running. Restart 'yarn dev:docker' and try again.`, {
+    cause: error,
+  });
+}
+
+await waitFor(10_000, 'embedded upstream operator detachment', () => !Fs.existsSync(actorPidPath), {
+  pollMs: 50,
+  retryErrors: false,
+  timeoutMessage: 'The embedded upstream operator did not detach before the visible app started.',
+});

--- a/src-tauri/dev.ts
+++ b/src-tauri/dev.ts
@@ -23,6 +23,7 @@ import {
   type IDevUpstreamServerRuntime,
   readComposeContainerId,
   readComposePortWithRetry,
+  resolveDevUpstreamRootDir,
   startDevUpstreamServer,
   waitForDevUpstreamEthereumRelayReady,
 } from '../e2e/scripts/devUpstreamServer.ts';
@@ -138,18 +139,29 @@ async function main(): Promise<void> {
   let devEthereumReadyPromise: Promise<void> | undefined;
   let devUpstreamPromise: Promise<void> | undefined;
   let devUpstreamRuntime: IDevUpstreamServerRuntime | undefined;
+  let devUpstreamActorPidPath: string | undefined;
   const shouldStartDevUpstream = !['0', 'false', 'no', 'off'].includes(
     readNonEmpty(process.env.ARGON_DEV_UPSTREAM)?.toLowerCase() ?? '',
   );
   if (devDockerArchiveUrl && shouldStartDevUpstream && (!isE2EAppRun || devEthereumConfig)) {
+    const actorPidPath = path.join(resolveDevUpstreamRootDir(), 'config', 'operator-actor.pid');
+    devUpstreamActorPidPath = actorPidPath;
+    fs.rmSync(actorPidPath, { force: true });
     devUpstreamPromise = startDevUpstreamServer({
       archiveUrl: devDockerArchiveUrl,
       devEthereum: startedDevEthereum,
       devEthereumConfig,
     })
-      .then(runtime => {
+      .then(async runtime => {
         devUpstreamRuntime = runtime;
-        console.log(`[tauri-dev][upstream-ready] upstream server is ready (vault alert actor pid ${process.pid})`);
+        try {
+          fs.writeFileSync(actorPidPath, `${process.pid}\n`);
+        } catch (error) {
+          await runtime.shutdown().catch(() => undefined);
+          devUpstreamRuntime = undefined;
+          throw error;
+        }
+        console.log(`[tauri-dev][upstream-ready] upstream server is ready (operator actor pid ${process.pid})`);
       })
       .catch(error => {
         console.error(`[tauri-dev] Failed to start upstream server: ${(error as Error).message}`);
@@ -157,18 +169,19 @@ async function main(): Promise<void> {
       });
 
     void devUpstreamPromise.catch(() => undefined);
-  }
 
-  process.on('SIGUSR2', () => {
-    void devUpstreamPromise
-      ?.then(async () => {
-        await devUpstreamRuntime?.stopVaultAlertPoller();
-        console.log('[tauri-dev] Vault alert actor stopped');
-      })
-      .catch(error => {
-        console.error(`[tauri-dev] Failed to stop vault alert actor: ${(error as Error).message}`);
-      });
-  });
+    process.on('SIGUSR2', () => {
+      void devUpstreamPromise
+        ?.then(async () => {
+          await devUpstreamRuntime?.detachOperator();
+          fs.rmSync(actorPidPath, { force: true });
+          console.log('[tauri-dev] Embedded upstream operator detached');
+        })
+        .catch(error => {
+          console.error(`[tauri-dev] Failed to detach embedded upstream operator: ${(error as Error).message}`);
+        });
+    });
+  }
 
   if (devEthereumSetup) {
     devEthereumRuntimeSetupPromise = devEthereumSetup.start();
@@ -309,6 +322,7 @@ async function main(): Promise<void> {
       await devEthereumMintingAuthorityPromise;
       await devEthereumMintingAuthorityRuntime?.shutdown().catch(() => undefined);
       await devUpstreamRuntime?.shutdown().catch(() => undefined);
+      if (devUpstreamActorPidPath) fs.rmSync(devUpstreamActorPidPath, { force: true });
     })();
     void shutdownPromise.finally(() => {
       process.exit(code ?? 0);


### PR DESCRIPTION
## Summary

`yarn dev:upstream:app` can now take over the existing dev upstream operator instead of competing with its embedded automation. The handoff keeps the shared Docker stack running, waits until both embedded operator loops and their chain subscription have stopped, then starts app2 with the same operator identity. Ordinary `yarn dev:docker` behavior is unchanged unless this explicit handoff is requested.

## Validation

- `yarn typecheck`
- `yarn lint:check`
- `git diff --check`
