### PR TITLE
fix: refresh app updates on manual checks

### DIFF
--- a/src-vue/__test__/AppUpdater.test.ts
+++ b/src-vue/__test__/AppUpdater.test.ts
@@ -49,3 +49,26 @@ it('blocks server installation across a UI reload after installing an app update
   expect(await isAppUpdateBlockingServerInstall()).toBe(false);
   expect(sessionValues.has('argon-app-update-requires-relaunch')).toBe(false);
 });
+
+it('lets a manual update check supersede an active background check', async () => {
+  let resolveBackgroundCheck!: (update: Awaited<ReturnType<typeof check>>) => void;
+  vi.mocked(check)
+    .mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveBackgroundCheck = resolve;
+        }),
+    )
+    .mockResolvedValueOnce({ version: '1.4.4' } as any);
+  const updater = useAppUpdater();
+
+  const backgroundCheck = updater.checkForUpdates();
+  await Promise.resolve();
+
+  const manualCheck = updater.checkForUpdates({ force: true });
+  resolveBackgroundCheck({ version: '1.4.3' } as any);
+
+  expect((await manualCheck)?.version).toBe('1.4.4');
+  await backgroundCheck;
+  expect(updater.update?.version).toBe('1.4.4');
+});

--- a/src-vue/overlays/AppUpdatesOverlay.vue
+++ b/src-vue/overlays/AppUpdatesOverlay.vue
@@ -148,16 +148,9 @@ Vue.watch(
   },
 );
 
-async function refreshUpdates() {
-  const newVersion = await updater.checkForUpdates();
-  if (newVersion) {
-    console.log(newVersion);
-  }
-}
-
 basicEmitter.on('openCheckForAppUpdatesOverlay', () => {
   isOpen.value = true;
 
-  void refreshUpdates().catch(console.error);
+  void updater.checkForUpdates({ force: true }).catch(console.error);
 });
 </script>

--- a/src-vue/stores/appUpdater.ts
+++ b/src-vue/stores/appUpdater.ts
@@ -40,6 +40,7 @@ export const useAppUpdater = defineStore('appUpdater', () => {
   let isStarted = false;
   let versionPromise: Promise<string> | null = null;
   let updateCheckPromise: Promise<AppUpdate> | null = null;
+  let latestUpdateCheckId = 0;
   let updatePollInterval: ReturnType<typeof setInterval> | null = null;
 
   function start() {
@@ -81,16 +82,21 @@ export const useAppUpdater = defineStore('appUpdater', () => {
     return versionPromise;
   }
 
-  async function checkForUpdates(): Promise<AppUpdate> {
-    if (updateCheckPromise) {
+  async function checkForUpdates({ force = false }: { force?: boolean } = {}): Promise<AppUpdate> {
+    if (updateCheckPromise && !force) {
       return updateCheckPromise;
     }
 
-    updateCheckPromise = Promise.resolve().then(async () => {
+    const updateCheckId = ++latestUpdateCheckId;
+    const nextUpdateCheckPromise = Promise.resolve().then(async () => {
       isChecking.value = true;
 
       try {
         const nextUpdate = await check();
+        if (updateCheckId !== latestUpdateCheckId) {
+          return nextUpdate;
+        }
+
         const hasNewVersion = nextUpdate?.version !== update.value?.version;
 
         errorMessage.value = '';
@@ -110,15 +116,20 @@ export const useAppUpdater = defineStore('appUpdater', () => {
           runtime: getRuntimeDiagnostics(),
           error: getErrorDiagnostics(error),
         });
-        errorMessage.value = 'Error checking for updates. Please try again later.';
+        if (updateCheckId === latestUpdateCheckId) {
+          errorMessage.value = 'Error checking for updates. Please try again later.';
+        }
         return update.value as AppUpdate;
       } finally {
-        isChecking.value = false;
-        updateCheckPromise = null;
+        if (updateCheckId === latestUpdateCheckId) {
+          isChecking.value = false;
+          updateCheckPromise = null;
+        }
       }
     });
 
-    return updateCheckPromise;
+    updateCheckPromise = nextUpdateCheckPromise;
+    return nextUpdateCheckPromise;
   }
 
   async function downloadAndInstallUpdate() {


### PR DESCRIPTION
Opening Check for Updates now starts a new updater request even when background polling is already in flight. The manual result remains authoritative if the older background request finishes later.

Validated with the updater store regression and Vue type checking.
