### PR TITLE
fix: prevent nonce-related transaction stalls

### DIFF
--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -162,6 +162,7 @@ import SponsorOverlay from './overlays/SponsorOverlay.vue';
 import { getMainchainClient, getMainchainClients } from './stores/mainchain.ts';
 import { getMyVault } from './stores/vaults.ts';
 import { getArgonBonds } from './stores/argonBonds.ts';
+import { getEthereumOutboundTransferTracker } from './stores/moveToEthereum.ts';
 
 const runtimeCompatibility = useRuntimeCompatibility();
 const { isBrowserUnsupported, shouldShowCompatibilityScreen } = storeToRefs(runtimeCompatibility);
@@ -182,6 +183,9 @@ if (!isBrowserUnsupported.value) {
   tour = useTour();
   bot = getBot();
   updater.start();
+  void config.isLoadedPromise
+    .then(() => getEthereumOutboundTransferTracker())
+    .catch(error => console.error('[App] Unable to start outbound Ethereum transfer tracking', error));
 }
 
 const order = [TopTab.Home, TopTab.Mining, TopTab.Vaulting];

--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   decodeFunctionData,
   keccak256,
+  parseTransaction,
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
   type Hex,
@@ -112,6 +113,71 @@ describe('EthereumClient', () => {
         fallbackErrorMessage: 'fallback',
       }),
     ).rejects.toThrow('Missing or invalid parameters. Double check you have provided the correct parameters.');
+  });
+
+  it('reserves distinct Ethereum nonces for concurrent outbound finalizations', async () => {
+    const walletKeys = createMockWalletKeys();
+    const ethereumClient = new EthereumClient(walletKeys, 'https://ethereum.test');
+    const gatewayAddress = repeatHex('11', 20);
+    const submittedNonces: number[] = [];
+    let nextNonce = 3;
+    const publicClient = {
+      getTransactionCount: vi.fn(async () => nextNonce),
+      estimateGas: vi.fn(async () => 100_000n),
+      estimateFeesPerGas: vi.fn(async () => ({
+        gasPrice: 1n,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+      })),
+      sendRawTransaction: vi.fn(async ({ serializedTransaction }: { serializedTransaction: Hex }) => {
+        const nonce = parseTransaction(serializedTransaction).nonce!;
+        submittedNonces.push(nonce);
+        nextNonce = nonce + 1;
+        return toHex(nonce, { size: 32 });
+      }),
+    };
+    Object.assign(ethereumClient, {
+      loadChainConfig: async () => ({
+        chainId: 1,
+        gatewayAddress,
+        argonTokenAddress: repeatHex('22', 20),
+        argonotTokenAddress: repeatHex('33', 20),
+      }),
+      createExecutionClient: async () => ({
+        chain: { id: 1 },
+        publicClient,
+      }),
+    });
+    const proof = {
+      authorizations: [
+        {
+          microgonCollateral: 100n,
+          micronotCollateral: 0n,
+          signature: `${repeatHex('00', 64)}1c` as const,
+        },
+      ],
+    };
+
+    await Promise.all(
+      [1n, 2n].map(argonTransferNonce =>
+        ethereumClient.finalizeTransferOutOfArgon({
+          request: {
+            argonAccountId: repeatHex('44', 32),
+            argonTransferNonce,
+            chainId: 1n,
+            microgonsPerArgonot: 3n,
+            recipient: walletKeys.ethereumAddress,
+            validUntilBlock: 500n,
+            token: repeatHex('22', 20),
+            amount: 100n,
+            mintingAuthorityTip: 1n,
+          },
+          proof,
+        }),
+      ),
+    );
+
+    expect(submittedNonces).toEqual([3, 4]);
   });
 
   it('routes Ethereum balance requests through plugin-http', async () => {

--- a/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
@@ -1795,7 +1795,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
     });
   });
 
-  it('resubmits a dropped Ethereum transfer after app restart', async () => {
+  it('resubmits a dropped Ethereum transfer only after visibility definitively returns false', async () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
     const transferId = 'outbound-submitted-target-chain';
@@ -1925,6 +1925,25 @@ describe('EthereumOutboundTransferTracker integration', () => {
       { ...staleSubmittedRecord!, updatedAt: new Date(0) },
     ]);
 
+    const isTransactionVisible = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary visibility rpc issue'))
+      .mockResolvedValue(false);
+    const waitForTransactionFinality = vi.fn(async ({ txHash }: { txHash: string }) => {
+      if (txHash === targetTxHash) {
+        throw new Error('temporary rpc issue');
+      }
+
+      return {
+        blockNumber: 99,
+        blockHash: `0x${'b3'.repeat(32)}`,
+        confirmations: 1,
+        expectedConfirmations: 1,
+        progressPct: 100,
+        isFinalized: true,
+      } satisfies IFinalizedEthereumTransactionProgress;
+    });
+
     const trackerAfterRestart = new EthereumOutboundTransferTracker(
       Promise.resolve(db),
       transactionTracker as any,
@@ -1946,21 +1965,8 @@ describe('EthereumOutboundTransferTracker integration', () => {
             }) satisfies IEthereumTransactionProgress,
         ),
         getTransactionFinalityPollMs: vi.fn(() => 1),
-        isTransactionVisible: vi.fn(async () => false),
-        waitForTransactionFinality: vi.fn(async ({ txHash }: { txHash: string }) => {
-          if (txHash === targetTxHash) {
-            throw new Error('the dropped hash should be replaced before waiting for finality');
-          }
-
-          return {
-            blockNumber: 99,
-            blockHash: `0x${'b3'.repeat(32)}`,
-            confirmations: 1,
-            expectedConfirmations: 1,
-            progressPct: 100,
-            isFinalized: true,
-          } satisfies IFinalizedEthereumTransactionProgress;
-        }),
+        isTransactionVisible,
+        waitForTransactionFinality,
         confirmTransferOutOfArgon: vi.fn(
           async () =>
             ({
@@ -1977,6 +1983,17 @@ describe('EthereumOutboundTransferTracker integration', () => {
 
     await vi.waitFor(async () => {
       const persisted = await db.crosschainOutboundTransfersTable.get(transferId);
+      expect(isTransactionVisible).toHaveBeenCalledTimes(1);
+      expect(waitForTransactionFinality).toHaveBeenCalledWith(expect.objectContaining({ txHash: targetTxHash }));
+      expect(persisted?.status).toBe(CrosschainOutboundTransferStatus.TransferSubmittedToTargetChain);
+      expect(persisted?.targetTxHash).toBe(targetTxHash);
+    });
+
+    blockWatch.emitFinalized({ blockNumber: 13, blockHash: '0xretry-visibility' });
+
+    await vi.waitFor(async () => {
+      const persisted = await db.crosschainOutboundTransfersTable.get(transferId);
+      expect(isTransactionVisible).toHaveBeenCalledTimes(2);
       expect(persisted?.status).toBe(CrosschainOutboundTransferStatus.TransferFinalizedOnTargetChain);
       expect(persisted?.targetTxHash).toBe(replacementTxHash);
       expect(persisted?.failureReason).toBeNull();

--- a/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
@@ -1795,11 +1795,12 @@ describe('EthereumOutboundTransferTracker integration', () => {
     });
   });
 
-  it('recovers a submitted Ethereum transfer after app restart', async () => {
+  it('resubmits a dropped Ethereum transfer after app restart', async () => {
     const db = await createTestDb();
     const walletKeys = createMockWalletKeys();
     const transferId = 'outbound-submitted-target-chain';
     const targetTxHash = `0x${'b2'.repeat(32)}` as const;
+    const replacementTxHash = `0x${'b4'.repeat(32)}` as const;
     const blockWatch = createBlockWatch({
       initialHeader: { blockNumber: 12, blockHash: '0xready' },
       getApi: async () => ({}),
@@ -1919,19 +1920,20 @@ describe('EthereumOutboundTransferTracker integration', () => {
       expect(transfer?.transferState.error).toBe('');
     });
 
+    const staleSubmittedRecord = await db.crosschainOutboundTransfersTable.get(transferId);
+    vi.spyOn(db.crosschainOutboundTransfersTable, 'fetchAll').mockResolvedValueOnce([
+      { ...staleSubmittedRecord!, updatedAt: new Date(0) },
+    ]);
+
     const trackerAfterRestart = new EthereumOutboundTransferTracker(
       Promise.resolve(db),
       transactionTracker as any,
       blockWatch.instance as any,
       walletKeys,
       {
-        estimateFinalizeTransferOutOfArgonFee: vi.fn(async () => {
-          throw new Error('should not re-estimate after Ethereum submission');
-        }),
+        estimateFinalizeTransferOutOfArgonFee: vi.fn(async () => 1n),
         getNativeBalanceWei: vi.fn(async () => 10n),
-        finalizeTransferOutOfArgon: vi.fn(async () => {
-          throw new Error('should not resubmit after Ethereum submission');
-        }),
+        finalizeTransferOutOfArgon: vi.fn(async () => replacementTxHash),
         getTransactionProgress: vi.fn(
           async () =>
             ({
@@ -1944,21 +1946,25 @@ describe('EthereumOutboundTransferTracker integration', () => {
             }) satisfies IEthereumTransactionProgress,
         ),
         getTransactionFinalityPollMs: vi.fn(() => 1),
-        waitForTransactionFinality: vi.fn(
-          async () =>
-            ({
-              blockNumber: 99,
-              blockHash: `0x${'b3'.repeat(32)}`,
-              confirmations: 1,
-              expectedConfirmations: 1,
-              progressPct: 100,
-              isFinalized: true,
-            }) satisfies IFinalizedEthereumTransactionProgress,
-        ),
+        isTransactionVisible: vi.fn(async () => false),
+        waitForTransactionFinality: vi.fn(async ({ txHash }: { txHash: string }) => {
+          if (txHash === targetTxHash) {
+            throw new Error('the dropped hash should be replaced before waiting for finality');
+          }
+
+          return {
+            blockNumber: 99,
+            blockHash: `0x${'b3'.repeat(32)}`,
+            confirmations: 1,
+            expectedConfirmations: 1,
+            progressPct: 100,
+            isFinalized: true,
+          } satisfies IFinalizedEthereumTransactionProgress;
+        }),
         confirmTransferOutOfArgon: vi.fn(
           async () =>
             ({
-              targetTxHash,
+              targetTxHash: replacementTxHash,
               targetBlockNumber: 99,
               targetBlockHash: `0x${'b3'.repeat(32)}`,
               gatewayActivityNonce: 11n,
@@ -1972,6 +1978,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
     await vi.waitFor(async () => {
       const persisted = await db.crosschainOutboundTransfersTable.get(transferId);
       expect(persisted?.status).toBe(CrosschainOutboundTransferStatus.TransferFinalizedOnTargetChain);
+      expect(persisted?.targetTxHash).toBe(replacementTxHash);
       expect(persisted?.failureReason).toBeNull();
       expect(trackerAfterRestart.getTransfer(transferId)?.transferState.error).toBe('');
       expect(trackerAfterRestart.getTransfer(transferId)?.transferState.progress.overallProgressPct).toBe(100);

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -7,6 +7,7 @@ import {
   logEthereumExecutionRpcFallback,
   MoveToken,
   NetworkConfig,
+  SingleFileQueue,
 } from '@argonprotocol/apps-core';
 import {
   decodeAddress,
@@ -173,6 +174,8 @@ type IPreparedGatewayRelay = IEthereumGatewayRelayPreview & {
 };
 
 export class EthereumClient {
+  #outboundFinalizationQueue = new SingleFileQueue();
+
   constructor(
     private readonly walletKeys: Pick<
       WalletKeys,
@@ -345,6 +348,11 @@ export class EthereumClient {
     };
   }
 
+  public async isTransactionVisible(txHash: Hash): Promise<boolean> {
+    const { publicClient } = await this.createExecutionClient();
+    return await isEthereumTransactionVisibleAtRpc(publicClient, txHash);
+  }
+
   public async waitForTransactionFinality(args: {
     txHash: Hash;
     blockNumber?: number;
@@ -392,26 +400,28 @@ export class EthereumClient {
   }
 
   public async finalizeTransferOutOfArgon(args: IEthereumFinalizeTransferOutOfArgonArgs): Promise<Hash> {
-    const chainConfig = await this.loadChainConfig();
-    const { chain, publicClient } = await this.createExecutionClient();
-    const { transaction, unsignedTransaction } = await buildEthereumUnsignedTransaction({
-      publicClient,
-      from: getAddress(this.walletKeys.ethereumAddress),
-      chainId: chain.id,
-      to: chainConfig.gatewayAddress,
-      data: encodeFunctionData({
-        abi: EvmContracts.mintingGatewayAbi,
-        functionName: 'finalizeTransferOutOfArgon',
-        args: [args.request, args.proof],
-      }),
-    });
-    await this.ensureEthereumSignerPolicyConfigured(chainConfig);
-    const signature = await this.walletKeys.signEthereumTransaction(unsignedTransaction);
-    return await submitEthereumTransaction({
-      publicClient,
-      serializedTransaction: serializeTransaction(transaction, signature),
-      fallbackErrorMessage: 'Unable to submit the Ethereum transfer right now.',
-    });
+    return await this.#outboundFinalizationQueue.add(async () => {
+      const chainConfig = await this.loadChainConfig();
+      const { chain, publicClient } = await this.createExecutionClient();
+      const { transaction, unsignedTransaction } = await buildEthereumUnsignedTransaction({
+        publicClient,
+        from: getAddress(this.walletKeys.ethereumAddress),
+        chainId: chain.id,
+        to: chainConfig.gatewayAddress,
+        data: encodeFunctionData({
+          abi: EvmContracts.mintingGatewayAbi,
+          functionName: 'finalizeTransferOutOfArgon',
+          args: [args.request, args.proof],
+        }),
+      });
+      await this.ensureEthereumSignerPolicyConfigured(chainConfig);
+      const signature = await this.walletKeys.signEthereumTransaction(unsignedTransaction);
+      return await submitEthereumTransaction({
+        publicClient,
+        serializedTransaction: serializeTransaction(transaction, signature),
+        fallbackErrorMessage: 'Unable to submit the Ethereum transfer right now.',
+      });
+    }).promise;
   }
 
   public async confirmTransferOutOfArgon(transfer: IEthereumTransferOutOfArgon): Promise<IEthereumTransferOutOfArgon> {
@@ -1591,8 +1601,12 @@ async function isSubmittedEthereumTransactionVisible(
   hash: Hash,
 ): Promise<boolean> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    if (await isEthereumTransactionVisibleAtRpc(publicClient, hash)) {
-      return true;
+    try {
+      if (await isEthereumTransactionVisibleAtRpc(publicClient, hash)) {
+        return true;
+      }
+    } catch {
+      // This is best-effort recovery after the original submission already failed.
     }
     await sleep(500);
   }
@@ -1609,7 +1623,7 @@ async function isEthereumTransactionVisibleAtRpc(
     return true;
   } catch (error) {
     if (!(error instanceof TransactionNotFoundError)) {
-      return false;
+      throw error;
     }
   }
 
@@ -1619,9 +1633,9 @@ async function isEthereumTransactionVisibleAtRpc(
     if (error instanceof TransactionReceiptNotFoundError || isIndexingInProgressError(error)) {
       return false;
     }
-  }
 
-  return false;
+    throw error;
+  }
 }
 
 function isIndexingInProgressError(error: unknown): boolean {

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -42,6 +42,7 @@ import type { MintingAuthorities, IMintingAuthorityAuthorizeMetadata } from './M
 import { existentialDepositMicrogons, existentialDepositMicronots } from './WalletForArgon.ts';
 
 const NETWORK = 'Ethereum';
+const ETHEREUM_TRANSACTION_NOT_FOUND_TIMEOUT_MS = 120_000;
 type IEthereumOutboundTransferClient = Pick<
   EthereumClient,
   | 'estimateFinalizeTransferOutOfArgonFee'
@@ -52,7 +53,7 @@ type IEthereumOutboundTransferClient = Pick<
   | 'getTransactionFinalityPollMs'
   | 'waitForTransactionFinality'
 > &
-  Partial<Pick<EthereumClient, 'estimateLikelyFinalizeTransferOutOfArgonFee'>>;
+  Partial<Pick<EthereumClient, 'estimateLikelyFinalizeTransferOutOfArgonFee' | 'isTransactionVisible'>>;
 
 export type ICrosschainTransferOutMetadata = {
   actionType: 'transferOutToEthereum';
@@ -891,6 +892,25 @@ export class EthereumOutboundTransferTracker {
 
     transfer.transferState.error = '';
     let activeRecord = record;
+    if (
+      activeRecord.status === CrosschainOutboundTransferStatus.TransferSubmittedToTargetChain &&
+      activeRecord.targetTxHash &&
+      this.ethereumClient.isTransactionVisible &&
+      Date.now() - activeRecord.updatedAt.getTime() >= ETHEREUM_TRANSACTION_NOT_FOUND_TIMEOUT_MS &&
+      !(await this.ethereumClient.isTransactionVisible(activeRecord.targetTxHash))
+    ) {
+      transfer.transferState.progress = setOutboundEthereumStepProgress(transfer.transferState.progress, {
+        progressPct: 0,
+        detail: 'Preparing Ethereum transfer retry...',
+      });
+      const db = await this.dbPromise;
+      activeRecord = (await db.crosschainOutboundTransfersTable.patch(activeRecord.id, {
+        status: CrosschainOutboundTransferStatus.MintingAuthorized,
+        progressJson: transfer.transferState.progress,
+      }))!;
+      transfer.persistedRecord = activeRecord;
+    }
+
     if (activeRecord.status === CrosschainOutboundTransferStatus.MintingAuthorized) {
       transfer.transferState.progress = setOutboundEthereumStepProgress(transfer.transferState.progress, {
         progressPct: 0,

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -892,13 +892,25 @@ export class EthereumOutboundTransferTracker {
 
     transfer.transferState.error = '';
     let activeRecord = record;
+    let shouldRetrySubmittedTransfer = false;
     if (
       activeRecord.status === CrosschainOutboundTransferStatus.TransferSubmittedToTargetChain &&
       activeRecord.targetTxHash &&
       this.ethereumClient.isTransactionVisible &&
-      Date.now() - activeRecord.updatedAt.getTime() >= ETHEREUM_TRANSACTION_NOT_FOUND_TIMEOUT_MS &&
-      !(await this.ethereumClient.isTransactionVisible(activeRecord.targetTxHash))
+      Date.now() - activeRecord.updatedAt.getTime() >= ETHEREUM_TRANSACTION_NOT_FOUND_TIMEOUT_MS
     ) {
+      try {
+        shouldRetrySubmittedTransfer =
+          (await this.ethereumClient.isTransactionVisible(activeRecord.targetTxHash)) === false;
+      } catch (error) {
+        console.warn(
+          `[EthereumOutboundTransferTracker] Unable to verify Ethereum transaction visibility for ${record.id}; continuing to wait for finality`,
+          error,
+        );
+      }
+    }
+
+    if (shouldRetrySubmittedTransfer) {
       transfer.transferState.progress = setOutboundEthereumStepProgress(transfer.transferState.progress, {
         progressPct: 0,
         detail: 'Preparing Ethereum transfer retry...',

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -919,6 +919,7 @@ export class MyVault {
           vaultId,
           committedMicronots,
         },
+        useLatestNonce: true,
       });
     }).promise;
   }


### PR DESCRIPTION
## Summary

Prevents nonce races from stranding outbound Ethereum transfers or vault commitment updates. Outbound finalizations now serialize pending nonce allocation, submitted transfers whose hashes never became visible are retried after app startup, and vault commitments use the latest chain nonce.

## Validation

- Concurrent outbound finalizations reserve distinct Ethereum nonces.
- Restart recovery replaces an absent Ethereum transaction and completes the persisted transfer.
- The focused transfer tests, typecheck, lint, and formatting checks pass.
