### PR TITLE
fix: stabilize recovered account history

### DIFF
--- a/src-tauri/migrations/31-vault-capital-reorgs/up.sql
+++ b/src-tauri/migrations/31-vault-capital-reorgs/up.sql
@@ -1,0 +1,34 @@
+DELETE FROM VaultCapitalHistory
+WHERE id NOT IN (
+  SELECT MAX(id)
+  FROM VaultCapitalHistory
+  GROUP BY
+    walletAddress,
+    vaultId,
+    blockNumber,
+    COALESCE(extrinsicIndex, -1),
+    eventType,
+    COALESCE(amount, ''),
+    COALESCE(securitization, ''),
+    COALESCE(securitizationTarget, ''),
+    COALESCE(releaseHeight, ''),
+    COALESCE(securitizationRemaining, ''),
+    COALESCE(securitizationReleased, '')
+);
+
+-- Collect releases the vault's full held balance once. Frame-start processing
+-- can emit multiple distinct burns in one block, so only collect is block-unique.
+DELETE FROM VaultRevenueEvents
+WHERE source = 'vaultCollect'
+  AND id NOT IN (
+    SELECT MAX(id)
+    FROM VaultRevenueEvents
+    WHERE source = 'vaultCollect'
+    GROUP BY blockNumber
+  );
+
+DROP INDEX idxVaultRevenueEventsBlockIdentity;
+
+CREATE UNIQUE INDEX idxVaultRevenueEventsBlockIdentity
+ON VaultRevenueEvents (blockNumber, source)
+WHERE source = 'vaultCollect';

--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import BigNumber from 'bignumber.js';
 import {
+  createDeferred,
   StorageFinder,
   TransactionEvents,
   type BlockWatch,
@@ -269,7 +270,7 @@ describe('BitcoinLocks recovery', () => {
     ]);
   });
 
-  it('publishes a rediscovered orphan without waiting for an app refresh', async () => {
+  it('publishes a rediscovered orphan after current-state reconciliation', async () => {
     const db = await createTestDb();
     const store = createStore({
       blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
@@ -278,11 +279,18 @@ describe('BitcoinLocks recovery', () => {
     const lock = createLock({
       uuid: 'late-orphan',
       utxoId: 7,
-      status: BitcoinLockStatus.LockPendingFunding,
+      status: BitcoinLockStatus.Released,
       createdAt: '2026-01-01T00:00:00Z',
     });
+    lock.removalReason = 'released';
     const utxoRef = { txid: `0x${'55'.repeat(32)}`, outputIndex: 1 };
     store.data.locksByUtxoId[7] = lock;
+    const releaseReconciliation = createDeferred<void>();
+    vi.spyOn(store.orphanReleases, 'reconcileOrphanReturns').mockImplementation(async () => {
+      await releaseReconciliation.promise;
+      const orphan = store.utxoTracking.getUtxosForLock(lock)[0];
+      await store.utxoTracking.setReleaseComplete(orphan);
+    });
 
     await store.recovery.beginHistoryReplay({ lockScope: 'all' });
     await store.recovery.recoverBlock(historyBlock(201), [
@@ -293,28 +301,49 @@ describe('BitcoinLocks recovery', () => {
         satoshis: 12_000n,
       }),
     ]);
+    expect(store.recovery.hasPendingHistoryRecovery).toBe(true);
+
     await store.recovery.commitHistoryReplay();
+
+    expect(store.data.isReconciliationPending).toBe(true);
+    expect(store.utxoTracking.getUnresolvedOrphanRecords([lock])).toHaveLength(1);
+
+    releaseReconciliation.resolve();
+    await vi.waitFor(() => expect(store.data.isReconciliationPending).toBe(false));
 
     expect(lock.isHistoryRecoveryPending).toBeUndefined();
     expect(store.getLockByUtxoId(7)).toBe(lock);
-    expect(store.utxoTracking.getUnresolvedOrphanRecords([lock])).toEqual([
+    expect(store.utxoTracking.getAllOrphanLifecycleUtxos()).toEqual([
       expect.objectContaining({
         txid: utxoRef.txid,
         vout: utxoRef.outputIndex,
         satoshis: 12_000n,
-        status: BitcoinUtxoStatus.Orphaned,
+        status: BitcoinUtxoStatus.ReleaseComplete,
       }),
     ]);
+    expect(store.utxoTracking.getUnresolvedOrphanRecords([lock])).toEqual([]);
   });
 
-  it('quarantines only recovering locks while regular locks remain active and syncable', async () => {
+  it('quarantines recovering locks from actions while keeping their current values visible', async () => {
     const store = createStore();
     const record = createLock({
       uuid: 'interim-release',
       utxoId: 7,
-      status: BitcoinLockStatus.LockPendingFunding,
+      status: BitcoinLockStatus.LockedAndIsMinting,
       createdAt: '2026-01-01T00:00:00Z',
     });
+    record.ratchets = [
+      {
+        mintAmount: 80n,
+        mintPending: 10n,
+        lockedTargetPrice: 100n,
+        securityFee: 2n,
+        txFee: 0n,
+        burned: 0n,
+        blockHeight: 10,
+        oracleBitcoinBlockHeight: 100,
+      },
+    ];
     record.fundingUtxoRecord = {
       status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,
       statusError: 'PSBT finalize error',
@@ -354,26 +383,56 @@ describe('BitcoinLocks recovery', () => {
     await store.syncLockReleaseStatusFromFundingRecord(record, releasingRecord);
     await store.syncLockReleaseStatusFromFundingRecord(regularRecord, releasingRecord);
 
-    expect(record.status).toBe(BitcoinLockStatus.LockPendingFunding);
+    expect(record.status).toBe(BitcoinLockStatus.LockedAndIsMinting);
     expect(regularRecord.status).toBe(BitcoinLockStatus.Releasing);
     expect(setStatus).toHaveBeenCalledOnce();
     expect(setStatus).toHaveBeenCalledWith(regularRecord, BitcoinLockStatus.Releasing);
 
     vi.spyOn(store, 'load').mockResolvedValue();
+    const recoverySummary = {
+      uuid: record.uuid,
+      record,
+      status: record.status,
+      satoshis: record.satoshis,
+      valueOfBtc: 100n,
+      startingCapital: 80n,
+      endingCapital: 88n,
+      pendingLiquidity: 10n,
+      receivedLiquidity: 70n,
+      totalFees: 2n,
+      unlockAmount: 60n,
+    } as ReturnType<typeof store.createLockSummary>;
     const regularSummary = {
+      uuid: regularRecord.uuid,
       record: regularRecord,
       status: regularRecord.status,
+      satoshis: regularRecord.satoshis,
+      valueOfBtc: 0n,
+      startingCapital: 0n,
+      endingCapital: 0n,
+      pendingLiquidity: 0n,
+      receivedLiquidity: 0n,
+      totalFees: 0n,
       unlockAmount: 0n,
     } as ReturnType<typeof store.createLockSummary>;
-    const createLockSummaryAt = vi.spyOn(store, 'createLockSummaryAt').mockResolvedValue(regularSummary);
+    const createLockSummaryAt = vi
+      .spyOn(store, 'createLockSummaryAt')
+      .mockImplementation(async lock => (lock === record ? recoverySummary : regularSummary));
     const financials = await new BitcoinFinancials(store).loadSnapshot({
       clientAt: Object.create(null),
-      hasCurrentPrice: false,
+      hasCurrentPrice: true,
     });
 
-    expect(createLockSummaryAt).toHaveBeenCalledOnce();
-    expect(createLockSummaryAt).toHaveBeenCalledWith(regularRecord, expect.anything());
-    expect(financials.summaries).toEqual([regularSummary]);
+    expect(createLockSummaryAt).toHaveBeenCalledTimes(2);
+    expect(financials.summaries).toEqual([regularSummary, recoverySummary]);
+    expect(financials.currentBitcoinDebt).toBe(60n);
+    expect(financials.hodlingInvestments).toEqual([]);
+    const recoveryPosition = financials.positions.find(position => position.id === `bitcoin-asset:${record.uuid}`);
+    expect(recoveryPosition).toMatchObject({ kind: 'bitcoin-asset', lock: record, currentValue: 110n });
+    if (recoveryPosition?.kind !== 'bitcoin-asset') throw new Error('Expected recovering Bitcoin asset position');
+    expect(recoveryPosition.investedCost).toBeUndefined();
+    expect(recoveryPosition.paidIncome).toBe(68n);
+    expect(recoveryPosition.performanceEndingCapital).toBeUndefined();
 
     delete record.isHistoryRecoveryPending;
     expect(store.getAllLocks()).toEqual([regularRecord, record]);
@@ -934,7 +993,7 @@ describe('BitcoinLocks recovery', () => {
     expect(syncCosignCounterSubscriptions).toHaveBeenCalledOnce();
   });
 
-  it('keeps recovered expired locks in history without processing them as active', async () => {
+  it('keeps recovered expired locks retired during a full history replay', async () => {
     const store = createStore();
     const record = createLock({
       uuid: 'expired-lock',
@@ -943,13 +1002,22 @@ describe('BitcoinLocks recovery', () => {
       createdAt: '2026-01-01T00:00:00Z',
     });
     record.removalReason = 'expired';
+    record.isHistoryRecoveryPending = true;
     store.data.locksByUtxoId[7] = record;
+
+    const setHistoryRecoveryPending = vi.fn();
+    const setStatus = vi.fn();
+    vi.spyOn(store, 'getTable').mockResolvedValue({ setHistoryRecoveryPending, setStatus } as never);
+
+    await store.recovery.beginHistoryReplay({ lockScope: 'all' });
+    await store.recovery.commitHistoryReplay();
 
     expect(store.getActiveLocks()).toEqual([]);
     expect(store.getAllLocks()).toEqual([record]);
     expect(store.getLockByUtxoId(7)).toBe(record);
-    const setStatus = vi.fn();
-    vi.spyOn(store, 'getTable').mockResolvedValue({ setStatus } as never);
+    expect(record.isHistoryRecoveryPending).toBeUndefined();
+    expect(setHistoryRecoveryPending).toHaveBeenCalledWith(record.uuid, false);
+    expect(setHistoryRecoveryPending).not.toHaveBeenCalledWith(record.uuid, true);
 
     await store.syncLockReleaseStatusFromFundingRecord(record, {
       status: BitcoinUtxoStatus.ReleaseIsProcessingOnBitcoin,

--- a/src-vue/__test__/FinancialHistoryImporter.test.ts
+++ b/src-vue/__test__/FinancialHistoryImporter.test.ts
@@ -129,63 +129,99 @@ describe('FinancialHistoryImporter', () => {
     expect(onCheckStart).not.toHaveBeenCalled();
   });
 
-  it('restarts a loaded Bitcoin recovery when its saved lock state may be newer than its checkpoint', async () => {
-    const upsert = vi.fn(async () => undefined);
+  it('retries incomplete incremental Bitcoin history from the beginning in the same recovery', async () => {
     const beginHistoryReplay = vi.fn();
     const commitHistoryReplay = vi.fn();
-    vi.mocked(findAddressActivity).mockResolvedValueOnce({
-      asOfBlock: 100,
-      definitionVersion: 2,
-      blocks: [],
-      coverage: { fromBlock: 0, toBlock: 100, gaps: [] },
-    });
+    const recoverBlock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Bitcoin lock 44 pending mint exceeds recovered history'))
+      .mockResolvedValue(undefined);
+    vi.mocked(findAddressActivity)
+      .mockResolvedValueOnce({
+        asOfBlock: 100,
+        definitionVersion: 2,
+        blocks: [
+          {
+            blockNumber: 95,
+            blockHash: '0x95',
+            specVersion: 151,
+            activityMask: AccountActivityKind.BitcoinMint,
+          },
+        ],
+        coverage: { fromBlock: 90, toBlock: 100, gaps: [] },
+      })
+      .mockResolvedValueOnce({
+        asOfBlock: 100,
+        definitionVersion: 2,
+        blocks: [
+          {
+            blockNumber: 10,
+            blockHash: '0x10',
+            specVersion: 151,
+            activityMask: AccountActivityKind.BitcoinLock,
+          },
+          {
+            blockNumber: 95,
+            blockHash: '0x95',
+            specVersion: 151,
+            activityMask: AccountActivityKind.BitcoinMint,
+          },
+        ],
+        coverage: { fromBlock: 0, toBlock: 100, gaps: [] },
+      });
 
-    await restoreFinancialHistory({
-      db: {
-        syncStateTable: {
-          get: vi.fn(async () => ({
-            accountId: '5owner',
-            asOfBlock: 90,
-            domains: ['bitcoin'],
-            domainCheckpoints: {
-              bitcoin: {
-                asOfBlock: 90,
-                definitionVersion: 2,
-                recoveryVersion: 7,
-                partialRecovery: true,
+    await expect(
+      restoreFinancialHistory({
+        db: {
+          syncStateTable: {
+            get: vi.fn(async () => ({
+              accountId: '5owner',
+              asOfBlock: 90,
+              domains: ['bitcoin'],
+              domainCheckpoints: {
+                bitcoin: { asOfBlock: 90, definitionVersion: 2, recoveryVersion: 7 },
               },
-            },
-          })),
-          upsert,
-        },
-      } as any,
-      blockWatch: {
-        finalizedBlockHeader: { blockNumber: 100 },
-        getFinalizedApi: vi.fn(async () => ({})),
-      } as any,
-      accountId: '5owner',
-      argonBonds: {} as any,
-      bitcoinLockRecovery: {
-        hasPendingHistoryRecovery: true,
-        beginHistoryReplay,
-        findMissingActiveLockIds: vi.fn(async () => []),
-        commitHistoryReplay,
-        cancelHistoryReplay: vi.fn(),
-      } as any,
-      vaultHistory: {} as any,
-      enabledDomains: ['bitcoin'],
-      recoverMissingCheckpointsFor: ['bitcoin'],
-      minimumAsOfBlock: 100,
-    });
+            })),
+            upsert: vi.fn(async () => undefined),
+          },
+        } as any,
+        blockWatch: {
+          finalizedBlockHeader: { blockNumber: 100 },
+          getHeader: vi.fn(async ({ blockNumber, blockHash }) => ({ blockNumber, blockHash })),
+          getEventsWithSpec: vi.fn(async () => ({ events: [], specVersion: 151 })),
+          getFinalizedApi: vi.fn(async () => ({})),
+        } as any,
+        accountId: '5owner',
+        argonBonds: {} as any,
+        bitcoinLockRecovery: {
+          hasPendingHistoryRecovery: false,
+          beginHistoryReplay,
+          recoverBlock,
+          findMissingActiveLockIds: vi.fn(async () => []),
+          commitHistoryReplay,
+          cancelHistoryReplay: vi.fn(),
+        } as any,
+        vaultHistory: {} as any,
+        enabledDomains: ['bitcoin'],
+        recoverMissingCheckpointsFor: ['bitcoin'],
+        minimumAsOfBlock: 100,
+      }),
+    ).resolves.toEqual({ importedBlockCount: 2, asOfBlock: 100, targetBlock: 100 });
 
-    expect(findAddressActivity).toHaveBeenCalledWith('5owner', {
+    expect(findAddressActivity).toHaveBeenNthCalledWith(1, '5owner', {
+      afterBlock: 90,
+      toBlock: 100,
+      activityMask: AccountActivityKind.BitcoinLock | AccountActivityKind.BitcoinMint,
+    });
+    expect(findAddressActivity).toHaveBeenNthCalledWith(2, '5owner', {
       afterBlock: 0,
       toBlock: 100,
       activityMask: AccountActivityKind.BitcoinLock | AccountActivityKind.BitcoinMint,
     });
-    expect(beginHistoryReplay).toHaveBeenCalledWith({ lockScope: 'pending' });
-    expect(commitHistoryReplay).toHaveBeenCalledWith(true);
-    expect(upsert).toHaveBeenCalledOnce();
+    expect(beginHistoryReplay).toHaveBeenNthCalledWith(1, { lockScope: 'encountered' });
+    expect(beginHistoryReplay).toHaveBeenNthCalledWith(2, { lockScope: 'all' });
+    expect(commitHistoryReplay).toHaveBeenNthCalledWith(1, false);
+    expect(commitHistoryReplay).toHaveBeenNthCalledWith(2, true);
   });
 
   it('repairs only pending Bitcoin locks when a fresh wallet has no recovery checkpoint', async () => {

--- a/src-vue/__test__/Financials.loading.test.ts
+++ b/src-vue/__test__/Financials.loading.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => {
       createLockSummary: vi.fn((_lock: object) => createBitcoinSummary(0n)),
       createLockSummaryAt: vi.fn(async (_lock: object, _api: object) => createBitcoinSummary(0n)),
       isLockedStatus: vi.fn(() => true),
+      isFinishedStatus: vi.fn(() => false),
       isReleaseStatus: vi.fn(() => false),
       isInactiveForVaultDisplay: vi.fn(() => false),
       refreshLockSummary: vi.fn(),
@@ -235,7 +236,9 @@ describe('financials store lifecycle', () => {
     mocks.bitcoinLocks.createLockSummaryAt.mockImplementation(async () => createBitcoinSummary(0n));
     mocks.bitcoinLocks.createLockSummaryAt.mockClear();
     mocks.bitcoinLocks.isLockedStatus.mockReturnValue(true);
+    mocks.bitcoinLocks.isFinishedStatus.mockReturnValue(false);
     mocks.bitcoinLocks.isReleaseStatus.mockReturnValue(false);
+    mocks.bitcoinLocks.isInactiveForVaultDisplay.mockReturnValue(false);
     mocks.vaults.load.mockResolvedValue();
     mocks.vaultingStats.argonBurnCapacity = 0;
     mocks.vaultingStats.microgonValueInVaults = 0n;
@@ -699,6 +702,40 @@ describe('financials store lifecycle', () => {
     expect(financials.savingsIsLoaded).toBe(false);
   });
 
+  it('archives funded Bitcoin history without presenting abandoned lock requests as transactions', () => {
+    const baseSummary = createBitcoinSummary(0n);
+    const abandonedSummary = {
+      ...baseSummary,
+      uuid: 'abandoned-lock-request',
+      status: 'LockExpiredWaitingForFundingAcknowledged',
+      record: {
+        ...baseSummary.record,
+        uuid: 'abandoned-lock-request',
+        status: 'LockExpiredWaitingForFundingAcknowledged',
+      },
+    };
+    const releasedSummary = {
+      ...baseSummary,
+      uuid: 'released-lock',
+      status: 'Released',
+      record: {
+        ...baseSummary.record,
+        uuid: 'released-lock',
+        status: 'Released',
+        removalReason: 'released',
+      },
+    };
+    mocks.bitcoinLocks.getAllLocks.mockReturnValue([abandonedSummary.record, releasedSummary.record]);
+    mocks.bitcoinLocks.createLockSummary.mockImplementation(lock => {
+      return lock === abandonedSummary.record ? abandonedSummary : releasedSummary;
+    });
+    mocks.bitcoinLocks.isInactiveForVaultDisplay.mockReturnValue(true);
+
+    const financials = useFinancials();
+
+    expect(financials.liquidInvisibleRecords).toEqual([releasedSummary]);
+  });
+
   it('requests recovery when live wallet tracking reports a history gap', async () => {
     mocks.config.hasExtensionTreasury = true;
 
@@ -720,16 +757,29 @@ describe('financials store lifecycle', () => {
     expect(mocks.restoreFinancialHistory).toHaveBeenCalledWith(expect.objectContaining({ minimumAsOfBlock: 10 }));
   });
 
-  it('keeps local positions available while recovery is unavailable', async () => {
+  it('publishes repaired positions when later history recovery fails', async () => {
+    const staleSummary = {
+      ...createBitcoinSummary(0n),
+      totalFees: 6_059_946n,
+    };
+    const recoveredSummary = {
+      ...staleSummary,
+      totalFees: 59_946n,
+    };
     mocks.config.hasExtensionTreasury = true;
     mocks.config.walletAccountsHadPreviousLife = true;
     mocks.needsFinancialHistoryRecovery.mockResolvedValue(true);
     mocks.restoreFinancialHistory.mockRejectedValue(new Error('indexer unavailable'));
+    mocks.bitcoinLocks.getAllLocks.mockReturnValue([staleSummary.record]);
+    mocks.bitcoinLocks.createLockSummaryAt.mockResolvedValueOnce(staleSummary).mockResolvedValue(recoveredSummary);
 
     const financials = useFinancials();
 
     await vi.waitFor(() => {
       expect(financials.historyRecovery.state).toBe('error');
+    });
+    await vi.waitFor(() => {
+      expect(financials.bitcoinLockDisplayRecords[0]?.totalFees).toBe(59_946n);
     });
     expect(financials.financialPositionAggregate.groupSummaries.liquid.state).toBe('ready');
   });

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -36,6 +36,7 @@ type IMyVaultTestTarget = {
   updateCollectDeadlines(): void;
   trackTxResultFee(txResult: unknown): Promise<void>;
   recordFee(txResult: { finalFee?: bigint; finalFeeTip?: bigint }): void;
+  onVaultCreated(txInfo: TransactionInfo<{ masterXpubPath: string }>): Promise<Vault>;
 };
 
 describe('MyVaultRecovery', () => {
@@ -1412,7 +1413,7 @@ describe('MyVault cosign recovery', () => {
     getMainchainClient.mockRestore();
   });
 
-  it('records finalized vault capital from the resulting vault state', async () => {
+  it('records finalized vault capital from the resulting vault state after re-inclusion', async () => {
     const capitalInsert = vi.fn(async () => undefined);
     const walletKeys = createMockWalletKeys();
     const api = {
@@ -1447,7 +1448,7 @@ describe('MyVault cosign recovery', () => {
 
     await myVault.recordFinalizedVaultCapital({
       tx: { blockHeight: 55, blockHash: '0x55', blockExtrinsicIndex: 2 },
-      txResult: { waitForFinalizedBlock: Promise.resolve(new Uint8Array()) },
+      txResult: { waitForFinalizedBlock: Promise.resolve(new Uint8Array([0xfa])) },
     } as any);
 
     expect(myVault.data.createdVault).toBe(liveVault);
@@ -1461,8 +1462,64 @@ describe('MyVault cosign recovery', () => {
         eventType: 'modified',
         securitization: 900n,
         securitizationTarget: 700n,
-        blockHash: '0x55',
+        blockHash: '0xfa',
         extrinsicIndex: 2,
+      }),
+    );
+    getVault.mockRestore();
+    getMainchainClient.mockRestore();
+  });
+
+  it('records a created vault against the finalized block after re-inclusion', async () => {
+    const capitalInsert = vi.fn(async () => undefined);
+    const metadataInsert = vi.fn(async () => ({ id: 7 }));
+    const finalizedBlockHash = new Uint8Array([0xfa]);
+    const vault = {
+      vaultId: 7,
+      securitization: 4_000n,
+    } as Vault;
+    const postProcessor = { resolve: vi.fn(), reject: vi.fn() };
+    const txInfo = {
+      tx: {
+        blockHash: '0xstale',
+        blockExtrinsicIndex: 5,
+        metadataJson: { masterXpubPath: '//vault' },
+      },
+      txResult: {
+        waitForFinalizedBlock: Promise.resolve(finalizedBlockHash),
+        events: [{ data: { vaultId: numberCodec(7) } }],
+        finalFee: 10n,
+      },
+      createPostProcessor: vi.fn(() => postProcessor),
+    } as unknown as TransactionInfo<{ masterXpubPath: string }>;
+    const api = {
+      query: {
+        system: { number: vi.fn(async () => numberCodec(55)) },
+      },
+    };
+    const client = {
+      at: vi.fn(async () => api),
+      events: {
+        vaults: {
+          VaultCreated: { is: vi.fn(() => true) },
+        },
+      },
+    };
+    const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue(client as any);
+    const getVault = vi.spyOn(Vault, 'get').mockResolvedValue(vault);
+    const { myVault } = createVault({
+      db: {
+        vaultsTable: { insert: metadataInsert },
+        vaultCapitalHistoryTable: { insert: capitalInsert },
+      },
+    });
+
+    await (myVault as unknown as IMyVaultTestTarget).onVaultCreated(txInfo);
+
+    expect(capitalInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'created',
+        blockHash: '0xfa',
       }),
     );
     getVault.mockRestore();

--- a/src-vue/__test__/VaultRevenueEventsTable.test.ts
+++ b/src-vue/__test__/VaultRevenueEventsTable.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createTestDb } from './helpers/db.ts';
 
 describe('VaultRevenueEventsTable', () => {
-  it('uses one collection per block while preserving pre-extrinsic history', async () => {
+  it('uses one collection per block while preserving distinct burns and pre-extrinsic history', async () => {
     const db = await createTestDb();
     const event = {
       amount: 20_000_000n,
@@ -17,6 +17,28 @@ describe('VaultRevenueEventsTable', () => {
     expect(db.vaultRevenueEventsTable.revision).toBe(1);
     await db.vaultRevenueEventsTable.insert({ ...event, amount: 5_000_000n, extrinsicIndex: 3 });
     expect(db.vaultRevenueEventsTable.revision).toBe(1);
+    await db.vaultRevenueEventsTable.insert({
+      ...event,
+      amount: 25_000_000n,
+      blockHash: '0xcanonical101',
+      extrinsicIndex: 2,
+    });
+    expect(db.vaultRevenueEventsTable.revision).toBe(2);
+
+    await db.vaultRevenueEventsTable.insert({
+      ...event,
+      amount: 7_000_000n,
+      source: 'vaultBurn',
+      blockNumber: 102,
+      blockHash: '0xblock102',
+    });
+    await db.vaultRevenueEventsTable.insert({
+      ...event,
+      amount: 8_000_000n,
+      source: 'vaultBurn',
+      blockNumber: 102,
+      blockHash: '0xblock102',
+    });
 
     await db.execute(
       `INSERT INTO VaultRevenueEvents (amount, source, blockNumber, blockHash)
@@ -33,12 +55,21 @@ describe('VaultRevenueEventsTable', () => {
     });
 
     const records = await db.vaultRevenueEventsTable.fetchAll();
-    expect(records).toHaveLength(2);
-    expect(records.reduce((total, record) => total + record.amount, 0n)).toBe(119_000_000n);
+    expect(records).toHaveLength(4);
+    expect(records.reduce((total, record) => total + record.amount, 0n)).toBe(139_000_000n);
     expect(records[0]).toMatchObject({
       amount: 99_000_000n,
       blockTime: new Date('2026-01-01T00:00:00Z'),
       extrinsicIndex: 4,
     });
+    expect(records[1]).toMatchObject({
+      amount: 25_000_000n,
+      blockHash: '0xcanonical101',
+      extrinsicIndex: 2,
+    });
+    expect(records.slice(2)).toMatchObject([
+      { amount: 7_000_000n, source: 'vaultBurn', blockNumber: 102 },
+      { amount: 8_000_000n, source: 'vaultBurn', blockNumber: 102 },
+    ]);
   });
 });

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -170,6 +170,7 @@ export default class BitcoinLocks {
     mismatchErrorsByLockUtxoId: { [lockUtxoId: number]: string };
     oracleBitcoinBlockHeight: number;
     bitcoinNetwork: BitcoinNetwork;
+    isReconciliationPending: boolean;
     latestArgonBlock?: Pick<IBlockHeaderInfo, 'blockNumber' | 'blockHash'>;
   };
 
@@ -211,8 +212,6 @@ export default class BitcoinLocks {
   #relayPollingUuids = new Set<string>();
   #mempool: BitcoinMempool;
   #reportedMissingFundingForReleaseLocks = new Set<string>();
-  #needsLoadReconciliation = false;
-
   constructor(
     private readonly dbPromise: Promise<Db>,
     private readonly walletKeys: WalletKeys,
@@ -230,6 +229,7 @@ export default class BitcoinLocks {
       mismatchErrorsByLockUtxoId: {},
       oracleBitcoinBlockHeight: 0,
       bitcoinNetwork: BitcoinNetwork.Bitcoin,
+      isReconciliationPending: false,
     };
     this.#mempool = mempool;
     this.utxoTracking = new BitcoinUtxoTracking({
@@ -583,7 +583,7 @@ export default class BitcoinLocks {
       await this.orphanReleases.syncCosignCounterSubscriptions(archiveClient).catch(error => {
         console.warn('[BitcoinLocks] Unable to watch orphan return counters', error);
       });
-      this.#needsLoadReconciliation = true;
+      this.data.isReconciliationPending = true;
       const initialBestBlock = this.blockWatch.bestBlockHeader;
       void this.#blockQueue
         .add(async () => {
@@ -616,7 +616,7 @@ export default class BitcoinLocks {
   }
 
   private async runPendingLoadReconciliation(): Promise<void> {
-    if (!this.#needsLoadReconciliation) {
+    if (!this.data.isReconciliationPending) {
       return;
     }
 
@@ -635,7 +635,7 @@ export default class BitcoinLocks {
       }
       await this.syncLockReleaseBitcoinProcessing(this.locksByUtxoId);
       await this.orphanReleases.syncBitcoinProcessing(this.oracleBitcoinBlockHeight);
-      this.#needsLoadReconciliation = false;
+      this.data.isReconciliationPending = false;
     } catch (error) {
       console.warn('[BitcoinLocks] Startup reconciliation did not finish; will retry on the next block', error);
     }
@@ -3116,7 +3116,7 @@ export default class BitcoinLocks {
     }
     if (!locks.length) return;
 
-    this.#needsLoadReconciliation = true;
+    this.data.isReconciliationPending = true;
     void this.#blockQueue
       .add(async () => {
         try {

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -1435,7 +1435,7 @@ export class MyVault {
         securitization: vault.securitization,
         securitizationTarget: bigIntMax(vault.securitization - vault.getRelockCapacity(), 0n),
         blockNumber: blockNumber.toNumber(),
-        blockHash: txInfo.tx.blockHash ?? u8aToHex(finalizedBlockHash),
+        blockHash: u8aToHex(finalizedBlockHash),
         blockTime: new Date(block.blockTime),
         extrinsicIndex: txInfo.tx.blockExtrinsicIndex ?? txInfo.txResult.extrinsicIndex,
       });
@@ -1472,7 +1472,7 @@ export class MyVault {
             amount: revenue,
             source: 'vaultCollect',
             blockNumber,
-            blockHash: txInfo.tx.blockHash ?? u8aToHex(finalizedBlockHash),
+            blockHash: u8aToHex(finalizedBlockHash),
             blockTime: new Date(block.blockTime),
             extrinsicIndex: txInfo.tx.blockExtrinsicIndex ?? txResult.extrinsicIndex,
           });
@@ -1609,9 +1609,9 @@ export class MyVault {
     const postProcessor = txInfo.createPostProcessor();
     try {
       const client = await getMainchainClient(true);
-      const blockHash = await txResult.waitForFinalizedBlock;
+      const finalizedBlockHash = await txResult.waitForFinalizedBlock;
       await this.#transactionTracker.ensureStoredEvents(txInfo);
-      const api = await client.at(blockHash);
+      const api = await client.at(finalizedBlockHash);
       const blockNumber = await api.query.system.number();
       let vaultId: number | undefined;
       for (const event of txResult.events) {
@@ -1640,7 +1640,7 @@ export class MyVault {
           vaultId,
           securitization: vault.securitization,
           blockNumber: blockNumber.toNumber(),
-          blockHash: tx.blockHash ?? u8aToHex(blockHash),
+          blockHash: u8aToHex(finalizedBlockHash),
           blockTime: new Date(block.blockTime),
           extrinsicIndex: tx.blockExtrinsicIndex ?? txResult.extrinsicIndex,
         });

--- a/src-vue/lib/db/VaultRevenueEventsTable.ts
+++ b/src-vue/lib/db/VaultRevenueEventsTable.ts
@@ -30,9 +30,15 @@ export class VaultRevenueEventsTable extends BaseTable {
         (amount, source, blockNumber, blockHash, blockTime, extrinsicIndex)
         VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT DO UPDATE SET
-          blockTime = COALESCE(VaultRevenueEvents.blockTime, excluded.blockTime),
-          extrinsicIndex = COALESCE(VaultRevenueEvents.extrinsicIndex, excluded.extrinsicIndex)
-        WHERE (VaultRevenueEvents.blockTime IS NULL AND excluded.blockTime IS NOT NULL)
+          amount = CASE
+            WHEN VaultRevenueEvents.blockHash != excluded.blockHash THEN excluded.amount
+            ELSE VaultRevenueEvents.amount
+          END,
+          blockHash = excluded.blockHash,
+          blockTime = COALESCE(excluded.blockTime, VaultRevenueEvents.blockTime),
+          extrinsicIndex = COALESCE(excluded.extrinsicIndex, VaultRevenueEvents.extrinsicIndex)
+        WHERE VaultRevenueEvents.blockHash != excluded.blockHash
+           OR (VaultRevenueEvents.blockTime IS NULL AND excluded.blockTime IS NOT NULL)
            OR (VaultRevenueEvents.extrinsicIndex IS NULL AND excluded.extrinsicIndex IS NOT NULL)
         RETURNING *;`,
       toSqlParams([amount, source, blockNumber, blockHash, blockTime, extrinsicIndex]),

--- a/src-vue/lib/db/VaultRevenueEventsTable.ts
+++ b/src-vue/lib/db/VaultRevenueEventsTable.ts
@@ -31,13 +31,13 @@ export class VaultRevenueEventsTable extends BaseTable {
         VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT DO UPDATE SET
           amount = CASE
-            WHEN VaultRevenueEvents.blockHash != excluded.blockHash THEN excluded.amount
+            WHEN VaultRevenueEvents.blockHash IS NOT excluded.blockHash THEN excluded.amount
             ELSE VaultRevenueEvents.amount
           END,
           blockHash = excluded.blockHash,
           blockTime = COALESCE(excluded.blockTime, VaultRevenueEvents.blockTime),
           extrinsicIndex = COALESCE(excluded.extrinsicIndex, VaultRevenueEvents.extrinsicIndex)
-        WHERE VaultRevenueEvents.blockHash != excluded.blockHash
+        WHERE VaultRevenueEvents.blockHash IS NOT excluded.blockHash
            OR (VaultRevenueEvents.blockTime IS NULL AND excluded.blockTime IS NOT NULL)
            OR (VaultRevenueEvents.extrinsicIndex IS NULL AND excluded.extrinsicIndex IS NOT NULL)
         RETURNING *;`,

--- a/src-vue/lib/financials/BitcoinLocks.ts
+++ b/src-vue/lib/financials/BitcoinLocks.ts
@@ -3,6 +3,7 @@ import {
   createFinancialPosition,
   type IBitcoinAssetFinancialPosition,
   type IBitcoinLiabilityFinancialPosition,
+  withInvestmentBasis,
 } from '../../interfaces/IFinancialPosition.ts';
 import type { IBitcoinLockSummary } from '../../interfaces/IBitcoinLockSummary.ts';
 import type { IBitcoinLockRecord } from '../../interfaces/IBitcoinLockRecord.ts';
@@ -37,7 +38,9 @@ export class BitcoinFinancials {
     await this.locks.load();
 
     const summaries = await Promise.all(
-      this.locks.getAllLocks().map(lock => this.locks.createLockSummaryAt(lock, args.clientAt)),
+      this.locks
+        .getAllLocks({ includeHistoryRecoveryPending: true })
+        .map(lock => this.locks.createLockSummaryAt(lock, args.clientAt)),
     );
     const hodlingInvestments: IPerformanceReturnInput[] = [];
     let currentBitcoinDebt = 0n;
@@ -46,7 +49,11 @@ export class BitcoinFinancials {
       const lock = summary.record;
 
       if (this.locks.isLockedStatus(lock)) currentBitcoinDebt += summary.unlockAmount;
-      if ((this.locks.isLockedStatus(lock) || this.locks.isReleaseStatus(lock)) && lock.ratchets[0]) {
+      if (
+        !lock.isHistoryRecoveryPending &&
+        (this.locks.isLockedStatus(lock) || this.locks.isReleaseStatus(lock)) &&
+        lock.ratchets[0]
+      ) {
         hodlingInvestments.push({
           startingDate: lock.createdAt,
           // Hodling compares BTC market movement; this is not the Bitcoin locking profit basis.
@@ -81,6 +88,7 @@ function createBitcoinLockPositions(
 ): BitcoinFinancialPosition[] {
   const { record } = summary;
   const paidIncome = summary.receivedLiquidity - summary.totalFees;
+  const hasConfirmedLockHistory = !record.isHistoryRecoveryPending;
 
   if (record.removalReason || summary.status === BitcoinLockStatus.Released) {
     if (record.removalReason === 'spent' && summary.pendingLiquidity === 0n) return [];
@@ -93,9 +101,10 @@ function createBitcoinLockPositions(
     const releaseRedemption = record.releaseRedemptionMicrogons ?? undefined;
     const releaseArgonTxFee = record.releaseArgonTxFeeMicrogons ?? undefined;
     const historicalTotalFees = summary.historicalTotalFees;
-    const releaseCompensation = hasConfirmedHistoryCoverage
-      ? (record.releaseCompensationMicrogons ?? 0n)
-      : (record.releaseCompensationMicrogons ?? undefined);
+    const releaseCompensation =
+      hasConfirmedHistoryCoverage && hasConfirmedLockHistory
+        ? (record.releaseCompensationMicrogons ?? 0n)
+        : (record.releaseCompensationMicrogons ?? undefined);
     const releasePaidIncome =
       releaseArgonTxFee !== undefined && releaseCompensation !== undefined
         ? paidIncome - releaseArgonTxFee + releaseCompensation
@@ -107,6 +116,7 @@ function createBitcoinLockPositions(
     if (
       isReleased &&
       hasConfirmedHistoryCoverage &&
+      hasConfirmedLockHistory &&
       record.removalBlockTime !== undefined &&
       removalBtcValue !== undefined &&
       releaseRedemption !== undefined &&
@@ -175,16 +185,19 @@ function createBitcoinLockPositions(
         id: `bitcoin-asset:${record.uuid}`,
         label: 'Locked Bitcoin',
         lifecycle: isReleasing ? 'releasing' : 'active',
-        performanceEndingCapital: summary.endingCapital,
+        ...(hasConfirmedLockHistory ? { performanceEndingCapital: summary.endingCapital } : {}),
         startedAt: record.createdAt,
         lock: summary.record,
       },
-      {
-        currentValue,
-        investedCost: summary.startingCapital,
-        paidIncome,
-        settledPrincipalValue: 0n,
-      },
+      withInvestmentBasis(
+        {
+          currentValue,
+          investedCost: summary.startingCapital,
+          paidIncome,
+          settledPrincipalValue: 0n,
+        },
+        hasConfirmedLockHistory,
+      ),
     ),
     createFinancialPosition('bitcoin-liability', {
       id: `bitcoin-liability:${record.uuid}`,

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -91,6 +91,7 @@ export class BitcoinLockRecovery {
 
   public get hasPendingHistoryRecovery(): boolean {
     return (
+      this.historyReplayLocksByUtxoId !== undefined ||
       this.activeLockRecoveryFailedUtxoIds.size > 0 ||
       [...Object.values(this.locksByUtxoId), ...this.pendingLocks].some(lock => lock.isHistoryRecoveryPending)
     );
@@ -104,8 +105,18 @@ export class BitcoinLockRecovery {
     this.historyReplayLocksByUtxoId = {};
     this.historyReplayLockScope = lockScope;
     if (lockScope !== 'all') this.activeLocksByUtxoId.clear();
+    let table: BitcoinLocksTable | undefined;
     for (const lock of [...Object.values(this.locksByUtxoId), ...this.pendingLocks]) {
       if (!lock.isHistoryRecoveryPending) continue;
+
+      if (this.isRetiredHistoryRecord(lock)) {
+        table ??= await this.getTable();
+        await table.setHistoryRecoveryPending(lock.uuid, false);
+        delete lock.isHistoryRecoveryPending;
+        this.historyRecoveryPendingUuids.delete(lock.uuid);
+        if (lock.utxoId !== undefined) this.historyRecoveryPendingUtxoIds.delete(lock.utxoId);
+        continue;
+      }
 
       this.historyRecoveryPendingUuids.add(lock.uuid);
       if (lock.utxoId !== undefined) this.historyRecoveryPendingUtxoIds.add(lock.utxoId);
@@ -190,7 +201,12 @@ export class BitcoinLockRecovery {
       completedLocks.push(liveLock);
     }
     this.activeLocksByUtxoId.clear();
-    this.onHistoryRecoveryComplete(completedLocks);
+    const reconciliationLocksByUuid = new Map(completedLocks.map(lock => [lock.uuid, lock]));
+    for (const utxoId of orphanLifecycleLockUtxoIds) {
+      const lock = this.locksByUtxoId[utxoId];
+      if (lock) reconciliationLocksByUuid.set(lock.uuid, lock);
+    }
+    this.onHistoryRecoveryComplete([...reconciliationLocksByUuid.values()]);
   }
 
   public async cancelHistoryReplay(): Promise<void> {
@@ -313,7 +329,7 @@ export class BitcoinLockRecovery {
             lockQueueOwnerUuid: options.lockQueueOwnerUuid,
           }));
         const recovered = this.createDetachedRecord(record);
-        recovered.status = BitcoinLockStatus.LockPendingFunding;
+        if (!this.isRetiredHistoryRecord(recovered)) recovered.status = BitcoinLockStatus.LockPendingFunding;
         recovered.satoshis = chainLock.satoshis;
         recovered.liquidityPromised = chainLock.liquidityPromised;
         recovered.lockedTargetPrice = chainLock.lockedTargetPrice;
@@ -818,7 +834,7 @@ export class BitcoinLockRecovery {
     }
     const mintAmount = isUpRatchet ? cumulativeLiquidity - previousLiquidity : cumulativeLiquidity;
     const burned = readRequiredEventBigInt(event, ['amountBurned'], block);
-    if (recovered.status !== BitcoinLockStatus.Released && recovered.status !== BitcoinLockStatus.Releasing) {
+    if (!this.isRetiredHistoryRecord(recovered) && recovered.status !== BitcoinLockStatus.Releasing) {
       recovered.status = BitcoinLockStatus.LockedAndIsMinting;
     }
 
@@ -870,17 +886,22 @@ export class BitcoinLockRecovery {
   private applyRecoveredRecord(recovered: IBitcoinLockRecord): IBitcoinLockRecord {
     const utxoId = recovered.utxoId!;
     const stagedLocks = this.historyReplayLocksByUtxoId;
-    if (stagedLocks) {
-      recovered.isHistoryRecoveryPending = true;
-      this.historyRecoveryPendingUtxoIds.add(utxoId);
-      this.historyRecoveryPendingUuids.add(recovered.uuid);
-    }
     const liveRecord = this.locksByUtxoId[utxoId];
     const current =
       stagedLocks?.[utxoId] ?? (stagedLocks && liveRecord ? this.createDetachedRecord(liveRecord) : liveRecord);
+    const retiredStatus = current && this.isRetiredHistoryRecord(current) ? current.status : undefined;
+    if (stagedLocks && retiredStatus === undefined && !this.isRetiredHistoryRecord(recovered)) {
+      recovered.isHistoryRecoveryPending = true;
+      this.historyRecoveryPendingUtxoIds.add(utxoId);
+      this.historyRecoveryPendingUuids.add(recovered.uuid);
+    } else if (retiredStatus !== undefined) {
+      recovered.status = retiredStatus;
+      delete recovered.isHistoryRecoveryPending;
+    }
     if (current) {
       recovered.fundingUtxoRecord ??= current.fundingUtxoRecord;
       Object.assign(current, recovered);
+      if (retiredStatus !== undefined) current.status = retiredStatus;
       if (stagedLocks) stagedLocks[utxoId] = current;
       return current;
     }
@@ -898,7 +919,9 @@ export class BitcoinLockRecovery {
     if (!this.historyReplayLocksByUtxoId) return;
 
     const utxoId = lock.utxoId;
-    if (utxoId === undefined || this.historyRecoveryPendingUtxoIds.has(utxoId)) return;
+    if (utxoId === undefined || this.historyRecoveryPendingUtxoIds.has(utxoId) || this.isRetiredHistoryRecord(lock)) {
+      return;
+    }
 
     const activeLock = this.activeLocksByUtxoId.get(utxoId);
     if (
@@ -949,6 +972,19 @@ export class BitcoinLockRecovery {
     }
 
     if (completedLocks.length) this.onHistoryRecoveryComplete(completedLocks);
+  }
+
+  private isRetiredHistoryRecord(lock: Pick<IBitcoinLockRecord, 'status' | 'removalReason'>): boolean {
+    return (
+      !!lock.removalReason ||
+      [
+        BitcoinLockStatus.Released,
+        BitcoinLockStatus.LockExpiredWaitingForFunding,
+        BitcoinLockStatus.LockExpiredWaitingForFundingAcknowledged,
+        BitcoinLockStatus.LockFailed,
+        BitcoinLockStatus.LockFailedAcknowledged,
+      ].includes(lock.status)
+    );
   }
 
   private hasCompleteRatchetEconomics(

--- a/src-vue/lib/recovery/index.ts
+++ b/src-vue/lib/recovery/index.ts
@@ -167,39 +167,46 @@ export async function restoreFinancialHistory(args: {
   };
 
   for (const domain of domainsToRestore) {
-    const checkpoint = domainCheckpoints[domain];
+    let checkpoint = domainCheckpoints[domain];
     const isBitcoinReplay = domain === 'bitcoin' && !!bitcoinLockRecovery;
     args.onProgress?.(importedBlockCount);
 
     try {
-      const result = await restoreFinancialHistoryDomain({
-        db,
-        blockWatch,
-        accountId,
-        argonBonds,
-        bitcoinLockRecovery,
-        vaultHistory,
-        domain,
-        checkpoint,
-        recoverMissingCheckpointsFor: args.recoverMissingCheckpointsFor,
-        mainchainClients: args.mainchainClients,
-        force: args.force,
-        targetBlock,
-        onActiveBitcoinLocksFound: args.onActiveBitcoinLocksFound,
-        onProgress: (recoveredBlockCount, totalBlockCount) =>
-          args.onProgress?.(importedBlockCount + recoveredBlockCount, {
-            domain,
-            recoveredBlockCount,
-            totalBlockCount,
-          }),
-        onCheckpoint: checkpoint => saveDomainCheckpoint(domain, checkpoint),
-      });
-      importedBlockCount += result.importedBlockCount;
+      let result!: Awaited<ReturnType<typeof restoreFinancialHistoryDomain>>;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        result = await restoreFinancialHistoryDomain({
+          db,
+          blockWatch,
+          accountId,
+          argonBonds,
+          bitcoinLockRecovery,
+          vaultHistory,
+          domain,
+          checkpoint,
+          recoverMissingCheckpointsFor: args.recoverMissingCheckpointsFor,
+          mainchainClients: args.mainchainClients,
+          force: args.force,
+          targetBlock,
+          onActiveBitcoinLocksFound: args.onActiveBitcoinLocksFound,
+          onProgress: (recoveredBlockCount, totalBlockCount) =>
+            args.onProgress?.(importedBlockCount + recoveredBlockCount, {
+              domain,
+              recoveredBlockCount,
+              totalBlockCount,
+            }),
+          onCheckpoint: checkpoint => saveDomainCheckpoint(domain, checkpoint),
+        });
 
-      if (isBitcoinReplay) {
-        await bitcoinLockRecovery.commitHistoryReplay(!result.error && result.checkpoint.asOfBlock >= targetBlock);
+        if (isBitcoinReplay) {
+          await bitcoinLockRecovery.commitHistoryReplay(!result.error && result.checkpoint.asOfBlock >= targetBlock);
+        }
+        await saveDomainCheckpoint(domain, result.checkpoint);
+
+        if (attempt > 0 || !isBitcoinReplay || !result.retryFromStart) break;
+        checkpoint = result.checkpoint;
       }
-      await saveDomainCheckpoint(domain, result.checkpoint);
+
+      importedBlockCount += result.importedBlockCount;
       if (result.error) throw new Error(result.error);
     } catch (error) {
       if (isBitcoinReplay) {
@@ -418,12 +425,19 @@ async function restoreFinancialHistoryDomain(args: {
   onActiveBitcoinLocksFound?: (count: number) => void;
   onProgress?: (importedBlockCount: number, totalBlockCount: number) => void;
   onCheckpoint?: (checkpoint: IFinancialHistoryCheckpoint) => Promise<void>;
-}): Promise<{ checkpoint: IFinancialHistoryCheckpoint; importedBlockCount: number; error?: string }> {
+}): Promise<{
+  checkpoint: IFinancialHistoryCheckpoint;
+  importedBlockCount: number;
+  error?: string;
+  retryFromStart?: boolean;
+}> {
   const { db, blockWatch, accountId, argonBonds, bitcoinLockRecovery, vaultHistory, domain, checkpoint } = args;
   const recoveryVersion = historyRecoveryVersions[domain];
   const recoveryVersionChanged =
     !!checkpoint && recoveryVersion !== undefined && checkpoint.recoveryVersion !== recoveryVersion;
-  const shouldRestartBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
+  const hasPendingBitcoinRecovery = domain === 'bitcoin' && bitcoinLockRecovery?.hasPendingHistoryRecovery;
+  const shouldRestartBitcoinRecovery =
+    domain === 'bitcoin' && (hasPendingBitcoinRecovery || checkpoint?.partialRecovery);
   let afterBlock =
     args.force || !checkpoint || recoveryVersionChanged || shouldRestartBitcoinRecovery ? 0 : checkpoint.asOfBlock;
 
@@ -464,7 +478,8 @@ async function restoreFinancialHistoryDomain(args: {
   if (domain === 'bitcoin' && bitcoinLockRecovery) {
     let lockScope: BitcoinHistoryReplayLockScope = afterBlock === 0 ? 'all' : 'encountered';
     const canRepairOnlyPendingLocks =
-      shouldRestartBitcoinRecovery &&
+      hasPendingBitcoinRecovery &&
+      !checkpoint?.partialRecovery &&
       !args.force &&
       !recoveryVersionChanged &&
       !definitionChanged &&
@@ -505,6 +520,7 @@ async function restoreFinancialHistoryDomain(args: {
       return {
         importedBlockCount,
         error: domainError,
+        ...(domain === 'bitcoin' && afterBlock > 0 ? { retryFromStart: true } : {}),
         checkpoint: {
           asOfBlock: Math.max(afterBlock, (result.failedAtBlock ?? afterBlock + 1) - 1),
           definitionVersion: indexedHistory.definitionVersion,

--- a/src-vue/overlays/troubleshooting/SSHAccess.vue
+++ b/src-vue/overlays/troubleshooting/SSHAccess.vue
@@ -78,7 +78,7 @@ const macLinuxCommand = Vue.computed(() => {
     'cat <<\'EOF\' > "$tmp"',
     privateKey.value.trim(),
     'EOF',
-    `ssh -i "$tmp" -p ${port} ${username}@${host}`,
+    `ssh -o IdentitiesOnly=yes -i "$tmp" -p ${port} ${username}@${host}`,
   ].join('\n');
 });
 
@@ -91,7 +91,7 @@ const windowsCommand = Vue.computed(() => {
     "@'",
     privateKey.value.trim(),
     "'@ | Set-Content -Path $path -NoNewline",
-    `ssh -i $path -p ${port} ${username}@${host}`,
+    `ssh -o IdentitiesOnly=yes -i $path -p ${port} ${username}@${host}`,
     'Remove-Item -Force $path',
   ].join('\n');
 });

--- a/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
+++ b/src-vue/screens/bitcoin-locks-screen/Dashboard.vue
@@ -17,7 +17,10 @@
       </div>
       <div class="w-1/3 border-b border-slate-400/30 py-5">
         <div class="text-argon-600 text-5xl font-bold">
-          {{ numeral(financials.liquidPerformanceReturn).format('0,0.[00]') }}%
+          <template v-if="financials.liquidPerformanceReturn !== undefined">
+            {{ numeral(financials.liquidPerformanceReturn).format('0,0.[00]') }}%
+          </template>
+          <template v-else>&mdash;</template>
         </div>
         <div class="font-light text-slate-900/70">Liquid Locking Returns</div>
       </div>
@@ -30,7 +33,10 @@
       </div>
       <div class="w-1/3 border-b border-slate-400/30 py-5">
         <div class="text-argon-600 text-5xl font-bold">
-          {{ numeral(financials.liquidHodlingReturn).format('0,0.[00]') }}%
+          <template v-if="financials.liquidHodlingReturn !== undefined">
+            {{ numeral(financials.liquidHodlingReturn).format('0,0.[00]') }}%
+          </template>
+          <template v-else>&mdash;</template>
         </div>
         <div class="font-light text-slate-900/70">Hodling Returns</div>
       </div>
@@ -220,6 +226,14 @@ const selectedLock = Vue.ref<IBitcoinLockSummary>();
 const selectedOrphan = Vue.ref<IBitcoinUtxoRecord>();
 
 const orphanRecords = Vue.computed(() => {
+  if (
+    financials.isHistoryRecoveryInProgress ||
+    bitcoinLocks.recovery.hasPendingHistoryRecovery ||
+    bitcoinLocks.data.isReconciliationPending
+  ) {
+    return [];
+  }
+
   const locks = bitcoinLocks.getAllLocks();
   const fundingRecordIds = new Set(
     locks

--- a/src-vue/screens/vaulting-screen/Dashboard.vue
+++ b/src-vue/screens/vaulting-screen/Dashboard.vue
@@ -388,6 +388,7 @@ function formatLockLabel(lock: { satoshis: bigint }): string {
 }
 
 function getLockTileStatus(lock: IBitcoinLockRecord): TileStatus {
+  if (lock.isHistoryRecoveryPending) return 'pending';
   if (bitcoinLocks.isLockedStatus(lock)) return 'active';
   if (bitcoinLocks.isReleaseStatus(lock)) return 'active';
   return 'pending';
@@ -397,7 +398,9 @@ const localVaultLocks = Vue.computed(() => {
   const vaultId = myVault.createdVault?.vaultId;
   if (!vaultId) return [];
 
-  return bitcoinLocks.getActiveLocks().filter(lock => lock.vaultId === vaultId);
+  return bitcoinLocks
+    .getAllLocks({ includeHistoryRecoveryPending: true })
+    .filter(lock => lock.vaultId === vaultId && !bitcoinLocks.isInactiveForVaultDisplay(lock));
 });
 
 const localLocksByUuid = Vue.computed(() => {
@@ -430,6 +433,8 @@ function handleBitcoinTileClick(key: string) {
   // Local lock
   const lock = localLocksByUuid.value[key];
   if (lock) {
+    if (lock.isHistoryRecoveryPending) return;
+
     if (bitcoinLocks.isLockedStatus(lock) || bitcoinLocks.isReleaseStatus(lock)) {
       openLockDetailOverlay(lock);
     } else {
@@ -483,7 +488,7 @@ const bitcoinMapItems = Vue.computed((): MapItem[] => {
       label: formatLockLabel(lock),
       amount: microgons,
       displayValue: formatMoney(microgons),
-      emphasis: bitcoinLocks.isLockedStatus(lock) ? 'strong' : 'default',
+      emphasis: bitcoinLocks.isLockedStatus(lock) && !lock.isHistoryRecoveryPending ? 'strong' : 'default',
       status: tileStatus,
     });
   }

--- a/src-vue/stores/financials.ts
+++ b/src-vue/stores/financials.ts
@@ -634,7 +634,10 @@ export const useFinancials = defineStore('financials', () => {
   });
 
   const liquidInvisibleRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
-    return bitcoinLockSummaries.value.filter(lock => bitcoinLocks.isInactiveForVaultDisplay(lock.record));
+    return bitcoinLockSummaries.value.filter(lock => {
+      if (!bitcoinLocks.isInactiveForVaultDisplay(lock.record)) return false;
+      return !!lock.record.removalReason || bitcoinLocks.isFinishedStatus(lock.record);
+    });
   });
 
   const liquidVisibleRecords = Vue.computed<IBitcoinLockSummary[]>(() => {
@@ -690,7 +693,7 @@ export const useFinancials = defineStore('financials', () => {
   });
 
   const liquidLockedRecords = Vue.computed(() => {
-    return liquidVisibleRecords.value.filter(lock => bitcoinLocks.isLockedStatus(lock.record));
+    return bitcoinLockSummaries.value.filter(lock => bitcoinLocks.isLockedStatus(lock.record));
   });
 
   const liquidTotalSatoshis = Vue.computed(() => {
@@ -698,12 +701,22 @@ export const useFinancials = defineStore('financials', () => {
   });
 
   const liquidPerformanceReturn = Vue.computed(() => {
-    return financialPositionAggregate.value.groupSummaries.bitcoin.returnSummary.percent ?? 0;
+    if (bitcoinLockDisplayRecords.value.some(lock => lock.record.isHistoryRecoveryPending)) return;
+
+    const percent = financialPositionAggregate.value.groupSummaries.bitcoin.returnSummary.percent;
+    if (bitcoinLockDisplayRecords.value.length && percent === undefined) return;
+
+    return percent ?? 0;
   });
 
   const liquidHodlingInvestments = Vue.ref<IPerformanceReturnInput[]>([]);
   const liquidHodlingReturn = Vue.computed(() => {
-    return calculatePerformanceReturn(liquidHodlingInvestments.value).percent;
+    if (bitcoinLockDisplayRecords.value.some(lock => lock.record.isHistoryRecoveryPending)) return;
+
+    const percent = calculatePerformanceReturn(liquidHodlingInvestments.value).percent;
+    if (bitcoinLockDisplayRecords.value.length && percent === undefined) return;
+
+    return percent ?? 0;
   });
 
   const liquidCurrentBitcoinDebt = Vue.ref(0n);
@@ -1080,7 +1093,6 @@ export const useFinancials = defineStore('financials', () => {
           message: `Investment history is indexed through block ${result.asOfBlock.toLocaleString()} and is still catching up`,
         };
       }
-      await queueAccountRefresh({ force: true });
       if (isRecoveryComplete) {
         historyRecovery.value = { state: 'ready', recoveredBlockCount: result.importedBlockCount };
       }
@@ -1094,6 +1106,14 @@ export const useFinancials = defineStore('financials', () => {
         };
       }
       throw error;
+    } finally {
+      // A later history domain can fail after an earlier one repaired durable records.
+      // Publish those repairs even though the overall recovery remains retryable.
+      try {
+        await queueAccountRefresh({ force: true });
+      } catch (error) {
+        console.warn('[FinancialHistory] Unable to publish recovered positions', error);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Restored accounts now publish repaired positions even when a later history domain remains retryable. Bitcoin recovery preserves retired lifecycle state, retries incomplete incremental history from the beginning, and keeps current balances visible while incomplete returns and actions remain unavailable.

Vault financial events now use finalized block hashes and safe migration identities. This prevents fork copies from inflating returns while preserving distinct capital changes and revenue burns. Generated troubleshooting SSH commands also use only the supplied temporary key, which prevents local SSH agents from exhausting authentication attempts.

## Validation

Focused recovery and financial suites pass, along with TypeScript and diff checks. The migration was also executed against a copy of the affected account database to confirm that exact fork duplicates are removed while distinct same-block records survive.
