### PR TITLE
fix: publish recovered bitcoin orphans without refresh

### DIFF
--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -269,6 +269,44 @@ describe('BitcoinLocks recovery', () => {
     ]);
   });
 
+  it('publishes a rediscovered orphan without waiting for an app refresh', async () => {
+    const db = await createTestDb();
+    const store = createStore({
+      blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
+      db,
+    });
+    const lock = createLock({
+      uuid: 'late-orphan',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockPendingFunding,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const utxoRef = { txid: `0x${'55'.repeat(32)}`, outputIndex: 1 };
+    store.data.locksByUtxoId[7] = lock;
+
+    await store.recovery.beginHistoryReplay({ lockScope: 'all' });
+    await store.recovery.recoverBlock(historyBlock(201), [
+      historyEvent(147, 'bitcoinLocks', 'OrphanedUtxoReceived', {
+        utxoId: 7,
+        utxoRef,
+        vaultId: 1,
+        satoshis: 12_000n,
+      }),
+    ]);
+    await store.recovery.commitHistoryReplay();
+
+    expect(lock.isHistoryRecoveryPending).toBeUndefined();
+    expect(store.getLockByUtxoId(7)).toBe(lock);
+    expect(store.utxoTracking.getUnresolvedOrphanRecords([lock])).toEqual([
+      expect.objectContaining({
+        txid: utxoRef.txid,
+        vout: utxoRef.outputIndex,
+        satoshis: 12_000n,
+        status: BitcoinUtxoStatus.Orphaned,
+      }),
+    ]);
+  });
+
   it('quarantines only recovering locks while regular locks remain active and syncable', async () => {
     const store = createStore();
     const record = createLock({

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -34,6 +34,7 @@ export class BitcoinLockRecovery {
   private readonly utxoTracking: Pick<
     BitcoinUtxoTracking,
     | 'getAcceptedFundingRecordForLock'
+    | 'getAllOrphanLifecycleUtxos'
     | 'getUtxoRecord'
     | 'isReleaseCompleteStatus'
     | 'isReleaseStatus'
@@ -172,7 +173,10 @@ export class BitcoinLockRecovery {
         const fundingRecord = this.utxoTracking.getAcceptedFundingRecordForLock(liveLock);
         const hasLiveReleaseState =
           liveLock.status === BitcoinLockStatus.Releasing && this.utxoTracking.isReleaseStatus(fundingRecord?.status);
-        if (!hasLiveReleaseState) continue;
+        const hasOrphanRecoveryState = this.utxoTracking
+          .getAllOrphanLifecycleUtxos()
+          .some(record => record.lockUtxoId === liveLock.utxoId);
+        if (!hasLiveReleaseState && !hasOrphanRecoveryState) continue;
       }
 
       await table.setHistoryRecoveryPending(uuid, false);

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -158,24 +158,26 @@ export class BitcoinLockRecovery {
 
     const table = await this.getTable();
     const completedLocks: IBitcoinLockRecord[] = [];
+    const orphanLifecycleLockUtxoIds = new Set(
+      this.utxoTracking.getAllOrphanLifecycleUtxos().map(record => record.lockUtxoId),
+    );
     for (const uuid of [...this.historyRecoveryPendingUuids]) {
       const liveLock =
         Object.values(this.locksByUtxoId).find(lock => lock.uuid === uuid) ??
         this.pendingLocks.find(lock => lock.uuid === uuid);
       if (!liveLock) continue;
 
+      const lockUtxoId = liveLock.utxoId;
       const isUnresolvedHistoricalLock =
         lockScope === 'all' &&
-        liveLock.utxoId !== undefined &&
+        lockUtxoId !== undefined &&
         !liveLock.removalReason &&
-        !this.activeLocksByUtxoId.has(liveLock.utxoId);
+        !this.activeLocksByUtxoId.has(lockUtxoId);
       if (isUnresolvedHistoricalLock) {
         const fundingRecord = this.utxoTracking.getAcceptedFundingRecordForLock(liveLock);
         const hasLiveReleaseState =
           liveLock.status === BitcoinLockStatus.Releasing && this.utxoTracking.isReleaseStatus(fundingRecord?.status);
-        const hasOrphanRecoveryState = this.utxoTracking
-          .getAllOrphanLifecycleUtxos()
-          .some(record => record.lockUtxoId === liveLock.utxoId);
+        const hasOrphanRecoveryState = orphanLifecycleLockUtxoIds.has(lockUtxoId);
         if (!hasLiveReleaseState && !hasOrphanRecoveryState) continue;
       }
 


### PR DESCRIPTION
Bitcoin locks that never received a funding UTXO can now become actionable as soon as history recovery rediscovers an orphan. Recovery publishes the lock when it has durable orphan lifecycle state, while locks with no recovered evidence remain quarantined. This removes the stale spinner and refresh-only archive transition.

Validation: the focused Bitcoin recovery suite passed (108 tests), along with Vue type checking, ESLint, and Prettier.
