### PR TITLE
fix: hide operations upgrade for restored active accounts

### DIFF
--- a/src-vue/__test__/OperationalAccount.test.ts
+++ b/src-vue/__test__/OperationalAccount.test.ts
@@ -2,6 +2,7 @@ import { expect, it, vi } from 'vitest';
 import { Keyring } from '@argonprotocol/mainchain';
 import {
   activateOperationalAccountSetup,
+  canRequestOperationsUpgrade,
   ensureOperationalAccountRegistered,
   getOnboardingSetupStatus,
   isValidOperatorName,
@@ -22,6 +23,36 @@ vi.mock('@argonprotocol/apps-core', async importOriginal => ({
   ...(await importOriginal()),
   getVaultByOperator: appsCoreMocks.getVaultByOperator,
 }));
+
+it.each([
+  {
+    state: 'before restored chain progress loads',
+    hasLoadedInitialOperationalProgress: false,
+    isUpgradedToOperations: false,
+    expected: false,
+  },
+  {
+    state: 'after an active operational account loads',
+    hasLoadedInitialOperationalProgress: true,
+    isUpgradedToOperations: true,
+    expected: false,
+  },
+  {
+    state: 'after an eligible treasury account loads',
+    hasLoadedInitialOperationalProgress: true,
+    isUpgradedToOperations: false,
+    expected: true,
+  },
+])('allows an Operations upgrade only $state', params => {
+  expect(
+    canRequestOperationsUpgrade({
+      hasLoadedInitialOperationalProgress: params.hasLoadedInitialOperationalProgress,
+      hasExtensionTreasury: true,
+      hasCompletedTreasuryCertification: true,
+      isUpgradedToOperations: params.isUpgradedToOperations,
+    }),
+  ).toBe(params.expected);
+});
 
 it.each([
   {

--- a/src-vue/lib/OperationalAccount.ts
+++ b/src-vue/lib/OperationalAccount.ts
@@ -240,6 +240,20 @@ export function getOnboardingSetupStatus(args: {
   return OnboardingSetupStatus.Checklist;
 }
 
+export function canRequestOperationsUpgrade(args: {
+  hasLoadedInitialOperationalProgress: boolean;
+  hasExtensionTreasury: boolean;
+  hasCompletedTreasuryCertification: boolean;
+  isUpgradedToOperations: boolean;
+}): boolean {
+  return (
+    args.hasLoadedInitialOperationalProgress &&
+    args.hasExtensionTreasury &&
+    args.hasCompletedTreasuryCertification &&
+    !args.isUpgradedToOperations
+  );
+}
+
 export async function setOperationalProfileName(args: {
   transactionTracker: TransactionTracker;
   walletKeys: WalletKeys;

--- a/src-vue/navigation/CertificationMenu.vue
+++ b/src-vue/navigation/CertificationMenu.vue
@@ -267,6 +267,7 @@ import {
 import DiamondIcon from '../assets/diamond.svg';
 import CertificationIcon from '../assets/certification.svg';
 import { hasOperationsUpgradeRequest } from '../lib/UpstreamOperatorClient.ts';
+import { canRequestOperationsUpgrade } from '../lib/OperationalAccount.ts';
 
 const config = getConfig();
 const controller = useCertificationController();
@@ -324,9 +325,13 @@ const isShowingActivatedTooltip = Vue.computed(() => {
 
 const isShowingUpgradeButton = Vue.computed(() => {
   return (
-    config.hasExtensionTreasury &&
-    !controller.chainProgress.isUpgradedToOperations &&
-    controller.completedTreasuryCertificationStepCount === treasuryCertificationStepIds.length &&
+    canRequestOperationsUpgrade({
+      hasLoadedInitialOperationalProgress: controller.hasLoadedInitialOperationalProgress,
+      hasExtensionTreasury: config.hasExtensionTreasury,
+      hasCompletedTreasuryCertification:
+        controller.completedTreasuryCertificationStepCount === treasuryCertificationStepIds.length,
+      isUpgradedToOperations: controller.chainProgress.isUpgradedToOperations,
+    }) &&
     !completionNoticeStepId.value &&
     !controller.isOperationalRewardsFlowActive
   );

--- a/src-vue/overlays/UpgradeToOperationsOverlay.vue
+++ b/src-vue/overlays/UpgradeToOperationsOverlay.vue
@@ -100,6 +100,7 @@ import AlertIcon from '../assets/alert.svg';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import numeral from '../lib/numeral.ts';
 import { hasOperationsUpgradeRequest } from '../lib/UpstreamOperatorClient.ts';
+import { canRequestOperationsUpgrade } from '../lib/OperationalAccount.ts';
 
 const config = getConfig();
 const controller = useCertificationController();
@@ -123,11 +124,13 @@ const upstreamName = Vue.computed(() => {
 });
 
 const isEligibleForUpgrade = Vue.computed(() => {
-  return (
-    config.hasExtensionTreasury &&
-    !controller.chainProgress.isUpgradedToOperations &&
-    controller.completedTreasuryCertificationStepCount === treasuryCertificationStepIds.length
-  );
+  return canRequestOperationsUpgrade({
+    hasLoadedInitialOperationalProgress: controller.hasLoadedInitialOperationalProgress,
+    hasExtensionTreasury: config.hasExtensionTreasury,
+    hasCompletedTreasuryCertification:
+      controller.completedTreasuryCertificationStepCount === treasuryCertificationStepIds.length,
+    isUpgradedToOperations: controller.chainProgress.isUpgradedToOperations,
+  });
 });
 
 const canRequestUpgrade = Vue.computed(() => {


### PR DESCRIPTION
Restored operational accounts no longer see an Operations upgrade action while their chain-backed account state is still loading. The action now appears only after account progress loads and confirms that a Treasury-certified account still needs Operations access.

Validation covers unresolved restore state, an already-active operational account, and a Treasury-certified account that still needs an upgrade.
