### PR TITLE
fix: keep bond and stake records clickable when overflowing

### DIFF
--- a/src-vue/screens/argon-bonds-screen/Dashboard.vue
+++ b/src-vue/screens/argon-bonds-screen/Dashboard.vue
@@ -32,8 +32,8 @@
     </section>
 
     <div class="relative flex min-h-0 grow flex-col">
-      <div class="flex flex-col overflow-y-auto px-9 pt-10 pb-5">
-        <div class="flex flex-row items-center text-slate-800/70">
+      <div class="flex grow flex-col overflow-y-auto pt-10">
+        <div class="flex flex-row items-center px-9 text-slate-800/70">
           <span class="grow">
             You have {{ bondLots.length }} bond transaction{{ bondLots.length === 1 ? '' : 's' }}...
           </span>
@@ -63,24 +63,24 @@
             </a>
           </div>
         </div>
-      </div>
 
-      <section class="flex flex-col gap-y-3 px-9">
-        <BondRecord
-          v-for="bondLot in bondLots"
-          :key="bondLot.id"
-          :bondLot="bondLot"
-          :isReleasing="bondLot.isReleasing"
-          :position="bondPositionsByLotId.get(bondLot.id)"
-          :returnPercent="bondReturnsByLotId.get(bondLot.id)"
-          @click="openDetail(bondLot)"
-          @liquidate="openDetail"
-        />
-      </section>
+        <section class="mt-4 flex grow flex-col gap-y-3 px-9 pb-10">
+          <BondRecord
+            v-for="bondLot in bondLots"
+            :key="bondLot.id"
+            :bondLot="bondLot"
+            :isReleasing="bondLot.isReleasing"
+            :position="bondPositionsByLotId.get(bondLot.id)"
+            :returnPercent="bondReturnsByLotId.get(bondLot.id)"
+            @click="openDetail(bondLot)"
+            @liquidate="openDetail"
+          />
+        </section>
+        <div class="relative px-0.5 pb-0.5">
+          <img src="/treasury-footers/argon-bonds.png" class="w-full opacity-50" alt="" />
+        </div>
+      </div>
       <div class="absolute top-0 left-0 h-10 w-full bg-linear-to-b from-white to-transparent" />
-    </div>
-    <div class="relative px-0.5 pb-0.5">
-      <img src="/treasury-footers/argon-bonds.png" class="w-full opacity-50" />
     </div>
   </div>
 

--- a/src-vue/screens/argonot-stakes-screen/Dashboard.vue
+++ b/src-vue/screens/argonot-stakes-screen/Dashboard.vue
@@ -32,8 +32,8 @@
     </section>
 
     <div class="relative flex min-h-0 grow flex-col">
-      <div class="flex flex-col overflow-y-auto px-9 pt-10 pb-5">
-        <div class="flex flex-row items-center text-slate-800/70">
+      <div class="flex grow flex-col overflow-y-auto pt-10">
+        <div class="flex flex-row items-center px-9 text-slate-800/70">
           <span class="grow">
             You have {{ stakeLots.length }} staking transaction{{ stakeLots.length === 1 ? '' : 's' }}...
           </span>
@@ -58,24 +58,24 @@
             </a>
           </div>
         </div>
-      </div>
 
-      <section class="flex flex-col gap-y-3 px-9">
-        <BondRecord
-          v-for="bondLot in stakeLots"
-          :key="bondLot.id"
-          :bondLot="bondLot"
-          :isReleasing="bondLot.isReleasing"
-          :position="stakePositionsByLotId.get(bondLot.id)"
-          :returnPercent="stakeReturnsByLotId.get(bondLot.id)"
-          @click="openDetail(bondLot)"
-          @liquidate="openDetail"
-        />
-      </section>
+        <section class="mt-4 flex grow flex-col gap-y-3 px-9 pb-10">
+          <BondRecord
+            v-for="bondLot in stakeLots"
+            :key="bondLot.id"
+            :bondLot="bondLot"
+            :isReleasing="bondLot.isReleasing"
+            :position="stakePositionsByLotId.get(bondLot.id)"
+            :returnPercent="stakeReturnsByLotId.get(bondLot.id)"
+            @click="openDetail(bondLot)"
+            @liquidate="openDetail"
+          />
+        </section>
+        <div class="relative px-0.5 pb-0.5">
+          <img src="/treasury-footers/argon-bonds.png" class="w-full opacity-50" alt="" />
+        </div>
+      </div>
       <div class="absolute top-0 left-0 h-10 w-full bg-linear-to-b from-white to-transparent" />
-    </div>
-    <div class="relative px-0.5 pb-0.5">
-      <img src="/treasury-footers/argon-bonds.png" class="w-full opacity-50" />
     </div>
   </div>
 


### PR DESCRIPTION
Long bond and Argonot stake lists now stay within their page scroll areas, so every record remains visible and clickable instead of rendering beneath the decorative footer.

Both dashboards now follow the established Bitcoin Locks list layout. The overflow behavior was exercised manually with one, three, and twelve temporary records; the fake data was removed before commit.
