### PR TITLE
fix(vaults): store completed revenue frame

### DIFF
--- a/core/__test__/Vaults.test.ts
+++ b/core/__test__/Vaults.test.ts
@@ -63,6 +63,50 @@ describe('Vaults load retry', () => {
   });
 });
 
+describe('Vault revenue sync', () => {
+  it('stores the latest completed frame when the current frame has finalized blocks', async () => {
+    const api = {
+      query: {
+        treasury: {},
+        vaults: {
+          revenuePerFrameByVault: { entries: vi.fn().mockResolvedValue([]) },
+        },
+      },
+    };
+    const miningFrames = {
+      load: vi.fn().mockResolvedValue(undefined),
+      frameIds: [20],
+      framesById: { 20: { firstBlockHash: '0x20' } },
+      getFrameStart: vi.fn().mockResolvedValue({
+        frame: {
+          firstBlockSpecVersion: 200,
+          firstBlockNumber: 100,
+          firstBlockHash: '0x20',
+          firstBlockTick: 1_000,
+        },
+        api,
+      }),
+      blockWatch: { finalizedBlockHeader: { blockNumber: 100 } },
+    };
+    const mainchainClients = {
+      get: vi.fn().mockResolvedValue({
+        query: {
+          vaults: {
+            vaultsById: { entries: vi.fn().mockResolvedValue([]) },
+          },
+        },
+      }),
+    };
+    const vaults = new Vaults('mainnet', {} as any, miningFrames as any, mainchainClients as any);
+    vaults.stats = createStats([]);
+    vaults.stats.synchedToFrame = 18;
+
+    await vaults.updateRevenue();
+
+    expect(vaults.stats.synchedToFrame).toBe(19);
+  });
+});
+
 describe('Vault and bond network returns', () => {
   it('uses the inclusive return window for coupon-net vault income and recorded external bond earnings', () => {
     const vaults = createVaults();

--- a/core/__test__/Vaults.test.ts
+++ b/core/__test__/Vaults.test.ts
@@ -65,6 +65,8 @@ describe('Vaults load retry', () => {
 
 describe('Vault revenue sync', () => {
   it('stores the latest completed frame when the current frame has finalized blocks', async () => {
+    vi.useFakeTimers();
+
     const api = {
       query: {
         treasury: {},
@@ -102,6 +104,9 @@ describe('Vault revenue sync', () => {
     vaults.stats.synchedToFrame = 18;
 
     await vaults.updateRevenue();
+
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
 
     expect(vaults.stats.synchedToFrame).toBe(19);
   });

--- a/core/src/Vaults.ts
+++ b/core/src/Vaults.ts
@@ -217,7 +217,7 @@ export class Vaults {
       const vaultFramesSeen = new Set<string>();
       const argonotPoolsByFrame = new Map<number, bigint>();
       const argonotCapitalByFrame = new Map<number, { participatingBonds: number; microgonsPerArgonot: bigint }>();
-      let newestFinalizedFrameSeen = 0;
+      let newestCompletedFrameSeen = 0;
 
       await new FrameIterator(clients, this.miningFrames, 'VaultHistory').iterateFramesLimited(
         async (frameId, firstBlockMeta, api, abortController) => {
@@ -231,7 +231,7 @@ export class Vaults {
           if (firstBlockMeta.blockNumber > finalizedHead.blockNumber) {
             return;
           }
-          newestFinalizedFrameSeen = Math.max(newestFinalizedFrameSeen, frameId);
+          newestCompletedFrameSeen = Math.max(newestCompletedFrameSeen, frameId - 1);
 
           if ('currentFrameArgonotBondParticipants' in api.query.treasury) {
             const [participantsOption, rates, events] = await Promise.all([
@@ -302,7 +302,7 @@ export class Vaults {
       this.stats.argonotStakingByFrame = [...retainedArgonotFrames, ...refreshedArgonotStats].sort(
         (a, b) => b.frameId - a.frameId,
       );
-      this.stats.synchedToFrame = Math.max(newestFinalizedFrameSeen, ...frameIdsSeen, this.stats.synchedToFrame);
+      this.stats.synchedToFrame = Math.max(newestCompletedFrameSeen, ...frameIdsSeen, this.stats.synchedToFrame);
       this.stats.formatVersion = VAULT_STATS_FORMAT_VERSION;
       await this.saveStats();
       refreshingDeferred.resolve(this.stats);


### PR DESCRIPTION
Vault revenue history now records the last completed frame instead of the active frame when its first block is finalized. This keeps the persisted sync cursor and revenue windows aligned with complete data while preserving newer observed or cached frames.

A regression test covers the active-frame boundary.
