### PR TITLE
fix: correct recovered server and elapsed status

### DIFF
--- a/src-vue/__test__/ElapsedTime.test.ts
+++ b/src-vue/__test__/ElapsedTime.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+import { getElapsedTime } from '../lib/ElapsedTime.ts';
+
+it('treats a future timestamp as zero elapsed time', () => {
+  expect(getElapsedTime(-300)).toEqual({
+    totalSeconds: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  });
+});

--- a/src-vue/components/CountupClock.vue
+++ b/src-vue/components/CountupClock.vue
@@ -8,6 +8,7 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import dayjs, { type Dayjs } from 'dayjs';
+import { getElapsedTime } from '../lib/ElapsedTime.ts';
 
 const props = defineProps<{
   time: Dayjs | null;
@@ -37,10 +38,11 @@ function updateTime() {
 
   if (props.time) {
     const now = dayjs.utc();
-    totalSecondsElapsed = now.diff(props.time, 'seconds');
-    hours.value = Math.floor(totalSecondsElapsed / 3600);
-    minutes.value = Math.floor((totalSecondsElapsed % 3600) / 60);
-    seconds.value = totalSecondsElapsed % 60;
+    const elapsed = getElapsedTime(now.diff(props.time, 'seconds'));
+    totalSecondsElapsed = elapsed.totalSeconds;
+    hours.value = elapsed.hours;
+    minutes.value = elapsed.minutes;
+    seconds.value = elapsed.seconds;
     isNull.value = false;
   } else {
     hours.value = 0;

--- a/src-vue/lib/ElapsedTime.ts
+++ b/src-vue/lib/ElapsedTime.ts
@@ -1,0 +1,10 @@
+export function getElapsedTime(totalSeconds: number) {
+  totalSeconds = Math.max(0, totalSeconds);
+
+  return {
+    totalSeconds,
+    hours: Math.floor(totalSeconds / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+  };
+}

--- a/src-vue/screens/mining-screen/SetupChecklist.vue
+++ b/src-vue/screens/mining-screen/SetupChecklist.vue
@@ -28,7 +28,7 @@
           class="flex flex-row cursor-pointer py-5 grow items-center"
         >
           <div class="flex flex-row">
-            <Checkbox :isChecked="wallets.isLoaded && hasMiningMachine" />
+            <Checkbox :isChecked="serverConnectIsChecked" />
             <div class="px-4">
               <h2 class="text-2xl text-argon-600 font-bold">
                 Connect a Cloud Machine
@@ -39,7 +39,7 @@
                   class="pointer-events-none absolute top-1/2 -right-3 -translate-y-1/2 translate-x-full z-50 -mt-0.5"
                 />
               </h2>
-              <p v-if="hasMiningMachine">
+              <p v-if="config.isServerAdded">
                 <template v-if="config.serverAdd?.localComputer">This local computer will be used to run your mining software. We've already checked its requirements.</template>
                 <template v-else-if="config.serverAdd?.digitalOcean">Your Digital Ocean API Key is ready to go. We will do all the work of creating and setting up your server.</template>
                 <template v-else>Your custom server is connected and verified. We'll do the work of installing and configuring the software.</template>
@@ -249,7 +249,7 @@ const averageAPY = Vue.ref(0);
 const calculatorLoadError = Vue.ref(false);
 
 const serverConnectIsChecked = Vue.computed(() => {
-  return wallets.isLoaded && hasMiningMachine.value;
+  return wallets.isLoaded && config.isServerAdded;
 });
 
 const currentStep = Vue.computed(() => {
@@ -317,12 +317,7 @@ const walletIsFullyFunded = Vue.computed(() => {
 });
 
 const canLaunchMiningBot = Vue.computed(() => {
-  return walletIsFullyFunded.value && hasMiningMachine.value && config.isServerInstalled && !basics.overlayIsOpen;
-});
-
-const hasMiningMachine = Vue.computed(() => {
-  const x = config.serverAdd;
-  return !!x?.customServer || !!x?.localComputer || !!x?.digitalOcean;
+  return walletIsFullyFunded.value && config.isServerAdded && config.isServerInstalled && !basics.overlayIsOpen;
 });
 
 function calculateAlignOffset(event: MouseEvent, parentElement: HTMLElement | null, align: 'start' | 'end') {

--- a/src-vue/screens/network-screen/BlankSlateBlocks.vue
+++ b/src-vue/screens/network-screen/BlankSlateBlocks.vue
@@ -76,6 +76,7 @@ import { useBlockchainStore } from '../../stores/blockchain.ts';
 import dayjs, { Dayjs } from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { Motion } from 'motion-v';
+import { getElapsedTime } from '../../lib/ElapsedTime.ts';
 
 dayjs.extend(utc);
 
@@ -185,9 +186,9 @@ async function loadBlocks() {
 function updateTimeSinceBlock(runContinuously: boolean = true) {
   if (lastBlockTimestamp) {
     const now = dayjs.utc();
-    const totalSecondsSinceBlock = now.diff(lastBlockTimestamp, 'seconds');
-    minutesSinceBlock.value = totalSecondsSinceBlock < 60 ? 0 : Math.floor(totalSecondsSinceBlock / 60);
-    secondsSinceBlock.value = totalSecondsSinceBlock % 60;
+    const elapsed = getElapsedTime(now.diff(lastBlockTimestamp, 'seconds'));
+    minutesSinceBlock.value = elapsed.totalSeconds < 60 ? 0 : Math.floor(elapsed.totalSeconds / 60);
+    secondsSinceBlock.value = elapsed.seconds;
   }
   if (runContinuously) {
     timeSinceBlockTimeout = setTimeout(updateTimeSinceBlock, 1000);

--- a/src-vue/screens/vaulting-screen/SetupChecklist.vue
+++ b/src-vue/screens/vaulting-screen/SetupChecklist.vue
@@ -40,7 +40,7 @@
                   class="pointer-events-none absolute top-1/2 -right-3 -translate-y-1/2 translate-x-full z-50 -mt-0.5"
                 />
               </h2>
-              <p v-if="hasMiningMachine">
+              <p v-if="config.isServerAdded">
                 <template v-if="config.serverAdd?.localComputer">This local computer will be used to run your mining software. We've already checked its requirements.</template>
                 <template v-else-if="config.serverAdd?.digitalOcean">Your Digital Ocean API Key is ready to go. We will do all the work of creating and setting up your server.</template>
                 <template v-else>Your custom server is connected and verified. We'll do the work of installing and configuring the software.</template>
@@ -201,7 +201,7 @@ const futureTransactionFeeBudgetMicrogons = 2n * BigInt(MICROGONS_PER_ARGON);
 const treasuryBondSuggestionIncrementMicrogons = 100n * BigInt(MICROGONS_PER_ARGON);
 
 const serverConnectIsChecked = Vue.computed(() => {
-  return wallets.isLoaded && hasMiningMachine.value;
+  return wallets.isLoaded && config.isServerAdded;
 });
 
 const currentStep = Vue.computed(() => {
@@ -258,11 +258,6 @@ const walletIsFullyFunded = Vue.computed(() => {
   }
 
   return true;
-});
-
-const hasMiningMachine = Vue.computed(() => {
-  const x = config.serverAdd;
-  return !!x?.customServer || !!x?.localComputer || !!x?.digitalOcean;
 });
 
 function calculateAlignOffset(event: MouseEvent, parentElement: HTMLElement | null, align: 'start' | 'end') {


### PR DESCRIPTION
## Summary

- Mark an existing configured server complete in Mining and Vaulting setup after account recovery, even before a miner or vault exists.
- Clamp future server activity timestamps to zero so count-up clocks show `0s ago` instead of negative time.

## Validation

- Added focused coverage for future elapsed timestamps.
- Vue typechecking and formatting checks pass.
