### PR TITLE
fix(server): harden fast sync recovery probe

### DIFF
--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -479,12 +479,15 @@ if ! (already_ran "ArgonInstall"); then
         command_output=$(read_router_syncstatus "/argon/syncstatus")
         unset allow_run_command_fail
 
-        argon_logs=$(run_compose "sudo docker compose logs --no-color --tail 100 argon-miner")
+        allow_run_command_fail=1
+        argon_logs=$(run_compose "sudo docker compose logs --no-color --tail 100 argon-miner 2>&1 | grep -m 1 -F 'ARGON_RECOVERY_REQUIRED: missing-state-anchor'")
+        unset allow_run_command_fail
         if grep -qF "ARGON_RECOVERY_REQUIRED: missing-state-anchor" <<<"$argon_logs"; then
           echo "Argon node requested recovery; resetting $ARGON_DATA_FOLDER/chains"
           run_compose "sudo docker compose stop argon-miner"
           run_command "sudo rm -rf -- \"${ARGON_DATA_FOLDER:?}/chains\""
           run_compose "sudo docker compose up argon-miner -d --force-recreate"
+          failures=0
           continue
         fi
 

--- a/server/scripts/installer.sh
+++ b/server/scripts/installer.sh
@@ -480,7 +480,7 @@ if ! (already_ran "ArgonInstall"); then
         unset allow_run_command_fail
 
         allow_run_command_fail=1
-        argon_logs=$(run_compose "sudo docker compose logs --no-color --tail 100 argon-miner 2>&1 | grep -m 1 -F 'ARGON_RECOVERY_REQUIRED: missing-state-anchor'")
+        argon_logs=$(run_compose "sudo docker compose logs --no-color --tail 100 argon-miner | grep -m 1 -F 'ARGON_RECOVERY_REQUIRED: missing-state-anchor'")
         unset allow_run_command_fail
         if grep -qF "ARGON_RECOVERY_REQUIRED: missing-state-anchor" <<<"$argon_logs"; then
           echo "Argon node requested recovery; resetting $ARGON_DATA_FOLDER/chains"


### PR DESCRIPTION
## Summary

Hardens the interrupted fast-sync recovery path. The installer now filters its per-second Docker log probe to the recovery marker and treats probe failures as non-fatal, avoiding repeated healthy log output. After recovery, the restarted sync receives a fresh status-error allowance instead of inheriting failures from the interrupted attempt.

Related: #569

## Validation

Bash syntax and ShellCheck pass for `server/scripts/installer.sh`.
