### PR TITLE
fix: retry stale latest-nonce submissions

### DIFF
--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -5,6 +5,7 @@ import { TxAttemptState, TransactionTracker } from '../lib/TransactionTracker.ts
 import { ExtrinsicType, type ITransactionRecord, TransactionStatus } from '../lib/db/TransactionsTable.ts';
 import { TransactionHistorySource, TransactionHistoryStatus } from '../lib/db/TransactionStatusHistoryTable.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
+import { createTestDb } from './helpers/db.ts';
 
 vi.mock('../stores/mainchain.ts', () => ({
   getMainchainClient: vi.fn(async () => ({})),
@@ -145,6 +146,217 @@ describe('TransactionTracker', () => {
     });
 
     await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Replace);
+  });
+
+  it('does not retry a transaction based only on its nonce finalizing elsewhere', async () => {
+    const db = await createTestDb();
+    const call = { section: 'crosschainTransfer', method: 'collateralizeTransfer' };
+    const createUnsignedTx = (method = call) => ({
+      method,
+      signAsync: vi.fn(async (_signer, options) => ({
+        hash: { toHex: () => `0x${options.nonce}` },
+        method: { toHuman: () => method },
+        nonce: numberCodec(options.nonce),
+        send: vi.fn(async () => undefined),
+      })),
+    });
+    const client = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn(async () => ({ number: numberCodec(100) })),
+        },
+        system: {
+          accountNextIndex: vi.fn(async () => numberCodec(7)),
+        },
+      },
+      tx: vi.fn((tx: { method: typeof call }) => createUnsignedTx(tx.method)),
+    };
+    const blockWatch = {
+      start: vi.fn().mockResolvedValue(undefined),
+      bestBlockHeader: { blockNumber: 105, blockHash: '0x69' },
+      finalizedBlockHeader: {
+        blockNumber: 105,
+        blockTime: new Date('2026-03-20T20:05:00Z').getTime(),
+        blockHash: '0x69',
+      },
+      getApi: vi.fn(async () => ({
+        query: {
+          system: {
+            account: vi.fn(async () => ({ nonce: numberCodec(8) })),
+          },
+        },
+      })),
+      events: { on: vi.fn() },
+    };
+    const tracker = new TransactionTracker(Promise.resolve(db), blockWatch as any);
+    vi.spyOn(tracker as any, 'watchForUpdates').mockResolvedValue(undefined);
+
+    try {
+      await tracker.load();
+      const originalTxInfo = await tracker.submitAndWatch({
+        client: client as any,
+        tx: createUnsignedTx() as any,
+        txSigner: { address: '5Alice' } as any,
+        extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+        useLatestNonce: true,
+      });
+      vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+      await (tracker as unknown as ITransactionTrackerTestApi).updatePendingStatuses({ blockNumber: 105 });
+
+      const storedTxs = await db.transactionsTable.fetchAll();
+      const originalStoredTx = storedTxs.find(record => record.id === originalTxInfo.tx.id)!;
+      const history = await db.transactionStatusHistoryTable.fetchByTransactionId(originalTxInfo.tx.id);
+      expect(storedTxs).toHaveLength(1);
+      expect(originalStoredTx.followOnTxId).toBeNull();
+      expect(originalStoredTx.status).toBe(TransactionStatus.Error);
+      expect(originalStoredTx.submissionErrorJson?.message).toBe(
+        'Transaction nonce was already used by another transaction.',
+      );
+      expect(history.map(({ status, source }) => [status, source])).toEqual([
+        [TransactionHistoryStatus.Submitted, TransactionHistorySource.Local],
+        [TransactionHistoryStatus.Invalid, TransactionHistorySource.Local],
+        [TransactionHistoryStatus.Error, TransactionHistorySource.Local],
+      ]);
+    } finally {
+      tracker.shutdown();
+      await db.close();
+    }
+  });
+
+  it('retries only a latest-nonce transaction rejected as outdated', async () => {
+    const db = await createTestDb();
+    const call = { section: 'crosschainTransfer', method: 'collateralizeTransfer' };
+    let nextNonce = 7;
+    let rejectedNonce = 7;
+    let submissionError = new Error('1010: Invalid Transaction: Transaction is outdated');
+    const createUnsignedTx = () => ({
+      signAsync: vi.fn(async (_signer, options) => ({
+        hash: { toHex: () => `0x${options.nonce}` },
+        method: { toHuman: () => call },
+        nonce: numberCodec(options.nonce),
+        send: vi.fn(async () => {
+          if (options.nonce === rejectedNonce) {
+            nextNonce += 1;
+            throw submissionError;
+          }
+        }),
+      })),
+    });
+    const client = {
+      rpc: {
+        chain: {
+          getHeader: vi.fn(async () => ({ number: numberCodec(100) })),
+        },
+        system: {
+          accountNextIndex: vi.fn(async () => numberCodec(nextNonce)),
+        },
+      },
+      tx: vi.fn(() => createUnsignedTx()),
+    };
+    const blockWatch = {
+      start: vi.fn().mockResolvedValue(undefined),
+      bestBlockHeader: { blockNumber: 100, blockHash: '0x64' },
+      finalizedBlockHeader: {
+        blockNumber: 100,
+        blockTime: new Date('2026-03-20T20:00:00Z').getTime(),
+        blockHash: '0x64',
+      },
+      events: { on: vi.fn() },
+    };
+    const tracker = new TransactionTracker(Promise.resolve(db), blockWatch as any);
+    vi.spyOn(tracker as any, 'watchForUpdates').mockResolvedValue(undefined);
+
+    try {
+      const txInfo = await tracker.submitAndWatch({
+        client: client as any,
+        tx: createUnsignedTx() as any,
+        txSigner: { address: '5Alice' } as any,
+        extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+        useLatestNonce: true,
+      });
+
+      const storedTxs = await db.transactionsTable.fetchAll();
+      expect(storedTxs).toHaveLength(2);
+      expect(storedTxs.map(record => record.txNonce).sort()).toEqual([7, 8]);
+      expect(storedTxs.find(record => record.txNonce === 7)?.status).toBe(TransactionStatus.Error);
+      expect(txInfo.tx.txNonce).toBe(8);
+      expect(txInfo.tx.status).toBe(TransactionStatus.Submitted);
+
+      nextNonce = 9;
+      rejectedNonce = 9;
+      submissionError = new Error('1010: Invalid Transaction: Payment');
+      const rejectedTxInfo = await tracker.submitAndWatch({
+        client: client as any,
+        tx: createUnsignedTx() as any,
+        txSigner: { address: '5Alice' } as any,
+        extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+        useLatestNonce: true,
+      });
+
+      const storedTxsAfterGenericError = await db.transactionsTable.fetchAll();
+      expect(storedTxsAfterGenericError).toHaveLength(3);
+      expect(storedTxsAfterGenericError.find(record => record.id === rejectedTxInfo.tx.id)?.status).toBe(
+        TransactionStatus.Error,
+      );
+      expect(storedTxsAfterGenericError.some(record => record.txNonce === 10)).toBe(false);
+    } finally {
+      tracker.shutdown();
+      await db.close();
+    }
+  });
+
+  it('checks the account nonce at the finalized block used for the status scan', async () => {
+    const tx = createTransaction({
+      id: 5,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      txNonce: 7,
+      blockHeight: undefined,
+      blockHash: undefined,
+    });
+    const { tracker, blockWatch } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 105,
+      finalizedAccountNonce: 7,
+    });
+    const trackerApi = tracker as unknown as ITransactionTrackerTestApi;
+    vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+
+    const statusUpdate = trackerApi.updatePendingStatuses({ blockNumber: 105 });
+    blockWatch.finalizedBlockHeader = {
+      blockNumber: 106,
+      blockHash: '0x6a',
+      blockTime: new Date('2026-03-20T20:06:00Z').getTime(),
+    };
+    await statusUpdate;
+
+    expect(blockWatch.getApi).toHaveBeenCalledWith({
+      blockNumber: 105,
+      blockHash: '0x69',
+      blockTime: expect.any(Number),
+    });
+  });
+
+  it('expires an overdue transaction when the finalized nonce lookup fails', async () => {
+    const tx = createTransaction({
+      id: 6,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 60,
+      txNonce: 7,
+      blockHeight: undefined,
+      blockHash: undefined,
+    });
+    const { tracker, table } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 125,
+      finalizedAccountError: new Error('WebSocket is not connected'),
+    });
+    const trackerApi = tracker as unknown as ITransactionTrackerTestApi;
+    vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+
+    await trackerApi.updatePendingStatuses({ blockNumber: 125 });
+
+    expect(table.markExpiredWaitingForBlock).toHaveBeenCalledWith(tx);
   });
 
   it('treats a dropped attempt as replaceable', async () => {
@@ -439,6 +651,7 @@ describe('TransactionTracker', () => {
 
   it('reserves local nonces above restored pending submissions for concurrent same-account work', async () => {
     vi.mocked(getMainchainClient).mockResolvedValue({
+      tx: vi.fn(() => ({ signAsync: vi.fn() })),
       rpc: {
         chain: {
           getHeader: vi.fn(async () => ({ number: numberCodec(125) })),
@@ -584,6 +797,8 @@ describe('TransactionTracker', () => {
 async function createTracker(args: {
   txs: ITransactionRecord[];
   finalizedHeight: number;
+  finalizedAccountNonce?: number;
+  finalizedAccountError?: Error;
   latestHistoryByTxId?: Map<number, any>;
   headerByHeight?: Record<number, string>;
 }) {
@@ -629,6 +844,16 @@ async function createTracker(args: {
       blockHash: `0x${args.finalizedHeight.toString(16)}`,
     },
     getFinalizedHash: vi.fn(async (blockHeight: number) => args.headerByHeight?.[blockHeight] ?? '0xfinalized-block'),
+    getApi: vi.fn(async () => ({
+      query: {
+        system: {
+          account: vi.fn(async () => {
+            if (args.finalizedAccountError) throw args.finalizedAccountError;
+            return { nonce: numberCodec(args.finalizedAccountNonce ?? 0) };
+          }),
+        },
+      },
+    })),
     getHeader: vi.fn(async (blockHeight: number) => {
       return {
         blockNumber: blockHeight,

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -337,6 +337,61 @@ describe('TransactionTracker', () => {
     });
   });
 
+  it('shares a finalized nonce query across same-account transactions in one status scan', async () => {
+    const txs = [
+      createTransaction({
+        id: 5,
+        status: TransactionStatus.Submitted,
+        txNonce: 7,
+        blockHeight: undefined,
+        blockHash: undefined,
+      }),
+      createTransaction({
+        id: 6,
+        status: TransactionStatus.Submitted,
+        txNonce: 8,
+        blockHeight: undefined,
+        blockHash: undefined,
+      }),
+    ];
+    const { tracker, finalizedAccountQuery } = await createTracker({
+      txs,
+      finalizedHeight: 105,
+      finalizedAccountNonce: 7,
+    });
+    const trackerApi = tracker as unknown as ITransactionTrackerTestApi;
+    vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+
+    await trackerApi.updatePendingStatuses({ blockNumber: 105 });
+    await trackerApi.updatePendingStatuses({ blockNumber: 105 });
+
+    expect(finalizedAccountQuery).toHaveBeenCalledOnce();
+  });
+
+  it('retries a failed finalized nonce query without waiting for a new finalized block', async () => {
+    const tx = createTransaction({
+      id: 6,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      txNonce: 7,
+      blockHeight: undefined,
+      blockHash: undefined,
+    });
+    const { tracker, table, finalizedAccountQuery } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 105,
+      finalizedAccountError: new Error('WebSocket is not connected'),
+    });
+    const trackerApi = tracker as unknown as ITransactionTrackerTestApi;
+    vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+
+    await trackerApi.updatePendingStatuses({ blockNumber: 105 });
+    await trackerApi.updatePendingStatuses({ blockNumber: 105 });
+
+    expect(finalizedAccountQuery).toHaveBeenCalledTimes(2);
+    expect(table.updateFinalizedHead).not.toHaveBeenCalled();
+  });
+
   it('expires an overdue transaction when the finalized nonce lookup fails', async () => {
     const tx = createTransaction({
       id: 6,
@@ -803,6 +858,10 @@ async function createTracker(args: {
   headerByHeight?: Record<number, string>;
 }) {
   let insertedId = Math.max(0, ...args.txs.map(tx => tx.id));
+  const finalizedAccountQuery = vi.fn(async () => {
+    if (args.finalizedAccountError) throw args.finalizedAccountError;
+    return { nonce: numberCodec(args.finalizedAccountNonce ?? 0) };
+  });
   const table = {
     fetchAll: vi.fn().mockResolvedValue(args.txs),
     insert: vi.fn(async (record: Partial<ITransactionRecord>) =>
@@ -847,10 +906,7 @@ async function createTracker(args: {
     getApi: vi.fn(async () => ({
       query: {
         system: {
-          account: vi.fn(async () => {
-            if (args.finalizedAccountError) throw args.finalizedAccountError;
-            return { nonce: numberCodec(args.finalizedAccountNonce ?? 0) };
-          }),
+          account: finalizedAccountQuery,
         },
       },
     })),
@@ -872,7 +928,7 @@ async function createTracker(args: {
   vi.spyOn(tracker as any, 'watchForUpdates').mockResolvedValue(undefined);
   await tracker.load();
 
-  return { tracker, table, blockWatch };
+  return { tracker, table, blockWatch, finalizedAccountQuery };
 }
 
 function createLoadTracker(args: {

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -486,6 +486,7 @@ export class TransactionTracker {
     const table = await this.getTable();
     const bestBlockNumber = bestBlockInfo.blockNumber;
     const checkedTxIds = new Set<number>();
+    const finalizedAccountNonceByAddress = new Map<string, Promise<number | undefined>>();
 
     for (const txInfo of this.data.txInfos) {
       const { tx, txResult } = txInfo;
@@ -577,11 +578,44 @@ export class TransactionTracker {
         } else {
           console.log('[TransactionTracker] No transaction found as of block', { bestBlockNumber, id: tx.id });
 
-          const invalidError = await this.getConsumedNonceError(tx, finalizedBlockHeader);
-          if (invalidError) {
-            await this.recordInvalidTransaction(tx, txResult, invalidError, TransactionHistorySource.Local);
-            checkedTxIds.add(tx.id);
-            continue;
+          let finalizedNonceLookupFailed = false;
+          if (tx.txNonce != null && tx.finalizedHeadHeight !== finalizedHeight) {
+            let finalizedAccountNoncePromise = finalizedAccountNonceByAddress.get(tx.accountAddress);
+            if (!finalizedAccountNoncePromise) {
+              finalizedAccountNoncePromise = (async () => {
+                try {
+                  const api = await this.blockWatch.getApi(finalizedBlockHeader);
+                  const account = await api.query.system.account(tx.accountAddress);
+                  return account.nonce.toNumber();
+                } catch (error) {
+                  console.warn('[TransactionTracker] Unable to check finalized account nonce', {
+                    accountAddress: tx.accountAddress,
+                    finalizedHeight,
+                    error,
+                  });
+                }
+              })();
+              finalizedAccountNonceByAddress.set(tx.accountAddress, finalizedAccountNoncePromise);
+            }
+
+            const finalizedAccountNonce = await finalizedAccountNoncePromise;
+            if (finalizedAccountNonce === undefined) {
+              finalizedNonceLookupFailed = true;
+            } else if (finalizedAccountNonce > tx.txNonce) {
+              const error = new TxSubmissionError(
+                TxSubmissionErrorCode.Invalid,
+                'Transaction nonce was already used by another transaction.',
+              );
+              txResult.submissionError = error;
+              await this.recordHistoryStatus({
+                transactionId: tx.id,
+                status: TransactionHistoryStatus.Invalid,
+                source: TransactionHistorySource.Local,
+              });
+              await this.recordSubmissionError(tx, error);
+              checkedTxIds.add(tx.id);
+              continue;
+            }
           }
 
           if (finalizedHeight - tx.submittedAtBlockHeight > MAX_BLOCKS_TO_CHECK) {
@@ -590,6 +624,9 @@ export class TransactionTracker {
             txResult.extrinsicError = new Error('Transaction expired waiting for block inclusion');
             await txResult.setFinalized();
             await table.markExpiredWaitingForBlock(tx);
+          } else if (finalizedNonceLookupFailed) {
+            // Retry this account at the same finalized head after a transient RPC failure.
+            continue;
           }
         }
         checkedTxIds.add(tx.id);
@@ -635,45 +672,6 @@ export class TransactionTracker {
     if (record.status === TransactionStatus.Error) return;
     const table = await this.getTable();
     await table.recordSubmissionError(record, error);
-  }
-
-  private async getConsumedNonceError(
-    record: ITransactionRecord,
-    finalizedBlockHeader: Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>,
-  ): Promise<TxSubmissionError | undefined> {
-    if (record.txNonce == null) return;
-
-    try {
-      const api = await this.blockWatch.getApi(finalizedBlockHeader);
-      const account = await api.query.system.account(record.accountAddress);
-      if (account.nonce.toNumber() <= record.txNonce) return;
-
-      return new TxSubmissionError(
-        TxSubmissionErrorCode.Invalid,
-        'Transaction nonce was already used by another transaction.',
-      );
-    } catch (error) {
-      console.warn('[TransactionTracker] Unable to check finalized account nonce', {
-        accountAddress: record.accountAddress,
-        finalizedHeight: finalizedBlockHeader.blockNumber,
-        error,
-      });
-    }
-  }
-
-  private async recordInvalidTransaction(
-    record: ITransactionRecord,
-    txResult: TxResult,
-    error: Error,
-    source: TransactionHistorySource,
-  ): Promise<void> {
-    txResult.submissionError = error;
-    await this.recordHistoryStatus({
-      transactionId: record.id,
-      status: TransactionHistoryStatus.Invalid,
-      source,
-    });
-    await this.recordSubmissionError(record, error);
   }
 
   private async reserveLatestNonce(

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -3,12 +3,15 @@ import {
   ExtrinsicError,
   type GenericEvent,
   hexToU8a,
+  isOutdatedTransactionError,
   ISubmittableOptions,
   type ISubmittableResult,
   SignedBlock,
   SubmittableExtrinsic,
   type TxSigningAccount,
   TxResult,
+  TxSubmissionError,
+  TxSubmissionErrorCode,
 } from '@argonprotocol/mainchain';
 import * as Vue from 'vue';
 import { Db } from './Db.ts';
@@ -210,13 +213,38 @@ export class TransactionTracker {
       metadata?: T;
     } & ISubmittableOptions,
   ): Promise<TransactionInfo<T>> {
-    const { client: providedClient, tx, txSigner, extrinsicType, metadata, useLatestNonce, ...apiOptions } = args;
     await this.load();
+    const txInfo = await this.submitAttempt(args);
+    await this.watchForUpdates();
+
+    return txInfo;
+  }
+
+  private async submitAttempt<T>(
+    args: {
+      client?: ArgonClient;
+      tx: SubmittableExtrinsic;
+      txSigner: TxSigningAccount;
+      extrinsicType: ExtrinsicType;
+      metadata?: T;
+    } & ISubmittableOptions,
+    outdatedNonceAttempt = 1,
+  ): Promise<TransactionInfo<T>> {
+    const { client: providedClient, tx, txSigner, extrinsicType, metadata, useLatestNonce, ...providedOptions } = args;
     const client = providedClient ?? (await getMainchainClient(false));
     console.log('[TransactionTracker] SUBMITTING TRANSACTION', extrinsicType);
     const submittedAtBlockHeight = await client.rpc.chain.getHeader().then(x => x.number.toNumber());
+    const shouldRetryLatestNonce = useLatestNonce && providedOptions.nonce === undefined;
+    const apiOptions = { ...providedOptions };
+    const retryArgs = shouldRetryLatestNonce
+      ? {
+          ...args,
+          client,
+          tx: client.tx(tx),
+        }
+      : undefined;
     let releaseNonceReservation: VoidFunction | undefined;
-    if (useLatestNonce && apiOptions.nonce === undefined) {
+    if (shouldRetryLatestNonce) {
       const reservation = await this.reserveLatestNonce(client, txSigner.address);
       apiOptions.nonce = reservation.nonce;
       releaseNonceReservation = reservation.release;
@@ -245,26 +273,33 @@ export class TransactionTracker {
         metadata,
       });
 
-      await signedTx
-        .send(result => {
+      let shouldRetryOutdatedNonce = false;
+      try {
+        await signedTx.send(result => {
           if (this.#isClosed) {
             return;
           }
           txResult.onSubscriptionResult(result);
           void this.handleWatchedResult(txInfo.tx, txResult, result);
-        })
-        .catch(async error => {
-          if (this.#isClosed) {
-            return;
-          }
-          txResult.submissionError = error as Error;
-          await this.recordSubmissionError(txInfo.tx, txResult.submissionError);
         });
+      } catch (error) {
+        if (this.#isClosed) {
+          return txInfo;
+        }
+        txResult.submissionError = error as Error;
+        await this.recordSubmissionError(txInfo.tx, txResult.submissionError);
+        shouldRetryOutdatedNonce =
+          retryArgs !== undefined && outdatedNonceAttempt < 3 && isOutdatedTransactionError(error);
+      }
+
+      if (shouldRetryOutdatedNonce && retryArgs) {
+        releaseNonceReservation?.();
+        releaseNonceReservation = undefined;
+        return await this.submitAttempt(retryArgs, outdatedNonceAttempt + 1);
+      }
     } finally {
       releaseNonceReservation?.();
     }
-
-    await this.watchForUpdates();
 
     return txInfo;
   }
@@ -446,8 +481,9 @@ export class TransactionTracker {
   }
 
   private async updatePendingStatuses(bestBlockInfo: IBlockHeaderInfo): Promise<void> {
+    const finalizedBlockHeader = { ...this.blockWatch.finalizedBlockHeader };
+    const { blockNumber: finalizedHeight, blockTime: finalizedBlockTime } = finalizedBlockHeader;
     const table = await this.getTable();
-    const { blockNumber: finalizedHeight, blockTime: finalizedBlockTime } = this.blockWatch.finalizedBlockHeader;
     const bestBlockNumber = bestBlockInfo.blockNumber;
     const checkedTxIds = new Set<number>();
 
@@ -541,6 +577,13 @@ export class TransactionTracker {
         } else {
           console.log('[TransactionTracker] No transaction found as of block', { bestBlockNumber, id: tx.id });
 
+          const invalidError = await this.getConsumedNonceError(tx, finalizedBlockHeader);
+          if (invalidError) {
+            await this.recordInvalidTransaction(tx, txResult, invalidError, TransactionHistorySource.Local);
+            checkedTxIds.add(tx.id);
+            continue;
+          }
+
           if (finalizedHeight - tx.submittedAtBlockHeight > MAX_BLOCKS_TO_CHECK) {
             // too old, stop checking
             console.log(`[TransactionTracker] Marking transaction #${tx.id} expired:`, tx.extrinsicHash);
@@ -592,6 +635,45 @@ export class TransactionTracker {
     if (record.status === TransactionStatus.Error) return;
     const table = await this.getTable();
     await table.recordSubmissionError(record, error);
+  }
+
+  private async getConsumedNonceError(
+    record: ITransactionRecord,
+    finalizedBlockHeader: Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>,
+  ): Promise<TxSubmissionError | undefined> {
+    if (record.txNonce == null) return;
+
+    try {
+      const api = await this.blockWatch.getApi(finalizedBlockHeader);
+      const account = await api.query.system.account(record.accountAddress);
+      if (account.nonce.toNumber() <= record.txNonce) return;
+
+      return new TxSubmissionError(
+        TxSubmissionErrorCode.Invalid,
+        'Transaction nonce was already used by another transaction.',
+      );
+    } catch (error) {
+      console.warn('[TransactionTracker] Unable to check finalized account nonce', {
+        accountAddress: record.accountAddress,
+        finalizedHeight: finalizedBlockHeader.blockNumber,
+        error,
+      });
+    }
+  }
+
+  private async recordInvalidTransaction(
+    record: ITransactionRecord,
+    txResult: TxResult,
+    error: Error,
+    source: TransactionHistorySource,
+  ): Promise<void> {
+    txResult.submissionError = error;
+    await this.recordHistoryStatus({
+      transactionId: record.id,
+      status: TransactionHistoryStatus.Invalid,
+      source,
+    });
+    await this.recordSubmissionError(record, error);
   }
 
   private async reserveLatestNonce(
@@ -819,7 +901,7 @@ export class TransactionTracker {
     if (txInfo.txResult.submissionError) {
       return false;
     }
-    return true;
+    return !this.isNonResumableWatchStatus(this.getLatestHistoryStatus(txInfo.tx.id));
   }
 
   private reservesNonceLane(txInfo: TransactionInfo, address: string) {


### PR DESCRIPTION
## Summary

Transactions submitted with the latest nonce now recover when the node directly rejects an attempt as stale. Each retry reserves a fresh nonce and the retry loop stops after three attempts; unrelated submission failures remain errors.

When a tracked transaction disappears and its nonce has already been consumed in finalized chain state, the tracker now retires it as invalid instead of waiting indefinitely. This later inference does not replay the transaction.

## Validation

- Relevant transaction tracker, minting authority, and Ethereum outbound transfer tests pass
- TypeScript, ESLint, and formatting checks pass
- A regression mutation confirmed that broad retry behavior fails the focused test
