### PR TITLE
fix(e2e): stabilize onboarding recovery flows

### DIFF
--- a/e2e/flows/operations/Mining.op.connectServer.ts
+++ b/e2e/flows/operations/Mining.op.connectServer.ts
@@ -10,7 +10,11 @@ type IConnectServerUiState = {
   dashboardVisible: boolean;
 };
 
-interface IConnectServerState extends IE2EOperationInspectState<Record<string, never>, IConnectServerUiState> {
+type IConnectServerChainState = {
+  isServerAdded: boolean;
+};
+
+interface IConnectServerState extends IE2EOperationInspectState<IConnectServerChainState, IConnectServerUiState> {
   connectEntryVisible: boolean;
   connectOverlayVisible: boolean;
   serverConnected: boolean;
@@ -21,17 +25,18 @@ const DEFAULT_CONNECT_READY_TIMEOUT_MS = 120_000;
 
 export default new Operation<IMiningFlowContext, IConnectServerState>(import.meta, {
   async inspect({ flow }) {
-    const [connectEntry, connectOverlay, dashboard] = await Promise.all([
+    const [setupState, connectEntry, connectOverlay, dashboard] = await Promise.all([
+      flow.queryApp(
+        refs => ({
+          isServerAdded: refs.config.isServerAdded,
+        }),
+        { timeoutMs: 10_000 },
+      ),
       flow.isVisible('SetupChecklist.openServerConnectPanel()'),
       flow.isVisible({ selector: '.ConnectOverlay' }),
       flow.isVisible('MiningDashboard'),
     ]);
-    const connectText = await flow
-      .getText('SetupChecklist.openServerConnectPanel()', { timeoutMs: 2_000 })
-      .catch(() => null);
-    const serverConnected = /used to run your mining software|api key is ready to go|connected and verified/i.test(
-      connectText ?? '',
-    );
+    const serverConnected = setupState?.isServerAdded ?? false;
     const isComplete = serverConnected || dashboard.visible;
     const canRun = connectOverlay.visible || (connectEntry.visible && !serverConnected && !dashboard.visible);
     let operationState: 'complete' | 'runnable' | 'processing' = 'processing';
@@ -46,7 +51,9 @@ export default new Operation<IMiningFlowContext, IConnectServerState>(import.met
       blockers.push('Mining server connect step is not visible.');
     }
     return {
-      chainState: {},
+      chainState: {
+        isServerAdded: serverConnected,
+      },
       uiState: {
         connectEntryVisible: connectEntry.visible,
         connectOverlayVisible: connectOverlay.visible,

--- a/e2e/flows/operations/Vaulting.op.connectServer.ts
+++ b/e2e/flows/operations/Vaulting.op.connectServer.ts
@@ -10,7 +10,11 @@ type IConnectServerUiState = {
   dashboardVisible: boolean;
 };
 
-interface IConnectServerState extends IE2EOperationInspectState<Record<string, never>, IConnectServerUiState> {
+type IConnectServerChainState = {
+  isServerAdded: boolean;
+};
+
+interface IConnectServerState extends IE2EOperationInspectState<IConnectServerChainState, IConnectServerUiState> {
   connectEntryVisible: boolean;
   connectOverlayVisible: boolean;
   serverConnected: boolean;
@@ -21,17 +25,18 @@ const DEFAULT_CONNECT_READY_TIMEOUT_MS = 120_000;
 
 export default new Operation<IVaultingFlowContext, IConnectServerState>(import.meta, {
   async inspect({ flow }) {
-    const [connectEntry, connectOverlay, dashboard] = await Promise.all([
+    const [setupState, connectEntry, connectOverlay, dashboard] = await Promise.all([
+      flow.queryApp(
+        refs => ({
+          isServerAdded: refs.config.isServerAdded,
+        }),
+        { timeoutMs: 10_000 },
+      ),
       flow.isVisible('SetupChecklist.openServerConnectPanel()'),
       flow.isVisible({ selector: '.ConnectOverlay' }),
       flow.isVisible('VaultingDashboard'),
     ]);
-    const connectText = await flow
-      .getText('SetupChecklist.openServerConnectPanel()', { timeoutMs: 2_000 })
-      .catch(() => null);
-    const serverConnected = /used to run your mining software|api key is ready to go|connected and verified/i.test(
-      connectText ?? '',
-    );
+    const serverConnected = setupState?.isServerAdded ?? false;
     const isComplete = serverConnected || dashboard.visible;
     const canRun = connectOverlay.visible || (connectEntry.visible && !serverConnected && !dashboard.visible);
     let operationState: 'complete' | 'runnable' | 'processing' = 'processing';
@@ -46,7 +51,9 @@ export default new Operation<IVaultingFlowContext, IConnectServerState>(import.m
       blockers.push('Vaulting server connect step is not visible.');
     }
     return {
-      chainState: {},
+      chainState: {
+        isServerAdded: serverConnected,
+      },
       uiState: {
         connectEntryVisible: connectEntry.visible,
         connectOverlayVisible: connectOverlay.visible,

--- a/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
+++ b/e2e/flows/operations/Vaulting.op.transferOutToEthereum.ts
@@ -106,7 +106,11 @@ export default new Operation<IVaultingFlowContext, ITransferOutToEthereumState>(
         1_000,
         async () => {
           if ((await flow.isVisible(moveToEthereumTarget)).clickable) return true;
-          await clickIfVisible(flow, 'WalletOverlay.chooseEthereumWallet()', { timeoutMs: 1_500 });
+          await clickIfVisible(
+            flow,
+            { selector: '[data-testid="WalletOverlay.transferOutPanel"] button[data-wallet-key^="ethereum:"]' },
+            { timeoutMs: 1_500 },
+          );
           return false;
         },
         {

--- a/src-vue/__test__/OperationalAccount.test.ts
+++ b/src-vue/__test__/OperationalAccount.test.ts
@@ -14,6 +14,15 @@ import { bigintCodec } from '../../core/__test__/helpers/codecs.ts';
 import { TxAttemptState } from '../lib/TransactionTracker.ts';
 import { normalizeOperatorNameInput } from '../lib/Utils.ts';
 
+const appsCoreMocks = vi.hoisted(() => ({
+  getVaultByOperator: vi.fn(),
+}));
+
+vi.mock('@argonprotocol/apps-core', async importOriginal => ({
+  ...(await importOriginal()),
+  getVaultByOperator: appsCoreMocks.getVaultByOperator,
+}));
+
 it.each([
   {
     runtime: 'previous runtime with a vault',
@@ -191,7 +200,7 @@ it('keeps names on vaults while both name extrinsics are available', () => {
   expect(usesOperationalProfileNameRuntime(client as any)).toBe(false);
 });
 
-it('tops up a vault delegate that falls below readiness while the operator name transaction is finalizing', async () => {
+it('uses the finalized vault profile before repairing an underfunded delegate', async () => {
   const profileTransaction = { tx: { id: 1 } };
   const delegateTransaction = { tx: { id: 2 } };
   const account = vi
@@ -209,20 +218,31 @@ it('tops up a vault delegate that falls below readiness while the operator name 
     name: '',
     delegateAccountId: 'delegate',
   };
+  const finalizedVault = {
+    ...createdVault,
+    name: 'OperatorOne',
+  };
+  const load = vi
+    .fn()
+    .mockResolvedValueOnce(undefined)
+    .mockImplementationOnce(async () => {
+      createdVault.name = 'OperatorOne';
+    });
   const myVault = {
     createdVault,
-    load: vi.fn(),
-    setupVaultInviteProfile: vi.fn(async ({ operatorName }) => {
-      createdVault.name = operatorName;
-      return profileTransaction;
-    }),
+    load,
+    setupVaultInviteProfile: vi.fn().mockResolvedValue(profileTransaction),
     ensureVaultDelegateReady: vi.fn().mockResolvedValue(delegateTransaction),
   };
   const transactionTracker = { load: vi.fn() };
   const walletKeys = {
+    vaultingAddress: 'vaulting',
     getVaultDelegateKeypair: vi.fn().mockResolvedValue({ address: 'delegate' }),
   };
   const transactions: unknown[] = [];
+  appsCoreMocks.getVaultByOperator
+    .mockResolvedValueOnce(finalizedVault)
+    .mockRejectedValueOnce(new Error('Archive RPC unavailable'));
 
   const setup = await activateOperationalAccountSetup({
     client: client as any,
@@ -242,7 +262,7 @@ it('tops up a vault delegate that falls below readiness while the operator name 
   expect(transactions).toEqual([profileTransaction, delegateTransaction]);
 });
 
-it('restores a finalized operator name transaction after onboarding remounts without its local draft', async () => {
+it('restores a finalized operator name transaction when the authoritative vault query is unavailable', async () => {
   const profileTransaction = {
     tx: {
       id: 1,
@@ -281,8 +301,10 @@ it('restores a finalized operator name transaction after onboarding remounts wit
     }),
   };
   const walletKeys = {
+    vaultingAddress: 'vaulting',
     getVaultDelegateKeypair: vi.fn().mockResolvedValue({ address: 'delegate' }),
   };
+  appsCoreMocks.getVaultByOperator.mockRejectedValue(new Error('Archive RPC unavailable'));
 
   const setup = await activateOperationalAccountSetup({
     client: client as any,

--- a/src-vue/interfaces/IConfigQueryRef.ts
+++ b/src-vue/interfaces/IConfigQueryRef.ts
@@ -5,4 +5,5 @@ export interface IConfigQueryRef
   showWelcomeOverlay: boolean;
   hasSavedBiddingRules: boolean;
   hasSavedVaultingRules: boolean;
+  isServerAdded: boolean;
 }

--- a/src-vue/lib/OperationalAccount.ts
+++ b/src-vue/lib/OperationalAccount.ts
@@ -12,6 +12,7 @@ import {
   createDeferred,
   getCertificationProgressFromOperationalAccount,
   getCertificationThresholds,
+  getVaultByOperator,
   type IOperationalAccessProof,
   MICROGONS_PER_ARGON,
   type RuntimeSpec157,
@@ -349,10 +350,19 @@ export async function activateOperationalAccountSetup(args: {
     await args.myVault.load(true);
   }
 
+  let vault = args.myVault.createdVault ?? undefined;
+  if (hasVault) {
+    const finalizedVault = await getVaultByOperator({
+      client: args.client,
+      operatorAddress: args.walletKeys.vaultingAddress,
+    }).catch(() => undefined);
+    vault = finalizedVault ?? vault;
+  }
+
   let setup = await loadOperationalAccountSetup({
     client: args.client,
     walletKeys: args.walletKeys,
-    vault: args.myVault.createdVault ?? undefined,
+    vault,
   });
 
   if (hasVault && !setup.vaultDelegateIsReady) {
@@ -364,10 +374,15 @@ export async function activateOperationalAccountSetup(args: {
     }
 
     await args.myVault.load(true);
+    const finalizedVault = await getVaultByOperator({
+      client: args.client,
+      operatorAddress: args.walletKeys.vaultingAddress,
+    }).catch(() => undefined);
+    vault = finalizedVault ?? args.myVault.createdVault ?? undefined;
     setup = await loadOperationalAccountSetup({
       client: args.client,
       walletKeys: args.walletKeys,
-      vault: args.myVault.createdVault ?? undefined,
+      vault,
     });
   }
 


### PR DESCRIPTION
Use authoritative app and chain state during setup recovery, and select the visible Ethereum wallet control so flows survive copy changes and startup timing.