### PR TITLE
fix(wallets): isolate move destinations

### DIFF
--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -57,6 +57,28 @@ describe('MoveCapital', () => {
     });
   });
 
+  it('derives the mining destination instead of using a supplied external address', async () => {
+    const { moveCapital } = createMoveCapital();
+    const client = {
+      tx: {
+        balances: {
+          transferAllowDeath: (recipient: string, amount: bigint) => ({ recipient, amount }),
+        },
+      },
+    } as any;
+
+    const { tx } = await moveCapital.buildTransaction(
+      MoveFrom.DefaultArgon,
+      MoveTo.MiningBot,
+      { ARGN: 1_000_000n },
+      'friend-address',
+      [],
+      client,
+    );
+
+    expect(tx).toEqual({ recipient: 'mining-bot-address', amount: 1_000_000n });
+  });
+
   it('keeps the default wallet reserves when sweeping to the bot', async () => {
     const { moveCapital, transactionTracker, postProcessMiningBidProxySetupSpy } = createMoveCapital();
     postProcessMiningBidProxySetupSpy.mockRestore();

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -415,6 +415,15 @@ export class MoveCapital {
   ) {
     client ??= await getMainchainClient(false);
     const txs: SubmittableExtrinsic[] = [...prependedTxs];
+
+    if (moveTo === MoveTo.MiningBot) {
+      toAddress = this.walletKeys.miningBotAddress;
+    } else if (moveTo === MoveTo.DefaultArgon) {
+      toAddress = this.walletKeys.defaultArgonAddress;
+    } else if (moveTo === MoveTo.VaultingSecurity) {
+      toAddress = this.walletKeys.vaultingAddress;
+    }
+
     const externalMeta = this.checkAddressType(toAddress);
 
     if (moveTo === MoveTo.External && !externalMeta.isArgonAddress) {

--- a/src-vue/overlays/move-capital/MoveCapitalCore.vue
+++ b/src-vue/overlays/move-capital/MoveCapitalCore.vue
@@ -563,18 +563,19 @@ Vue.onMounted(async () => {
     if (transactionsShownCompleted.has(txInfo.tx.id)) {
       continue;
     }
+    const metadata = txInfo.tx.metadataJson as ITransactionMoveMetadata;
     if (
       txInfo.tx.extrinsicType === ExtrinsicType.Transfer &&
-      normalizeMoveFrom(txInfo.tx.metadataJson.moveFrom) === moveFrom.value &&
-      txInfo.tx.metadataJson.assetsToMove?.[props.moveToken] > 0n
+      normalizeMoveFrom(metadata.moveFrom) === moveFrom.value &&
+      normalizeMoveTo(metadata.moveTo) === props.moveTo &&
+      (metadata.assetsToMove[props.moveToken] ?? 0n) > 0n
     ) {
-      const metdata = txInfo.tx.metadataJson as ITransactionMoveMetadata;
       pendingTxInfo.value = txInfo;
       emit('transactionPending', true);
       isProcessing.value = true;
-      amountToMove.value = metdata.assetsToMove[MoveToken.ARGN] ?? metdata.assetsToMove[MoveToken.ARGNOT] ?? 0n;
-      moveTo.value = normalizeMoveTo(metdata.moveTo);
-      externalAddress.value = metdata.externalAddress || '';
+      amountToMove.value = metadata.assetsToMove[MoveToken.ARGN] ?? metadata.assetsToMove[MoveToken.ARGNOT] ?? 0n;
+      moveTo.value = normalizeMoveTo(metadata.moveTo);
+      externalAddress.value = metadata.externalAddress || '';
       checkExternalAddress();
       console.log('Resuming pending transfer: %o', txInfo);
       trackTxInfo(txInfo);

--- a/src-vue/overlays/move-capital/MoveCapitalCore.vue
+++ b/src-vue/overlays/move-capital/MoveCapitalCore.vue
@@ -567,8 +567,8 @@ Vue.onMounted(async () => {
     if (
       txInfo.tx.extrinsicType === ExtrinsicType.Transfer &&
       normalizeMoveFrom(metadata.moveFrom) === moveFrom.value &&
-      normalizeMoveTo(metadata.moveTo) === props.moveTo &&
-      (metadata.assetsToMove[props.moveToken] ?? 0n) > 0n
+      (props.moveTo === undefined || normalizeMoveTo(metadata.moveTo) === props.moveTo) &&
+      (metadata.assetsToMove?.[props.moveToken] ?? 0n) > 0n
     ) {
       pendingTxInfo.value = txInfo;
       emit('transactionPending', true);

--- a/src-vue/wallets/WalletDialog.vue
+++ b/src-vue/wallets/WalletDialog.vue
@@ -121,7 +121,7 @@
                 :moveFrom="customTransferMoveFrom"
                 :moveTo="props.transferOut?.customArgonAddress ? MoveTo.External : undefined"
                 :externalAddress="customArgonAddress"
-                @customTransferStarted="customArgonAddressLocked = true"
+                @customTransferPending="customArgonAddressLocked = $event"
                 :showGuidance="props.showGuidance"
                 :guidanceContext="props.guidanceContext"
                 :indentTokensLeft="!!props.transferIn?.wallet"

--- a/src-vue/wallets/components/ArgonTokens.vue
+++ b/src-vue/wallets/components/ArgonTokens.vue
@@ -27,7 +27,7 @@
         @transactionPending="updateTransferPending(MoveToken.ARGN, $event)"
       >
         <MoveArrowButton
-          :disabled="!moveMicrogons || !canMoveToDestination"
+          :disabled="!moveMicrogons || (!canMoveToDestination && !argonTransferPending)"
           :pending="argonTransferPending"
           :placement="props.movePlacement"
           :title="argonMoveTitle"
@@ -61,7 +61,7 @@
         @transactionPending="updateTransferPending(MoveToken.ARGNOT, $event)"
       >
         <MoveArrowButton
-          :disabled="!moveMicronots || !canMoveToDestination"
+          :disabled="!moveMicronots || (!canMoveToDestination && !argonotTransferPending)"
           :pending="argonotTransferPending"
           :placement="props.movePlacement"
           :title="argonotMoveTitle"
@@ -147,7 +147,7 @@ const emit = defineEmits<{
       availableAmount: bigint;
     },
   ): void;
-  (e: 'customTransferStarted'): void;
+  (e: 'customTransferPending', value: boolean): void;
 }>();
 
 function updateTransferPending(moveToken: MoveToken, isPending: boolean) {
@@ -156,8 +156,8 @@ function updateTransferPending(moveToken: MoveToken, isPending: boolean) {
   } else {
     argonotTransferPending.value = isPending;
   }
-  if (isPending && props.moveTo === MoveTo.External) {
-    emit('customTransferStarted');
+  if (props.moveTo === MoveTo.External) {
+    emit('customTransferPending', argonTransferPending.value || argonotTransferPending.value);
   }
 }
 

--- a/src-vue/wallets/components/WalletPanel.vue
+++ b/src-vue/wallets/components/WalletPanel.vue
@@ -40,7 +40,7 @@
           :indentLeft="props.indentTokensLeft"
           :indentRight="props.indentTokensRight"
           @openTransferOverlay="emit('openTransferOverlay', $event)"
-          @customTransferStarted="emit('customTransferStarted')"
+          @customTransferPending="emit('customTransferPending', $event)"
         />
       </div>
     </div>
@@ -89,7 +89,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (event: 'openTransferOverlay', transfer: { moveToken: IEthereumMoveToken; availableAmount: bigint }): void;
-  (event: 'customTransferStarted'): void;
+  (event: 'customTransferPending', value: boolean): void;
 }>();
 
 const financials = useFinancials();


### PR DESCRIPTION
## Summary

Wallet moves now send funds only to the destination selected for that transfer. Internal destinations are derived from the wallet keys, and pending recovery requires the same source, token, and destination so an older external address cannot replace a mining-wallet choice.

Pending external transfers remain accessible after closing and reopening the address panel. The address field unlocks after all active token transfers finish.

## Validation

Added a transaction-boundary test for mining destination isolation. The focused test suite, full typecheck, and repository lint pass. The desktop interaction was reviewed through its event flow but was not manually exercised in a running app.
