### PR TITLE
fix: save troubleshooting packages to downloads

### DIFF
--- a/src-vue/overlays/troubleshooting/DebugPackage.vue
+++ b/src-vue/overlays/troubleshooting/DebugPackage.vue
@@ -40,7 +40,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import { appConfigDir, appLogDir, join, tempDir } from '@tauri-apps/api/path';
+import { appConfigDir, appLogDir, downloadDir, join, tempDir } from '@tauri-apps/api/path';
 import { listen } from '@tauri-apps/api/event';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import Checkbox from '../../components/Checkbox.vue';
@@ -79,7 +79,7 @@ async function downloadTroubleshooting() {
     const osProfilePath = await join(troubleshootingRoot, 'os-profile.json');
     const collectionErrorsPath = await join(troubleshootingRoot, 'collection-errors.txt');
     const collectionErrors: string[] = [];
-    let zipPath = await join(await tempDir(), `argon_${INSTANCE_NAME}_troubleshooting_${timestamp}.zip`);
+    const zipPath = await join(await downloadDir(), `argon_${INSTANCE_NAME}_troubleshooting_${timestamp}.zip`);
     let serverPackagePath: string | undefined;
     let hasOsProfile = false;
 
@@ -94,7 +94,6 @@ async function downloadTroubleshooting() {
         });
         serverPackagePath = downloadPath;
         removeOnFinish.push({ path: downloadPath });
-        zipPath = downloadPath.replace('.tar.gz', '.zip');
       } catch (error) {
         console.warn('Unable to include server troubleshooting package:', error);
         collectionErrors.push(`Server troubleshooting package: ${String(error)}`);


### PR DESCRIPTION
Troubleshooting exports now save their final ZIP to Downloads and reveal that file when generation completes. Previously, server-backed exports replaced the final ZIP destination with the downloaded server archive's temporary path, while local-only exports also wrote the final ZIP to temp. Temporary staging and server archives remain in temp and continue to be cleaned up.

Vue type checking and formatting checks pass. Finder selection still needs desktop verification.
