### PR TITLE
fix: show buffered bitcoin certification target

### DIFF
--- a/src-vue/overlays/MemberInviteOverlay.vue
+++ b/src-vue/overlays/MemberInviteOverlay.vue
@@ -97,13 +97,13 @@
               <div
                 v-if="
                   maximumBitcoinLockMicrogons > 0n &&
-                  maximumBitcoinLockMicrogons < controller.rewardConfig.treasuryMinimumBitcoin
+                  maximumBitcoinLockMicrogons < treasuryBitcoinCertificationDisplayAmount
                 "
                 class="mt-3 border-l-2 border-amber-400 py-0.5 pl-3 text-xs leading-5 text-amber-700"
               >
                 Treasury certification requires at least
-                {{ microgonToArgonNm(controller.rewardConfig.treasuryMinimumBitcoin).format('0,0.[00]') }} ARGN of
-                Bitcoin. Increase this gift to cover that requirement.
+                {{ microgonToArgonNm(treasuryBitcoinCertificationDisplayAmount).format('0,0.[00]') }} ARGN of Bitcoin.
+                Increase this gift to cover that requirement.
               </div>
             </div>
           </div>
@@ -168,7 +168,10 @@ import type { TransactionInfo } from '../lib/TransactionInfo.ts';
 import { generateProgressLabel } from '../lib/Utils.ts';
 import { useBasics } from '../stores/basics.ts';
 import { getBitcoinLocks } from '../stores/bitcoin.ts';
-import { useCertificationController } from '../stores/certificationController.ts';
+import {
+  treasuryBitcoinCertificationDisplayAmount,
+  useCertificationController,
+} from '../stores/certificationController.ts';
 import { getConfig } from '../stores/config.ts';
 import { getCurrency } from '../stores/currency.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';

--- a/src-vue/stores/certificationController.ts
+++ b/src-vue/stores/certificationController.ts
@@ -127,6 +127,7 @@ export const operationalSteps: Record<OperationalStepId, IOperationalStep> = {
   },
 };
 
+export const treasuryBitcoinCertificationDisplayAmount = 600n * BigInt(MICROGONS_PER_ARGON);
 export const treasuryCertificationStepIds = [
   OperationalStepId.BackupMnemonic,
   OperationalStepId.LiquidLock,
@@ -505,7 +506,7 @@ export const useCertificationController = defineStore('certificationController',
       return formatArgonRequirementText(rewardConfig.value.operationalMinimumVaultSecuritization, 'securitization');
     }
     if (stepId === OperationalStepId.LiquidLock) {
-      return formatArgonRequirementText(rewardConfig.value.treasuryMinimumBitcoin, 'bitcoin');
+      return formatArgonRequirementText(treasuryBitcoinCertificationDisplayAmount, 'bitcoin');
     }
     if (stepId === OperationalStepId.AcquireArgonBonds) {
       return formatArgonRequirementText(rewardConfig.value.treasuryMinimumBonds, 'bonds');


### PR DESCRIPTION
## Summary

Treasury Bitcoin certification now guides users to lock A600, giving them headroom against price movement while the lock is being created. The existing member-invite warning uses the same display target, while cumulative eligibility remains unchanged at the runtime A500 threshold.

## Validation

- `yarn vue-tsc --noEmit`
- `yarn lint:check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes frontend guidance only; the runtime certification threshold remains A500.
