### PR TITLE
fix: preserve wallet imports and Operations upgrade requests

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,7 +67,7 @@ hex = "0.4.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
 sp-core = { version="38.1.0", features = ["default"] }
 zip = { version="6",features= ["time"] }
-time = { version = "0.3", default-features = false }
+time = { version = "0.3", default-features = false, features = ["std"] }
 walkdir = "2.5.0"
 dotenvy = "0.15"
 fs2 = "0.4"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,14 +178,16 @@ async fn read_embedded_file(app: AppHandle, local_relative_path: String) -> Resu
 }
 
 #[tauri::command]
-async fn overwrite_mnemonic(
+async fn import_mnemonic(
     app: AppHandle,
     signer_policy: State<'_, EthereumSignerPolicyState>,
     mnemonic: String,
 ) -> Result<security::Security, String> {
-    log::info!("overwrite_mnemonic");
-    let security =
-        security::Security::save_with_mnemonic(&app, &mnemonic).map_err(|e| e.to_string())?;
+    log::info!("import_mnemonic");
+    migrations::backup_current_instance_database_for_import(&app)
+        .await
+        .map_err(|e| e.to_string())?;
+    let security = Security::import_mnemonic(&app, &mnemonic).map_err(|e| e.to_string())?;
     *signer_policy.policy.lock().await = None;
     Ok(security)
 }
@@ -974,7 +976,7 @@ pub fn run() {
             expose_mnemonic,
             export_default_ethereum_private_key,
             encrypt_wallet_secret,
-            overwrite_mnemonic,
+            import_mnemonic,
             measure_latency,
             load_instance,
             report_empty_app_root_after_activation,

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -80,6 +80,11 @@ pub fn backup_current_instance_database(app: &AppHandle) -> AnyhowResult<bool> {
     backup_database_if_needed(&config_dir, &current_version)
 }
 
+pub async fn backup_current_instance_database_for_import(app: &AppHandle) -> AnyhowResult<()> {
+    backup_database_for_import(&Utils::get_absolute_config_instance_dir(app)).await?;
+    Ok(())
+}
+
 pub async fn run_db_migrations(absolute_db_path: PathBuf) -> Result<(), String> {
     let opts = sqlx::sqlite::SqliteConnectOptions::new()
         .filename(&absolute_db_path)
@@ -100,6 +105,44 @@ pub async fn run_db_migrations(absolute_db_path: PathBuf) -> Result<(), String> 
 
     pool.close().await;
     Ok(())
+}
+
+async fn backup_database_for_import(config_dir: &Path) -> AnyhowResult<Option<PathBuf>> {
+    let database_path = config_dir.join(DATABASE_FILENAME);
+    if !database_path.exists() {
+        return Ok(None);
+    }
+
+    let timestamp = Utils::iso_timestamp_for_filename();
+    let backup_version = read_previous_version(&config_dir.join(APP_VERSION_FILENAME))?
+        .unwrap_or_else(|| INITIAL_TRACKED_APP_VERSION.to_string());
+    let backup_dir = create_backup_dir(config_dir, &backup_version)?;
+    let backup_path = backup_dir.join(format!(
+        "database-before-mnemonic-import-{timestamp}.sqlite"
+    ));
+    let options = sqlx::sqlite::SqliteConnectOptions::new().filename(&database_path);
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .with_context(|| format!("Failed to open {} for backup", database_path.display()))?;
+
+    let backup_result = sqlx::query("VACUUM INTO ?")
+        .bind(backup_path.to_string_lossy().as_ref())
+        .execute(&pool)
+        .await;
+    pool.close().await;
+    backup_result.with_context(|| {
+        format!(
+            "Failed to back up {} to {}",
+            database_path.display(),
+            backup_path.display()
+        )
+    })?;
+
+    log::info!(
+        "Backed up instance database before mnemonic import. Backup = {}",
+        backup_path.display()
+    );
+    Ok(Some(backup_path))
 }
 
 fn backup_database_if_needed(config_dir: &Path, current_version: &str) -> AnyhowResult<bool> {
@@ -180,14 +223,14 @@ fn write_current_version(version_path: &Path, current_version: &str) -> AnyhowRe
         .with_context(|| format!("Failed to write {}", version_path.display()))
 }
 
-fn create_backup_dir(config_dir: &Path, previous_version: &str) -> AnyhowResult<PathBuf> {
+fn create_backup_dir(config_dir: &Path, backup_name: &str) -> AnyhowResult<PathBuf> {
     let backups_dir = config_dir.join(DATABASE_BACKUPS_DIR);
     fs::create_dir_all(&backups_dir)
         .with_context(|| format!("Failed to create {}", backups_dir.display()))?;
 
-    let backup_dir_name = previous_version.replace(['/', '\\'], "_");
+    let backup_dir_name = backup_name.replace(['/', '\\'], "_");
     if backup_dir_name.is_empty() || matches!(backup_dir_name.as_str(), "." | "..") {
-        return Err(anyhow!("Invalid previous version: {previous_version}"));
+        return Err(anyhow!("Invalid backup name: {backup_name}"));
     }
 
     let backup_dir = backups_dir.join(backup_dir_name);
@@ -198,7 +241,9 @@ fn create_backup_dir(config_dir: &Path, previous_version: &str) -> AnyhowResult<
 
 #[cfg(test)]
 mod tests {
-    use super::{INITIAL_TRACKED_APP_VERSION, backup_database_if_needed};
+    use super::{
+        INITIAL_TRACKED_APP_VERSION, backup_database_for_import, backup_database_if_needed,
+    };
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -270,6 +315,77 @@ mod tests {
         assert!(!temp_dir.join("database-backups").exists());
 
         fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn creates_a_complete_database_snapshot_for_import() {
+        tauri::async_runtime::block_on(async {
+            let temp_dir = create_temp_dir("mnemonic-import");
+            let database_path = temp_dir.join("database.sqlite");
+            let version_backup_dir = temp_dir.join("database-backups").join("2.3.4");
+            fs::create_dir_all(&version_backup_dir).unwrap();
+            fs::write(
+                version_backup_dir.join("database.sqlite"),
+                b"version backup",
+            )
+            .unwrap();
+            fs::write(temp_dir.join("app-version.txt"), "2.3.4").unwrap();
+            let options = sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(&database_path)
+                .create_if_missing(true);
+            let pool = sqlx::SqlitePool::connect_with(options).await.unwrap();
+            sqlx::query("CREATE TABLE account_data (value TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            sqlx::query("INSERT INTO account_data (value) VALUES ('current account')")
+                .execute(&pool)
+                .await
+                .unwrap();
+
+            let backup_path = backup_database_for_import(&temp_dir)
+                .await
+                .unwrap()
+                .expect("the existing database should be backed up");
+
+            assert_eq!(backup_path.parent().unwrap(), version_backup_dir);
+            let backup_file_name = backup_path.file_name().unwrap().to_string_lossy();
+            assert!(backup_file_name.starts_with("database-before-mnemonic-import-"));
+            assert!(backup_file_name.ends_with(".sqlite"));
+            let backup_timestamp = backup_file_name
+                .strip_prefix("database-before-mnemonic-import-")
+                .unwrap()
+                .strip_suffix(".sqlite")
+                .unwrap();
+            assert_eq!(backup_timestamp.len(), 24);
+            assert_eq!(backup_timestamp.as_bytes()[10], b'T');
+            assert_eq!(backup_timestamp.as_bytes()[23], b'Z');
+            assert_eq!(
+                fs::read(backup_path.parent().unwrap().join("database.sqlite")).unwrap(),
+                b"version backup"
+            );
+
+            sqlx::query("UPDATE account_data SET value = 'changed after backup'")
+                .execute(&pool)
+                .await
+                .unwrap();
+            pool.close().await;
+
+            let backup_options = sqlx::sqlite::SqliteConnectOptions::new().filename(&backup_path);
+            let backup_pool = sqlx::SqlitePool::connect_with(backup_options)
+                .await
+                .unwrap();
+            let backed_up_value = sqlx::query_scalar::<_, String>("SELECT value FROM account_data")
+                .fetch_one(&backup_pool)
+                .await
+                .unwrap();
+            backup_pool.close().await;
+
+            assert_eq!(backed_up_value, "current account");
+            assert!(database_path.exists());
+
+            fs::remove_dir_all(temp_dir).unwrap();
+        });
     }
 
     fn read_backup_entries(temp_dir: &Path) -> Vec<PathBuf> {

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -570,6 +570,14 @@ impl Security {
         Self::write_wallet_file(app, mnemonic)
     }
 
+    pub fn import_mnemonic(app: &AppHandle, mnemonic: &str) -> Result<Self> {
+        backup_mnemonic_if_different(&Utils::get_absolute_config_instance_dir(app), mnemonic)?;
+
+        let security = Self::write_wallet_file(app, mnemonic)?;
+        write_mnemonic_file(&Self::legacy_mnemonic_path(app), mnemonic)?;
+        Ok(security)
+    }
+
     fn create_with_addresses(mnemonic: &str, public_key: &str) -> Result<Self> {
         let mining_hold_account = Self::sr_derive_from_mnemonic(mnemonic, "//holding")?; // If we had a do-over, it would be called mining
         let mining_bot_account = Self::sr_derive_from_mnemonic(mnemonic, "//mining")?; // If we had a do-over, it would be called miningBot
@@ -730,11 +738,51 @@ fn write_mnemonic_file_if_missing(path: &Path, mnemonic: &str) -> Result<()> {
     }
 }
 
+fn write_mnemonic_file(path: &Path, mnemonic: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let mut file = options.open(path)?;
+    file.write_all(mnemonic.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn backup_mnemonic_if_different(config_dir: &Path, imported_mnemonic: &str) -> Result<()> {
+    let mnemonic_path = config_dir.join("mnemonic");
+    if !mnemonic_path.exists() {
+        return Ok(());
+    }
+
+    let existing_mnemonic = fs::read_to_string(&mnemonic_path)?;
+    if existing_mnemonic.trim().is_empty() || existing_mnemonic.trim() == imported_mnemonic.trim() {
+        return Ok(());
+    }
+
+    let backup_dir = config_dir
+        .join("mnemonic-backups")
+        .join(Utils::iso_timestamp_for_filename());
+    fs::create_dir_all(&backup_dir)?;
+
+    write_mnemonic_file_if_missing(&backup_dir.join("mnemonic"), &existing_mnemonic)?;
+
+    log::info!("Backed up the existing mnemonic bridge before mnemonic import");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        Security, WalletFile, default_ethereum_hd_prefixes, get_ethereum_hd_path,
-        read_wallet_recovery_mnemonic, wallet_recovery_mnemonic, write_mnemonic_file_if_missing,
+        Security, WalletFile, backup_mnemonic_if_different, default_ethereum_hd_prefixes,
+        get_ethereum_hd_path, read_wallet_recovery_mnemonic, wallet_recovery_mnemonic,
+        write_mnemonic_file, write_mnemonic_file_if_missing,
     };
     use crate::ethereum_signer;
     use sp_core::Pair;
@@ -954,6 +1002,66 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&mnemonic_path).expect("mnemonic file should exist"),
             "existing mnemonic"
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn backs_up_plaintext_mnemonic_only_when_import_differs() {
+        let test_dir = unique_test_dir("backs-up-plaintext-mnemonic-only-when-import-differs");
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let existing_mnemonic = "test test test test test test test test test test test junk";
+        let imported_mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        fs::write(test_dir.join("mnemonic"), existing_mnemonic)
+            .expect("existing mnemonic should be written");
+
+        backup_mnemonic_if_different(&test_dir, existing_mnemonic)
+            .expect("matching mnemonic should not need backup");
+        assert!(!test_dir.join("mnemonic-backups").exists());
+
+        backup_mnemonic_if_different(&test_dir, imported_mnemonic)
+            .expect("different mnemonic should be backed up");
+
+        let backup_root = test_dir.join("mnemonic-backups");
+        let backup_dirs = fs::read_dir(&backup_root)
+            .expect("backup root should exist")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("backup directory should be readable");
+        assert_eq!(backup_dirs.len(), 1);
+
+        let backup_timestamp = backup_dirs[0].file_name();
+        let backup_timestamp = backup_timestamp.to_string_lossy();
+        assert_eq!(backup_timestamp.len(), 24);
+        assert_eq!(backup_timestamp.as_bytes()[10], b'T');
+        assert_eq!(backup_timestamp.as_bytes()[23], b'Z');
+
+        assert_eq!(
+            fs::read_to_string(backup_dirs[0].path().join("mnemonic"))
+                .expect("mnemonic backup should be readable"),
+            existing_mnemonic
+        );
+
+        fs::remove_dir_all(&test_dir).expect("test dir should be removed");
+    }
+
+    #[test]
+    fn replaces_active_plaintext_mnemonic_during_import() {
+        let test_dir = unique_test_dir("replaces-active-plaintext-mnemonic-during-import");
+        fs::create_dir_all(&test_dir).expect("test dir should be created");
+
+        let mnemonic_path = test_dir.join("mnemonic");
+        fs::write(&mnemonic_path, "existing mnemonic")
+            .expect("existing mnemonic should be written");
+        let imported_mnemonic = "test test test test test test test test test test test junk";
+
+        write_mnemonic_file(&mnemonic_path, imported_mnemonic)
+            .expect("active mnemonic should be replaced");
+
+        assert_eq!(
+            fs::read_to_string(&mnemonic_path).expect("active mnemonic should be readable"),
+            imported_mnemonic
         );
 
         fs::remove_dir_all(&test_dir).expect("test dir should be removed");

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -3,6 +3,7 @@ use rand::RngCore;
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use tauri::{AppHandle, Manager};
 
 static ENV_DOCKER: &str = include_str!("../../server/.env.dev-docker");
@@ -89,6 +90,20 @@ impl Utils {
                 tauri::path::BaseDirectory::AppConfig,
             )
             .expect("Failed to resolve config instance directory")
+    }
+
+    pub fn iso_timestamp_for_filename() -> String {
+        let timestamp = time::OffsetDateTime::from(SystemTime::now());
+        format!(
+            "{:04}-{:02}-{:02}T{:02}-{:02}-{:02}.{:03}Z",
+            timestamp.year(),
+            u8::from(timestamp.month()),
+            timestamp.day(),
+            timestamp.hour(),
+            timestamp.minute(),
+            timestamp.second(),
+            timestamp.millisecond(),
+        )
     }
 
     pub fn get_embedded_path(app: &AppHandle, path: impl AsRef<Path>) -> anyhow::Result<PathBuf> {

--- a/src-vue/__test__/Importer.test.ts
+++ b/src-vue/__test__/Importer.test.ts
@@ -11,6 +11,7 @@ import { type IConfig, MiningSetupStatus, VaultingSetupStatus } from '../interfa
 import Restarter from '../lib/Restarter.ts';
 import { MemoryWalletKeys } from '../lib/MemoryWalletKeys.ts';
 import type { Db } from '../lib/Db.ts';
+import { invokeWithTimeout } from '../lib/tauriApi.ts';
 
 const importMocks = vi.hoisted(() => ({
   closeWallets: vi.fn(),
@@ -42,6 +43,39 @@ vi.mock('../lib/IndexerClient.ts', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   importMocks.getOperatorVaultId.mockResolvedValue({ isSome: false });
+});
+
+it('keeps the current database when mnemonic import fails', async () => {
+  const { mnemonic, walletKeys } = createTestWallet('//Alice');
+  const db = {
+    reconnect: vi.fn(),
+    configTable: { insertOrReplace: vi.fn() },
+  } as unknown as Db;
+  importMocks.getFinalizedClient.mockResolvedValue({
+    query: {
+      operationalAccounts: {
+        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
+      },
+      vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
+    },
+  });
+  importMocks.readBalances.mockResolvedValue([
+    emptyBalance,
+    emptyBalance,
+    { ...emptyBalance, availableMicrogons: 1n },
+    emptyBalance,
+  ]);
+  importMocks.findMiningActivity.mockResolvedValue({ blocks: [], coverage: { gaps: [] } });
+  vi.spyOn(Mining, 'fetchMiningSeatsForAccount').mockResolvedValue({});
+  vi.mocked(invokeWithTimeout).mockRejectedValueOnce(new Error('import failed'));
+  const deleteDatabase = vi.spyOn(Restarter.prototype, 'deleteAndCreateLocalDatabase').mockResolvedValue();
+
+  await expect(
+    new Importer({} as Config, walletKeys, Promise.resolve(db)).importFromMnemonic(mnemonic),
+  ).rejects.toThrow('import failed');
+
+  expect(invokeWithTimeout).toHaveBeenCalledWith('import_mnemonic', { mnemonic }, 10_000);
+  expect(deleteDatabase).not.toHaveBeenCalled();
 });
 
 it('restores completed mining setup from imported operational account state', async () => {

--- a/src-vue/__test__/Importer.test.ts
+++ b/src-vue/__test__/Importer.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
   importMocks.getOperatorVaultId.mockResolvedValue({ isSome: false });
 });
 
-it('keeps the current database when mnemonic import fails', async () => {
+it('stops background sync before importing and keeps the current database on failure', async () => {
   const { mnemonic, walletKeys } = createTestWallet('//Alice');
   const db = {
     reconnect: vi.fn(),
@@ -75,6 +75,11 @@ it('keeps the current database when mnemonic import fails', async () => {
   ).rejects.toThrow('import failed');
 
   expect(invokeWithTimeout).toHaveBeenCalledWith('import_mnemonic', { mnemonic }, 10_000);
+  expect(importMocks.closeWallets).toHaveBeenCalledOnce();
+  expect(importMocks.stopBlockWatch).toHaveBeenCalledOnce();
+  expect(importMocks.stopBlockWatch.mock.invocationCallOrder[0]).toBeLessThan(
+    vi.mocked(invokeWithTimeout).mock.invocationCallOrder[0],
+  );
   expect(deleteDatabase).not.toHaveBeenCalled();
 });
 

--- a/src-vue/__test__/UpstreamOperatorClient.test.ts
+++ b/src-vue/__test__/UpstreamOperatorClient.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, it, vi } from 'vitest';
 import { RequestStatusError, ServerAuthClient } from '../lib/ServerAuthClient.ts';
-import { UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
+import { hasOperationsUpgradeRequest, UpstreamOperatorClient } from '../lib/UpstreamOperatorClient.ts';
 import { createMockWalletKeys } from './helpers/wallet.ts';
 import { BootstrapType } from '../interfaces/IConfig.ts';
 
@@ -26,6 +26,15 @@ vi.mock('../stores/bootstrapRecovery.ts', () => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+it('keeps an operations upgrade pending after the upstream records the request', () => {
+  expect(
+    hasOperationsUpgradeRequest({
+      operationsUpgradeRequestedAt: new Date('2026-08-10T12:00:00Z'),
+      restorePackageRevision: '2.0',
+    }),
+  ).toBe(true);
 });
 
 it('refuses redirects when claiming a pasted invite', async () => {

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -110,8 +110,8 @@ export default class Importer {
       throw new Error('No existing wallet value was found for that mnemonic on this network.');
     }
 
-    const security = await invokeWithTimeout('import_mnemonic', { mnemonic }, 10_000);
     await this.shutdownBackgroundSync();
+    const security = await invokeWithTimeout('import_mnemonic', { mnemonic }, 10_000);
     const restarter = new Restarter(this.dbPromise, this.config);
     await restarter.deleteAndCreateLocalDatabase();
     const db = await this.dbPromise;

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -110,13 +110,13 @@ export default class Importer {
       throw new Error('No existing wallet value was found for that mnemonic on this network.');
     }
 
+    const security = await invokeWithTimeout('import_mnemonic', { mnemonic }, 10_000);
     await this.shutdownBackgroundSync();
     const restarter = new Restarter(this.dbPromise, this.config);
     await restarter.deleteAndCreateLocalDatabase();
     const db = await this.dbPromise;
     await db.reconnect();
 
-    const security = await invokeWithTimeout('overwrite_mnemonic', { mnemonic }, 10_000);
     Object.assign(SECURITY, security);
 
     // The live Config and wallet singletons still reference the previous mnemonic until the app reloads.

--- a/src-vue/lib/UpstreamOperatorClient.ts
+++ b/src-vue/lib/UpstreamOperatorClient.ts
@@ -33,6 +33,9 @@ type UpstreamOperatorSessionAuth = {
   getSessionId: () => Promise<string>;
   invalidateSessionId: () => Promise<void>;
 };
+type OperationsUpgradeRequestState = Pick<Partial<IMemberInvite>, 'operationsUpgradeRequestedAt'> & {
+  restorePackageRevision?: string;
+};
 
 const BOOTSTRAP_LOADING_HOST = 'loading';
 
@@ -351,6 +354,13 @@ export class UpstreamOperatorClient {
       return await request(sessionId);
     }
   }
+}
+
+export function hasOperationsUpgradeRequest({
+  operationsUpgradeRequestedAt,
+  restorePackageRevision,
+}: OperationsUpgradeRequestState): boolean {
+  return !!operationsUpgradeRequestedAt || restorePackageRevision?.endsWith('.1') === true;
 }
 
 function buildAuthenticatedUrl(operatorHost: string, path: string, sessionId?: string): string {

--- a/src-vue/lib/tauriApi.ts
+++ b/src-vue/lib/tauriApi.ts
@@ -7,7 +7,7 @@ export class InvokeTimeout extends Error {
 }
 
 const SENSITIVE_COMMANDS = new Set([
-  'overwrite_mnemonic',
+  'import_mnemonic',
   'encrypt_wallet_secret',
   'derive_external_ethereum_addresses',
   'derive_external_ethereum_address_from_private_key',

--- a/src-vue/navigation/CertificationMenu.vue
+++ b/src-vue/navigation/CertificationMenu.vue
@@ -264,6 +264,7 @@ import {
 } from '../stores/certificationController.ts';
 import DiamondIcon from '../assets/diamond.svg';
 import CertificationIcon from '../assets/certification.svg';
+import { hasOperationsUpgradeRequest } from '../lib/UpstreamOperatorClient.ts';
 
 const config = getConfig();
 const controller = useCertificationController();
@@ -291,7 +292,9 @@ const isCertificationMenuVisible = Vue.computed(() => {
   return !controller.isOperationalRewardsFlowActive;
 });
 const hasRequestedOperationsUpgrade = Vue.computed(() => {
-  return config.upstreamOperator?.restorePackageRevision?.endsWith('.1') ?? false;
+  return hasOperationsUpgradeRequest({
+    restorePackageRevision: config.upstreamOperator?.restorePackageRevision,
+  });
 });
 
 const currentStepIds = Vue.computed(() => {

--- a/src-vue/overlays/UpgradeToOperationsOverlay.vue
+++ b/src-vue/overlays/UpgradeToOperationsOverlay.vue
@@ -99,6 +99,7 @@ import OverlayBase from './OverlayBase.vue';
 import AlertIcon from '../assets/alert.svg';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import numeral from '../lib/numeral.ts';
+import { hasOperationsUpgradeRequest } from '../lib/UpstreamOperatorClient.ts';
 
 const config = getConfig();
 const controller = useCertificationController();
@@ -142,7 +143,12 @@ const canRequestUpgrade = Vue.computed(() => {
     return false;
   }
 
-  if (invite.value?.operationsUpgradeRequestedAt && controller.chainProgress.hasOperationalAccount) {
+  if (
+    hasOperationsUpgradeRequest({
+      ...(invite.value ?? {}),
+      restorePackageRevision: config.upstreamOperator?.restorePackageRevision,
+    })
+  ) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Wallet imports now preserve recoverable state before replacing the active mnemonic. The app creates a versioned database snapshot, backs up a differing mnemonic bridge, and activates the imported wallet through one native operation.

Recorded Operations upgrade requests now remain pending in both the navigation menu and upgrade overlay. This prevents duplicate requests when upstream state refreshes.

## Validation

- Rust test suite
- Focused wallet-import and upstream-operator tests
- TypeScript typecheck and repository commit checks
