### PR TITLE
feat: clarify bitcoin lock amounts and funding

### DIFF
--- a/e2e/argon/oracle/test-price-index.json
+++ b/e2e/argon/oracle/test-price-index.json
@@ -1,6 +1,6 @@
 {
-  "argon_usd_target_price": 1.034,
-  "argon_usd_price": 1.034,
+  "argon_usd_target_price": 1.06,
+  "argon_usd_price": 1.06,
   "argon_time_weighted_average_liquidity": 100000000,
   "argonot_usd_price": 0.05,
   "btc_usd_price": 120000.0

--- a/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
+++ b/e2e/flows/operations/Bitcoin.op.fundLockExact.ts
@@ -8,6 +8,7 @@ import type { IBitcoinVaultMismatchState } from '../types/srcVue.ts';
 import { Operation } from './index.ts';
 import type { IBitcoinFlowContext } from '../contexts/bitcoinContext.ts';
 import type { IE2EOperationInspectState, IE2EOperationState } from '../types.ts';
+import { clickIfVisible } from '../helpers/utils.ts';
 import bitcoinEnsureMismatchActionPanel from './Bitcoin.op.ensureMismatchActionPanel.ts';
 import { BITCOIN_LOCK_ENTRY_SELECTOR } from './Bitcoin.op.activateTab.ts';
 
@@ -99,6 +100,13 @@ function createBitcoinFundLockExactOperation(): Operation<IBitcoinFlowContext, I
         minimumSatoshis: flowState.lockFundingDetails.amountSatoshis,
         minerAddress,
       });
+      const checkedForTransfer = await clickIfVisible(flow, 'LockReadyForBitcoin.checkForBitcoin()');
+      if (!checkedForTransfer) {
+        const latest = await flow.inspect<IFundLockExactState>();
+        if (latest.uiState.lockingOverlayState !== 'ProcessingOnBitcoin') {
+          throw new Error(`${flowName}: the Bitcoin transfer check was not clickable.`);
+        }
+      }
       await flow.poll<IFundLockExactState>(
         latest => {
           if (latest.state === 'uiStateMismatch') {

--- a/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
+++ b/e2e/flows/operations/Bitcoin.op.startBitcoinLock.ts
@@ -111,6 +111,8 @@ export default new Operation<IBitcoinFlowContext, IStartBitcoinLockState>(import
         },
       );
     } else if (input.minimumLockSatoshis != null) {
+      await flow.click('LockStart.amountUnit');
+      await flow.click('BTC');
       await flow.type(
         { selector: '[data-testid="LockStart.bitcoinAmount"] [data-testid="input-number"]' },
         formatUnitsToDecimal(input.minimumLockSatoshis, SATOSHIS_PER_BTC, `${flowName}.minimumLockSatoshis`),

--- a/src-vue/__test__/BitcoinLocks.test.ts
+++ b/src-vue/__test__/BitcoinLocks.test.ts
@@ -1950,6 +1950,22 @@ describe('BitcoinLocks ratchet preview', () => {
 describe('BitcoinLocks capacity owners', () => {
   afterEach(() => vi.restoreAllMocks());
 
+  it('keeps vault capacity while rounding the Bitcoin requirement up', async () => {
+    const store = createStore();
+    vi.spyOn(BitcoinLock, 'calculateRedemptionAmount').mockImplementation((_priceIndex, targetPrice) => targetPrice);
+
+    expect(await store.satoshisForArgonLiquidity(3n, 200_000_000n)).toBe(2n);
+
+    vi.spyOn(store, 'satoshisForArgonLiquidity').mockResolvedValue(301n);
+    const capacity = await store.getLockableBitcoinCapacity({
+      vault: { availableBitcoinSpace: () => 300n } as never,
+      microgonsAtTargetPerBtc: 200_000_000n,
+    });
+
+    expect(capacity.availableLiquidityMicrogons).toBe(300n);
+    expect(capacity.availableSatoshis).toBe(301n);
+  });
+
   it('uses the prospective owner for lockable capacity', async () => {
     const store = createStore();
     const availableBitcoinSpace = vi.fn(() => 300n);

--- a/src-vue/components/InputMoney.vue
+++ b/src-vue/components/InputMoney.vue
@@ -39,6 +39,7 @@ const props = withDefaults(
     minDecimals?: number;
     maxDecimals?: number;
     prefix?: string;
+    symbol?: string;
   }>(),
   {
     options: () => [],
@@ -58,7 +59,7 @@ const emit = defineEmits<{
 }>();
 
 const prefix = Vue.computed(() => {
-  return (props.prefix || '') + currency.symbol;
+  return (props.prefix || '') + (props.symbol ?? currency.symbol);
 });
 
 const modelValue = Vue.computed(() => {

--- a/src-vue/lib/BitcoinLocks.ts
+++ b/src-vue/lib/BitcoinLocks.ts
@@ -744,9 +744,37 @@ export default class BitcoinLocks {
     await db.execute('DELETE FROM BitcoinLockVaultHdSeq', []);
   }
 
-  public async satoshisForArgonLiquidity(microgonLiquidity: bigint): Promise<bigint> {
-    await this.#currency.load(true);
-    return BitcoinLock.satoshisRequiredForRedemptionAmount(this.#currency.priceIndex, microgonLiquidity);
+  public async satoshisForArgonLiquidity(microgonLiquidity: bigint, microgonsAtTargetPerBtc?: bigint): Promise<bigint> {
+    if (microgonsAtTargetPerBtc === undefined) {
+      await this.#currency.load(true);
+      return BitcoinLock.satoshisRequiredForRedemptionAmount(this.#currency.priceIndex, microgonLiquidity);
+    }
+
+    if (microgonLiquidity <= 0n || microgonsAtTargetPerBtc <= 0n) return 0n;
+
+    let lowerSatoshis = 0n;
+    let upperSatoshis = 1n;
+    while (this.argonLiquidityForSatoshis(upperSatoshis, microgonsAtTargetPerBtc) < microgonLiquidity) {
+      upperSatoshis *= 2n;
+    }
+
+    while (lowerSatoshis < upperSatoshis) {
+      const satoshis = (lowerSatoshis + upperSatoshis) / 2n;
+      if (this.argonLiquidityForSatoshis(satoshis, microgonsAtTargetPerBtc) >= microgonLiquidity) {
+        upperSatoshis = satoshis;
+      } else {
+        lowerSatoshis = satoshis + 1n;
+      }
+    }
+    return lowerSatoshis;
+  }
+
+  public argonLiquidityForSatoshis(satoshis: bigint, microgonsAtTargetPerBtc?: bigint): bigint {
+    const targetPrice =
+      microgonsAtTargetPerBtc === undefined
+        ? this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(satoshis)
+        : (microgonsAtTargetPerBtc * satoshis) / SATOSHIS_PER_BITCOIN;
+    return BitcoinLock.calculateRedemptionAmount(this.#currency.priceIndex, targetPrice);
   }
 
   public async getLockableBitcoinCapacity(args: {
@@ -754,13 +782,14 @@ export default class BitcoinLocks {
     lockOwner?: string;
     maxSatoshis?: bigint;
     projectedBackfillSecuritizationLocked?: bigint;
+    microgonsAtTargetPerBtc?: bigint;
   }): Promise<{
     availableSatoshis: bigint;
     availableLiquidityMicrogons: bigint;
     vaultCapacitySatoshis: bigint;
     vaultCapacityLiquidityMicrogons: bigint;
   }> {
-    const { vault, lockOwner, maxSatoshis, projectedBackfillSecuritizationLocked } = args;
+    const { vault, lockOwner, maxSatoshis, projectedBackfillSecuritizationLocked, microgonsAtTargetPerBtc } = args;
     let vaultCapacityLiquidityMicrogons: bigint;
     if (projectedBackfillSecuritizationLocked == null) {
       vaultCapacityLiquidityMicrogons = vault.availableBitcoinSpace(lockOwner) ?? 0n;
@@ -780,25 +809,16 @@ export default class BitcoinLocks {
     if (!this.#currency.isLoaded) {
       await this.#currency.load();
     }
-    const vaultCapacitySatoshis = BitcoinLock.satoshisRequiredForRedemptionAmount(
-      this.#currency.priceIndex,
-      vaultCapacityLiquidityMicrogons,
-    );
-    let availableSatoshis =
-      maxSatoshis != null && maxSatoshis < vaultCapacitySatoshis ? maxSatoshis : vaultCapacitySatoshis;
-
-    while (
-      availableSatoshis > 0n &&
-      BitcoinLock.calculateRedemptionAmountFromSatoshis(this.#currency.priceIndex, availableSatoshis) >
-        vaultCapacityLiquidityMicrogons
-    ) {
-      availableSatoshis -= 1n;
+    const vaultCapacitySatoshis =
+      microgonsAtTargetPerBtc === undefined
+        ? BitcoinLock.satoshisRequiredForRedemptionAmount(this.#currency.priceIndex, vaultCapacityLiquidityMicrogons)
+        : await this.satoshisForArgonLiquidity(vaultCapacityLiquidityMicrogons, microgonsAtTargetPerBtc);
+    let availableSatoshis = vaultCapacitySatoshis;
+    let availableLiquidityMicrogons = vaultCapacityLiquidityMicrogons;
+    if (maxSatoshis != null && maxSatoshis < vaultCapacitySatoshis) {
+      availableSatoshis = maxSatoshis;
+      availableLiquidityMicrogons = this.argonLiquidityForSatoshis(availableSatoshis, microgonsAtTargetPerBtc);
     }
-
-    const availableLiquidityMicrogons = BitcoinLock.calculateRedemptionAmountFromSatoshis(
-      this.#currency.priceIndex,
-      availableSatoshis,
-    );
 
     return {
       availableSatoshis,
@@ -812,8 +832,9 @@ export default class BitcoinLocks {
     vault: Vault;
     txSigner: TxSigningAccount;
     tip?: bigint;
+    microgonsAtTargetPerBtc?: bigint;
   }): Promise<{ canAfford: boolean; txFeePlusTip: bigint; securityFee: bigint }> {
-    const { vault, txSigner, tip = 0n } = args;
+    const { vault, txSigner, tip = 0n, microgonsAtTargetPerBtc } = args;
     const ownerBitcoinXpriv = await this.walletKeys.getBitcoinChildXpriv(
       `m/1018'/0'/${vault.vaultId}'/0/0'`,
       this.bitcoinNetwork,
@@ -828,6 +849,7 @@ export default class BitcoinLocks {
       ownerBitcoinPubkey,
       txSigner,
       tip,
+      microgonsAtTargetPerBtc,
       satoshis: await this.minimumSatoshiPerLock(),
     });
   }
@@ -842,6 +864,7 @@ export default class BitcoinLocks {
     satoshis: bigint;
     tip?: bigint;
     operatorCoupon?: IOperatorBitcoinLockCouponRoute;
+    microgonsAtTargetPerBtc?: bigint;
   }): Promise<{ pendingLock: IBitcoinLockRecord; txInfo?: TransactionInfo<IBitcoinRequestLockMetadata> }> {
     const { vault, satoshis, tip, operatorCoupon } = args;
     const txSigner = await this.walletKeys.getLiquidLockingKeypair();
@@ -871,6 +894,7 @@ export default class BitcoinLocks {
         vault,
         satoshis,
         operatorCoupon,
+        microgonsAtTargetPerBtc: args.microgonsAtTargetPerBtc,
       });
     }
 
@@ -882,8 +906,9 @@ export default class BitcoinLocks {
       );
     }
     const submitTxClient = await getMainchainClient(false);
-    const microgonsAtTargetPerBtc = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
-    const liquidityPromised = BitcoinLock.calculateRedemptionAmountFromSatoshis(this.#currency.priceIndex, satoshis);
+    const microgonsAtTargetPerBtc =
+      args.microgonsAtTargetPerBtc ?? this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
+    const liquidityPromised = this.argonLiquidityForSatoshis(satoshis, microgonsAtTargetPerBtc);
 
     const { ownerBitcoinPubkey, hdPath } = await this.getNextUtxoPubkey(args);
     const { tx, securityFee } = await BitcoinLock.createInitializeTx({
@@ -927,6 +952,7 @@ export default class BitcoinLocks {
     vault: Vault;
     satoshis: bigint;
     operatorCoupon: IOperatorBitcoinLockCouponRoute;
+    microgonsAtTargetPerBtc?: bigint;
   }): Promise<{ pendingLock: IBitcoinLockRecord; txInfo?: TransactionInfo<IBitcoinRequestLockMetadata> }> {
     const { offerCode } = args.operatorCoupon;
     const operatorHost = await this.upstreamOperatorClient.resolveOperatorHost();
@@ -934,11 +960,9 @@ export default class BitcoinLocks {
       throw new Error('No upstream operator host configured.');
     }
 
-    const microgonsAtTargetPerBtc = this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
-    const liquidityPromised = BitcoinLock.calculateRedemptionAmountFromSatoshis(
-      this.#currency.priceIndex,
-      args.satoshis,
-    );
+    const microgonsAtTargetPerBtc =
+      args.microgonsAtTargetPerBtc ?? this.#currency.priceIndex.getSatoshiPriceInTargetMicrogons(SATOSHIS_PER_BITCOIN);
+    const liquidityPromised = this.argonLiquidityForSatoshis(args.satoshis, microgonsAtTargetPerBtc);
     const { ownerBitcoinPubkey, hdPath } = await this.getNextUtxoPubkey({ vault: args.vault });
 
     const relay = await this.upstreamOperatorClient.initializeBitcoinLock(offerCode, {

--- a/src-vue/lib/numeral.ts
+++ b/src-vue/lib/numeral.ts
@@ -24,6 +24,10 @@ export default function numeral(input?: any): Numeral {
   return numeralOriginal(input);
 }
 
+export function formatBtc(btc: number): string {
+  return numeral(btc).format('0,0.00[000000]');
+}
+
 numeralOriginal.fn.formatIfElse = function (condition, ifFormat, elseFormat) {
   const format = chooseIfElseFormat(condition, ifFormat, elseFormat, this._value);
   return this.format(format);

--- a/src-vue/overlays/BitcoinLockingOverlay.vue
+++ b/src-vue/overlays/BitcoinLockingOverlay.vue
@@ -124,7 +124,7 @@ import basicEmitter from '../emitters/basicEmitter.ts';
 import { getMiningFrames } from '../stores/mainchain.ts';
 import { useFinancials } from '../stores/financials.ts';
 import { useCertificationController } from '../stores/certificationController.ts';
-import numeral from '../lib/numeral.ts';
+import { formatBtc } from '../lib/numeral.ts';
 
 const bitcoinLocks = getBitcoinLocks();
 const config = getConfig();
@@ -285,7 +285,7 @@ const stepItems = Vue.computed<IStepHeaderItem[]>(() => [
   },
   {
     label: 'Choose Amount',
-    value: btcBeingLocked.value == null ? undefined : `${numeral(btcBeingLocked.value).format('0,0.[000000]')} BTC`,
+    value: btcBeingLocked.value == null ? undefined : `${formatBtc(btcBeingLocked.value)} BTC`,
     tooltip: "Choose how much BTC you want to lock. The more you lock, the more Argons you'll receive.",
     isActive: () => lockStep.value === LockStep.Start,
   },

--- a/src-vue/overlays/BondPurchaseOverlay.vue
+++ b/src-vue/overlays/BondPurchaseOverlay.vue
@@ -79,9 +79,9 @@
       class="flex min-h-105 flex-col items-center justify-center px-10 py-5 text-center"
     >
       <AlertIcon class="h-18 text-yellow-700" />
-      <h1 class="mt-8 text-xl font-bold text-yellow-800">This Vault Has No Argon Bond Space</h1>
+      <h1 class="mt-8 text-xl font-bold text-yellow-800">{{ vaultLabel }} has no Argon Bond space</h1>
       <p class="mt-4 max-w-150 text-lg leading-relaxed font-light">
-        Contact the person who invited you and let them know their vault has no more Argon Bond space.
+        Contact {{ vaultName || 'the person who invited you' }} to create more Bond space.
       </p>
     </div>
     <div v-else class="px-10 py-5">
@@ -106,6 +106,28 @@
               Min
             </button>
             <span class="h-4 border-l border-gray-300 mx-3" />
+            <Tooltip
+              v-if="certificationPurchaseAmount > 0"
+              :asChild="true"
+              content="Sets this purchase to the amount still needed for Treasury Certification."
+              side="top"
+            >
+              <span class="inline-flex cursor-help items-center gap-0.5 text-sm">
+                <span v-if="purchaseAmount === certificationPurchaseAmount" class="text-gray-600/60">
+                  Certification
+                </span>
+                <button
+                  v-else
+                  type="button"
+                  class="text-argon-600 hover:text-argon-700 cursor-pointer"
+                  @click="purchaseAmount = certificationPurchaseAmount"
+                >
+                  Certification
+                </button>
+                <InformationCircleIcon class="size-3.5 text-gray-400" />
+              </span>
+            </Tooltip>
+            <span v-if="certificationPurchaseAmount > 0" class="h-4 border-l border-gray-300 mx-3" />
             <span v-if="purchaseAmount === maxPurchaseAmount" class="text-sm text-gray-600/60">
               You're At Max Amount
             </span>
@@ -121,7 +143,6 @@
           <InputNumber
             v-model="purchaseAmount"
             :min="minPurchaseAllowed"
-            :max="maxPurchaseAmount"
             :dragBy="1"
             :dragByMin="1"
             :minDecimals="0"
@@ -134,7 +155,27 @@
             }}{{ bondToMoneyNm(purchaseAmount).format('0,0.00') }}) will be pulled from your Internal App
             Wallet for this acquisition.
           </div>
-          <WalletFundingCallout v-if="neededMicrogons" @open-wallet="openWallet">
+          <div
+            v-if="isOverVaultBondCapacity"
+            class="relative mt-3 flex items-center rounded border border-yellow-400/70 bg-yellow-100 px-3 py-3 text-yellow-900"
+          >
+            <AlertIcon class="mr-2 h-4 shrink-0 text-yellow-700" />
+            <span>
+              <template
+                v-if="
+                  certificationPurchaseAmount > maxPurchaseAmount && purchaseAmount === certificationPurchaseAmount
+                "
+              >
+                Treasury Certification needs {{ numeral(certificationPurchaseAmount).format('0,0') }} more Argon
+                Bonds. {{ vaultLabel }} can only create {{ numeral(maxPurchaseAmount).format('0,0') }} right now.
+              </template>
+              <template v-else>
+                {{ vaultLabel }} can only create {{ numeral(maxPurchaseAmount).format('0,0') }} Argon Bonds right now.
+              </template>
+              Contact {{ vaultName || 'the person who invited you' }} to create more Bond space.
+            </span>
+          </div>
+          <WalletFundingCallout v-else-if="neededMicrogons" @open-wallet="openWallet">
             <AlertIcon class="h-4 text-yellow-700 mr-2" />
             Your wallet needs {{ availableMicrogons ? '' : 'another' }} {{ microgonToArgonNm(neededMicrogons).format('0,0.[00]') }} ARGN to purchase these
             bonds.
@@ -188,7 +229,7 @@
           </button>
           <button
             type="button"
-            :disabled="isSubmitting || purchaseAmount <= 0 || neededMicrogons > 0n"
+            :disabled="isSubmitting || purchaseAmount <= 0 || isOverVaultBondCapacity || neededMicrogons > 0n"
             class="bg-argon-button hover:bg-argon-button-hover rounded-md px-5 py-2 cursor-pointer font-semibold text-white disabled:opacity-40"
             @click="submit"
           >
@@ -204,6 +245,7 @@
 <script setup lang="ts">
 import * as Vue from 'vue';
 import BigNumber from 'bignumber.js';
+import { InformationCircleIcon } from '@heroicons/vue/24/outline';
 import OverlayBase from './OverlayBase.vue';
 import SelectAVault from '../components/SelectAVault.vue';
 import { Vault } from '@argonprotocol/mainchain';
@@ -215,6 +257,7 @@ import { getWalletKeys, useWallets } from '../stores/wallets.ts';
 import { getArgonBonds } from '../stores/argonBonds.ts';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import InputNumber from '../components/InputNumber.vue';
+import Tooltip from '../components/Tooltip.vue';
 import ProgressBar from '../components/ProgressBar.vue';
 import { type TransactionInfo } from '../lib/TransactionInfo.ts';
 import { ExtrinsicType, TransactionStatus } from '../lib/db/TransactionsTable.ts';
@@ -233,6 +276,7 @@ import WalletFundingCallout from '../components/WalletFundingCallout.vue';
 import AlertIcon from '../assets/alert.svg?component';
 import BondPurchaseComplete from './BondPurchaseComplete.vue';
 import { useFinancials } from '../stores/financials.ts';
+import { useCertificationController } from '../stores/certificationController.ts';
 
 const MICROGONS_PER_ARGON_BIGINT = BigInt(MICROGONS_PER_ARGON);
 
@@ -246,6 +290,7 @@ const vaultingStats = useVaultingStats();
 const transactionTracker = getTransactionTracker();
 const vaults = getVaults();
 const financials = useFinancials();
+const certificationController = useCertificationController();
 
 const { microgonToArgonNm, microgonToMoneyNm } = createNumeralHelpers(currency);
 
@@ -282,6 +327,13 @@ const vaultAvailableCapacity = Vue.computed(() => {
   return argonBonds.availableBondSpace(vault.value);
 });
 
+const vaultName = Vue.computed(() => vault.value?.name?.trim() || config.upstreamOperator?.name?.trim());
+
+const vaultLabel = Vue.computed(() => {
+  if (vaultName.value) return `${vaultName.value}’s Vault`;
+  return 'This vault';
+});
+
 const spendableWalletBalance = Vue.computed(() => {
   return getSpendableDefaultArgonMicrogons(availableMicrogons.value);
 });
@@ -289,6 +341,16 @@ const spendableWalletBalance = Vue.computed(() => {
 const maxPurchaseAmount = Vue.computed(() => {
   return Number(vaultAvailableCapacity.value / MICROGONS_PER_ARGON_BIGINT);
 });
+
+const certificationPurchaseAmount = Vue.computed(() => {
+  const remainingMicrogons =
+    certificationController.rewardConfig.treasuryMinimumBonds - argonBonds.bondTotals.activeBondMicrogons;
+  if (remainingMicrogons <= 0n) return 0;
+
+  return Number((remainingMicrogons + MICROGONS_PER_ARGON_BIGINT - 1n) / MICROGONS_PER_ARGON_BIGINT);
+});
+
+const isOverVaultBondCapacity = Vue.computed(() => purchaseAmount.value > maxPurchaseAmount.value);
 
 const neededMicrogons = Vue.computed(() => {
   const purchaseMicrogons = BigInt(purchaseAmount.value) * MICROGONS_PER_ARGON_BIGINT;
@@ -446,6 +508,10 @@ async function submit() {
   isSubmitting.value = true;
 
   try {
+    if (isOverVaultBondCapacity.value) {
+      throw new Error('This vault needs more locked Bitcoin before it can create this many Argon Bonds.');
+    }
+
     const bondPurchaseMicrogons = BigInt(purchaseAmount.value) * MICROGONS_PER_ARGON_BIGINT;
     const client = await getMainchainClient(false);
     const signer = await walletKeys.getDefaultArgonKeypair();
@@ -483,6 +549,9 @@ async function initializePurchase(session = ++purchaseSession) {
   unsubVault?.();
   unsubVault = undefined;
 
+  await certificationController.isLoadedPromise;
+  if (session !== purchaseSession) return;
+
   if (vaultId.value) {
     const initializingVaultId = vaultId.value;
     vault.value = vaults.vaultsById[initializingVaultId];
@@ -514,7 +583,7 @@ async function initializePurchase(session = ++purchaseSession) {
     trackTxInfo(pendingBuyTxInfo);
   }
 
-  purchaseAmount.value = maxPurchaseAmount.value;
+  purchaseAmount.value = certificationPurchaseAmount.value || maxPurchaseAmount.value;
 }
 
 function handleVaultSelected(v: Vault) {

--- a/src-vue/overlays/BondPurchaseOverlay.vue
+++ b/src-vue/overlays/BondPurchaseOverlay.vue
@@ -509,7 +509,7 @@ async function submit() {
 
   try {
     if (isOverVaultBondCapacity.value) {
-      throw new Error('This vault needs more locked Bitcoin before it can create this many Argon Bonds.');
+      throw new Error(`${vaultLabel.value} does not have enough Bond space for this purchase.`);
     }
 
     const bondPurchaseMicrogons = BigInt(purchaseAmount.value) * MICROGONS_PER_ARGON_BIGINT;

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
@@ -12,13 +12,13 @@
     <p>
       <template v-if="isSubmittingToChain">
         Your request to lock
-        {{ satToBtcNm(personalLock.satoshis ?? 0n).format('0,0.[00000000]') }}
+        {{ formatBtc(currency.convertSatToBtc(personalLock.satoshis ?? 0n)) }}
         of BTC (around {{ currency.symbol }}{{ satToMoneyNm(props.personalLock.satoshis).format('0,0.00') }} worth) is
         being submitted to Argon.
       </template>
       <template v-else>
         Your request to lock
-        {{ satToBtcNm(personalLock.satoshis ?? 0n).format('0,0.[00000000]') }} of BTC (around {{ currency.symbol
+        {{ formatBtc(currency.convertSatToBtc(personalLock.satoshis ?? 0n)) }} of BTC (around {{ currency.symbol
         }}{{ satToMoneyNm(props.personalLock.satoshis).format('0,0.00') }} worth) has been submitted to Argon and is
         awaiting confirmation. This usually takes a few minutes.
       </template>
@@ -47,7 +47,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
+import numeral, { createNumeralHelpers, formatBtc } from '../../lib/numeral.ts';
 import ProgressBar from '../../components/ProgressBar.vue';
 import { getCurrency } from '../../stores/currency.ts';
 import { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
@@ -62,7 +62,7 @@ const props = defineProps<{
 const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
 
-const { satToBtcNm, satToMoneyNm } = createNumeralHelpers(currency);
+const { satToMoneyNm } = createNumeralHelpers(currency);
 
 const bitcoinLockProgress = useBitcoinLockProgress();
 const personalLock = Vue.computed(() => props.personalLock);

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
@@ -19,11 +19,14 @@
         </div>
       </div>
     </template>
+    <p v-else-if="!satoshisObserved" class="pt-2">
+      We’re looking for your Bitcoin transfer. It can take a few moments for the transaction to appear on the Bitcoin
+      network.
+    </p>
     <p v-else-if="isWaitingForFirstBitcoinBlock" class="pt-2">
       <template v-if="observedBtcLabel !== undefined">
         We detected a transfer of {{ observedBtcLabel }} BTC in Bitcoin's mempool.
       </template>
-      <template v-else>We detected your Bitcoin transfer in Bitcoin's mempool.</template>
       We’re waiting for the first Bitcoin block before confirmation tracking begins.
     </p>
 
@@ -42,7 +45,9 @@
       class="mt-12 flex items-center justify-center gap-3 text-center text-gray-500"
     >
       <Spinner class="h-5 w-5" />
-      <span>Waiting for the first Bitcoin block...</span>
+      <span>
+        {{ !satoshisObserved ? 'Looking for your Bitcoin transfer...' : 'Waiting for the first Bitcoin block...' }}
+      </span>
     </div>
 
     <template v-else>
@@ -61,7 +66,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import numeral from '../../lib/numeral.ts';
+import numeral, { formatBtc } from '../../lib/numeral.ts';
 import { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { getBitcoinLocks } from '../../stores/bitcoin.ts';
@@ -96,18 +101,18 @@ const hasMismatch = Vue.computed(() => {
 });
 const isInvalidAmount = Vue.ref<boolean>(false);
 const reservedBtcLabel = Vue.computed(() => {
-  return numeral(currency.convertSatToBtc(personalLock.value.satoshis ?? 0n)).format('0,0.[00000000]');
+  return formatBtc(currency.convertSatToBtc(personalLock.value.satoshis ?? 0n));
 });
 const observedBtcLabel = Vue.computed(() => {
   if (satoshisObserved.value === undefined) return undefined;
-  return numeral(currency.convertSatToBtc(satoshisObserved.value)).format('0,0.[00000000]');
+  return formatBtc(currency.convertSatToBtc(satoshisObserved.value));
 });
 const differenceBtcLabel = Vue.computed(() => {
   const observed = satoshisObserved.value;
   if (observed === undefined) return '0 BTC';
   const diff = observed - personalLock.value.satoshis;
   const absDiff = diff < 0n ? -diff : diff;
-  const formatted = numeral(currency.convertSatToBtc(absDiff)).format('0,0.[00000000]');
+  const formatted = formatBtc(currency.convertSatToBtc(absDiff));
   if (diff > 0n) return `+${formatted} BTC`;
   if (diff < 0n) return `-${formatted} BTC`;
   return `${formatted} BTC`;

--- a/src-vue/overlays/bitcoin-locking/LockMinting.vue
+++ b/src-vue/overlays/bitcoin-locking/LockMinting.vue
@@ -2,13 +2,13 @@
   <div class="space-y-5 px-10 pt-5 pb-5">
     <p v-if="isMismatchAccepted">
       Funding difference accepted. Argon has locked your adjusted
-      {{ satToBtcNm(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n).format('0,0.[00000000]') }} of BTC
+      {{ formatBtc(currency.convertSatToBtc(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n)) }} of BTC
       (around {{ currency.symbol
       }}{{ satToMoneyNm(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n).format('0,0.00') }}).
     </p>
     <p v-else>
       Argon has processed and locked your
-      {{ satToBtcNm(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n).format('0,0.[00000000]') }} of BTC
+      {{ formatBtc(currency.convertSatToBtc(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n)) }} of BTC
       (around {{ currency.symbol
       }}{{ satToMoneyNm(fundingUtxoRecord?.satoshis ?? personalLock.satoshis ?? 0n).format('0,0.00') }}).
     </p>
@@ -36,7 +36,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
+import { createNumeralHelpers, formatBtc } from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
 import { getBitcoinLocks } from '../../stores/bitcoin.ts';
@@ -46,7 +46,7 @@ import { TransactionStatus } from '../../lib/db/TransactionsTable.ts';
 const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
 
-const { microgonToArgonNm, satToBtcNm, satToMoneyNm } = createNumeralHelpers(currency);
+const { microgonToArgonNm, satToMoneyNm } = createNumeralHelpers(currency);
 
 const props = defineProps<{
   personalLock: IBitcoinLockRecord;

--- a/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
@@ -84,7 +84,7 @@
 
       <p class="mt-8 leading-normal font-light text-gray-600 select-text">
         Once your transaction is confirmed, Argon Network will mint you
-        {{ currency.symbol }}{{ microgonToArgonNm(props.personalLock.liquidityPromised).format('0,0.[00]') }}, which is
+        {{ currency.symbol }}{{ microgonToMoneyNm(props.personalLock.liquidityPromised).format('0,0.[00]') }}, which is
         the current market value of {{ formatBtc(currency.convertSatToBtc(props.personalLock.satoshis)) }} BTC. If you
         accidentally send a different amount, the network will pause and let you accept the adjusted amount or return
         the BTC.
@@ -160,7 +160,7 @@ const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
 const floatingZIndex = useFloatingZIndex();
 
-const { microgonToArgonNm, satToMoneyNm } = createNumeralHelpers(currency);
+const { microgonToMoneyNm, satToMoneyNm } = createNumeralHelpers(currency);
 
 const fundingBip21 = Vue.ref('');
 const scriptPaytoAddress = Vue.ref('');
@@ -228,7 +228,12 @@ Vue.onMounted(async () => {
     console.error('Error formatting P2WSH address:', error);
     throw new Error('Failed to format P2WSH address');
   }
-  const btcAmount = formatBtc(Number(props.personalLock.satoshis) / Number(SATS_PER_BTC));
+  const wholeBtc = props.personalLock.satoshis / SATS_PER_BTC;
+  const fractionalSatoshis = (props.personalLock.satoshis % SATS_PER_BTC)
+    .toString()
+    .padStart(8, '0')
+    .replace(/0+$/, '');
+  const btcAmount = fractionalSatoshis ? `${wholeBtc}.${fractionalSatoshis}` : wholeBtc.toString();
   const label = encodeURIComponent(`Argon Vault #${props.personalLock.vaultId} (utxo id=${props.personalLock.utxoId})`);
   const message = encodeURIComponent(
     `Personal BTC Funding for Vault #${props.personalLock.vaultId}, Utxo Id #${props.personalLock.utxoId}`,

--- a/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
@@ -20,7 +20,7 @@
       <p class="mt-5 text-gray-600 select-text">
         2. Send exactly
         <strong data-testid="LockReadyForBitcoin.amount">
-          {{ satToBtcNm(props.personalLock.satoshis).format('0,0.[00000000]') }}
+          {{ formatBtc(currency.convertSatToBtc(props.personalLock.satoshis)) }}
         </strong>
         BTC (&asymp; {{ currency.symbol }}{{ satToMoneyNm(props.personalLock.satoshis).format('0,0.00') }}) to this
         address:
@@ -80,35 +80,48 @@
         </TooltipProvider>
       </div>
 
-      <p class="mt-5 text-gray-600 select-text">3. Click the “I Locked My Bitcoin” button below.</p>
+      <p class="mt-5 text-gray-600 select-text">3. Click “Check for My Bitcoin” to look for your transfer.</p>
 
       <p class="mt-8 leading-normal font-light text-gray-600 select-text">
         Once your transaction is confirmed, Argon Network will mint you
-        {{ microgonToArgonNm(props.personalLock.liquidityPromised).format('0,0.[00]') }} ARGN, which is the current
-        market value of {{ satToBtcNm(props.personalLock.satoshis).format('0,0.[00000000]') }} BTC. If you accidentally
-        send a different amount, the network will pause and let you accept the adjusted amount or return the BTC.
+        {{ currency.symbol }}{{ microgonToArgonNm(props.personalLock.liquidityPromised).format('0,0.[00]') }}, which is
+        the current market value of {{ formatBtc(currency.convertSatToBtc(props.personalLock.satoshis)) }} BTC. If you
+        accidentally send a different amount, the network will pause and let you accept the adjusted amount or return
+        the BTC.
       </p>
     </div>
 
-    <div class="mt-3 flex flex-row items-center justify-end gap-x-3 border-t border-slate-200 pt-5 pb-3">
-      <button
-        class="cursor-pointer rounded-md border border-slate-300 px-10 py-2 text-slate-600 hover:bg-slate-50 disabled:opacity-40"
-        @click="closeOverlay"
-        :disabled="isSaving"
+    <div class="mt-3 border-t border-slate-200 pt-4 pb-3">
+      <div
+        v-if="fundingCheckMessage"
+        data-testid="LockReadyForBitcoin.fundingCheckMessage"
+        class="mb-3 flex items-start rounded-md border border-yellow-400/70 bg-yellow-100 px-4 py-3 text-sm text-yellow-900"
       >
-        Close and Finish Later
-      </button>
-      <button
-        :disabled="cannotContinue"
-        @click="submitLiquidLock"
-        class="bg-argon-button enabled:hover:bg-argon-button-hover cursor-pointer rounded-md px-10 py-2 font-semibold text-white disabled:cursor-default disabled:opacity-40"
-      >
-        <template v-if="isSaving">Checking Bitcoin Network...</template>
-        <template v-else>
-          I Locked My Bitcoin
-          <ChevronDoubleRightIcon class="relative -top-px inline-block size-5" />
-        </template>
-      </button>
+        <AlertIcon class="mt-0.5 mr-3 size-5 shrink-0 text-yellow-700" />
+        <span>{{ fundingCheckMessage }}</span>
+      </div>
+
+      <div class="flex flex-row items-center justify-end gap-x-3">
+        <button
+          class="cursor-pointer rounded-md border border-slate-300 px-10 py-2 text-slate-600 hover:bg-slate-50 disabled:opacity-40"
+          @click="closeOverlay"
+        >
+          Close and Finish Later
+        </button>
+        <button
+          data-testid="LockReadyForBitcoin.checkForBitcoin()"
+          :disabled="isCheckingForBitcoin || retrySeconds !== undefined"
+          @click="checkForBitcoin"
+          class="bg-argon-button enabled:hover:bg-argon-button-hover min-w-68 cursor-pointer rounded-md px-10 py-2 font-semibold text-white disabled:cursor-default disabled:opacity-60"
+        >
+          <template v-if="isCheckingForBitcoin">Checking Bitcoin Network...</template>
+          <template v-else-if="retrySeconds !== undefined">Checking again in {{ retrySeconds }}s</template>
+          <template v-else>
+            Check for My Bitcoin
+            <ChevronDoubleRightIcon class="relative -top-px inline-block size-5" />
+          </template>
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -117,11 +130,12 @@
 import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
+import { createNumeralHelpers, formatBtc } from '../../lib/numeral.ts';
 import { abbreviateAddress } from '../../lib/Utils.ts';
 import CopyToClipboard from '../../components/CopyToClipboard.vue';
 import BitcoinQrCode from '../../components/BitcoinQrCode.vue';
 import CountdownClock from '../../components/CountdownClock.vue';
+import AlertIcon from '../../assets/alert.svg?component';
 import CopyIcon from '../../assets/copy.svg?component';
 import ClockIcon from '../../assets/clock.svg?component';
 import { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
@@ -146,7 +160,7 @@ const currency = getCurrency();
 const bitcoinLocks = getBitcoinLocks();
 const floatingZIndex = useFloatingZIndex();
 
-const { microgonToArgonNm, satToMoneyNm, satToBtcNm } = createNumeralHelpers(currency);
+const { microgonToArgonNm, satToMoneyNm } = createNumeralHelpers(currency);
 
 const fundingBip21 = Vue.ref('');
 const scriptPaytoAddress = Vue.ref('');
@@ -154,22 +168,55 @@ const scriptPaytoAddressPrefix = Vue.computed(() => scriptPaytoAddress.value.sli
 const scriptPaytoAddressSuffix = Vue.computed(() => scriptPaytoAddress.value.slice(-18));
 const scriptPaytoAddressCopy = Vue.ref<{ copy: () => void }>();
 const fundingExpirationTime = Vue.ref(dayjs.utc());
-const isSaving = Vue.ref(false);
-const cannotContinue = Vue.computed(() => isSaving.value);
+const isCheckingForBitcoin = Vue.ref(false);
+const retrySeconds = Vue.ref<number>();
+const fundingCheckMessage = Vue.ref('');
+
+let retryCountdownInterval: ReturnType<typeof setInterval> | undefined;
 
 function closeOverlay() {
   emit('close');
 }
 
-async function submitLiquidLock() {
-  if (isSaving.value) return;
+async function checkForBitcoin() {
+  if (isCheckingForBitcoin.value) return;
 
-  isSaving.value = true;
+  stopFundingRetryCountdown();
+  isCheckingForBitcoin.value = true;
   try {
-    await bitcoinLocks.utxoTracking.syncPendingFundingSignals(props.personalLock);
+    const observation = await bitcoinLocks.utxoTracking.observeMempoolFunding(props.personalLock);
+    if (observation) return;
+
+    fundingCheckMessage.value = 'We haven’t found your transfer yet, but we’ll keep checking automatically.';
+  } catch (error) {
+    console.error('Error checking for Bitcoin funding:', error);
+    fundingCheckMessage.value = 'We couldn’t check the Bitcoin network just now, but we’ll try again automatically.';
   } finally {
-    isSaving.value = false;
+    isCheckingForBitcoin.value = false;
   }
+
+  startFundingRetryCountdown();
+}
+
+function startFundingRetryCountdown() {
+  stopFundingRetryCountdown();
+  retrySeconds.value = 30;
+  retryCountdownInterval = setInterval(() => {
+    if (retrySeconds.value === undefined) return;
+    if (retrySeconds.value > 1) {
+      retrySeconds.value -= 1;
+      return;
+    }
+
+    stopFundingRetryCountdown();
+    void checkForBitcoin();
+  }, 1e3);
+}
+
+function stopFundingRetryCountdown() {
+  if (retryCountdownInterval) clearInterval(retryCountdownInterval);
+  retryCountdownInterval = undefined;
+  retrySeconds.value = undefined;
 }
 
 Vue.onMounted(async () => {
@@ -181,11 +228,13 @@ Vue.onMounted(async () => {
     console.error('Error formatting P2WSH address:', error);
     throw new Error('Failed to format P2WSH address');
   }
-  const btcAmount = numeral(Number(props.personalLock.satoshis) / Number(SATS_PER_BTC)).format('0,0.[00000000]');
+  const btcAmount = formatBtc(Number(props.personalLock.satoshis) / Number(SATS_PER_BTC));
   const label = encodeURIComponent(`Argon Vault #${props.personalLock.vaultId} (utxo id=${props.personalLock.utxoId})`);
   const message = encodeURIComponent(
     `Personal BTC Funding for Vault #${props.personalLock.vaultId}, Utxo Id #${props.personalLock.utxoId}`,
   );
   fundingBip21.value = `bitcoin:${scriptPaytoAddress.value}?amount=${btcAmount}&label=${label}&message=${message}`;
 });
+
+Vue.onUnmounted(stopFundingRetryCountdown);
 </script>

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -61,7 +61,7 @@
             <span class="mx-2 text-gray-300">|</span>
             <Tooltip
               :asChild="true"
-              :content="`Sets this lock to the ${argonSymbol}600 Treasury Certification minimum.`"
+              :content="`Sets this lock to the ${argonSymbol}${microgonToArgonNm(treasuryBitcoinCertificationDisplayAmount).format('0,0')} Treasury Certification minimum.`"
               side="top"
             >
               <span class="inline-flex cursor-help items-center gap-0.5">
@@ -799,7 +799,7 @@ async function refreshConversionQuote(): Promise<boolean> {
   try {
     return await refresh;
   } finally {
-    if (pendingQuoteRefresh === refresh) pendingQuoteRefresh = undefined;
+    pendingQuoteRefresh = undefined;
   }
 }
 

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -45,59 +45,60 @@
       </div>
 
       <div class="mt-8 flex flex-col">
-        <div class="mb-2 flex flex-row items-center">
-          <label class="grow font-bold opacity-40">Bitcoin to Lock</label>
-          <span v-if="bitcoinAmount === minLockBtc" class="text-sm text-gray-600/60">You're At Min Amount</span>
-          <button
-            v-else
-            type="button"
-            class="text-argon-600 hover:text-argon-700 cursor-pointer text-sm"
-            :disabled="isSaving || isLoadingLiquidity || availableLiquidityBtc <= 0"
-            @click="setBitcoinAmount(minLockBtc)"
-          >
-            Min
-          </button>
-          <span class="mx-3 h-4 border-l border-gray-300" />
-          <span v-if="bitcoinAmount === availableLiquidityBtc" class="text-sm text-gray-600/60">
-            You're At Max Amount
-          </span>
-          <button
-            v-else
-            type="button"
-            class="text-argon-600 hover:text-argon-700 cursor-pointer text-sm"
-            :disabled="isSaving || isLoadingLiquidity || availableLiquidityBtc <= 0"
-            @click="setBitcoinAmount(availableLiquidityBtc)"
-          >
-            Max
-          </button>
+        <div class="mb-2 flex flex-row items-baseline">
+          <label class="grow font-bold opacity-40">Amount to Lock</label>
+          <div class="flex items-baseline text-sm">
+            <span v-if="isMinimumAmount" class="text-gray-600/60">Min</span>
+            <button
+              v-else
+              type="button"
+              class="text-argon-600 hover:text-argon-700 cursor-pointer"
+              :disabled="isSaving || isLoadingLiquidity || availableLiquidityBtc <= 0"
+              @click="setMinimumAmount"
+            >
+              Min
+            </button>
+            <span class="mx-2 text-gray-300">|</span>
+            <Tooltip
+              :asChild="true"
+              :content="`Sets this lock to the ${argonSymbol}600 Treasury Certification minimum.`"
+              side="top"
+            >
+              <span class="inline-flex cursor-help items-center gap-0.5">
+                <span v-if="isCertificationAmount" class="text-gray-600/60">Certification</span>
+                <button
+                  v-else
+                  type="button"
+                  class="text-argon-600 hover:text-argon-700 cursor-pointer"
+                  :disabled="isSaving || isLoadingLiquidity || availableLiquidityBtc <= 0"
+                  @click="setCertificationAmount"
+                >
+                  Certification
+                </button>
+                <InformationCircleIcon class="size-3.5 text-gray-400" />
+              </span>
+            </Tooltip>
+            <span class="mx-2 text-gray-300">|</span>
+            <span v-if="isMaximumAmount" class="text-gray-600/60">Max</span>
+            <button
+              v-else
+              type="button"
+              class="text-argon-600 hover:text-argon-700 cursor-pointer"
+              :disabled="isSaving || isLoadingLiquidity || availableLiquidityBtc <= 0"
+              @click="setMaximumAmount"
+            >
+              Max
+            </button>
+          </div>
         </div>
         <div
           ref="amountInputs"
           class="focus-within:inner-input-shadow focus-within:outline-argon-button shadow-inner-lg relative flex w-full cursor-text flex-row items-center rounded-md border border-slate-700/50 focus-within:z-90 focus-within:outline-2 focus-within:-outline-offset-2"
-          @click="focusBitcoinAmount"
+          @click="focusAmountInput"
         >
-          <div class="w-1/2">
-            <InputNumber
-              data-testid="LockStart.bitcoinAmount"
-              v-model="bitcoinAmount"
-              @input="handleBtcChange"
-              :disabled="isSaving || isLoadingLiquidity"
-              :maxDecimals="8"
-              :min="0"
-              :max="availableLiquidityBtc"
-              suffix=" BTC"
-              :dragBy="0.1"
-              :dragByMin="0.01"
-              :hideArrows="true"
-              class="w-fit border-0 px-1 py-2 text-[17px]! focus-within:shadow-none! focus-within:outline-0! hover:bg-transparent!"
-            />
-          </div>
-          <!--          <div class="relative z-10 h-5 w-5 bg-white px-2 font-light">-->
-          <!--            <div class="absolute top-[7.5px] left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl opacity-50">=</div>-->
-          <!--          </div>-->
-          <!--          <div class="absolute top-1/2 left-1/2 h-[140%] w-px origin-center -translate-x-1/2 -translate-y-1/2 rotate-45 bg-slate-700/30" />-->
-          <div class="flex w-1/2 flex-row justify-end">
+          <div class="min-w-0 grow">
             <InputMoney
+              v-if="amountUnit === UnitOfMeasurement.ARGN"
               data-testid="LockStart.argonAmount"
               :data-synced-value="lastSetLiquidityMicrogons.toString()"
               v-model="liquidityToReceive"
@@ -105,23 +106,91 @@
               :disabled="isSaving || isLoadingLiquidity"
               :maxDecimals="0"
               :min="0n"
-              :max="availableLiquidityMicrogons"
               :dragBy="1_000_000n"
               :dragByMin="1_000_000n"
-              prefix="~"
-              suffix=" CURRENT MARKET VALUE"
+              :hideArrows="true"
+              :symbol="argonSymbol"
+              class="w-fit border-0 px-1 py-2 text-[17px]! focus-within:shadow-none! focus-within:outline-0! hover:bg-transparent!"
+            />
+            <InputNumber
+              v-else-if="amountUnit === UnitOfMeasurement.BTC"
+              data-testid="LockStart.bitcoinAmount"
+              v-model="bitcoinAmount"
+              @input="handleBtcChange"
+              :disabled="isSaving || isLoadingLiquidity"
+              :minDecimals="2"
+              :maxDecimals="8"
+              :min="0"
+              :dragBy="0.1"
+              :dragByMin="0.01"
+              :hideArrows="true"
+              class="w-fit border-0 px-1 py-2 text-[17px]! focus-within:shadow-none! focus-within:outline-0! hover:bg-transparent!"
+            />
+            <InputNumber
+              v-else
+              data-testid="LockStart.currencyAmount"
+              v-model="fiatAmount"
+              @input="handleFiatChange"
+              :disabled="isSaving || isLoadingLiquidity"
+              :minDecimals="2"
+              :maxDecimals="2"
+              :min="0"
+              :prefix="selectedCurrencyRecord?.symbol"
+              :dragBy="1"
+              :dragByMin="0.01"
+              :hideArrows="true"
               class="w-fit border-0 px-1 py-2 text-[17px]! focus-within:shadow-none! focus-within:outline-0! hover:bg-transparent!"
             />
           </div>
+          <InputMenu
+            :model-value="amountUnit"
+            :options="amountUnitOptions"
+            dataTestid="LockStart.amountUnit"
+            :disabled="isSaving || isLoadingLiquidity"
+            class="ml-2 h-auto! w-auto! min-w-18 self-stretch! rounded-none! border-0! border-l! border-slate-300! bg-transparent! px-3! font-semibold text-slate-500 shadow-none! hover:bg-transparent! hover:text-slate-700!"
+            @click.stop
+            @update:model-value="setAmountUnit"
+          />
         </div>
-        <div class="text-md mt-2 text-slate-700/70">
-          Cost: {{ microgonToArgonNm(securityFee).format('0,0.[00]') }} ARGN will be pulled from your Internal App
-          Wallet. See One-Time Lock Fee below.
+        <div class="mt-2 flex items-center justify-between gap-4 text-sm text-slate-500">
+          <span
+            data-testid="LockStart.convertedAmount"
+            class="rounded px-1 transition-colors duration-300"
+            :class="isConversionRateHighlighted ? 'animate-pulse bg-amber-100 text-amber-800' : ''"
+          >
+            {{ convertedAmountLabel }}
+          </span>
+          <span class="shrink-0">
+            One-time fee:
+            <template v-if="isFeeWaived">Waived</template>
+            <template v-else>
+              {{ argonSymbol }}{{ microgonToArgonNm(securityFee).format('0,0.00') }}, paid from your wallet
+            </template>
+          </span>
         </div>
-        <WalletFundingCallout v-if="neededMicrogons" @open-wallet="openWallet">
+        <div
+          v-if="isOverVaultBitcoinCapacity"
+          class="relative mt-3 flex items-center rounded border border-yellow-400/70 bg-yellow-100 px-3 py-3 text-yellow-900"
+        >
+          <AlertIcon class="mr-2 h-4 shrink-0 text-yellow-700" />
+          <span>
+            <template v-if="liquidityToReceive === treasuryBitcoinCertificationDisplayAmount">
+              Treasury Certification requires {{ argonSymbol
+              }}{{ microgonToArgonNm(treasuryBitcoinCertificationDisplayAmount).format('0,0') }} of locked Bitcoin, but
+              {{ vaultLabel }} currently has space for only {{ argonSymbol
+              }}{{ microgonToArgonNm(availableLiquidityMicrogons).format('0,0') }}.
+            </template>
+            <template v-else>
+              {{ vaultLabel }} currently has space for only {{ argonSymbol
+              }}{{ microgonToArgonNm(availableLiquidityMicrogons).format('0,0') }} of locked Bitcoin.
+            </template>
+            Choose Max to use that available Bitcoin space.
+          </span>
+        </div>
+        <WalletFundingCallout v-else-if="neededMicrogons" @open-wallet="openWallet">
           <AlertIcon class="mr-2 h-4 text-yellow-700" />
-          Your wallet needs {{ availableMicrogons ? '' : 'another' }}
-          {{ microgonToArgonNm(neededMicrogons).format('0,0.[00]') }} ARGN to initialize this lock.
+          Your wallet needs {{ availableMicrogons ? '' : 'another' }} {{ argonSymbol
+          }}{{ microgonToArgonNm(neededMicrogons).format('0,0.[00]') }} to initialize this lock.
         </WalletFundingCallout>
 
         <section class="border-argon-600/30 mt-6 rounded-md border">
@@ -130,12 +199,12 @@
               <header class="font-bold opacity-40">ONE-TIME LOCK FEE</header>
               <div class="text-argon-600 py-1 text-3xl font-bold">
                 <template v-if="isFeeWaived">Waived</template>
-                <template v-else>{{ currency.symbol }}{{ microgonToMoneyNm(securityFee).format('0,0.00') }}</template>
+                <template v-else>{{ argonSymbol }}{{ microgonToArgonNm(securityFee).format('0,0.00') }}</template>
               </div>
               <div class="font-light opacity-80">
                 <template v-if="isOperatorCouponLock">
-                  {{ couponProviderLabel }} Gifted You {{ currency.symbol
-                  }}{{ microgonToMoneyNm(oneTimeLockFee).format('0,0.00') }}
+                  {{ couponProviderLabel }} Gifted You {{ argonSymbol
+                  }}{{ microgonToArgonNm(oneTimeLockFee).format('0,0.00') }}
                 </template>
                 <template v-else-if="isVaultOperator">No Operator Fee Charged</template>
                 <template v-else>It's the Only Cost of Locking</template>
@@ -145,7 +214,7 @@
             <div class="w-1/3 px-3">
               <header class="font-bold opacity-40">YOU WILL RECEIVE</header>
               <div class="text-argon-600 py-1 text-3xl font-bold">
-                {{ currency.symbol }}{{ microgonToMoneyNm(liquidityToReceive).format('0,0') }}
+                {{ argonSymbol }}{{ microgonToArgonNm(liquidityToReceive).format('0,0') }}
               </div>
               <div class="font-light opacity-80">In Unencumbered Argons</div>
             </div>
@@ -153,14 +222,13 @@
             <div class="w-1/3 px-3">
               <header class="font-bold opacity-40">PROJECTED EARNINGS</header>
               <div class="text-argon-600 py-1 text-3xl font-bold">
-                +{{ currency.symbol }}{{ microgonToMoneyNm(projectedEarnings).format('0,0') }}
+                +{{ argonSymbol }}{{ microgonToArgonNm(projectedEarnings).format('0,0') }}
               </div>
               <div class="font-light opacity-80">Modeled Over One Year</div>
             </div>
           </div>
           <div class="mx-2 border-t border-slate-600/30 px-2 py-3 font-light italic opacity-70">
-            * The value of your {{ numeral(bitcoinAmount).format('0,0.[00000000]') }} BTC is protected even if bitcoin's
-            market's price falls.
+            * The value of your {{ formatBtc(bitcoinAmount) }} BTC is protected even if bitcoin's market's price falls.
             <a :href="`${NetworkConfig.websiteHost}/docs/assets-and-entities/bitcoin-locks`" target="_blank">
               Learn more.
             </a>
@@ -194,26 +262,30 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import { ChevronDoubleRightIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import { ChevronDoubleRightIcon, ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/vue/24/outline';
 import InputNumber from '../../components/InputNumber.vue';
 import InputMoney from '../../components/InputMoney.vue';
-import numeral, { createNumeralHelpers } from '../../lib/numeral.ts';
+import InputMenu from '../../components/InputMenu.vue';
+import Tooltip from '../../components/Tooltip.vue';
+import { createNumeralHelpers, formatBtc } from '../../lib/numeral.ts';
 import { getCurrency } from '../../stores/currency.ts';
-import { BitcoinLock, MICROGONS_PER_ARGON, SATS_PER_BTC, Vault } from '@argonprotocol/mainchain';
+import { MICROGONS_PER_ARGON, SATS_PER_BTC, Vault } from '@argonprotocol/mainchain';
 import type { IBitcoinLockCouponStatus } from '@argonprotocol/apps-router';
 import { useDebounceFn } from '@vueuse/core';
 import { getBitcoinLockCoupons, getBitcoinLocks } from '../../stores/bitcoin.ts';
 import { getConfig } from '../../stores/config.ts';
 import { getVaults } from '../../stores/vaults.ts';
 import { getWalletKeys, useWallets } from '../../stores/wallets.ts';
+import { getMainchainClient } from '../../stores/mainchain.ts';
 import type { IBitcoinLockRecord } from '../../lib/db/BitcoinLocksTable.ts';
-import { bigNumberToBigInt, NetworkConfig } from '@argonprotocol/apps-core';
+import { bigNumberToBigInt, type ICurrencyKey, NetworkConfig, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import WalletFundingCallout from '../../components/WalletFundingCallout.vue';
 import basicEmitter from '../../emitters/basicEmitter.ts';
 import { WalletType } from '../../lib/Wallet.ts';
 import AlertIcon from '../../assets/alert.svg?component';
 import BigNumber from 'bignumber.js';
 import { useVaultingStats } from '../../stores/vaultingStats.ts';
+import { treasuryBitcoinCertificationDisplayAmount } from '../../stores/certificationController.ts';
 
 const props = defineProps<{
   coupon?: IBitcoinLockCouponStatus;
@@ -235,32 +307,92 @@ const wallets = useWallets();
 const walletKeys = getWalletKeys();
 const vaultingStats = useVaultingStats();
 
-const { microgonToMoneyNm, microgonToArgonNm } = createNumeralHelpers(currency);
+const { microgonToArgonNm } = createNumeralHelpers(currency);
+const argonSymbol = currency.recordsByKey[UnitOfMeasurement.ARGN].symbol;
+const vaultLabel = Vue.computed(() => {
+  const name = props.vault.name?.trim();
+  if (name) return `${name}’s Vault`;
+  return 'This vault';
+});
 
 const availableLiquidityMicrogons = Vue.ref(0n);
 const availableLiquidityBtc = Vue.ref(0);
 const minimumLockSatoshis = Vue.ref(0n);
+const conversionQuoteMicrogonsPerBtc = Vue.ref(0n);
+const isConversionRateHighlighted = Vue.ref(false);
 
 const isSaving = Vue.ref(false);
 const isLoadingLiquidity = Vue.ref(true);
 const errorMessage = Vue.ref<string | null>(null);
 const bitcoinAmount = Vue.ref(0);
+const fiatAmount = Vue.ref(0);
 const liquidityToReceive = Vue.ref(0n);
 const lockSatoshis = Vue.ref(0n);
 const securityFee = Vue.ref(0n);
 const hasEditedAmounts = Vue.ref(false);
 const amountInputs = Vue.ref<HTMLElement | null>(null);
+type AmountUnit = ICurrencyKey | UnitOfMeasurement.BTC;
+const amountUnit = Vue.ref<AmountUnit>(UnitOfMeasurement.ARGN);
 
-function focusBitcoinAmount(event: MouseEvent) {
+const isFiatAmountUnit = Vue.computed(() => {
+  return amountUnit.value !== UnitOfMeasurement.ARGN && amountUnit.value !== UnitOfMeasurement.BTC;
+});
+const selectedCurrencyRecord = Vue.computed(() => {
+  if (!isFiatAmountUnit.value) return undefined;
+  return currency.recordsByKey[amountUnit.value as ICurrencyKey];
+});
+const amountUnitOptions = Vue.computed(() => {
+  const options = [
+    { name: UnitOfMeasurement.ARGN, value: UnitOfMeasurement.ARGN },
+    { name: UnitOfMeasurement.BTC, value: UnitOfMeasurement.BTC },
+    { name: UnitOfMeasurement.USD, value: UnitOfMeasurement.USD },
+  ];
+  if (config.isLoaded && config.isValidJurisdiction) {
+    options.push(
+      ...Object.values(currency.recordsByKey)
+        .filter(record => record.key !== UnitOfMeasurement.ARGN && record.key !== UnitOfMeasurement.USD)
+        .map(record => ({ name: record.key, value: record.key })),
+    );
+  }
+  return options;
+});
+function focusAmountInput(event: MouseEvent) {
   const target = event.target as HTMLElement;
-  if (target.closest('[data-testid="LockStart.bitcoinAmount"], [data-testid="LockStart.argonAmount"]')) return;
+  if (
+    target.closest(
+      '[data-testid="LockStart.bitcoinAmount"], [data-testid="LockStart.argonAmount"], [data-testid="LockStart.currencyAmount"], [data-testid="LockStart.amountUnit"]',
+    )
+  ) {
+    return;
+  }
 
   amountInputs.value?.querySelector<HTMLElement>('[data-testid="input-number"]')?.focus();
 }
 
-const minLockBtc = Vue.computed(() =>
-  Math.min(currency.convertSatToBtc(minimumLockSatoshis.value), availableLiquidityBtc.value),
+function setAmountUnit(unit: string) {
+  amountUnit.value = unit as AmountUnit;
+  if (isFiatAmountUnit.value) {
+    fiatAmount.value = currency.convertMicrogonTo(liquidityToReceive.value, amountUnit.value);
+    lastSetFiatAmount = fiatAmount.value;
+  }
+  void Vue.nextTick(() => amountInputs.value?.querySelector<HTMLElement>('[data-testid="input-number"]')?.focus());
+}
+
+const isMinimumAmount = Vue.computed(() => lockSatoshis.value === minimumLockSatoshis.value);
+const isCertificationAmount = Vue.computed(
+  () => liquidityToReceive.value === treasuryBitcoinCertificationDisplayAmount,
 );
+const isMaximumAmount = Vue.computed(() => liquidityToReceive.value === availableLiquidityMicrogons.value);
+const isOverVaultBitcoinCapacity = Vue.computed(() => liquidityToReceive.value > availableLiquidityMicrogons.value);
+const convertedAmountLabel = Vue.computed(() => {
+  if (amountUnit.value === UnitOfMeasurement.ARGN) {
+    return `\u2248 ${formatBtc(bitcoinAmount.value)} BTC`;
+  }
+  if (amountUnit.value === UnitOfMeasurement.BTC) {
+    return `\u2248 ${argonSymbol}${microgonToArgonNm(liquidityToReceive.value).format('0,0')}`;
+  }
+  return `\u2248 ${argonSymbol}${microgonToArgonNm(liquidityToReceive.value).format('0,0')} · ${formatBtc(bitcoinAmount.value)} BTC`;
+});
 
 const isVaultOperator = Vue.computed(() => {
   return walletKeys.defaultArgonAddress === props.vault.operatorAccountId;
@@ -349,11 +481,20 @@ const cannotContinue = Vue.computed(() => {
 
 const debouncedHandleBtcChange = useDebounceFn(internalHandleBtcChange, 100, { maxWait: 200 });
 const debouncedHandleArgonChange = useDebounceFn(internalHandleArgonChange, 100, { maxWait: 200 });
+const debouncedHandleFiatChange = useDebounceFn(internalHandleFiatChange, 100, { maxWait: 200 });
 
 const lastSetLiquidityMicrogons = Vue.ref(0n);
 let lastSetBitcoinAmount = 0;
+let lastSetFiatAmount = 0;
 let availableLiquiditySyncId = 0;
 let pendingAmountSync: Promise<unknown> | undefined;
+let pendingQuoteRefresh: Promise<boolean> | undefined;
+let conversionQuoteExpiresAt = 0;
+let conversionQuoteRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+let conversionHighlightTimeout: ReturnType<typeof setTimeout> | undefined;
+let isUnmounted = false;
+
+const CONVERSION_QUOTE_REFRESH_ERROR = 'Unable to refresh the Bitcoin conversion rate. Retrying shortly.';
 
 function updateFeeEstimate() {
   if (!props.vault || liquidityToReceive.value <= 0n || isVaultOperator.value || isOperatorCouponLock.value) {
@@ -374,13 +515,17 @@ function initializeDefaultAmounts(satoshis: bigint, liquidityMicrogons: bigint) 
 
   lastSetLiquidityMicrogons.value = liquidityMicrogons;
   lastSetBitcoinAmount = btc;
+  if (isFiatAmountUnit.value) {
+    fiatAmount.value = currency.convertMicrogonTo(liquidityMicrogons, amountUnit.value);
+    lastSetFiatAmount = fiatAmount.value;
+  }
 }
 
 async function internalHandleArgonChange(liquidityMicrogons: bigint) {
   if (liquidityMicrogons === lastSetLiquidityMicrogons.value) {
     return;
   }
-  const sats = await bitcoinLocks.satoshisForArgonLiquidity(liquidityMicrogons);
+  const sats = await bitcoinLocks.satoshisForArgonLiquidity(liquidityMicrogons, conversionQuoteMicrogonsPerBtc.value);
   lockSatoshis.value = sats;
   const btc = currency.convertSatToBtc(sats);
   bitcoinAmount.value = btc;
@@ -395,9 +540,29 @@ async function internalHandleBtcChange(value: number) {
   }
   const satoshis = BigInt(Math.round(value * Number(SATS_PER_BTC)));
   lockSatoshis.value = satoshis;
-  liquidityToReceive.value = BitcoinLock.calculateRedemptionAmountFromSatoshis(currency.priceIndex, satoshis);
+  liquidityToReceive.value = bitcoinLocks.argonLiquidityForSatoshis(satoshis, conversionQuoteMicrogonsPerBtc.value);
   lastSetLiquidityMicrogons.value = liquidityToReceive.value;
   lastSetBitcoinAmount = value;
+  updateFeeEstimate();
+}
+
+async function internalHandleFiatChange({ value, unit }: { value: number; unit: ICurrencyKey }) {
+  if (unit !== amountUnit.value || value === lastSetFiatAmount) {
+    return;
+  }
+  const liquidityMicrogons = currency.convertOtherUnitizedTokenToMicrogon(value, unit);
+  const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(
+    liquidityMicrogons,
+    conversionQuoteMicrogonsPerBtc.value,
+  );
+  if (unit !== amountUnit.value) return;
+
+  liquidityToReceive.value = liquidityMicrogons;
+  lockSatoshis.value = satoshis;
+  bitcoinAmount.value = currency.convertSatToBtc(satoshis);
+  lastSetLiquidityMicrogons.value = liquidityMicrogons;
+  lastSetBitcoinAmount = bitcoinAmount.value;
+  lastSetFiatAmount = value;
   updateFeeEstimate();
 }
 
@@ -421,9 +586,42 @@ function handleBtcChange(value: number) {
   pendingAmountSync = sync;
 }
 
-function setBitcoinAmount(value: number) {
-  bitcoinAmount.value = value;
-  handleBtcChange(value);
+function handleFiatChange(value: number) {
+  hasEditedAmounts.value = true;
+  const unit = amountUnit.value as ICurrencyKey;
+  const sync = debouncedHandleFiatChange({ value, unit }).finally(() => {
+    if (pendingAmountSync === sync) {
+      pendingAmountSync = undefined;
+    }
+  });
+  pendingAmountSync = sync;
+}
+
+function setMinimumAmount() {
+  const liquidityMicrogons = bitcoinLocks.argonLiquidityForSatoshis(
+    minimumLockSatoshis.value,
+    conversionQuoteMicrogonsPerBtc.value,
+  );
+  initializeDefaultAmounts(minimumLockSatoshis.value, liquidityMicrogons);
+  updateFeeEstimate();
+}
+
+async function setCertificationAmount() {
+  const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(
+    treasuryBitcoinCertificationDisplayAmount,
+    conversionQuoteMicrogonsPerBtc.value,
+  );
+  initializeDefaultAmounts(satoshis, treasuryBitcoinCertificationDisplayAmount);
+  updateFeeEstimate();
+}
+
+async function setMaximumAmount() {
+  const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(
+    availableLiquidityMicrogons.value,
+    conversionQuoteMicrogonsPerBtc.value,
+  );
+  initializeDefaultAmounts(satoshis, availableLiquidityMicrogons.value);
+  updateFeeEstimate();
 }
 
 async function submitLiquidLock() {
@@ -433,29 +631,37 @@ async function submitLiquidLock() {
     await config.isLoadedPromise;
     await pendingAmountSync;
 
+    if (Date.now() >= conversionQuoteExpiresAt) {
+      const quoteChanged = await refreshConversionQuote();
+      if (quoteChanged) {
+        errorMessage.value = 'The Bitcoin conversion rate was updated. Review the new amount and continue again.';
+        return;
+      }
+    }
+
     let satoshis = lockSatoshis.value;
     isSaving.value = true;
     errorMessage.value = null;
     if (satoshis <= 0n && liquidityToReceive.value > 0n) {
-      satoshis = await bitcoinLocks.satoshisForArgonLiquidity(liquidityToReceive.value);
+      satoshis = await bitcoinLocks.satoshisForArgonLiquidity(
+        liquidityToReceive.value,
+        conversionQuoteMicrogonsPerBtc.value,
+      );
       lockSatoshis.value = satoshis;
     }
     if (satoshis <= 0n) {
       throw new Error('Please enter a valid amount of Argons to receive.');
     }
-    if (
-      BitcoinLock.calculateRedemptionAmountFromSatoshis(currency.priceIndex, satoshis) >
-      (props.vault.availableBitcoinSpace(capacityLockOwner.value) ?? 0n)
-    ) {
-      throw new Error(
-        "This amount rounds above the vault's remaining capacity. Lower the requested Argons slightly and try again.",
-      );
+    const currentAvailableLiquidity = props.vault.availableBitcoinSpace(capacityLockOwner.value) ?? 0n;
+    if (liquidityToReceive.value - currentAvailableLiquidity > 1n) {
+      throw new Error("This amount is above the vault's remaining capacity. Lower the requested Argons and try again.");
     }
 
     await bitcoinLocks.initializeLock({
       satoshis,
       vault: props.vault,
       operatorCoupon: operatorCoupon.value,
+      microgonsAtTargetPerBtc: conversionQuoteMicrogonsPerBtc.value,
     });
     if (operatorCoupon.value) {
       await bitcoinLockCoupons.refresh();
@@ -484,38 +690,143 @@ async function setLiquidityVariables() {
       vault: props.vault,
       lockOwner: capacityLockOwner.value,
       maxSatoshis: coupon && isOperatorCouponLock.value ? coupon.coupon.maxSatoshis : undefined,
+      microgonsAtTargetPerBtc: conversionQuoteMicrogonsPerBtc.value,
     }),
     bitcoinLocks.minimumSatoshiPerLock(),
   ]);
-  const { availableSatoshis: nextAvailableSatoshis, availableLiquidityMicrogons: nextAvailableLiquidityMicrogons } =
-    capacity;
+  const {
+    availableLiquidityMicrogons: nextAvailableLiquidityMicrogons,
+    availableSatoshis: nextAvailableSatoshis,
+    vaultCapacitySatoshis,
+  } = capacity;
+  const wholeArgonMicrogons = BigInt(MICROGONS_PER_ARGON);
+  const partialArgonMicrogons = nextAvailableLiquidityMicrogons % wholeArgonMicrogons;
   const nextWholeArgonLiquidityMicrogons =
-    nextAvailableLiquidityMicrogons - (nextAvailableLiquidityMicrogons % BigInt(MICROGONS_PER_ARGON));
+    nextAvailableSatoshis === vaultCapacitySatoshis && partialArgonMicrogons === wholeArgonMicrogons - 1n
+      ? nextAvailableLiquidityMicrogons + 1n
+      : nextAvailableLiquidityMicrogons - partialArgonMicrogons;
   const nextWholeArgonSatoshis =
     nextWholeArgonLiquidityMicrogons > 0n
-      ? await bitcoinLocks.satoshisForArgonLiquidity(nextWholeArgonLiquidityMicrogons)
+      ? await bitcoinLocks.satoshisForArgonLiquidity(
+          nextWholeArgonLiquidityMicrogons,
+          conversionQuoteMicrogonsPerBtc.value,
+        )
+      : 0n;
+  const defaultLiquidityMicrogons = treasuryBitcoinCertificationDisplayAmount;
+  const defaultSatoshis =
+    defaultLiquidityMicrogons > 0n
+      ? await bitcoinLocks.satoshisForArgonLiquidity(defaultLiquidityMicrogons, conversionQuoteMicrogonsPerBtc.value)
       : 0n;
 
   if (syncId !== availableLiquiditySyncId) return;
 
   availableLiquidityMicrogons.value = nextWholeArgonLiquidityMicrogons;
-  availableLiquidityBtc.value = currency.convertSatToBtc(nextAvailableSatoshis);
+  availableLiquidityBtc.value = currency.convertSatToBtc(nextWholeArgonSatoshis);
   minimumLockSatoshis.value = nextMinimumLockSatoshis;
 
   if (!hasEditedAmounts.value || (liquidityToReceive.value === 0n && lockSatoshis.value === 0n)) {
-    initializeDefaultAmounts(nextWholeArgonSatoshis, nextWholeArgonLiquidityMicrogons);
+    initializeDefaultAmounts(defaultSatoshis, defaultLiquidityMicrogons);
     if (syncId !== availableLiquiditySyncId) return;
   }
 
   updateFeeEstimate();
 }
 
+async function refreshConversionQuote(): Promise<boolean> {
+  if (pendingQuoteRefresh) return await pendingQuoteRefresh;
+
+  const refresh = (async () => {
+    const quoteClient = await getMainchainClient(false);
+    const [, eligibleRates, currentTick] = await Promise.all([
+      currency.fetchMainchainRates(quoteClient, { ignoreCache: true }),
+      quoteClient.query.bitcoinLocks.microgonPerBtcHistory(),
+      quoteClient.query.ticks.currentTick(),
+    ]);
+
+    const previousQuote = conversionQuoteMicrogonsPerBtc.value;
+    const eligibleRate = eligibleRates.at(-1);
+    if (!eligibleRate || eligibleRate[1].toBigInt() <= 0n) {
+      throw new Error('Network bitcoin pricing is currently unavailable. Please try again later.');
+    }
+    const nextQuote = eligibleRate[1].toBigInt();
+    const quoteTicksRemaining = Math.max(
+      1,
+      eligibleRate[0].toNumber() +
+        quoteClient.consts.bitcoinLocks.maxBtcPriceTickAge.toNumber() -
+        currentTick.toNumber(),
+    );
+    const quoteDurationMillis = quoteTicksRemaining * NetworkConfig.tickMillis;
+
+    conversionQuoteMicrogonsPerBtc.value = nextQuote;
+    try {
+      await setLiquidityVariables();
+
+      if (hasEditedAmounts.value) {
+        if (amountUnit.value === UnitOfMeasurement.ARGN) {
+          const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(liquidityToReceive.value, nextQuote);
+          initializeDefaultAmounts(satoshis, liquidityToReceive.value);
+        } else if (amountUnit.value === UnitOfMeasurement.BTC) {
+          const liquidityMicrogons = bitcoinLocks.argonLiquidityForSatoshis(lockSatoshis.value, nextQuote);
+          initializeDefaultAmounts(lockSatoshis.value, liquidityMicrogons);
+        } else {
+          const liquidityMicrogons = currency.convertOtherUnitizedTokenToMicrogon(fiatAmount.value, amountUnit.value);
+          const satoshis = await bitcoinLocks.satoshisForArgonLiquidity(liquidityMicrogons, nextQuote);
+          initializeDefaultAmounts(satoshis, liquidityMicrogons);
+        }
+        updateFeeEstimate();
+      }
+    } catch (error) {
+      conversionQuoteMicrogonsPerBtc.value = previousQuote;
+      throw error;
+    }
+
+    conversionQuoteExpiresAt = Date.now() + quoteDurationMillis;
+    if (errorMessage.value === CONVERSION_QUOTE_REFRESH_ERROR) errorMessage.value = null;
+    scheduleConversionQuoteRefresh(quoteDurationMillis);
+
+    const quoteChanged = previousQuote > 0n && previousQuote !== nextQuote;
+    if (quoteChanged && !isUnmounted) {
+      isConversionRateHighlighted.value = true;
+      if (conversionHighlightTimeout) clearTimeout(conversionHighlightTimeout);
+      conversionHighlightTimeout = setTimeout(() => {
+        isConversionRateHighlighted.value = false;
+      }, 4e3);
+    }
+    return quoteChanged;
+  })();
+
+  pendingQuoteRefresh = refresh;
+  try {
+    return await refresh;
+  } finally {
+    if (pendingQuoteRefresh === refresh) pendingQuoteRefresh = undefined;
+  }
+}
+
+function scheduleConversionQuoteRefresh(delay: number) {
+  if (isUnmounted) return;
+  if (conversionQuoteRefreshTimeout) clearTimeout(conversionQuoteRefreshTimeout);
+  conversionQuoteRefreshTimeout = setTimeout(() => {
+    void refreshConversionQuote().catch(error => {
+      console.error('Error refreshing Bitcoin conversion quote:', error);
+      errorMessage.value = CONVERSION_QUOTE_REFRESH_ERROR;
+      scheduleConversionQuoteRefresh(30e3);
+    });
+  }, delay);
+}
+
 Vue.onMounted(async () => {
   await config.isLoadedPromise;
   try {
-    await setLiquidityVariables();
+    await refreshConversionQuote();
   } finally {
     isLoadingLiquidity.value = false;
   }
+});
+
+Vue.onUnmounted(() => {
+  isUnmounted = true;
+  if (conversionQuoteRefreshTimeout) clearTimeout(conversionQuoteRefreshTimeout);
+  if (conversionHighlightTimeout) clearTimeout(conversionHighlightTimeout);
 });
 </script>


### PR DESCRIPTION
## Summary

Bitcoin locking now defaults to the Treasury Certification amount in whole Argons. Users can choose ARGN, BTC, USD, or a configured local currency without competing editable values, and the conversion stays tied to the network-defined quote window.

Certification and capacity guidance now explains the selected vault's limits on both Bitcoin locks and Argon Bonds instead of silently reducing the requested amount. Bitcoin funding can also be checked immediately; if the transfer is not found, the warning stays visible and the button counts down to the next check.

## Validation

- TypeScript validation passed.
- 53 focused Bitcoin lock and UTXO tracking tests passed.
- Operation selector rules passed.
- The full Bitcoin lock flow was attempted, but the harness could not activate the Bitcoin Locks entry point after onboarding and did not reach the changed screen.
