### PR TITLE
fix: stabilize pending transaction recovery

### DIFF
--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -154,7 +154,7 @@ export async function startDevUpstreamServer(args: {
     seatGoalType: SeatGoalType.Max,
     seatGoalCount: 4,
     maximumBidFormulaType: BidAmountFormulaType.Custom,
-    maximumBidCustom: 500_000n,
+    maximumBidCustom: 280_000n,
   };
 
   await Promise.all([

--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -29,10 +29,14 @@ import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
 import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
 import * as vaultStore from '../stores/vaults.ts';
 import { createTestDb } from './helpers/db.ts';
+import { createBitcoinLockConfig } from './helpers/bitcoin.ts';
+import { getMainchainClient } from '../stores/mainchain.ts';
 
 vi.mock('../stores/mainchain.ts', () => ({
   getMainchainClient: vi.fn(async () => ({})),
 }));
+
+afterEach(() => vi.useRealTimers());
 
 function createStore(
   options: {
@@ -164,6 +168,52 @@ function historyEvent(
     phase: { isApplyExtrinsic: true, asApplyExtrinsic: numberCodec(extrinsicIndex) },
   };
 }
+
+it('keeps a funding expiration estimate stable until the oracle Bitcoin height changes', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-11T18:00:00Z'));
+
+  const db = await createTestDb();
+  const blockWatch = Object.assign(Object.create(null), {
+    start: async () => undefined,
+    events: { on: () => () => undefined },
+    bestBlockHeader: { blockNumber: 0, blockHash: '0x0' },
+  }) as BlockWatch;
+  const archiveClient = {
+    consts: { bitcoinLocks: { argonTicksPerDay: { toNumber: () => 1_440 } } },
+    query: {
+      bitcoinLocks: {
+        utxoIdsByOwnerAccount: { keys: vi.fn(async () => []) },
+      },
+    },
+  };
+  blockWatch.getFinalizedApi = vi.fn(async () => archiveClient) as never;
+  vi.mocked(getMainchainClient).mockResolvedValue(archiveClient as never);
+  vi.spyOn(BitcoinLock, 'getConfig').mockResolvedValue(
+    createBitcoinLockConfig({ pendingConfirmationExpirationBlocks: 6 }),
+  );
+  const store = createStore({ blockWatch, db });
+
+  await store.load();
+  store.data.oracleBitcoinBlockHeight = 100;
+
+  const lock = createLock({
+    uuid: 'pending-lock',
+    status: BitcoinLockStatus.LockPendingFunding,
+    createdAt: '2026-08-11T18:00:00Z',
+  });
+  const initialExpiration = store.verifyExpirationTime(lock);
+
+  await vi.advanceTimersByTimeAsync(2_000);
+
+  expect(store.verifyExpirationTime(lock)).toBe(initialExpiration);
+
+  store.data.oracleBitcoinBlockHeight = 101;
+
+  expect(store.verifyExpirationTime(lock)).not.toBe(initialExpiration);
+
+  store.unsubscribeFromArgonBlocks();
+});
 
 describe('BitcoinLocks recovery', () => {
   it('recognizes and clears recovery flags restored from the database', async () => {

--- a/src-vue/__test__/MiningAccount.test.ts
+++ b/src-vue/__test__/MiningAccount.test.ts
@@ -41,7 +41,7 @@ it('submits mining bid proxy registration through the archive client', async () 
     },
   };
   const transactionTracker = {
-    findLatestTxInfo: vi.fn(),
+    findLatestTxAttempt: vi.fn().mockResolvedValue(undefined),
     submitAndWatch: vi.fn().mockResolvedValue({ tx: { id: 1 } }),
   };
   const walletKeys = {

--- a/src-vue/__test__/MintingAuthorities.test.ts
+++ b/src-vue/__test__/MintingAuthorities.test.ts
@@ -7,14 +7,38 @@ import {
   getOwnedEthereumMintingAuthorities,
   getNextMintingAuthoritySigner,
   restoreOwnedEthereumMintingAuthorities,
+  type IMintingAuthorityRegisterMetadata,
 } from '../lib/MintingAuthorities.ts';
 import { getEthereumHdPath } from '../lib/WalletKeys.ts';
 import { DEFAULT_MEMORY_WALLET_KEYS_ETHEREUM_HD_PREFIXES } from '../lib/MemoryWalletKeys.ts';
 import { mnemonicToAccount } from 'viem/accounts';
+import { TransactionInfo } from '../lib/TransactionInfo.ts';
+import type { ITransactionRecord } from '../lib/db/TransactionsTable.ts';
+import type { TxResult } from '@argonprotocol/mainchain';
 
 const TEST_MNEMONIC = 'test test test test test test test test test test test junk';
 
 describe('MintingAuthorities', () => {
+  it('settles registration post-processing when setup fails before finalization', async () => {
+    const setupError = new Error('database unavailable');
+    const txInfo = new TransactionInfo<IMintingAuthorityRegisterMetadata>({
+      tx: {
+        metadataJson: { authorityIndex: 0 },
+      } as ITransactionRecord,
+      txResult: {} as TxResult,
+    });
+    const mintingAuthorities = new MintingAuthorities(
+      Promise.reject(setupError),
+      {} as WalletKeys,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(mintingAuthorities['onRegister'](txInfo)).rejects.toThrow(setupError);
+    await expect(txInfo.waitForPostProcessing).rejects.toThrow(setupError);
+    expect(txInfo.isPostProcessed).toBe(true);
+  });
+
   it('only scans missing signer indexes for a council account after its unrecognized registration', async () => {
     const db = await createTestDb();
     const walletKeys = createWalletKeysStub();

--- a/src-vue/__test__/MoveCapital.test.ts
+++ b/src-vue/__test__/MoveCapital.test.ts
@@ -424,7 +424,7 @@ describe('MoveCapital', () => {
     await expect(secondSweep).resolves.toEqual({ kind: 'submitted', txInfo });
   });
 
-  it('follows an existing tracked default Argon mining transfer after reload', async () => {
+  it('resumes an existing pending default Argon mining transfer after reload', async () => {
     const existingTxInfo = {
       tx: {
         id: 7,
@@ -436,7 +436,7 @@ describe('MoveCapital', () => {
       },
     } as any;
     const { moveCapital, transactionTracker } = createMoveCapital(existingTxInfo);
-    transactionTracker.getTxAttemptState.mockResolvedValue(TxAttemptState.Follow);
+    transactionTracker.getTxAttemptState.mockResolvedValue(TxAttemptState.Pending);
 
     const result = await moveCapital.moveConfiguredDefaultArgonToBot(
       createMiningTransferArgs(

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -203,7 +203,7 @@ describe('MyVault cosign recovery', () => {
 
     const latestTxAttempt = await myVault.findLatestReleaseCosignTxAttempt(11);
 
-    expect(latestTxAttempt).toMatchObject({ txInfo, txAttemptState: TxAttemptState.Follow });
+    expect(latestTxAttempt).toMatchObject({ txInfo, txAttemptState: TxAttemptState.Pending });
   });
 
   it('ignores an old submitted cosign tx after the grace window', async () => {
@@ -1585,7 +1585,7 @@ function createVault(args?: {
   const txInfos = args?.txInfos ?? [];
   const submitAndWatch = args?.submitAndWatch ?? vi.fn();
   const trackTxResult = args?.trackTxResult ?? vi.fn();
-  const getTxAttemptState = vi.fn(async (txInfo: TransactionInfo, finalizedBlockGrace: number) => {
+  const getTxAttemptState = vi.fn(async (txInfo: TransactionInfo, waitForConfirmations: number) => {
     const latestHistoryStatus = historyByTxId[txInfo.tx.id]?.at(-1)?.status;
     if (
       txInfo.tx.submissionErrorJson ||
@@ -1632,8 +1632,8 @@ function createVault(args?: {
 
     const finalizedHeight = blockWatch.finalizedBlockHeader.blockNumber;
     if (txInfo.tx.status === TransactionStatus.Submitted) {
-      return finalizedHeight - txInfo.tx.submittedAtBlockHeight <= finalizedBlockGrace
-        ? TxAttemptState.Follow
+      return finalizedHeight - txInfo.tx.submittedAtBlockHeight <= waitForConfirmations
+        ? TxAttemptState.Pending
         : TxAttemptState.Replace;
     }
 
@@ -1645,10 +1645,10 @@ function createVault(args?: {
 
       const header = await blockWatch.getHeader(blockHeight).catch(() => undefined);
       if (!header || header.blockHash === blockHash) {
-        return TxAttemptState.Follow;
+        return TxAttemptState.Pending;
       }
 
-      return finalizedHeight - blockHeight <= finalizedBlockGrace ? TxAttemptState.Follow : TxAttemptState.Replace;
+      return finalizedHeight - blockHeight <= waitForConfirmations ? TxAttemptState.Pending : TxAttemptState.Replace;
     }
 
     if (txInfo.tx.status === TransactionStatus.Finalized) {

--- a/src-vue/__test__/OperationalAccount.test.ts
+++ b/src-vue/__test__/OperationalAccount.test.ts
@@ -35,8 +35,7 @@ it('submits operational registration once the treasury wallet can afford it', as
   };
   const transactionTracker = {
     load: vi.fn(),
-    findLatestTxInfo: vi.fn(),
-    getTxAttemptState: vi.fn(),
+    findLatestTxAttempt: vi.fn(),
     submitAndWatch: vi.fn().mockResolvedValue({ tx: { id: 1 } }),
   };
   const walletKeys = {
@@ -103,8 +102,7 @@ it('waits for more treasury funds before submitting operational registration', a
   };
   const transactionTracker = {
     load: vi.fn(),
-    findLatestTxInfo: vi.fn(),
-    getTxAttemptState: vi.fn(),
+    findLatestTxAttempt: vi.fn(),
     submitAndWatch: vi.fn(),
   };
   const walletKeys = {
@@ -158,8 +156,7 @@ it('waits for the runtime upgrade before submitting an access-proof registration
   };
   const transactionTracker = {
     load: vi.fn(),
-    findLatestTxInfo: vi.fn(),
-    getTxAttemptState: vi.fn(),
+    findLatestTxAttempt: vi.fn(),
     submitAndWatch: vi.fn(),
   };
   const walletKeys = {

--- a/src-vue/__test__/TransactionTracker.integration.test.ts
+++ b/src-vue/__test__/TransactionTracker.integration.test.ts
@@ -171,7 +171,7 @@ describe.skipIf(skipE2E).sequential('Transaction tracker tests', { timeout: 60e3
       {
         isFinalized: true,
         blockNumber: tx.submittedAtBlockHeight + 65,
-        blockHash: '0xabc',
+        blockHash: blockwatch.finalizedBlockHeader.blockHash,
         parentHash: '0xdef',
         tick: 0,
         author: '0x123',
@@ -180,6 +180,7 @@ describe.skipIf(skipE2E).sequential('Transaction tracker tests', { timeout: 60e3
     ];
 
     vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+    vi.spyOn(client.rpc.author, 'pendingExtrinsics').mockResolvedValueOnce([] as any);
 
     // @ts-expect-error Now actually watch for updates
     await transactionTracker.updatePendingStatuses(70);

--- a/src-vue/__test__/TransactionTracker.test.ts
+++ b/src-vue/__test__/TransactionTracker.test.ts
@@ -12,6 +12,7 @@ vi.mock('../stores/mainchain.ts', () => ({
 }));
 
 type ITransactionTrackerTestApi = {
+  handleWatchedResult: (tx: ITransactionRecord, txResult: any, result: any) => Promise<void>;
   updatePendingStatuses: (bestBlockInfo: { blockNumber: number }) => Promise<void>;
   watchForUpdates: () => Promise<void>;
 };
@@ -70,6 +71,35 @@ describe('TransactionTracker', () => {
     expect(tracker.data.txInfosByType[ExtrinsicType.VaultCollect]).toBeUndefined();
   });
 
+  it('waits for the initial load before finding the latest transaction attempt', async () => {
+    let resolveLoad!: (value: ITransactionRecord[]) => void;
+    const loadRows = new Promise<ITransactionRecord[]>(resolve => {
+      resolveLoad = resolve;
+    });
+    const tx = createTransaction({
+      id: 22,
+      extrinsicType: ExtrinsicType.MiningBidProxySetup,
+      status: TransactionStatus.Finalized,
+      isFinalized: true,
+    });
+    const { tracker, table } = createLoadTracker({ txsByLoad: [loadRows] });
+
+    const attemptPromise = tracker.findLatestTxAttempt({
+      extrinsicType: ExtrinsicType.MiningBidProxySetup,
+      waitForConfirmations: 2,
+    });
+
+    await vi.waitFor(() => expect(table.fetchAll).toHaveBeenCalledOnce());
+    expect(tracker.data.txInfos).toHaveLength(0);
+
+    resolveLoad([tx]);
+
+    await expect(attemptPromise).resolves.toMatchObject({
+      txInfo: { tx: { id: tx.id } },
+      txAttemptState: TxAttemptState.Finalized,
+    });
+  });
+
   it('does not resume dropped attempts at load, but keeps tracking them on-chain', async () => {
     const tx = createTransaction({
       id: 1,
@@ -118,34 +148,503 @@ describe('TransactionTracker', () => {
     expect(txResult.isFinalized).toBe(false);
   });
 
-  it('treats a recent submitted attempt as followable', async () => {
+  it('treats a recent submitted attempt as pending', async () => {
     const tx = createTransaction({
       id: 2,
       status: TransactionStatus.Submitted,
       submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
       extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
     });
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
     const { tracker } = await createTracker({
       txs: [tx],
       finalizedHeight: 101,
     });
 
-    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Follow);
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(findTransaction).toHaveBeenCalledOnce();
+    findTransaction.mockRestore();
   });
 
-  it('treats a stale submitted attempt as replaceable', async () => {
+  it('replaces a recent submitted attempt when its finalized nonce was already used', async () => {
     const tx = createTransaction({
       id: 3,
       status: TransactionStatus.Submitted,
       submittedAtBlockHeight: 100,
+      txNonce: 4,
+      blockHeight: undefined,
+      blockHash: undefined,
       extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
     });
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+    const { tracker, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 101,
+      finalizedAccountNonce: 5,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Replace);
+    expect(historyTable.record).toHaveBeenCalledWith({
+      transactionId: tx.id,
+      status: TransactionHistoryStatus.Invalid,
+      source: TransactionHistorySource.Local,
+    });
+    findTransaction.mockRestore();
+  });
+
+  it('preserves a consumed nonce error when the submitted attempt is overdue', async () => {
+    const tx = createTransaction({
+      id: 4,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      txNonce: 4,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
     const { tracker } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 161,
+      finalizedAccountNonce: 5,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Replace);
+
+    const txResult = tracker.data.txInfos[0].txResult;
+    expect(txResult.submissionError?.message).toBe('Transaction nonce was already used by another transaction.');
+    expect(txResult.extrinsicError).toBeUndefined();
+    expect(txResult.isFinalized).toBe(false);
+    findTransaction.mockRestore();
+  });
+
+  it('drops a stale submitted attempt and releases its nonce for replacement', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      txNonce: 4,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const replacementTx = {
+      signAsync: vi.fn(async (_signer, options) => ({
+        hash: { toHex: () => '0xreplacement' },
+        method: { toHuman: () => ({ section: 'proxy', method: 'addProxy' }) },
+        nonce: numberCodec(options.nonce),
+        send: vi.fn(async () => undefined),
+      })),
+    };
+    const client = {
+      tx: vi.fn(() => replacementTx),
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => []),
+        },
+        chain: {
+          getHeader: vi.fn(async () => ({ number: numberCodec(103) })),
+        },
+        system: {
+          accountNextIndex: vi.fn(async () => numberCodec(4)),
+        },
+      },
+    };
+    vi.mocked(getMainchainClient).mockResolvedValue(client as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+    const { tracker, historyTable } = await createTracker({
       txs: [tx],
       finalizedHeight: 103,
     });
 
     await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Replace);
+    expect(historyTable.record).toHaveBeenCalledWith({
+      transactionId: tx.id,
+      status: TransactionHistoryStatus.Dropped,
+      source: TransactionHistorySource.Local,
+    });
+
+    await tracker.submitAndWatch({
+      client: client as any,
+      tx: replacementTx as any,
+      txSigner: { address: tx.accountAddress } as any,
+      extrinsicType: tx.extrinsicType,
+      useLatestNonce: true,
+    });
+    expect(replacementTx.signAsync).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ nonce: 4 }));
+    findTransaction.mockRestore();
+  });
+
+  it('keeps a stale submitted attempt pending while it remains in the transaction pool', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => [{ hash: { toHex: () => tx.extrinsicHash } }]),
+        },
+      },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+    const { tracker, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(historyTable.record).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('keeps an overdue submitted attempt pending while it remains in the transaction pool', async () => {
+    const tx = createTransaction({
+      id: 4,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      txNonce: 4,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => [{ hash: { toHex: () => tx.extrinsicHash } }]),
+        },
+      },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+    const { tracker, table, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 161,
+      finalizedAccountNonce: 4,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(table.markExpiredWaitingForBlock).not.toHaveBeenCalled();
+    expect(historyTable.record).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('keeps a stale submitted attempt pending when found in a canonical block', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const pendingExtrinsics = vi.fn(async () => []);
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: { pendingExtrinsics },
+      },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce({
+      blockNumber: 102,
+      blockHash: '0xcanonical',
+      blockTime: new Date('2026-03-20T20:04:00Z').getTime(),
+      extrinsicIndex: 1,
+      fee: 1n,
+      tip: 0n,
+      extrinsicEvents: [],
+    });
+    const { tracker, table, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(table.recordInBlock).toHaveBeenCalledWith(tx, {
+      blockNumber: 102,
+      blockHash: '0xcanonical',
+      blockTime: new Date('2026-03-20T20:04:00Z'),
+      feePlusTip: 1n,
+      tip: 0n,
+      extrinsicError: undefined,
+      transactionEvents: [],
+      extrinsicIndex: 1,
+    });
+    expect(pendingExtrinsics).not.toHaveBeenCalled();
+    expect(historyTable.record).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('rechecks canonical blocks when the best head changes during the transaction pool lookup', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const canonicalTransaction = {
+      blockNumber: 104,
+      blockHash: '0xcanonical',
+      blockTime: new Date('2026-03-20T20:06:00Z').getTime(),
+      extrinsicIndex: 1,
+      fee: 1n,
+      tip: 0n,
+      extrinsicEvents: [],
+    };
+    const findTransaction = vi
+      .spyOn(TransactionEvents, 'findByExtrinsicHash')
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(canonicalTransaction);
+    const { tracker, table, historyTable, blockWatch } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => {
+            blockWatch.bestBlockHeader = { blockNumber: 104 };
+            return [];
+          }),
+        },
+      },
+    } as any);
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(findTransaction).toHaveBeenCalledTimes(2);
+    expect(table.recordInBlock).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ blockNumber: 104, blockHash: '0xcanonical' }),
+    );
+    expect(historyTable.record).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('does not rescan a transaction after it is dropped while a status update is queued', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    let finishPoolLookup!: () => void;
+    const poolLookup = new Promise<void>(resolve => {
+      finishPoolLookup = resolve;
+    });
+    const pendingExtrinsics = vi.fn(async () => {
+      await poolLookup;
+      return [];
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: { author: { pendingExtrinsics } },
+    } as any);
+    const findTransaction = vi
+      .spyOn(TransactionEvents, 'findByExtrinsicHash')
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        blockNumber: 104,
+        blockHash: '0xlate',
+        blockTime: new Date('2026-03-20T20:06:00Z').getTime(),
+        extrinsicIndex: 1,
+        fee: 1n,
+        tip: 0n,
+        extrinsicEvents: [],
+      });
+    const { tracker, table } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+    const attemptState = tracker.getTxAttemptState(tracker.data.txInfos[0], 2);
+    await vi.waitFor(() => expect(pendingExtrinsics).toHaveBeenCalledOnce());
+
+    const statusUpdate = (tracker as unknown as ITransactionTrackerTestApi).updatePendingStatuses({
+      blockNumber: 104,
+    });
+    finishPoolLookup();
+
+    await expect(attemptState).resolves.toBe(TxAttemptState.Replace);
+    await statusUpdate;
+    expect(findTransaction).toHaveBeenCalledOnce();
+    expect(table.recordInBlock).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('keeps an attempt pending when an in-block watch update arrives during the pool lookup', async () => {
+    const tx = createTransaction({
+      id: 7,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    let finishPoolLookup!: () => void;
+    const poolLookup = new Promise<void>(resolve => {
+      finishPoolLookup = resolve;
+    });
+    const pendingExtrinsics = vi.fn(async () => {
+      await poolLookup;
+      return [];
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: { author: { pendingExtrinsics } },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+    let finishWatchLookup!: () => void;
+    const watchLookup = new Promise<void>(resolve => {
+      finishWatchLookup = resolve;
+    });
+    const findWatchedTransaction = vi
+      .spyOn(TransactionEvents, 'findByExtrinsicHashInBlock')
+      .mockImplementation(async () => {
+        await watchLookup;
+        return {
+          blockNumber: 102,
+          blockHash: '0xin-block',
+          blockTime: new Date('2026-03-20T20:04:00Z').getTime(),
+          extrinsicIndex: 1,
+          fee: 1n,
+          tip: 0n,
+          extrinsicEvents: [],
+        };
+      });
+    const { tracker, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+    const attemptState = tracker.getTxAttemptState(tracker.data.txInfos[0], 2);
+    await vi.waitFor(() => expect(pendingExtrinsics).toHaveBeenCalledOnce());
+
+    const watchUpdate = (tracker as unknown as ITransactionTrackerTestApi).handleWatchedResult(
+      tx,
+      {
+        blockNumber: 102,
+        isFinalized: false,
+      },
+      {
+        status: {
+          isBroadcast: false,
+          isInBlock: true,
+          isFinalized: false,
+          isRetracted: false,
+          isUsurped: false,
+          isDropped: false,
+          isInvalid: false,
+          asInBlock: { toHex: () => '0xin-block' },
+        },
+      },
+    );
+    await Promise.resolve();
+    finishPoolLookup();
+
+    await expect(attemptState).resolves.toBe(TxAttemptState.Pending);
+    finishWatchLookup();
+    await watchUpdate;
+    expect(historyTable.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: TransactionHistoryStatus.Dropped }),
+    );
+    findTransaction.mockRestore();
+    findWatchedTransaction.mockRestore();
+  });
+
+  it('keeps a stale submitted attempt pending when the transaction pool is unavailable', async () => {
+    const tx = createTransaction({
+      id: 3,
+      status: TransactionStatus.Submitted,
+      submittedAtBlockHeight: 100,
+      blockHeight: undefined,
+      blockHash: undefined,
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn().mockRejectedValue(new Error('Transaction pool unavailable')),
+        },
+      },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValueOnce(undefined);
+    const { tracker, historyTable } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+    expect(historyTable.record).not.toHaveBeenCalled();
+    findTransaction.mockRestore();
+  });
+
+  it('replaces an in-block attempt missing from canonical history after the grace window', async () => {
+    const tx = createTransaction({
+      id: 4,
+      status: TransactionStatus.InBlock,
+      blockHeight: 100,
+      blockHash: '0xmissing',
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    vi.mocked(getMainchainClient).mockResolvedValue({
+      rpc: {
+        author: {
+          pendingExtrinsics: vi.fn(async () => []),
+        },
+      },
+    } as any);
+    const findTransaction = vi.spyOn(TransactionEvents, 'findByExtrinsicHash').mockResolvedValue(undefined);
+    const { tracker, blockWatch } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 101,
+    });
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+
+    blockWatch.finalizedBlockHeader.blockNumber = 103;
+    blockWatch.getFinalizedHash.mockResolvedValue('0xcanonical');
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Replace);
+    findTransaction.mockRestore();
+  });
+
+  it('keeps an in-block attempt pending when its finalized hash remains canonical', async () => {
+    const tx = createTransaction({
+      id: 5,
+      status: TransactionStatus.InBlock,
+      blockHeight: 100,
+      blockHash: '0xcanonical',
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const { tracker, blockWatch } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+    blockWatch.getFinalizedHash.mockResolvedValue('0xcanonical');
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
+  });
+
+  it('keeps a stale in-block attempt pending when canonical history is unavailable', async () => {
+    const tx = createTransaction({
+      id: 6,
+      status: TransactionStatus.InBlock,
+      blockHeight: 100,
+      blockHash: '0xunknown',
+      extrinsicType: ExtrinsicType.VaultCosignBitcoinRelease,
+    });
+    const { tracker, blockWatch } = await createTracker({
+      txs: [tx],
+      finalizedHeight: 103,
+    });
+    blockWatch.getFinalizedHash.mockRejectedValue(new Error('Finalized history unavailable'));
+
+    await expect(tracker.getTxAttemptState(tracker.data.txInfos[0], 2)).resolves.toBe(TxAttemptState.Pending);
   });
 
   it('does not retry a transaction based only on its nonce finalizing elsewhere', async () => {
@@ -392,7 +891,7 @@ describe('TransactionTracker', () => {
     expect(table.updateFinalizedHead).not.toHaveBeenCalled();
   });
 
-  it('expires an overdue transaction when the finalized nonce lookup fails', async () => {
+  it('keeps an overdue transaction pending when the finalized nonce lookup fails', async () => {
     const tx = createTransaction({
       id: 6,
       status: TransactionStatus.Submitted,
@@ -411,7 +910,7 @@ describe('TransactionTracker', () => {
 
     await trackerApi.updatePendingStatuses({ blockNumber: 125 });
 
-    expect(table.markExpiredWaitingForBlock).toHaveBeenCalledWith(tx);
+    expect(table.markExpiredWaitingForBlock).not.toHaveBeenCalled();
   });
 
   it('treats a dropped attempt as replaceable', async () => {
@@ -877,6 +1376,7 @@ async function createTracker(args: {
     ),
     markFinalized: vi.fn(async (record: ITransactionRecord) => record),
     recordInBlock: vi.fn(async (record: ITransactionRecord) => record),
+    recordSubmissionError: vi.fn(async (record: ITransactionRecord) => record),
     markExpiredWaitingForBlock: vi.fn(async (record: ITransactionRecord) => record),
     updateFinalizedHead: vi.fn(
       async (record: ITransactionRecord, finalizedDetails: { blockNumber: number; blockTime: Date }) => {
@@ -928,7 +1428,7 @@ async function createTracker(args: {
   vi.spyOn(tracker as any, 'watchForUpdates').mockResolvedValue(undefined);
   await tracker.load();
 
-  return { tracker, table, blockWatch, finalizedAccountQuery };
+  return { tracker, table, historyTable, blockWatch, finalizedAccountQuery };
 }
 
 function createLoadTracker(args: {

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -212,6 +212,10 @@ export default class BitcoinLocks {
   #relayPollingUuids = new Set<string>();
   #mempool: BitcoinMempool;
   #reportedMissingFundingForReleaseLocks = new Set<string>();
+  #fundingExpirationEstimateByCreatedHeight = new Map<
+    number,
+    { oracleBitcoinBlockHeight: number; expirationTime: number }
+  >();
   constructor(
     private readonly dbPromise: Promise<Db>,
     private readonly walletKeys: WalletKeys,
@@ -370,12 +374,25 @@ export default class BitcoinLocks {
     if (!this.#config) {
       throw new Error('Bitcoin lock configuration is not loaded for verify time.');
     }
-    const expirationHeight = this.#config.pendingConfirmationExpirationBlocks + lock.lockDetails.createdAtHeight;
+    const { createdAtHeight } = lock.lockDetails;
+    const expirationHeight = this.#config.pendingConfirmationExpirationBlocks + createdAtHeight;
+    const oracleBitcoinBlockHeight = this.oracleBitcoinBlockHeight;
 
-    if (expirationHeight <= this.oracleBitcoinBlockHeight) {
+    if (expirationHeight <= oracleBitcoinBlockHeight) {
       return Date.now() - 1; // Already expired
     }
-    return Date.now() + (expirationHeight - this.oracleBitcoinBlockHeight) * BITCOIN_BLOCK_MILLIS;
+
+    const previousEstimate = this.#fundingExpirationEstimateByCreatedHeight.get(createdAtHeight);
+    if (previousEstimate?.oracleBitcoinBlockHeight === oracleBitcoinBlockHeight) {
+      return previousEstimate.expirationTime;
+    }
+
+    const expirationTime = Date.now() + (expirationHeight - oracleBitcoinBlockHeight) * BITCOIN_BLOCK_MILLIS;
+    this.#fundingExpirationEstimateByCreatedHeight.set(createdAtHeight, {
+      oracleBitcoinBlockHeight,
+      expirationTime,
+    });
+    return expirationTime;
   }
 
   public getFundingWindowProgress(lock: Pick<IBitcoinLockRecord, 'lockDetails'>): number {

--- a/src-vue/lib/MiningAccount.ts
+++ b/src-vue/lib/MiningAccount.ts
@@ -34,28 +34,21 @@ export async function planMiningBidProxySetup(args: {
 
 export async function findTrackedMiningBidProxySetup(args: {
   transactionTracker: TransactionTracker;
-  followWindowFinalizedBlocks?: number;
+  waitForConfirmations?: number;
 }): Promise<TransactionInfo<MiningBidProxySetupMetadata> | undefined> {
-  const latestMiningBidProxySetupTxInfo = args.transactionTracker.findLatestTxInfo<MiningBidProxySetupMetadata>(
-    txInfo => txInfo.tx.extrinsicType === ExtrinsicType.MiningBidProxySetup,
-  );
-  if (!latestMiningBidProxySetupTxInfo) {
-    return;
-  }
-
-  const txAttemptState = await args.transactionTracker.getTxAttemptState(
-    latestMiningBidProxySetupTxInfo,
-    args.followWindowFinalizedBlocks ?? 2,
-  );
-  if (txAttemptState === TxAttemptState.Follow) {
-    return latestMiningBidProxySetupTxInfo;
+  const latestAttempt = await args.transactionTracker.findLatestTxAttempt<MiningBidProxySetupMetadata>({
+    extrinsicType: ExtrinsicType.MiningBidProxySetup,
+    waitForConfirmations: args.waitForConfirmations ?? 2,
+  });
+  if (latestAttempt?.txAttemptState === TxAttemptState.Pending) {
+    return latestAttempt.txInfo;
   }
 }
 
 export async function ensureMiningBidProxySetup(args: {
   transactionTracker: TransactionTracker;
   walletKeys: WalletKeys;
-  followWindowFinalizedBlocks?: number;
+  waitForConfirmations?: number;
   client?: ArgonClient;
 }): Promise<MiningBidProxySetupResult> {
   const trackedTxInfo = await findTrackedMiningBidProxySetup(args);

--- a/src-vue/lib/MintingAuthorities.ts
+++ b/src-vue/lib/MintingAuthorities.ts
@@ -404,23 +404,22 @@ export class MintingAuthorities {
 
   private async onRegister(txInfo: TransactionInfo<IMintingAuthorityRegisterMetadata>): Promise<void> {
     const postProcessor = txInfo.createPostProcessor();
-    const db = await this.dbPromise;
-    const client = await getMainchainClient(false);
     const { authorityIndex } = txInfo.tx.metadataJson;
 
     try {
-      await txInfo.txResult.waitForFinalizedBlock;
-    } catch (error) {
-      await db.walletHdKeysTable.delete({
-        keyRole: 'mintingAuthority',
-        scopeKey: this.walletKeys.vaultingAddress.toLowerCase(),
-        hdIndex: authorityIndex,
-      });
-      postProcessor.reject(error as Error);
-      throw error;
-    }
+      const db = await this.dbPromise;
+      try {
+        await txInfo.txResult.waitForFinalizedBlock;
+      } catch (error) {
+        await db.walletHdKeysTable.delete({
+          keyRole: 'mintingAuthority',
+          scopeKey: this.walletKeys.vaultingAddress.toLowerCase(),
+          hdIndex: authorityIndex,
+        });
+        throw error;
+      }
 
-    try {
+      const client = await getMainchainClient(false);
       const blockHash = txInfo.tx.blockHash ?? (await txInfo.txResult.waitForInFirstBlock);
       await this.refresh(await client.at(blockHash));
       postProcessor.resolve();

--- a/src-vue/lib/MoveCapital.ts
+++ b/src-vue/lib/MoveCapital.ts
@@ -30,7 +30,7 @@ export interface IAssetsToMove {
 }
 
 let pendingDefaultArgonMiningTransferPromise: Promise<DefaultArgonMiningTransferResult> | undefined;
-const DEFAULT_ARGON_MINING_TRANSFER_FOLLOW_WINDOW_FINALIZED_BLOCKS = 2;
+const DEFAULT_ARGON_MINING_TRANSFER_CONFIRMATIONS_TO_WAIT = 2;
 
 export class MoveCapital {
   public transactionError: string = '';
@@ -129,9 +129,9 @@ export class MoveCapital {
     if (latestSweepTxInfo) {
       const txAttemptState = await this.transactionTracker.getTxAttemptState(
         latestSweepTxInfo,
-        DEFAULT_ARGON_MINING_TRANSFER_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+        DEFAULT_ARGON_MINING_TRANSFER_CONFIRMATIONS_TO_WAIT,
       );
-      if (txAttemptState === TxAttemptState.Follow) {
+      if (txAttemptState === TxAttemptState.Pending) {
         return { kind: 'trackingExisting', txInfo: latestSweepTxInfo };
       }
     }
@@ -213,12 +213,12 @@ export class MoveCapital {
           txInfo: latestDefaultArgonMiningTransferTxInfo,
           txAttemptState: await this.transactionTracker.getTxAttemptState(
             latestDefaultArgonMiningTransferTxInfo,
-            DEFAULT_ARGON_MINING_TRANSFER_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+            DEFAULT_ARGON_MINING_TRANSFER_CONFIRMATIONS_TO_WAIT,
           ),
         }
       : undefined;
 
-    if (latestDefaultArgonMiningTransferAttempt?.txAttemptState === TxAttemptState.Follow) {
+    if (latestDefaultArgonMiningTransferAttempt?.txAttemptState === TxAttemptState.Pending) {
       return {
         kind: 'trackingExisting',
         txInfo: latestDefaultArgonMiningTransferAttempt.txInfo,
@@ -369,7 +369,7 @@ export class MoveCapital {
       const proxySetup = await ensureMiningBidProxySetup({
         transactionTracker: this.transactionTracker,
         walletKeys: this.walletKeys,
-        followWindowFinalizedBlocks: DEFAULT_ARGON_MINING_TRANSFER_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+        waitForConfirmations: DEFAULT_ARGON_MINING_TRANSFER_CONFIRMATIONS_TO_WAIT,
       });
       if (proxySetup.kind === 'trackingExisting' || proxySetup.kind === 'submitted') {
         await proxySetup.txInfo.waitForPostProcessing;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -123,8 +123,8 @@ export type IVaultBackfillChanges = {
   }[];
 };
 
-// Keep following a submitted/reorged cosign attempt briefly before retrying it.
-const COSIGN_ATTEMPT_FOLLOW_WINDOW_FINALIZED_BLOCKS = 2;
+// Keep a submitted or recently reorged cosign attempt pending briefly before retrying it.
+const COSIGN_ATTEMPT_CONFIRMATIONS_TO_WAIT = 2;
 
 export class MyVault {
   // The shared vault delegate now fronts both bitcoin lock relay work and Ethereum proof/beacon relay submissions.
@@ -1004,7 +1004,7 @@ export class MyVault {
 
       if (
         latestTxAttempt &&
-        (latestTxAttempt.txAttemptState === TxAttemptState.Follow ||
+        (latestTxAttempt.txAttemptState === TxAttemptState.Pending ||
           latestTxAttempt.txAttemptState === TxAttemptState.Finalized)
       ) {
         return { txInfo: latestTxAttempt.txInfo, vaultSignature: cosignResult.vaultSignature };
@@ -1054,7 +1054,7 @@ export class MyVault {
 
       if (
         latestTxAttempt &&
-        (latestTxAttempt.txAttemptState === TxAttemptState.Follow ||
+        (latestTxAttempt.txAttemptState === TxAttemptState.Pending ||
           latestTxAttempt.txAttemptState === TxAttemptState.Finalized)
       ) {
         const cosignResult = await this.buildOrphanCosignTx(args);
@@ -1222,7 +1222,7 @@ export class MyVault {
       txInfo: latestTxInfo,
       txAttemptState: await this.#transactionTracker.getTxAttemptState(
         latestTxInfo,
-        COSIGN_ATTEMPT_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+        COSIGN_ATTEMPT_CONFIRMATIONS_TO_WAIT,
       ),
     };
   }
@@ -1263,7 +1263,7 @@ export class MyVault {
       txInfo: latestTxInfo,
       txAttemptState: await this.#transactionTracker.getTxAttemptState(
         latestTxInfo,
-        COSIGN_ATTEMPT_FOLLOW_WINDOW_FINALIZED_BLOCKS,
+        COSIGN_ATTEMPT_CONFIRMATIONS_TO_WAIT,
       ),
     };
   }
@@ -1304,7 +1304,7 @@ export class MyVault {
         });
         if (
           latestTxAttempt &&
-          (latestTxAttempt.txAttemptState === TxAttemptState.Follow ||
+          (latestTxAttempt.txAttemptState === TxAttemptState.Pending ||
             latestTxAttempt.txAttemptState === TxAttemptState.Finalized)
         ) {
           continue;

--- a/src-vue/lib/OperationalAccount.ts
+++ b/src-vue/lib/OperationalAccount.ts
@@ -116,7 +116,7 @@ interface IEnsureOperationalAccountRegisteredArgs {
   walletKeys: WalletKeys;
   accessProof: IOperationalAccessProof | null;
   availableMicrogons: bigint;
-  followWindowFinalizedBlocks?: number;
+  waitForConfirmations?: number;
   client?: ArgonClient;
 }
 
@@ -197,17 +197,12 @@ export async function ensureOperationalAccountRegistered(
 ): Promise<TransactionInfo | undefined> {
   await args.transactionTracker.load();
 
-  const latestRegistrationTxInfo = args.transactionTracker.findLatestTxInfo(txInfo => {
-    return txInfo.tx.extrinsicType === ExtrinsicType.OperationalRegister;
+  const latestRegistrationAttempt = await args.transactionTracker.findLatestTxAttempt({
+    extrinsicType: ExtrinsicType.OperationalRegister,
+    waitForConfirmations: args.waitForConfirmations ?? 2,
   });
-  if (latestRegistrationTxInfo) {
-    const txAttemptState = await args.transactionTracker.getTxAttemptState(
-      latestRegistrationTxInfo,
-      args.followWindowFinalizedBlocks ?? 2,
-    );
-    if (txAttemptState === TxAttemptState.Follow) {
-      return latestRegistrationTxInfo;
-    }
+  if (latestRegistrationAttempt?.txAttemptState === TxAttemptState.Pending) {
+    return latestRegistrationAttempt.txInfo;
   }
 
   const client = args.client ?? (await getMainchainClient(false));

--- a/src-vue/lib/TransactionInfo.ts
+++ b/src-vue/lib/TransactionInfo.ts
@@ -195,9 +195,13 @@ export class TransactionInfo<MetadataType = unknown> {
 
     this.blockProgress.setIsFinalized(isFinalized);
     this.blockProgress.setBlockHeightGoal(this.tx.blockHeight);
-    const progressPct = this.blockProgress.getProgress();
+    let progressPct = this.blockProgress.getProgress();
     const confirmations = this.blockProgress.getConfirmations();
     const expectedConfirmations = this.blockProgress.expectedConfirmations;
+
+    if (progressPct > 99 && this.postProcessor && !this.postProcessor.isSettled) {
+      progressPct = 99;
+    }
 
     const error = this.txResult.submissionError ?? this.txResult.extrinsicError;
 
@@ -227,10 +231,6 @@ export class TransactionInfo<MetadataType = unknown> {
         status.expectedConfirmations = followOnStatus.expectedConfirmations;
         status.isFinalized &&= followOnStatus.isFinalized;
       }
-    }
-
-    if (status.progressPct > 99 && this.postProcessor && !this.postProcessor.isSettled) {
-      status.progressPct = 99;
     }
 
     const progressMessage = this.getWaitingForFinalizationMessage(status);

--- a/src-vue/lib/TransactionTracker.ts
+++ b/src-vue/lib/TransactionTracker.ts
@@ -41,9 +41,16 @@ type IWatchedTxStatus = {
 };
 
 export enum TxAttemptState {
-  Follow = 'Follow',
+  Pending = 'Pending',
   Finalized = 'Finalized',
   Replace = 'Replace',
+}
+
+enum TxReconciliationState {
+  Included = 'Included',
+  InPool = 'InPool',
+  Absent = 'Absent',
+  Unavailable = 'Unavailable',
 }
 
 export class TransactionTracker {
@@ -60,6 +67,9 @@ export class TransactionTracker {
   #bestBlockNumber?: number;
   #watchUnsubscribe?: () => void;
   #nonceLaneByAddress = new Map<string, Promise<void>>();
+  #statusLaneByTxId = new Map<number, Promise<void>>();
+  #pendingWatchResultsByTxId = new Map<number, number>();
+  #reconciliationByTxId = new Map<number, { head: string; state: TxReconciliationState }>();
   #isClosed = false;
 
   constructor(
@@ -95,6 +105,7 @@ export class TransactionTracker {
       const client = await getMainchainClient(false);
       await this.blockWatch.start();
 
+      this.#reconciliationByTxId.clear();
       this.data.txInfos.length = 0;
       for (const extrinsicType of Object.keys(this.data.txInfosByType)) {
         delete this.data.txInfosByType[extrinsicType as ExtrinsicType];
@@ -327,88 +338,161 @@ export class TransactionTracker {
       | undefined;
   }
 
-  public async getTxAttemptState(
-    txInfo: TransactionInfo,
-    followWindowFinalizedBlocks: number,
-  ): Promise<TxAttemptState> {
-    if (
-      txInfo.tx.submissionErrorJson ||
-      txInfo.tx.blockExtrinsicErrorJson ||
-      txInfo.tx.status === TransactionStatus.Error ||
-      txInfo.tx.status === TransactionStatus.TimedOutWaitingForBlock
-    ) {
-      return TxAttemptState.Replace;
-    }
+  public async findLatestTxAttempt<MetadataType = unknown>(args: {
+    extrinsicType: ExtrinsicType | ExtrinsicType[];
+    waitForConfirmations: number;
+    matches?: (txInfo: TransactionInfo<MetadataType>) => boolean;
+  }): Promise<{ txInfo: TransactionInfo<MetadataType>; txAttemptState: TxAttemptState } | undefined> {
+    await this.load();
 
-    const latestHistoryStatus = this.getLatestHistoryStatus(txInfo.tx.id);
-    if (
-      latestHistoryStatus === TransactionHistoryStatus.Dropped ||
-      latestHistoryStatus === TransactionHistoryStatus.Usurped ||
-      latestHistoryStatus === TransactionHistoryStatus.Invalid
-    ) {
-      return TxAttemptState.Replace;
-    }
+    const extrinsicTypes = Array.isArray(args.extrinsicType) ? args.extrinsicType : [args.extrinsicType];
+    const txInfo = this.findLatestTxInfo<MetadataType>(candidate => {
+      return extrinsicTypes.includes(candidate.tx.extrinsicType) && (args.matches?.(candidate) ?? true);
+    });
+    if (!txInfo) return;
 
-    if (latestHistoryStatus === TransactionHistoryStatus.Retracted && txInfo.tx.txNonce != null) {
-      for (const otherTxInfo of this.data.txInfos) {
-        if (otherTxInfo.tx.id === txInfo.tx.id) continue;
-        if (otherTxInfo.tx.accountAddress !== txInfo.tx.accountAddress) continue;
-        if (otherTxInfo.tx.txNonce == null || otherTxInfo.tx.txNonce < txInfo.tx.txNonce) continue;
+    return {
+      txInfo,
+      txAttemptState: await this.getTxAttemptState(txInfo, args.waitForConfirmations),
+    };
+  }
 
-        if (otherTxInfo.tx.status === TransactionStatus.Finalized) {
-          return TxAttemptState.Replace;
-        }
-
-        if (otherTxInfo.tx.status !== TransactionStatus.InBlock) {
-          continue;
-        }
-
-        const { blockHash, blockHeight } = otherTxInfo.tx;
-        if (!blockHash || blockHeight == null) {
-          continue;
-        }
-
-        const header = await this.blockWatch.getHeader(blockHeight).catch(() => undefined);
-        if (header?.blockHash === blockHash) {
-          return TxAttemptState.Replace;
-        }
-      }
-    }
-
-    const finalizedHeight = this.blockWatch.finalizedBlockHeader.blockNumber;
-
-    if (txInfo.tx.status === TransactionStatus.Submitted) {
-      if (finalizedHeight - txInfo.tx.submittedAtBlockHeight <= followWindowFinalizedBlocks) {
-        return TxAttemptState.Follow;
-      }
-      return TxAttemptState.Replace;
-    }
-
-    if (txInfo.tx.status === TransactionStatus.InBlock) {
-      const { blockHash, blockHeight } = txInfo.tx;
-      if (!blockHash || blockHeight == null) {
+  public async getTxAttemptState(txInfo: TransactionInfo, waitForConfirmations: number): Promise<TxAttemptState> {
+    return await this.runInTransactionStatusLane(txInfo.tx.id, async () => {
+      if (
+        txInfo.tx.submissionErrorJson ||
+        txInfo.tx.blockExtrinsicErrorJson ||
+        txInfo.tx.status === TransactionStatus.Error ||
+        txInfo.tx.status === TransactionStatus.TimedOutWaitingForBlock
+      ) {
         return TxAttemptState.Replace;
       }
 
-      const header = await this.blockWatch.getHeader(blockHeight).catch(() => undefined);
-      if (!header) {
-        return TxAttemptState.Follow;
-      }
-      if (header.blockHash === blockHash) {
-        return TxAttemptState.Follow;
-      }
-      if (finalizedHeight - blockHeight <= followWindowFinalizedBlocks) {
-        return TxAttemptState.Follow;
+      const latestHistoryStatus = this.getLatestHistoryStatus(txInfo.tx.id);
+      if (
+        latestHistoryStatus === TransactionHistoryStatus.Dropped ||
+        latestHistoryStatus === TransactionHistoryStatus.Usurped ||
+        latestHistoryStatus === TransactionHistoryStatus.Invalid
+      ) {
+        return TxAttemptState.Replace;
       }
 
+      if (latestHistoryStatus === TransactionHistoryStatus.Retracted && txInfo.tx.txNonce != null) {
+        for (const otherTxInfo of this.data.txInfos) {
+          if (otherTxInfo.tx.id === txInfo.tx.id) continue;
+          if (otherTxInfo.tx.accountAddress !== txInfo.tx.accountAddress) continue;
+          if (otherTxInfo.tx.txNonce == null || otherTxInfo.tx.txNonce < txInfo.tx.txNonce) continue;
+
+          if (otherTxInfo.tx.status === TransactionStatus.Finalized) {
+            return TxAttemptState.Replace;
+          }
+
+          if (otherTxInfo.tx.status !== TransactionStatus.InBlock) {
+            continue;
+          }
+
+          const { blockHash, blockHeight } = otherTxInfo.tx;
+          if (!blockHash || blockHeight == null) {
+            continue;
+          }
+
+          const header = await this.blockWatch.getHeader(blockHeight).catch(() => undefined);
+          if (header?.blockHash === blockHash) {
+            return TxAttemptState.Replace;
+          }
+        }
+      }
+
+      let reconciliationState: TxReconciliationState | undefined;
+      if (this.isTrackedAsPending(txInfo)) {
+        try {
+          reconciliationState = await this.reconcilePendingTransaction({
+            txInfo,
+            bestBlockInfo: { ...this.blockWatch.bestBlockHeader },
+            finalizedBlockHeader: { ...this.blockWatch.finalizedBlockHeader },
+            finalizedAccountNonceByAddress: new Map(),
+          });
+        } catch (error) {
+          console.warn('[TransactionTracker] Unable to reconcile transaction before choosing an attempt', {
+            transactionId: txInfo.tx.id,
+            error,
+          });
+          return TxAttemptState.Pending;
+        }
+      }
+
+      if (txInfo.txResult.submissionError || txInfo.txResult.extrinsicError) {
+        return TxAttemptState.Replace;
+      }
+      if (txInfo.tx.status === TransactionStatus.Finalized) {
+        return TxAttemptState.Finalized;
+      }
+      if (
+        reconciliationState === TxReconciliationState.Included ||
+        reconciliationState === TxReconciliationState.InPool
+      ) {
+        return TxAttemptState.Pending;
+      }
+
+      const finalizedHeight = this.blockWatch.finalizedBlockHeader.blockNumber;
+      const attemptHeight = txInfo.tx.blockHeight ?? txInfo.tx.submittedAtBlockHeight;
+      if (finalizedHeight - attemptHeight <= waitForConfirmations) {
+        return TxAttemptState.Pending;
+      }
+      if (txInfo.tx.status !== TransactionStatus.Submitted && txInfo.tx.status !== TransactionStatus.InBlock) {
+        return TxAttemptState.Replace;
+      }
+      if (reconciliationState === TxReconciliationState.Unavailable) {
+        return TxAttemptState.Pending;
+      }
+
+      try {
+        if (await this.isInTransactionPool(txInfo.tx.extrinsicHash)) {
+          return TxAttemptState.Pending;
+        }
+      } catch (error) {
+        console.warn('[TransactionTracker] Unable to check transaction pool before replacing transaction', {
+          transactionId: txInfo.tx.id,
+          error,
+        });
+        return TxAttemptState.Pending;
+      }
+
+      try {
+        reconciliationState = await this.reconcilePendingTransaction({
+          txInfo,
+          bestBlockInfo: { ...this.blockWatch.bestBlockHeader },
+          finalizedBlockHeader: { ...this.blockWatch.finalizedBlockHeader },
+          finalizedAccountNonceByAddress: new Map(),
+        });
+      } catch (error) {
+        console.warn('[TransactionTracker] Unable to reconcile transaction before replacing it', {
+          transactionId: txInfo.tx.id,
+          error,
+        });
+        return TxAttemptState.Pending;
+      }
+      if (
+        reconciliationState === TxReconciliationState.Included ||
+        reconciliationState === TxReconciliationState.InPool ||
+        reconciliationState === TxReconciliationState.Unavailable
+      ) {
+        return TxAttemptState.Pending;
+      }
+      if (!this.isTrackedAsPending(txInfo)) {
+        return TxAttemptState.Replace;
+      }
+      if (this.#pendingWatchResultsByTxId.has(txInfo.tx.id)) {
+        return TxAttemptState.Pending;
+      }
+
+      await this.recordHistoryStatus({
+        transactionId: txInfo.tx.id,
+        status: TransactionHistoryStatus.Dropped,
+        source: TransactionHistorySource.Local,
+      });
       return TxAttemptState.Replace;
-    }
-
-    if (txInfo.tx.status === TransactionStatus.Finalized) {
-      return TxAttemptState.Finalized;
-    }
-
-    return TxAttemptState.Replace;
+    });
   }
 
   public async trackTxResult<T>(
@@ -482,170 +566,214 @@ export class TransactionTracker {
 
   private async updatePendingStatuses(bestBlockInfo: IBlockHeaderInfo): Promise<void> {
     const finalizedBlockHeader = { ...this.blockWatch.finalizedBlockHeader };
-    const { blockNumber: finalizedHeight, blockTime: finalizedBlockTime } = finalizedBlockHeader;
-    const table = await this.getTable();
-    const bestBlockNumber = bestBlockInfo.blockNumber;
-    const checkedTxIds = new Set<number>();
     const finalizedAccountNonceByAddress = new Map<string, Promise<number | undefined>>();
 
     for (const txInfo of this.data.txInfos) {
-      const { tx, txResult } = txInfo;
       if (!this.isTrackedAsPending(txInfo)) {
         continue;
       }
       try {
-        const latestHistoryStatus = this.getLatestHistoryStatus(tx.id);
-        const shouldRescanBestBlockTx =
-          latestHistoryStatus === TransactionHistoryStatus.Retracted ||
-          this.isNonResumableWatchStatus(latestHistoryStatus);
-
-        if (tx.blockHeight) {
-          if (tx.blockHeight <= finalizedHeight) {
-            // ensure this block hash is still valid
-            const finalizedHash = await this.blockWatch.getFinalizedHash(tx.blockHeight);
-            if (finalizedHash === tx.blockHash) {
-              await table.markFinalized(tx, {
-                blockNumber: finalizedHeight,
-                blockTime: new Date(finalizedBlockTime),
-              });
-              await txResult.setFinalized();
-              checkedTxIds.add(tx.id);
-              continue;
-            }
-          } else if (!shouldRescanBestBlockTx) {
-            // The tx is already in a best block. Wait for finalization before attempting
-            // expensive relocation scans across the recent chain window.
-            checkedTxIds.add(tx.id);
-            continue;
+        await this.runInTransactionStatusLane(txInfo.tx.id, async () => {
+          if (!this.isTrackedAsPending(txInfo)) {
+            return;
           }
-        }
-
-        // first check if we can find the transaction (this is particularly relevant if we re-open the app after 60 blocks)
-        const MAX_BLOCKS_TO_CHECK = 60;
-        const searchStartBlockHeight = this.getSearchStartBlockHeight(tx);
-        const maxBlocksToCheck = Math.min(
-          MAX_BLOCKS_TO_CHECK,
-          Math.max(0, bestBlockInfo.blockNumber - searchStartBlockHeight),
-        );
-        const findTransactionResult = await TransactionEvents.findByExtrinsicHash({
-          blockWatch: this.blockWatch,
-          extrinsicHash: tx.extrinsicHash,
-          maxBlocksToCheck,
-          bestBlockHeight: bestBlockInfo.blockNumber,
-          searchStartBlockHeight,
-          blockCache: this.#blockCache,
+          await this.reconcilePendingTransaction({
+            txInfo,
+            bestBlockInfo,
+            finalizedBlockHeader,
+            finalizedAccountNonceByAddress,
+          });
         });
-        if (findTransactionResult) {
-          const originalBlockHash = tx.blockHash;
-          if (originalBlockHash === findTransactionResult.blockHash) {
-            // no change
-            const { extrinsicEvents, ...txResult } = findTransactionResult;
-            console.log('[TransactionTracker] No change in block', {
-              id: tx.id,
-              ...txResult,
-              transactionEvents: extrinsicEvents.map(x => x.toHuman()),
-            });
-            checkedTxIds.add(tx.id);
-            continue;
-          }
+      } catch (error) {
+        console.error(`[TransactionTracker] Error updating pending transaction #${txInfo.tx.id} status:`, error);
+      }
+    }
+    if (this.data.txInfos.every(x => !this.isTrackedAsPending(x))) {
+      this.stopWatching();
+    }
+  }
+
+  private async reconcilePendingTransaction(args: {
+    txInfo: TransactionInfo;
+    bestBlockInfo: IBlockHeaderInfo;
+    finalizedBlockHeader: IBlockHeaderInfo;
+    finalizedAccountNonceByAddress: Map<string, Promise<number | undefined>>;
+  }): Promise<TxReconciliationState> {
+    const { txInfo, bestBlockInfo, finalizedBlockHeader, finalizedAccountNonceByAddress } = args;
+    const { tx, txResult } = txInfo;
+    const finalizedHeight = finalizedBlockHeader.blockNumber;
+    const finalizedBlockTime = finalizedBlockHeader.blockTime;
+    const reconciliationHead = `${bestBlockInfo.blockNumber}:${bestBlockInfo.blockHash}:${finalizedHeight}:${finalizedBlockHeader.blockHash}`;
+    const cachedReconciliation = this.#reconciliationByTxId.get(tx.id);
+    if (cachedReconciliation?.head === reconciliationHead) {
+      return cachedReconciliation.state;
+    }
+
+    const table = await this.getTable();
+    let reconciliationState: TxReconciliationState | undefined;
+    const latestHistoryStatus = this.getLatestHistoryStatus(tx.id);
+    const shouldRescanBestBlockTx =
+      latestHistoryStatus === TransactionHistoryStatus.Retracted || this.isNonResumableWatchStatus(latestHistoryStatus);
+
+    if (tx.blockHeight) {
+      if (tx.blockHeight <= finalizedHeight) {
+        const finalizedHash = await this.blockWatch.getFinalizedHash(tx.blockHeight);
+        if (finalizedHash === tx.blockHash) {
+          await table.markFinalized(tx, {
+            blockNumber: finalizedHeight,
+            blockTime: new Date(finalizedBlockTime),
+          });
+          await txResult.setFinalized();
+          reconciliationState = TxReconciliationState.Included;
+        }
+      } else if (!shouldRescanBestBlockTx) {
+        reconciliationState = TxReconciliationState.Included;
+      }
+    }
+
+    const MAX_BLOCKS_TO_CHECK = 60;
+    if (!reconciliationState) {
+      const searchStartBlockHeight = this.getSearchStartBlockHeight(tx);
+      const maxBlocksToCheck = Math.min(
+        MAX_BLOCKS_TO_CHECK,
+        Math.max(0, bestBlockInfo.blockNumber - searchStartBlockHeight),
+      );
+      const findTransactionResult = await TransactionEvents.findByExtrinsicHash({
+        blockWatch: this.blockWatch,
+        extrinsicHash: tx.extrinsicHash,
+        maxBlocksToCheck,
+        bestBlockHeight: bestBlockInfo.blockNumber,
+        searchStartBlockHeight,
+        blockCache: this.#blockCache,
+      });
+      if (findTransactionResult) {
+        reconciliationState = TxReconciliationState.Included;
+        if (tx.blockHash === findTransactionResult.blockHash) {
+          const { extrinsicEvents, ...txResultDetails } = findTransactionResult;
+          console.log('[TransactionTracker] No change in block', {
+            id: tx.id,
+            ...txResultDetails,
+            transactionEvents: extrinsicEvents.map(x => x.toHuman()),
+          });
+        } else {
           const { blockHash, blockNumber, blockTime, fee, tip, error, extrinsicEvents, extrinsicIndex } =
             findTransactionResult;
-          const u8aBlockHash = hexToU8a(blockHash);
           await table.recordInBlock(tx, {
-            blockNumber: blockNumber,
+            blockNumber,
             blockHash,
             blockTime: new Date(blockTime),
             feePlusTip: fee,
-            tip: tip,
+            tip,
             extrinsicError: error,
             transactionEvents: extrinsicEvents,
             extrinsicIndex,
           });
           await txResult.setSeenInBlock({
-            blockHash: u8aBlockHash,
-            blockNumber: blockNumber,
+            blockHash: hexToU8a(blockHash),
+            blockNumber,
             events: extrinsicEvents,
             extrinsicIndex,
           });
 
-          if (findTransactionResult.blockNumber <= finalizedHeight) {
+          if (blockNumber <= finalizedHeight) {
             await table.markFinalized(tx, {
               blockNumber: finalizedHeight,
               blockTime: new Date(finalizedBlockTime),
             });
             await txResult.setFinalized();
           }
-        } else {
-          console.log('[TransactionTracker] No transaction found as of block', { bestBlockNumber, id: tx.id });
+        }
+      } else {
+        reconciliationState = TxReconciliationState.Absent;
+        console.log('[TransactionTracker] No transaction found as of block', {
+          bestBlockNumber: bestBlockInfo.blockNumber,
+          id: tx.id,
+        });
 
-          let finalizedNonceLookupFailed = false;
-          if (tx.txNonce != null && tx.finalizedHeadHeight !== finalizedHeight) {
-            let finalizedAccountNoncePromise = finalizedAccountNonceByAddress.get(tx.accountAddress);
-            if (!finalizedAccountNoncePromise) {
-              finalizedAccountNoncePromise = (async () => {
-                try {
-                  const api = await this.blockWatch.getApi(finalizedBlockHeader);
-                  const account = await api.query.system.account(tx.accountAddress);
-                  return account.nonce.toNumber();
-                } catch (error) {
-                  console.warn('[TransactionTracker] Unable to check finalized account nonce', {
-                    accountAddress: tx.accountAddress,
-                    finalizedHeight,
-                    error,
-                  });
-                }
-              })();
-              finalizedAccountNonceByAddress.set(tx.accountAddress, finalizedAccountNoncePromise);
-            }
-
-            const finalizedAccountNonce = await finalizedAccountNoncePromise;
-            if (finalizedAccountNonce === undefined) {
-              finalizedNonceLookupFailed = true;
-            } else if (finalizedAccountNonce > tx.txNonce) {
-              const error = new TxSubmissionError(
-                TxSubmissionErrorCode.Invalid,
-                'Transaction nonce was already used by another transaction.',
-              );
-              txResult.submissionError = error;
-              await this.recordHistoryStatus({
-                transactionId: tx.id,
-                status: TransactionHistoryStatus.Invalid,
-                source: TransactionHistorySource.Local,
-              });
-              await this.recordSubmissionError(tx, error);
-              checkedTxIds.add(tx.id);
-              continue;
-            }
+        if (tx.txNonce != null && tx.finalizedHeadHeight !== finalizedHeight) {
+          let finalizedAccountNoncePromise = finalizedAccountNonceByAddress.get(tx.accountAddress);
+          if (!finalizedAccountNoncePromise) {
+            finalizedAccountNoncePromise = (async () => {
+              try {
+                const api = await this.blockWatch.getApi(finalizedBlockHeader);
+                const account = await api.query.system.account(tx.accountAddress);
+                return account.nonce.toNumber();
+              } catch (error) {
+                console.warn('[TransactionTracker] Unable to check finalized account nonce', {
+                  accountAddress: tx.accountAddress,
+                  finalizedHeight,
+                  error,
+                });
+              }
+            })();
+            finalizedAccountNonceByAddress.set(tx.accountAddress, finalizedAccountNoncePromise);
           }
 
-          if (finalizedHeight - tx.submittedAtBlockHeight > MAX_BLOCKS_TO_CHECK) {
-            // too old, stop checking
-            console.log(`[TransactionTracker] Marking transaction #${tx.id} expired:`, tx.extrinsicHash);
-            txResult.extrinsicError = new Error('Transaction expired waiting for block inclusion');
-            await txResult.setFinalized();
-            await table.markExpiredWaitingForBlock(tx);
-          } else if (finalizedNonceLookupFailed) {
-            // Retry this account at the same finalized head after a transient RPC failure.
-            continue;
+          const finalizedAccountNonce = await finalizedAccountNoncePromise;
+          if (finalizedAccountNonce === undefined) {
+            reconciliationState = TxReconciliationState.Unavailable;
+          } else if (finalizedAccountNonce > tx.txNonce) {
+            const error = new TxSubmissionError(
+              TxSubmissionErrorCode.Invalid,
+              'Transaction nonce was already used by another transaction.',
+            );
+            txResult.submissionError = error;
+            await this.recordHistoryStatus({
+              transactionId: tx.id,
+              status: TransactionHistoryStatus.Invalid,
+              source: TransactionHistorySource.Local,
+            });
+            await this.recordSubmissionError(tx, error);
+            return TxReconciliationState.Absent;
           }
         }
-        checkedTxIds.add(tx.id);
-      } catch (error) {
-        console.error(`[TransactionTracker] Error updating pending transaction #${tx.id} status:`, error);
+
+        if (
+          reconciliationState === TxReconciliationState.Absent &&
+          finalizedHeight - tx.submittedAtBlockHeight > MAX_BLOCKS_TO_CHECK
+        ) {
+          try {
+            if (await this.isInTransactionPool(tx.extrinsicHash)) {
+              reconciliationState = TxReconciliationState.InPool;
+            } else {
+              console.log(`[TransactionTracker] Marking transaction #${tx.id} expired:`, tx.extrinsicHash);
+              txResult.extrinsicError = new Error('Transaction expired waiting for block inclusion');
+              await txResult.setFinalized();
+              await table.markExpiredWaitingForBlock(tx);
+            }
+          } catch (error) {
+            console.warn('[TransactionTracker] Unable to check transaction pool before expiring transaction', {
+              transactionId: tx.id,
+              error,
+            });
+            reconciliationState = TxReconciliationState.Unavailable;
+          }
+        }
       }
     }
-    for (const txInfo of this.data.txInfos) {
-      if (txInfo.tx.status === TransactionStatus.Finalized || txInfo.tx.status === TransactionStatus.Error) continue;
-      if (!checkedTxIds.has(txInfo.tx.id)) continue;
-      await table.updateFinalizedHead(txInfo.tx, {
+
+    if (reconciliationState === TxReconciliationState.Unavailable) {
+      return reconciliationState;
+    }
+    if (tx.status !== TransactionStatus.Finalized && tx.status !== TransactionStatus.Error) {
+      await table.updateFinalizedHead(tx, {
         blockNumber: finalizedHeight,
         blockTime: new Date(finalizedBlockTime),
       });
       txInfo.finalizedHeadHeight = finalizedHeight;
     }
-    if (this.data.txInfos.every(x => !this.isTrackedAsPending(x))) {
-      this.stopWatching();
+    if (reconciliationState === TxReconciliationState.InPool) {
+      return reconciliationState;
     }
+
+    this.#reconciliationByTxId.set(tx.id, { head: reconciliationHead, state: reconciliationState });
+    return reconciliationState;
+  }
+
+  private async isInTransactionPool(extrinsicHash: string): Promise<boolean> {
+    const client = await getMainchainClient(false);
+    const pendingExtrinsics = await client.rpc.author.pendingExtrinsics();
+    return pendingExtrinsics.some(extrinsic => extrinsic.hash.toHex() === extrinsicHash);
   }
 
   private async getTable(): Promise<TransactionsTable> {
@@ -672,6 +800,26 @@ export class TransactionTracker {
     if (record.status === TransactionStatus.Error) return;
     const table = await this.getTable();
     await table.recordSubmissionError(record, error);
+  }
+
+  private async runInTransactionStatusLane<T>(transactionId: number, callback: () => Promise<T>): Promise<T> {
+    const priorLane = this.#statusLaneByTxId.get(transactionId) ?? Promise.resolve();
+    let releaseLane!: VoidFunction;
+    const lane = new Promise<void>(resolve => {
+      releaseLane = resolve;
+    });
+    const currentLane = priorLane.then(() => lane);
+    this.#statusLaneByTxId.set(transactionId, currentLane);
+
+    await priorLane;
+    try {
+      return await callback();
+    } finally {
+      releaseLane();
+      if (this.#statusLaneByTxId.get(transactionId) === currentLane) {
+        this.#statusLaneByTxId.delete(transactionId);
+      }
+    }
   }
 
   private async reserveLatestNonce(
@@ -722,35 +870,49 @@ export class TransactionTracker {
     if (this.#isClosed) {
       return;
     }
-    try {
-      const { status } = result;
-      const isInBlock = status.isInBlock;
-      const isFinalized = status.isFinalized || txResult.isFinalized;
-      let blockHash: string | undefined;
-      if (isInBlock) {
-        blockHash = status.asInBlock.toHex();
-      } else if (status.isFinalized) {
-        blockHash = status.asFinalized.toHex();
-      }
-      const submissionError = txResult.submissionError;
+    this.#pendingWatchResultsByTxId.set(record.id, (this.#pendingWatchResultsByTxId.get(record.id) ?? 0) + 1);
 
-      await this.recordWatchStatus(record, {
-        isBroadcast: status.isBroadcast,
-        isInBlock,
-        isFinalized,
-        isRetracted: status.isRetracted,
-        isUsurped: status.isUsurped,
-        isDropped: status.isDropped,
-        isInvalid: status.isInvalid,
-        blockHash,
-        blockNumber: txResult.blockNumber,
-        replacementTxHash: status.isUsurped ? status.asUsurped.toHex() : undefined,
+    try {
+      await this.runInTransactionStatusLane(record.id, async () => {
+        if (this.#isClosed) {
+          return;
+        }
+        const { status } = result;
+        const isInBlock = status.isInBlock;
+        const isFinalized = status.isFinalized || txResult.isFinalized;
+        let blockHash: string | undefined;
+        if (isInBlock) {
+          blockHash = status.asInBlock.toHex();
+        } else if (status.isFinalized) {
+          blockHash = status.asFinalized.toHex();
+        }
+        const submissionError = txResult.submissionError;
+
+        await this.recordWatchStatus(record, {
+          isBroadcast: status.isBroadcast,
+          isInBlock,
+          isFinalized,
+          isRetracted: status.isRetracted,
+          isUsurped: status.isUsurped,
+          isDropped: status.isDropped,
+          isInvalid: status.isInvalid,
+          blockHash,
+          blockNumber: txResult.blockNumber,
+          replacementTxHash: status.isUsurped ? status.asUsurped.toHex() : undefined,
+        });
+        if (submissionError) {
+          await this.recordSubmissionError(record, submissionError);
+        }
       });
-      if (submissionError) {
-        await this.recordSubmissionError(record, submissionError);
-      }
     } catch (error) {
       console.error(`[TransactionTracker] Error handling watched tx #${record.id} update`, error);
+    } finally {
+      const pendingWatchResults = (this.#pendingWatchResultsByTxId.get(record.id) ?? 1) - 1;
+      if (pendingWatchResults > 0) {
+        this.#pendingWatchResultsByTxId.set(record.id, pendingWatchResults);
+      } else {
+        this.#pendingWatchResultsByTxId.delete(record.id);
+      }
     }
   }
 
@@ -769,6 +931,8 @@ export class TransactionTracker {
       replacementTxHash,
     }: IWatchedTxStatus,
   ) {
+    this.#reconciliationByTxId.delete(record.id);
+
     if (isBroadcast) {
       await this.recordHistoryStatus({
         transactionId: record.id,

--- a/src-vue/lib/VaultCollectBuilder.ts
+++ b/src-vue/lib/VaultCollectBuilder.ts
@@ -255,7 +255,7 @@ async function buildCollectBitcoinTxs(args: {
     const latestTxAttempt = await myVault.findLatestReleaseCosignTxAttempt(utxoId);
     if (
       latestTxAttempt &&
-      (latestTxAttempt.txAttemptState === TxAttemptState.Follow ||
+      (latestTxAttempt.txAttemptState === TxAttemptState.Pending ||
         latestTxAttempt.txAttemptState === TxAttemptState.Finalized)
     ) {
       continue;

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -226,7 +226,7 @@ async function ensureTrackedSetupTransfer(force = false) {
   const txInfo = findLatestSetupTxInfo();
   if (txInfo) {
     const txAttemptState = await transactionTracker.getTxAttemptState(txInfo, 2);
-    if (txAttemptState === TxAttemptState.Follow) {
+    if (txAttemptState === TxAttemptState.Pending) {
       trackTxInfo(txInfo);
       return;
     }


### PR DESCRIPTION
## Summary

Transactions that lose or outlive their original subscription now recover from canonical chain state before the app decides to retry. Watch and polling updates are serialized per transaction, and an attempt is replaced only after checking canonical blocks, finalized nonce ownership, and the transaction pool. RPC uncertainty keeps the attempt pending.

Callers now share the same pending-attempt semantics and confirmation window. Transaction progress remains below 100% until post-processing settles, while Bitcoin funding countdown estimates stay stable across ordinary UI refreshes. The dev upstream bidder also keeps more capital available during full-flow testing.

## Validation

- 133 affected unit tests passed across transaction tracking, callers, Bitcoin locks, and post-processing.
- Full TypeScript typechecking, Prettier, and ESLint passed.
- A manual docknet session finalized all 12 submitted transactions with canonical block hashes and no errors, drops, or replacements. This included a Bitcoin request that took 78.5 seconds and 34 blocks to finalize without being replaced.
