### PR TITLE
feat: add crosschain transfer operations

### DIFF
--- a/core/__test__/NetworkConfig.test.ts
+++ b/core/__test__/NetworkConfig.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getEthereumTransactionExplorerUrl, NetworkConfig } from '../src/NetworkConfig.ts';
+
+describe('NetworkConfig', () => {
+  afterEach(() => {
+    NetworkConfig.clearRuntimeOverride();
+  });
+
+  it('builds Ethereum transaction links for the selected network', () => {
+    NetworkConfig.setNetwork('testnet');
+
+    expect(getEthereumTransactionExplorerUrl('0xabc')).toBe('https://sepolia.etherscan.io/tx/0xabc');
+  });
+
+  it('does not offer an Ethereum transaction link without a configured explorer', () => {
+    NetworkConfig.setNetwork('dev-docker');
+
+    expect(getEthereumTransactionExplorerUrl('0xabc')).toBeUndefined();
+  });
+});

--- a/core/network.config.json
+++ b/core/network.config.json
@@ -9,6 +9,7 @@
     "ethereumNetwork": {
       "beaconApiUrl": "",
       "executionRpcUrls": [],
+      "explorerUrl": "",
       "finalityBlocks": 16,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },
@@ -32,6 +33,7 @@
     "ethereumNetwork": {
       "beaconApiUrl": "",
       "executionRpcUrls": [],
+      "explorerUrl": "",
       "finalityBlocks": 16,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },
@@ -59,6 +61,7 @@
         "https://11155111.rpc.thirdweb.com",
         "https://public.1rpc.io/sepolia"
       ],
+      "explorerUrl": "https://sepolia.etherscan.io",
       "finalityBlocks": 32,
       "usdcTokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
     },
@@ -82,6 +85,7 @@
     "ethereumNetwork": {
       "beaconApiUrl": "https://ethereum-beacon-api.publicnode.com",
       "executionRpcUrls": ["https://ethereum-rpc.publicnode.com", "https://eth.drpc.org", "https://public.1rpc.io/eth"],
+      "explorerUrl": "https://etherscan.io",
       "finalityBlocks": 32,
       "usdcTokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     },

--- a/core/src/NetworkConfig.ts
+++ b/core/src/NetworkConfig.ts
@@ -145,6 +145,7 @@ export interface INetworkConfig {
 export interface IEthereumNetworkConfig {
   beaconApiUrl: string;
   executionRpcUrls: string[];
+  explorerUrl: string;
   finalityBlocks: number;
   usdcTokenAddress: string;
 }
@@ -160,6 +161,13 @@ export const ETHEREUM_EXECUTION_RPC_TRANSPORT = {
   fallbackRetryCount: 1,
   timeoutMs: 15_000,
 } as const;
+
+export function getEthereumTransactionExplorerUrl(transactionHash: string): string | undefined {
+  const explorerUrl = NetworkConfig.get().ethereumNetwork.explorerUrl.trim().replace(/\/$/, '');
+  if (!explorerUrl) return;
+
+  return `${explorerUrl}/tx/${transactionHash}`;
+}
 
 export function getEthereumExecutionRpcUrls(configuredExecutionRpcUrl?: string): string[] {
   const ethereumNetwork = NetworkConfig.get().ethereumNetwork;

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -562,7 +562,7 @@ export class AppVaultOperator {
       return false;
     }
 
-    const txInfo = await this.mintingAuthorities.authorize(nextPending.transferId);
+    const txInfo = await this.mintingAuthorities.authorize([nextPending.transferId]);
     await txInfo.waitForPostProcessing;
     return true;
   }

--- a/src-vue/App.vue
+++ b/src-vue/App.vue
@@ -37,6 +37,7 @@
 
             <Mining v-else-if="controller.selectedTab === TopTab.Mining" />
             <Vaulting v-else-if="controller.selectedTab === TopTab.Vaulting" />
+            <CrosschainTransfers v-else-if="controller.selectedTab === TopTab.CrosschainTransfers" />
             <Onboarding
               v-else-if="controller.selectedTab === TopTab.Onboarding || controller.selectedTab === 'Invites' as TopTab"
             />
@@ -56,6 +57,7 @@
       <WalletDialogs />
       <WalletDisconnectOverlay />
       <TransactionsOverlay />
+      <CrosschainHistoryOverlay />
       <SecuritizationOverlay />
       <FlexibleAssetsOverlay />
       <TreasuryBondsOverlay />
@@ -101,10 +103,12 @@ import { createMenu } from './NativeMenu.ts';
 import Network from './screens/Network.vue';
 import Mining from './screens/Mining.vue';
 import Vaulting from './screens/Vaulting.vue';
+import CrosschainTransfers from './screens/CrosschainTransfers.vue';
 import ServerConnectPanel from './panels/ServerConnectPanel.vue';
 import WalletDialogs from './wallets/WalletDialogs.vue';
 import WalletDisconnectOverlay from './overlays/WalletDisconnectOverlay.vue';
 import TransactionsOverlay from './overlays/TransactionsOverlay.vue';
+import CrosschainHistoryOverlay from './overlays/CrosschainHistoryOverlay.vue';
 import ServerRemoveOverlay from './overlays/ServerRemoveOverlay.vue';
 import SecuritySettingsOverlay from './overlays/SecuritySettingsOverlay.vue';
 import ImportAccountOverlay from './overlays/ImportAccountOverlay.vue';

--- a/src-vue/NativeMenu.ts
+++ b/src-vue/NativeMenu.ts
@@ -133,19 +133,9 @@ export async function createMenu() {
         text: 'Crosschain Transfers',
         items: [
           {
-            id: 'experimental-set-argonot-commitment',
-            text: 'Set Vault Argonot Commitment',
-            action: () => basicEmitter.emit('openArgonotCommitmentOverlay'),
-          },
-          {
             id: 'experimental-create-minting-authority-request',
             text: 'Register a Minting Authority',
             action: () => basicEmitter.emit('openMintingAuthorityRequestOverlay'),
-          },
-          {
-            id: 'experimental-relay-gateway-activities',
-            text: 'Relay Gateway Activities',
-            action: () => basicEmitter.emit('openGatewayRelayOverlay'),
           },
           ...(IS_LOCAL_BUILD && NETWORK_NAME === 'dev-docker'
             ? [

--- a/src-vue/__test__/Config.test.ts
+++ b/src-vue/__test__/Config.test.ts
@@ -94,6 +94,24 @@ it('can load config from db state', async () => {
   expect(config.postWelcomeLaunchCount).toBe(4);
 });
 
+it('keeps Crosschain Transfers available after it has been activated', async () => {
+  const db = await createTestDb();
+  const { walletKeys } = createTestWallet('//Alice');
+  instanceChecks.delete(Config.prototype.constructor);
+  const config = new Config(Promise.resolve(db), walletKeys);
+  await config.load();
+
+  config.hasActivatedCrosschain = true;
+  await config.save();
+
+  instanceChecks.delete(Config.prototype.constructor);
+  const restoredConfig = new Config(Promise.resolve(db), walletKeys);
+  await restoredConfig.load();
+
+  expect(restoredConfig.hasActivatedCrosschain).toBe(true);
+  await db.close();
+});
+
 it('does not recover operation state from cached mining or vault activity', async () => {
   const dbPromise = createMockedDbPromise({
     miningSetupStatus: `"${MiningSetupStatus.Checklist}"`,

--- a/src-vue/__test__/CrosschainHistory.test.ts
+++ b/src-vue/__test__/CrosschainHistory.test.ts
@@ -1,0 +1,326 @@
+import { AccountActivityKind, createDeferred, MoveToken } from '@argonprotocol/apps-core';
+import { describe, expect, it, vi } from 'vitest';
+import { CrosschainHistory, type ICrosschainHistoryRecord } from '../lib/CrosschainHistory.ts';
+import { FinancialCacheTypes, type FinancialCacheTable } from '../lib/db/FinancialCacheTable.ts';
+
+describe('CrosschainHistory', () => {
+  it('keeps loaded history visible when a refresh fails', async () => {
+    const record = transferAuthorizationRecord();
+    const history = new CrosschainHistory(
+      { vaultingAddress: record.accountId },
+      {
+        start: vi.fn(async () => undefined),
+        finalizedBlockHeader: { blockNumber: 12 },
+      } as any,
+      undefined,
+      vi.fn(async () => {
+        throw new Error('Indexer unavailable');
+      }),
+    );
+    history.data.records = [record];
+
+    const refreshPromise = history.refresh();
+
+    expect(history.data.records).toMatchObject([record]);
+    expect(history.data.isSyncing).toBe(true);
+
+    await refreshPromise;
+
+    expect(history.data.records).toMatchObject([record]);
+    expect(history.data.error).toBe('Indexer unavailable');
+  });
+
+  it('restores cached history before refreshing from its saved block', async () => {
+    const record = transferAuthorizationRecord();
+    const findActivity = vi.fn(async () => {
+      throw new Error('Indexer unavailable');
+    });
+    const getCachedHistory = vi.fn(async () => ({
+      records: [record],
+      definitionVersion: 3,
+      refreshedThroughBlock: 10,
+    }));
+    const updateCachedHistory = vi.fn();
+    const financialCache = Promise.resolve({
+      get: getCachedHistory,
+      upsert: updateCachedHistory,
+    } as unknown as FinancialCacheTable);
+    const history = new CrosschainHistory(
+      { vaultingAddress: record.accountId },
+      {
+        start: vi.fn(async () => undefined),
+        finalizedBlockHeader: { blockNumber: 12 },
+      } as any,
+      financialCache,
+      findActivity,
+    );
+
+    await history.refresh();
+
+    expect(getCachedHistory).toHaveBeenCalledWith(FinancialCacheTypes.CrosschainHistory, '5vault');
+    expect(findActivity).toHaveBeenCalledWith('5vault', {
+      afterBlock: 10,
+      toBlock: 12,
+      activityMask: AccountActivityKind.Fee,
+    });
+    expect(history.data.records).toEqual([record]);
+    expect(history.data.error).toBe('Indexer unavailable');
+    expect(updateCachedHistory).not.toHaveBeenCalled();
+  });
+
+  it('caches a complete refreshed history snapshot', async () => {
+    const record = transferAuthorizationRecord();
+    const updateCachedHistory = vi.fn(async () => undefined);
+    const cache = {
+      get: vi.fn(async () => undefined),
+      upsert: updateCachedHistory,
+    } as unknown as FinancialCacheTable;
+    const history = new CrosschainHistory(
+      { vaultingAddress: record.accountId },
+      {
+        start: vi.fn(async () => undefined),
+        finalizedBlockHeader: { blockNumber: 12 },
+      } as any,
+      Promise.resolve(cache),
+      vi.fn(async () => ({
+        blocks: [],
+        asOfBlock: 12,
+        definitionVersion: 4,
+        coverage: { fromBlock: 0, toBlock: 12, gaps: [] },
+      })),
+    );
+    history.data.records = [record];
+
+    await history.refresh();
+
+    expect(updateCachedHistory).toHaveBeenCalledWith(FinancialCacheTypes.CrosschainHistory, '5vault', {
+      records: [record],
+      definitionVersion: 4,
+      refreshedThroughBlock: 12,
+    });
+  });
+
+  it('refreshes again when finalized state advances during an active refresh', async () => {
+    const releaseFirstRefresh = createDeferred<void>();
+    const finalizedBlockHeader = { blockNumber: 12 };
+    const findActivity = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await releaseFirstRefresh.promise;
+        return {
+          blocks: [],
+          asOfBlock: 12,
+          definitionVersion: 4,
+          coverage: { fromBlock: 0, toBlock: 12, gaps: [] },
+        };
+      })
+      .mockResolvedValueOnce({
+        blocks: [],
+        asOfBlock: 13,
+        definitionVersion: 4,
+        coverage: { fromBlock: 12, toBlock: 13, gaps: [] },
+      });
+    const history = new CrosschainHistory(
+      { vaultingAddress: '5vault' },
+      {
+        start: vi.fn(async () => undefined),
+        finalizedBlockHeader,
+      } as any,
+      undefined,
+      findActivity,
+    );
+
+    const firstRefresh = history.refresh();
+    await vi.waitFor(() => expect(findActivity).toHaveBeenCalledTimes(1));
+    finalizedBlockHeader.blockNumber = 13;
+    const nextRefresh = history.refresh();
+    releaseFirstRefresh.resolve();
+    await Promise.all([firstRefresh, nextRefresh]);
+
+    expect(findActivity).toHaveBeenNthCalledWith(1, '5vault', {
+      afterBlock: 0,
+      toBlock: 12,
+      activityMask: AccountActivityKind.Fee,
+    });
+    expect(findActivity).toHaveBeenNthCalledWith(2, '5vault', {
+      afterBlock: 12,
+      toBlock: 13,
+      activityMask: AccountActivityKind.Fee,
+    });
+    expect(history.data.coverageComplete).toBe(true);
+  });
+
+  it('only labels a recipient as previously seen after complete indexed coverage', () => {
+    const record = transferAuthorizationRecord();
+    const history = new CrosschainHistory({ vaultingAddress: record.accountId }, {} as any);
+    history.data.records = [record];
+
+    expect(
+      history.hasSeenRecipient(
+        record.details.kind === 'transferAuthorization' ? record.details.destinationAccount : '',
+      ),
+    ).toBeUndefined();
+
+    history.data.coverageComplete = true;
+
+    expect(history.hasSeenRecipient('0xrecipient')).toBe(true);
+    expect(history.hasSeenRecipient('0xnew')).toBe(false);
+  });
+
+  it('totals each sponsored transfer once using the approved ARGNOT rate', () => {
+    const argnTransfer = transferAuthorizationRecord();
+    const transferDetails = argnTransfer.details as Extract<
+      ICrosschainHistoryRecord['details'],
+      { kind: 'transferAuthorization' }
+    >;
+    const duplicateArgnTransfer = {
+      ...argnTransfer,
+      id: '0xblock:3',
+    };
+    const argonotTransfer: ICrosschainHistoryRecord = {
+      ...argnTransfer,
+      id: '0xblock:4',
+      details: {
+        ...transferDetails,
+        transferId: '0xargonot-transfer',
+        moveToken: MoveToken.ARGNOT,
+        amount: 2_000_000n,
+      },
+    };
+    const history = new CrosschainHistory({ vaultingAddress: argnTransfer.accountId }, {} as any);
+    history.data.records = [argnTransfer, duplicateArgnTransfer, argonotTransfer];
+
+    expect(history.getSponsoredTransferValue(4_000_000n)).toBe(13_000_000n);
+  });
+
+  it('keeps this wallet council signatures in its crosschain history', async () => {
+    const block = {
+      blockNumber: 10,
+      blockHash: '0xblock',
+      blockTime: Date.parse('2026-08-15T12:00:00.000Z'),
+    };
+    const approvalEvent = (queueNonce: bigint, signer: string) => ({
+      phase: { isApplyExtrinsic: true, asApplyExtrinsic: { toNumber: () => 1 } },
+      event: {
+        section: 'crosschainTransfer',
+        method: 'QueueEntryApprovalRecorded',
+        data: {
+          approvalQueueNonce: { toBigInt: () => queueNonce },
+          target: {
+            isMintingAuthorityActivation: true,
+            isMintingAuthorityDeactivation: false,
+            isGlobalIssuanceCouncilRotation: false,
+            asMintingAuthorityActivation: { toHex: () => signer },
+          },
+        },
+      },
+    });
+    const events = [approvalEvent(1n, '0xauthority-one'), approvalEvent(2n, '0xauthority-two')];
+    const api = {
+      events: {
+        crosschainTransfer: {
+          QueueEntryApprovalRecorded: {
+            is: (event: { method: string }) => event.method === 'QueueEntryApprovalRecorded',
+          },
+          TransferCollateralized: { is: () => false },
+          MintingAuthorityRegistered: { is: () => false },
+        },
+      },
+      query: {
+        crosschainTransfer: {
+          mintingAuthoritiesBySigner: vi.fn(async () => ({
+            isSome: true,
+            unwrap: () => ({ accountId: { toString: () => '5owner' } }),
+          })),
+        },
+      },
+    };
+    const findActivity = vi
+      .fn()
+      .mockResolvedValueOnce({
+        blocks: [{ blockNumber: 10, blockHash: '0xblock', specVersion: 157, activityMask: AccountActivityKind.Fee }],
+        asOfBlock: 12,
+        definitionVersion: 1,
+        coverage: { fromBlock: 0, toBlock: 12, gaps: [] },
+      })
+      .mockResolvedValueOnce({
+        blocks: [],
+        asOfBlock: 12,
+        definitionVersion: 1,
+        coverage: { fromBlock: 12, toBlock: 12, gaps: [] },
+      });
+    const history = new CrosschainHistory(
+      { vaultingAddress: '5vault' },
+      {
+        start: vi.fn(async () => undefined),
+        finalizedBlockHeader: { blockNumber: 12 },
+        getHeader: vi.fn(async () => block),
+        getEventsWithSpec: vi.fn(async () => ({ api, events, specVersion: 157 })),
+        getBlock: vi.fn(async () => ({
+          block: {
+            extrinsics: [undefined, { isSigned: true, signer: { toString: () => '5vault' } }],
+          },
+        })),
+      } as any,
+      undefined,
+      findActivity,
+    );
+
+    await history.refresh();
+    await history.refresh();
+
+    expect(findActivity).toHaveBeenNthCalledWith(1, '5vault', {
+      afterBlock: 0,
+      toBlock: 12,
+      activityMask: AccountActivityKind.Fee,
+    });
+    expect(findActivity).toHaveBeenNthCalledWith(2, '5vault', {
+      afterBlock: 12,
+      toBlock: 12,
+      activityMask: AccountActivityKind.Fee,
+    });
+    expect(history.data.records).toMatchObject([
+      {
+        details: {
+          kind: 'councilApproval',
+          queueNonce: 2n,
+          targetKind: 'mintingAuthorityActivation',
+          targetValue: '0xauthority-two',
+        },
+      },
+      {
+        details: {
+          kind: 'councilApproval',
+          queueNonce: 1n,
+          targetKind: 'mintingAuthorityActivation',
+          targetValue: '0xauthority-one',
+        },
+      },
+    ]);
+    expect(history.data.coverageComplete).toBe(true);
+  });
+});
+
+function transferAuthorizationRecord(): ICrosschainHistoryRecord {
+  return {
+    accountId: '5vault',
+    id: '0xblock:2',
+    blockNumber: 10,
+    blockTime: new Date('2026-08-15T12:00:00.000Z'),
+    extrinsicIndex: 1,
+    eventIndex: 2,
+    details: {
+      kind: 'transferAuthorization',
+      transferId: '0xtransfer',
+      authoritySigningKey: '0xauthority',
+      authorityOwnerAccount: '5vault',
+      sourceAccount: '5source',
+      destinationAccount: '0xrecipient',
+      moveToken: MoveToken.ARGN,
+      amount: 5_000_000n,
+      reward: 50_000n,
+      microgonCollateral: 10_000_000n,
+      micronotCollateral: 1_000_000n,
+    },
+  };
+}

--- a/src-vue/__test__/CrosschainTransferView.test.ts
+++ b/src-vue/__test__/CrosschainTransferView.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createKnownCrosschainSourceIdentities,
+  formatCrosschainSourceIdentity,
+  getCrosschainAccessState,
+} from '../lib/CrosschainTransferView.ts';
+
+describe('CrosschainTransferView', () => {
+  it('allows a registered council signer to activate Crosschain without a minting authority', () => {
+    expect(
+      getCrosschainAccessState({
+        hasActivatedCrosschain: false,
+        authorityCount: 0,
+        councilSigner: `0x${'11'.repeat(20)}`,
+      }),
+    ).toEqual({ hasAccess: true, hasMintingAuthority: false });
+  });
+
+  it('resolves a created vault across local account roles and a configured upstream by vault id', () => {
+    const defaultAccount = `0x${'11'.repeat(32)}`;
+    const vaultingAccount = `0x${'22'.repeat(32)}`;
+    const ownOperatorAccount = `0x${'33'.repeat(32)}`;
+    const upstreamOperatorAccount = `0x${'44'.repeat(32)}`;
+    const createdVault = {
+      name: 'Atlas',
+      operatorAccountId: ownOperatorAccount,
+    };
+    const upstreamVault = {
+      name: 'Beacon',
+      operatorAccountId: upstreamOperatorAccount,
+    };
+
+    const identities = createKnownCrosschainSourceIdentities({
+      networkName: 'dev-docker',
+      createdVault,
+      vaultsById: { 1: createdVault, 2: upstreamVault },
+      localAccountIds: [defaultAccount, vaultingAccount],
+      upstreamOperator: { name: 'Beacon', vaultId: 2 },
+    });
+
+    expect(identities.get(defaultAccount)).toEqual({ name: 'Atlas', kind: 'vault' });
+    expect(identities.get(vaultingAccount)).toEqual({ name: 'Atlas', kind: 'vault' });
+    expect(identities.get(ownOperatorAccount)).toEqual({ name: 'Atlas', kind: 'vault' });
+    expect(identities.get(upstreamOperatorAccount)).toEqual({ name: 'Beacon', kind: 'vault' });
+  });
+
+  it('uses normalized operator names and falls back to the upstream name for local minting requests', () => {
+    const localAccount = `0x${'55'.repeat(32)}`;
+    const upstreamAccount = `0x${'66'.repeat(32)}`;
+    const identities = createKnownCrosschainSourceIdentities({
+      networkName: 'dev-docker',
+      vaultsById: {
+        2: {
+          name: 'dev-docker-On-chain Operator',
+          operatorAccountId: upstreamAccount,
+        },
+      },
+      localAccountIds: [localAccount],
+      upstreamOperator: { name: 'Configured Upstream', vaultId: 2 },
+    });
+
+    const localIdentity = identities.get(localAccount);
+    const upstreamIdentity = identities.get(upstreamAccount);
+
+    expect(localIdentity).toEqual({ name: 'Configured Upstream', kind: 'upstream' });
+    expect(upstreamIdentity).toEqual({ name: 'On-chain Operator', kind: 'vault' });
+    expect(formatCrosschainSourceIdentity(localIdentity!)).toBe('Upstream: Configured Upstream');
+    expect(formatCrosschainSourceIdentity(upstreamIdentity!)).toBe('On-chain Operator');
+  });
+
+  it('labels a remote transfer source with its on-chain upstream operator', () => {
+    const sourceAccount = `0x${'77'.repeat(32)}`;
+    const sponsorVaultAccount = `0x${'88'.repeat(32)}`;
+    const identities = createKnownCrosschainSourceIdentities({
+      networkName: 'dev-docker',
+      vaultsById: {
+        3: {
+          name: 'dev-docker-JC',
+          operatorAccountId: sponsorVaultAccount,
+        },
+      },
+      localAccountIds: [],
+      sourceUpstreamVaultAccountsByAccount: new Map([[sourceAccount, sponsorVaultAccount]]),
+    });
+
+    const sourceIdentity = identities.get(sourceAccount);
+
+    expect(sourceIdentity).toEqual({ name: 'JC', kind: 'upstream' });
+    expect(formatCrosschainSourceIdentity(sourceIdentity!)).toBe('Upstream: JC');
+  });
+});

--- a/src-vue/__test__/EthereumClient.test.ts
+++ b/src-vue/__test__/EthereumClient.test.ts
@@ -3,6 +3,8 @@ import { decodeAddress, EvmContracts } from '@argonprotocol/mainchain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
   getAddress,
   keccak256,
   parseTransaction,
@@ -285,6 +287,74 @@ describe('EthereumClient', () => {
     ]);
   });
 
+  it('reads the gateway approval nonce currently applied on Ethereum', async () => {
+    const fixture = createCouncilRotationRelayFixture();
+
+    await expect(fixture.ethereumClient.getGatewayApprovalNonce()).resolves.toBe(0n);
+  });
+
+  it('hydrates Ethereum block numbers for live gateway approval rows in one block-range lookup', async () => {
+    const fixture = createCouncilRotationRelayFixture();
+    const zeroHash: Hex = `0x${'00'.repeat(32)}`;
+    const signingKey: Hex = `0x${'11'.repeat(20)}`;
+    const topics = encodeEventTopics({
+      abi: EvmContracts.mintingGatewayAbi,
+      eventName: 'MintingAuthorityDeactivated',
+      args: { signingKey },
+    });
+    const data = encodeAbiParameters(
+      [
+        { name: 'microgonCollateral', type: 'uint128' },
+        { name: 'micronotCollateral', type: 'uint128' },
+        { name: 'approvalHash', type: 'bytes32' },
+        { name: 'relayerArgonAccountId', type: 'bytes32' },
+        {
+          name: 'gatewayState',
+          type: 'tuple',
+          components: [
+            { name: 'gatewayActivityNonce', type: 'uint64' },
+            { name: 'argonApprovalsNonce', type: 'uint64' },
+            { name: 'argonCirculation', type: 'uint128' },
+            { name: 'argonotCirculation', type: 'uint128' },
+          ],
+        },
+      ],
+      [
+        0n,
+        0n,
+        zeroHash,
+        zeroHash,
+        {
+          gatewayActivityNonce: 7n,
+          argonApprovalsNonce: 8n,
+          argonCirculation: 0n,
+          argonotCirculation: 0n,
+        },
+      ],
+    );
+    const getLogs = vi.fn(async () => [{ data, topics, blockNumber: 120n }]);
+    const publicClient = {
+      readContract: vi.fn(async ({ functionName }: { functionName: string }) => {
+        if (functionName === 'latestActivityBlockLocatorIndex') return 4n;
+        if (functionName === 'activityBlockLocators') return [120n, 7n, 7n, zeroHash];
+        throw new Error(`Unexpected function ${functionName}`);
+      }),
+      getLogs,
+    };
+    Object.assign(fixture.ethereumClient, {
+      createExecutionClient: async () => ({ publicClient }),
+    });
+
+    await expect(fixture.ethereumClient.getGatewayApprovalBlockNumbers([8n], 115n)).resolves.toEqual(
+      new Map([[8n, 120n]]),
+    );
+    expect(getLogs).toHaveBeenCalledWith({
+      address: fixture.gatewayAddress,
+      fromBlock: 116n,
+      toBlock: 120n,
+    });
+  });
+
   it('relays a standalone council rotation when an unreimbursed relay is explicitly allowed', async () => {
     const fixture = createCouncilRotationRelayFixture();
     fixture.entries.delete(2n);
@@ -555,6 +625,7 @@ function createCouncilRotationRelayFixture(corruption?: 'council' | 'payload' | 
     entries,
     ethereumClient,
     finalizedClient,
+    gatewayAddress,
     rotatedCouncilSignatures,
     rotationTarget,
     sendRawTransaction,

--- a/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
+++ b/src-vue/__test__/EthereumOutboundTransferTracker.integration.test.ts
@@ -227,7 +227,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
 
     blockWatch.emitFinalized(transferHeader);
     await vi.waitFor(() => {
-      expect(mintingAuthorities.authorize).toHaveBeenCalledWith(onChainTransferId);
+      expect(mintingAuthorities.authorize).toHaveBeenCalledWith([onChainTransferId]);
     });
 
     blockWatch.emitFinalized(readyHeader);
@@ -1435,7 +1435,7 @@ describe('EthereumOutboundTransferTracker integration', () => {
     await tracker.load();
 
     await vi.waitFor(() => {
-      expect(authorize).toHaveBeenCalledWith(onChainTransferId);
+      expect(authorize).toHaveBeenCalledWith([onChainTransferId]);
       expect(tracker.getTransfer(transferId)?.transferState.error).toBe('');
       expect(tracker.getTransfer(transferId)?.transferState.needsAttention).toBe(false);
       expect(tracker.getTransfer(transferId)?.transferState.progress.currentStepLabel).toBe(

--- a/src-vue/__test__/FinancialCacheTable.test.ts
+++ b/src-vue/__test__/FinancialCacheTable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { UnitOfMeasurement } from '@argonprotocol/apps-core';
+import { MoveToken, UnitOfMeasurement } from '@argonprotocol/apps-core';
 import { FinancialCacheTypes } from '../lib/db/FinancialCacheTable.ts';
 import { createTestDb } from './helpers/db.ts';
 
@@ -44,5 +44,41 @@ describe('FinancialCacheTable', () => {
       ],
       observedAt,
     });
+  });
+
+  it('round trips crosschain history snapshots with dates and bigints', async () => {
+    const db = await createTestDb();
+    const snapshot = {
+      records: [
+        {
+          accountId: '5vault',
+          id: '0xblock:2',
+          blockNumber: 10,
+          blockTime: new Date('2026-08-15T12:00:00.000Z'),
+          extrinsicIndex: 1,
+          eventIndex: 2,
+          details: {
+            kind: 'transferAuthorization' as const,
+            transferId: '0xtransfer',
+            authoritySigningKey: '0xauthority',
+            sourceAccount: '5source',
+            destinationAccount: '0xrecipient',
+            moveToken: MoveToken.ARGN,
+            amount: 5_000_000n,
+            reward: 50_000n,
+            microgonCollateral: 10_000_000n,
+            micronotCollateral: 1_000_000n,
+          },
+        },
+      ],
+      definitionVersion: 3,
+      refreshedThroughBlock: 10,
+    };
+
+    await db.financialCacheTable.upsert(FinancialCacheTypes.CrosschainHistory, '5vault', snapshot);
+
+    await expect(db.financialCacheTable.get(FinancialCacheTypes.CrosschainHistory, '5vault')).resolves.toEqual(
+      snapshot,
+    );
   });
 });

--- a/src-vue/__test__/GlobalCouncil.test.ts
+++ b/src-vue/__test__/GlobalCouncil.test.ts
@@ -15,7 +15,7 @@ describe('GlobalCouncil', () => {
       globalCouncil as unknown as {
         syncApprovedGatewayRelay: (args: {
           councilSigner?: string;
-          hasSignedApprovalsAwaitingRelay: boolean;
+          hasReadyGatewayUpdates: boolean;
           sharedRelayQueueKey?: string;
         }) => Promise<void>;
       }
@@ -23,7 +23,7 @@ describe('GlobalCouncil', () => {
 
     await syncApprovedGatewayRelay({
       councilSigner: '0xabc',
-      hasSignedApprovalsAwaitingRelay: true,
+      hasReadyGatewayUpdates: true,
       sharedRelayQueueKey: undefined,
     });
 
@@ -54,7 +54,7 @@ describe('GlobalCouncil', () => {
         globalCouncil as unknown as {
           syncApprovedGatewayRelay: (args: {
             councilSigner?: string;
-            hasSignedApprovalsAwaitingRelay: boolean;
+            hasReadyGatewayUpdates: boolean;
             sharedRelayQueueKey?: string;
           }) => Promise<void>;
         }
@@ -62,13 +62,13 @@ describe('GlobalCouncil', () => {
 
       await syncApprovedGatewayRelay({
         councilSigner: '0xabc',
-        hasSignedApprovalsAwaitingRelay: false,
+        hasReadyGatewayUpdates: false,
         sharedRelayQueueKey: '9:9',
       });
       await vi.advanceTimersByTimeAsync(getEthereumFinalityMillis() * 3);
       await syncApprovedGatewayRelay({
         councilSigner: '0xabc',
-        hasSignedApprovalsAwaitingRelay: false,
+        hasReadyGatewayUpdates: false,
         sharedRelayQueueKey: '9:9',
       });
 
@@ -100,7 +100,7 @@ describe('GlobalCouncil', () => {
         globalCouncil as unknown as {
           syncApprovedGatewayRelay: (args: {
             councilSigner?: string;
-            hasSignedApprovalsAwaitingRelay: boolean;
+            hasReadyGatewayUpdates: boolean;
             sharedRelayQueueKey?: string;
           }) => Promise<void>;
         }
@@ -108,13 +108,13 @@ describe('GlobalCouncil', () => {
 
       await syncApprovedGatewayRelay({
         councilSigner: '0xabc',
-        hasSignedApprovalsAwaitingRelay: true,
+        hasReadyGatewayUpdates: true,
         sharedRelayQueueKey: '9:9',
       });
       await vi.advanceTimersByTimeAsync(getEthereumFinalityMillis() * 3);
       await syncApprovedGatewayRelay({
         councilSigner: '0xabc',
-        hasSignedApprovalsAwaitingRelay: true,
+        hasReadyGatewayUpdates: true,
         sharedRelayQueueKey: '9:9',
       });
 
@@ -134,7 +134,7 @@ describe('GlobalCouncil', () => {
     }
   });
 
-  it('includes deactivation approvals in the pending queue', async () => {
+  it('describes every pending gateway update', async () => {
     const globalCouncil = new GlobalCouncil(
       Promise.resolve({
         walletHdKeysTable: {
@@ -153,7 +153,7 @@ describe('GlobalCouncil', () => {
         globalCouncil as unknown as {
           syncApprovedGatewayRelay: (args: {
             councilSigner?: string;
-            hasSignedApprovalsAwaitingRelay: boolean;
+            hasReadyGatewayUpdates: boolean;
             sharedRelayQueueKey?: string;
           }) => Promise<void>;
         },
@@ -163,50 +163,179 @@ describe('GlobalCouncil', () => {
 
     const approvalHashOne = { toHex: () => '0x11' };
     const approvalHashTwo = { toHex: () => '0x22' };
+    const approvalHashThree = { toHex: () => '0x33' };
     const finalizedClient = {
       query: {
         crosschainTransfer: {
           councilSignerByDestinationChainAndAccountId: vi.fn(async () => some(hexValue('0xabc'))),
           councilApprovalCursorByDestinationChainAndAccountId: vi.fn(async () => some(bigintValue(0n))),
-          gatewayStateBySourceChain: vi.fn(async () => some({ argonApprovalsNonce: bigintValue(0n) })),
-          nextCouncilApprovalQueueNonceByDestinationChain: vi.fn(async () => bigintValue(2n)),
-          councilApprovalQueueByDestinationChainAndNonce: vi.fn(async (_chain: string, nonce: bigint) => {
-            if (nonce === 1n) {
-              return some({
-                target: {
-                  isMintingAuthorityActivation: true,
-                  isMintingAuthorityDeactivation: false,
-                },
-                approvalHash: approvalHashOne,
-              });
-            }
-            if (nonce === 2n) {
-              return some({
-                target: {
-                  isMintingAuthorityActivation: false,
-                  isMintingAuthorityDeactivation: true,
-                },
-                approvalHash: approvalHashTwo,
-              });
-            }
-            return none();
-          }),
+          gatewayStateBySourceChain: vi.fn(async () =>
+            some({ argonApprovalsNonce: bigintValue(0n), gatewayActivityNonce: bigintValue(47n) }),
+          ),
+          nextCouncilApprovalQueueNonceByDestinationChain: vi.fn(async () => bigintValue(33n)),
+          activeGlobalIssuanceCouncilByDestinationChain: vi.fn(async () => some(hexValue('0xactive'))),
+          transferOutQuoteMicrogonsPerArgonotByDestinationChain: vi.fn(async () => some(bigintValue(750_000n))),
+          globalIssuanceCouncilByHash: {
+            multi: vi.fn(async (hashes: string[]) =>
+              hashes.map(hash =>
+                some(
+                  council(
+                    hash === '0xactive' ? ['5existing', '5leaving'] : ['5existing', '5new-one', '5new-two'],
+                    hash === '0xactive' ? 1_000_000n : 2_000_000n,
+                  ),
+                ),
+              ),
+            ),
+          },
+          mintingAuthoritiesBySigner: {
+            multi: vi.fn(async (signers: string[]) =>
+              signers.map(signer => some({ accountId: { toString: () => `owner-${signer}` } })),
+            ),
+          },
+          councilApprovalQueueByDestinationChainAndNonce: {
+            multi: vi.fn(async (keys: Array<[string, bigint]>) =>
+              keys.map(([, nonce]) => {
+                if (nonce === 1n) {
+                  return some({
+                    approvingCouncilHash: hexValue('0xactive'),
+                    approvedTotalWeight: bigintValue(0n),
+                    signatures: new Map(),
+                    target: {
+                      isMintingAuthorityActivation: true,
+                      isMintingAuthorityDeactivation: false,
+                      isGlobalIssuanceCouncilRotation: false,
+                      asMintingAuthorityActivation: hexValue('0xaaaa'),
+                    },
+                    approvalHash: approvalHashOne,
+                  });
+                }
+                if (nonce === 2n) {
+                  return some({
+                    approvingCouncilHash: hexValue('0xactive'),
+                    approvedTotalWeight: bigintValue(0n),
+                    signatures: new Map(),
+                    target: {
+                      isMintingAuthorityActivation: false,
+                      isMintingAuthorityDeactivation: true,
+                      isGlobalIssuanceCouncilRotation: false,
+                      asMintingAuthorityDeactivation: hexValue('0xbbbb'),
+                    },
+                    approvalHash: approvalHashTwo,
+                  });
+                }
+                if (nonce === 3n) {
+                  return some({
+                    approvingCouncilHash: hexValue('0xactive'),
+                    approvedTotalWeight: bigintValue(0n),
+                    signatures: new Map(),
+                    target: {
+                      isMintingAuthorityActivation: false,
+                      isMintingAuthorityDeactivation: false,
+                      isGlobalIssuanceCouncilRotation: true,
+                      asGlobalIssuanceCouncilRotation: hexValue('0xcccc'),
+                    },
+                    approvalHash: approvalHashThree,
+                  });
+                }
+                if (nonce <= 33n) {
+                  return some({
+                    approvingCouncilHash: hexValue('0xactive'),
+                    approvedTotalWeight: bigintValue(0n),
+                    signatures: new Map(),
+                    target: {
+                      isMintingAuthorityActivation: true,
+                      isMintingAuthorityDeactivation: false,
+                      isGlobalIssuanceCouncilRotation: false,
+                      asMintingAuthorityActivation: hexValue(`0x${nonce.toString(16).padStart(4, '0')}`),
+                    },
+                    approvalHash: hexValue(`0x${nonce.toString(16).padStart(2, '0')}`),
+                  });
+                }
+                return none();
+              }),
+            ),
+          },
         },
       },
     };
 
-    await expect(globalCouncil.refresh(finalizedClient as any)).resolves.toEqual([
-      { approvalHash: '0x11' },
-      { approvalHash: '0x22' },
+    const pendingApprovals = await globalCouncil.refresh(finalizedClient as any);
+
+    expect(pendingApprovals.slice(0, 3)).toEqual([
+      {
+        approvalHash: '0x11',
+        queueNonce: 1n,
+        targetKind: 'mintingAuthorityActivation',
+        targetSigningKey: '0xaaaa',
+        authorityOwnerAccount: 'owner-0xaaaa',
+      },
+      {
+        approvalHash: '0x22',
+        queueNonce: 2n,
+        targetKind: 'mintingAuthorityDeactivation',
+        targetSigningKey: '0xbbbb',
+        authorityOwnerAccount: 'owner-0xbbbb',
+      },
+      {
+        approvalHash: '0x33',
+        queueNonce: 3n,
+        targetKind: 'globalIssuanceCouncilRotation',
+        targetCouncilHash: '0xcccc',
+        councilChange: {
+          vaultCount: 3,
+          newVaultCount: 2,
+          leavingVaultCount: 1,
+          epochMicrogonsPerArgonot: 2_000_000n,
+        },
+      },
     ]);
+    expect(pendingApprovals).toHaveLength(33);
+    expect(globalCouncil.data.gatewayActivityCount).toBe(47n);
+    expect(globalCouncil.data.activeEpochMicrogonsPerArgonot).toBe(1_000_000n);
+    expect(globalCouncil.data.transferOutMicrogonsPerArgonot).toBe(750_000n);
+    expect(
+      finalizedClient.query.crosschainTransfer.councilApprovalQueueByDestinationChainAndNonce.multi,
+    ).toHaveBeenCalledTimes(2);
     expect(syncApprovedGatewayRelay).toHaveBeenCalledWith({
       councilSigner: '0xabc',
-      hasSignedApprovalsAwaitingRelay: false,
+      hasReadyGatewayUpdates: false,
       sharedRelayQueueKey: undefined,
     });
   });
 
-  it('keeps the shared relay queue key when signed approvals are already awaiting Ethereum relay', async () => {
+  it('signs enriched approvals with their original approval hashes', async () => {
+    const signEthereumPersonalMessage = vi.fn(async (approvalHash: string) => `signature-${approvalHash}`);
+    const globalCouncil = new GlobalCouncil(
+      Promise.resolve({} as any),
+      {
+        councilSignerEthereumHdPath: `m/44'/60'/1'/0'`,
+        signEthereumPersonalMessage,
+      } as any,
+      {} as any,
+    );
+
+    const approveQueueEntries = vi.fn((_chain: string, signatures: string[]) => ({ signatures }));
+    await globalCouncil.buildApprovePendingGatewayUpdateTxs(
+      {
+        consts: { crosschainTransfer: { maxQueueApprovalsPerCall: { toNumber: () => 10 } } },
+        createType: vi.fn((_type: string, signatures: string[]) => signatures),
+        tx: { crosschainTransfer: { approveQueueEntries } },
+      } as any,
+      [
+        {
+          approvalHash: '0x33',
+          queueNonce: 3n,
+          targetKind: 'globalIssuanceCouncilRotation',
+          targetCouncilHash: '0xcccc',
+        },
+      ],
+    );
+
+    expect(signEthereumPersonalMessage).toHaveBeenCalledOnce();
+    expect(signEthereumPersonalMessage).toHaveBeenCalledWith('0x33', `m/44'/60'/1'/0'`, 'argon');
+  });
+
+  it('marks a signed gateway update ready only after the council reaches quorum', async () => {
     const globalCouncil = new GlobalCouncil(
       Promise.resolve({
         walletHdKeysTable: {
@@ -225,7 +354,7 @@ describe('GlobalCouncil', () => {
         globalCouncil as unknown as {
           syncApprovedGatewayRelay: (args: {
             councilSigner?: string;
-            hasSignedApprovalsAwaitingRelay: boolean;
+            hasReadyGatewayUpdates: boolean;
             sharedRelayQueueKey?: string;
           }) => Promise<void>;
         },
@@ -233,6 +362,7 @@ describe('GlobalCouncil', () => {
       )
       .mockResolvedValue(undefined);
 
+    let approvedWeight = 0n;
     const finalizedClient = {
       query: {
         crosschainTransfer: {
@@ -240,15 +370,67 @@ describe('GlobalCouncil', () => {
           councilApprovalCursorByDestinationChainAndAccountId: vi.fn(async () => some(bigintValue(2n))),
           gatewayStateBySourceChain: vi.fn(async () => some({ argonApprovalsNonce: bigintValue(1n) })),
           nextCouncilApprovalQueueNonceByDestinationChain: vi.fn(async () => bigintValue(2n)),
-          councilApprovalQueueByDestinationChainAndNonce: vi.fn(async () => none()),
+          activeGlobalIssuanceCouncilByDestinationChain: vi.fn(async () => none()),
+          transferOutQuoteMicrogonsPerArgonotByDestinationChain: vi.fn(async () => none()),
+          globalIssuanceCouncilByHash: {
+            multi: vi.fn(async () => [some(council(['5council-member'], 1_000_000n))]),
+          },
+          mintingAuthoritiesBySigner: {
+            multi: vi.fn(async () => [some({ accountId: { toString: () => '5authority-owner' } })]),
+          },
+          councilApprovalQueueByDestinationChainAndNonce: {
+            multi: vi.fn(async () => [
+              some({
+                approvingCouncilHash: hexValue('0xapproving'),
+                approvedTotalWeight: bigintValue(approvedWeight),
+                signatures: new Map([['0xabc', '0xsig']]),
+                target: {
+                  isMintingAuthorityActivation: true,
+                  isMintingAuthorityDeactivation: false,
+                  isGlobalIssuanceCouncilRotation: false,
+                  asMintingAuthorityActivation: hexValue('0xaaaa'),
+                },
+                approvalHash: hexValue('0x11'),
+              }),
+            ]),
+          },
         },
       },
     };
 
     await expect(globalCouncil.refresh(finalizedClient as any)).resolves.toEqual([]);
-    expect(syncApprovedGatewayRelay).toHaveBeenCalledWith({
+    expect(globalCouncil.data.approvalQueue).toMatchObject([
+      {
+        approvalHash: '0x11',
+        approvalProgress: {
+          approvedWeight: 0n,
+          totalWeight: 1n,
+          signatureCount: 1,
+          memberCount: 1,
+        },
+        queueNonce: 2n,
+        status: 'awaitingCouncilQuorum',
+        targetKind: 'mintingAuthorityActivation',
+        targetSigningKey: '0xaaaa',
+        authorityOwnerAccount: '5authority-owner',
+      },
+    ]);
+    expect(syncApprovedGatewayRelay).toHaveBeenLastCalledWith({
       councilSigner: '0xabc',
-      hasSignedApprovalsAwaitingRelay: true,
+      hasReadyGatewayUpdates: false,
+      sharedRelayQueueKey: undefined,
+    });
+
+    approvedWeight = 1n;
+    await globalCouncil.refresh(finalizedClient as any);
+
+    expect(globalCouncil.data.approvalQueue[0]).toMatchObject({
+      approvalProgress: { approvedWeight: 1n },
+      status: 'readyForRelay',
+    });
+    expect(syncApprovedGatewayRelay).toHaveBeenLastCalledWith({
+      councilSigner: '0xabc',
+      hasReadyGatewayUpdates: true,
       sharedRelayQueueKey: '1:2',
     });
   });
@@ -279,5 +461,15 @@ function none() {
   return {
     isSome: false,
     isNone: true,
+  };
+}
+
+function council(accountIds: string[], epochMicrogonsPerArgonot: bigint) {
+  return {
+    members: new Map(
+      accountIds.map((accountId, index) => [`0x${index}`, { accountId: { toString: () => accountId } }]),
+    ),
+    totalWeight: bigintValue(BigInt(accountIds.length)),
+    epochMicrogonsPerArgonot: bigintValue(epochMicrogonsPerArgonot),
   };
 }

--- a/src-vue/__test__/Importer.test.ts
+++ b/src-vue/__test__/Importer.test.ts
@@ -149,6 +149,7 @@ it('restores completed mining setup from imported operational account state', as
     walletPreviousLifeRecovered: 'false',
     hasExtensionTreasury: 'true',
     hasExtensionOperations: 'true',
+    hasActivatedCrosschain: 'false',
     certificationDetails: JsonExt.stringify({ hasSavedMnemonic: true }, 2),
     miningSetupStatus: JsonExt.stringify(MiningSetupStatus.Finished, 2),
     vaultingSetupStatus: JsonExt.stringify(VaultingSetupStatus.Finished, 2),
@@ -299,6 +300,42 @@ it('does not invent extensions from an imported basic wallet balance', async () 
       hasExtensionTreasury: 'false',
       hasExtensionOperations: 'false',
       miningSetupStatus: JsonExt.stringify(MiningSetupStatus.None, 2),
+    }),
+  );
+});
+
+it('restores Crosschain Transfers for an unfunded account with a minting-authority council signer', async () => {
+  const { mnemonic, walletKeys } = createTestWallet('//Alice');
+  const insertOrReplace = vi.fn();
+  const db = {
+    reconnect: vi.fn(),
+    configTable: { insertOrReplace },
+  } as unknown as Db;
+  importMocks.getFinalizedClient.mockResolvedValue({
+    query: {
+      operationalAccounts: {
+        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
+      },
+      vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
+      crosschainTransfer: {
+        councilSignerByDestinationChainAndAccountId: vi.fn().mockResolvedValue({ isSome: true }),
+      },
+    },
+  });
+  importMocks.readBalances.mockResolvedValue([emptyBalance, emptyBalance, emptyBalance, emptyBalance]);
+  importMocks.findMiningActivity.mockResolvedValue({ blocks: [], coverage: { gaps: [] } });
+  vi.spyOn(Mining, 'fetchMiningSeatsForAccount').mockResolvedValue({});
+  vi.spyOn(Restarter.prototype, 'deleteAndCreateLocalDatabase').mockResolvedValue();
+  vi.spyOn(Restarter.prototype, 'restart').mockImplementation(() => undefined);
+
+  await new Importer({} as Config, walletKeys, Promise.resolve(db)).importFromMnemonic(mnemonic);
+
+  expect(insertOrReplace).toHaveBeenCalledWith(
+    expect.objectContaining({
+      walletAccountsHadPreviousLife: 'true',
+      hasExtensionTreasury: 'true',
+      hasExtensionOperations: 'true',
+      hasActivatedCrosschain: 'true',
     }),
   );
 });

--- a/src-vue/__test__/MintingAuthorities.test.ts
+++ b/src-vue/__test__/MintingAuthorities.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
+import { MoveToken } from '@argonprotocol/apps-core';
 import type { WalletKeys } from '../lib/WalletKeys.ts';
 import { createTestDb } from './helpers/db.ts';
 import {
   MintingAuthorities,
+  type IEthereumMintingAuthority,
+  getActiveMintingAuthorityRemaining,
+  getMintingAuthorityBackedTransfers,
   getPendingMintingAuthorizations,
   getOwnedEthereumMintingAuthorities,
   getNextMintingAuthoritySigner,
@@ -37,6 +41,70 @@ describe('MintingAuthorities', () => {
     await expect(mintingAuthorities['onRegister'](txInfo)).rejects.toThrow(setupError);
     await expect(txInfo.waitForPostProcessing).rejects.toThrow(setupError);
     expect(txInfo.isPostProcessed).toBe(true);
+  });
+
+  it('calculates transfer capacity from active unreserved collateral only', () => {
+    const activeAuthority = {
+      isActive: true,
+      gatewayRemainingMicrogonCollateral: 10_000_000n,
+      pendingReservedMicrogonCollateral: 2_000_000n,
+      gatewayRemainingMicronotCollateral: 5_000_000n,
+      pendingReservedMicronotCollateral: 1_000_000n,
+    } as IEthereumMintingAuthority;
+    const deactivatingAuthority = {
+      isActive: false,
+      isDeactivating: true,
+      gatewayRemainingMicrogonCollateral: 99_000_000n,
+      pendingReservedMicrogonCollateral: 0n,
+      gatewayRemainingMicronotCollateral: 99_000_000n,
+      pendingReservedMicronotCollateral: 0n,
+    } as IEthereumMintingAuthority;
+
+    expect(getActiveMintingAuthorityRemaining([activeAuthority, deactivatingAuthority], 2_000_000n)).toEqual({
+      microgons: 8_000_000n,
+      micronots: 4_000_000n,
+      valueMicrogons: 16_000_000n,
+    });
+  });
+
+  it('restores an imported active authority without local signer-index records', async () => {
+    const db = await createTestDb();
+    const walletKeys = createWalletKeysStub();
+    const signer = (await walletKeys.getEthereumAddresses([walletKeys.getMintingAuthorityEthereumHdPath(0)]))[0];
+    const finalizedClient = {
+      query: {
+        crosschainTransfer: {
+          chainConfigBySourceChain: vi.fn(async () => ({ isNone: true })),
+          councilSignerByDestinationChainAndAccountId: vi.fn(async () => ({ isNone: false })),
+          mintingAuthoritiesBySigner: {
+            multi: vi.fn(async (signers: string[]) =>
+              signers.map(candidate =>
+                candidate === signer ? someAuthority(walletKeys.vaultingAddress, candidate) : noneAuthority(),
+              ),
+            ),
+          },
+        },
+      },
+    };
+    const mintingAuthorities = new MintingAuthorities(
+      Promise.resolve(db),
+      walletKeys as unknown as WalletKeys,
+      {
+        blockWatch: {
+          start: vi.fn(async () => undefined),
+          getFinalizedApi: vi.fn(async () => finalizedClient),
+        },
+      } as any,
+      {
+        pendingBlockTxInfosAtLoad: [],
+        data: { txInfos: [] },
+      } as any,
+    );
+
+    await mintingAuthorities.load();
+
+    expect(mintingAuthorities.data.authorities).toHaveLength(1);
+    expect(mintingAuthorities.data.authorities[0]).toMatchObject({ signer, authorityIndex: 0, isActive: true });
   });
 
   it('only scans missing signer indexes for a council account after its unrecognized registration', async () => {
@@ -334,6 +402,21 @@ describe('MintingAuthorities', () => {
     expect(authorizations[0]).toMatchObject({
       transferId: '0x' + '02'.repeat(32),
       authorityIndex: 0,
+      moveToken: MoveToken.ARGN,
+      sourceAccount: '5SourceAccount',
+      destinationSigningKey: authority.signer,
+      finalizeRequest: {
+        argonAccountId: '0x' + 'aa'.repeat(32),
+        argonTransferNonce: 1n,
+        chainId: 1n,
+        recipient: '0x' + 'bb'.repeat(20),
+        validUntilBlock: 123n,
+        token: '0x' + 'bb'.repeat(20),
+        amount: 80n,
+        mintingAuthorityTip: 1n,
+        microgonsPerArgonot: 1_000_000n,
+      },
+      mintingAuthorityTip: 1n,
       microgonCollateral: 70n,
       micronotCollateral: 0n,
       securityAmountMicrogons: 70n,
@@ -355,6 +438,73 @@ describe('MintingAuthorities', () => {
     expect(authorizations).toEqual([]);
     expect(client.query.crosschainTransfer.chainConfigBySourceChain).not.toHaveBeenCalled();
     expect(client.query.crosschainTransfer.pendingCollateralizationRequestsByChain).not.toHaveBeenCalled();
+  });
+
+  it('loads transfers already backed by an owned minting authority', async () => {
+    const signer = '0x' + '11'.repeat(20);
+    const transferId = '0x' + '01'.repeat(32);
+    let isReady = false;
+    const client = {
+      query: {
+        crosschainTransfer: {
+          transferOutById: {
+            multi: vi.fn(async () => [
+              {
+                isNone: false,
+                unwrap: () => ({
+                  state: { isReady },
+                  asset: { isArgon: true },
+                  argonAccountId: accountValue('0x' + 'aa'.repeat(32), '5SourceAccount'),
+                  argonTransferNonce: bigintValue(7n),
+                  destinationAccount: hexValue('0x' + 'bb'.repeat(20)),
+                  amount: bigintValue(80n),
+                  validUntilEthereumBlock: bigintValue(123n),
+                  mintingAuthorityTip: bigintValue(2n),
+                  totalAttachedCollateral: bigintValue(60n),
+                  mintingAuthorityCollateralBySigner: new Map([
+                    [
+                      hexValue(signer),
+                      {
+                        microgonCollateral: bigintValue(40n),
+                        micronotCollateral: bigintValue(20n),
+                      },
+                    ],
+                  ]),
+                }),
+              },
+            ]),
+          },
+        },
+      },
+    };
+    const authority = {
+      signer,
+      activePendingTransferIds: [transferId],
+    } as any;
+    const transfers = await getMintingAuthorityBackedTransfers(client as any, [authority]);
+
+    expect(transfers).toEqual([
+      {
+        transferId,
+        status: 'waitingForAuthorizations',
+        moveToken: MoveToken.ARGN,
+        sourceAccount: '5SourceAccount',
+        sourceTransferNonce: 7n,
+        destinationAccount: '0x' + 'bb'.repeat(20),
+        amount: 80n,
+        validUntilEthereumBlock: 123n,
+        mintingAuthorityTip: 2n,
+        totalAttachedCollateral: 60n,
+        ownedMicrogonCollateral: 40n,
+        ownedMicronotCollateral: 20n,
+        authoritySigners: [signer],
+      },
+    ]);
+
+    isReady = true;
+    await expect(getMintingAuthorityBackedTransfers(client as any, [authority])).resolves.toMatchObject([
+      { transferId, status: 'readyForEthereum' },
+    ]);
   });
 
   it('can plan an exact transfer even when the generic queue planner would spend the authority on an earlier request', async () => {
@@ -428,9 +578,9 @@ describe('MintingAuthorities', () => {
     });
   });
 
-  it('batches all current minting authorizations with utility.batch', async () => {
+  it('authorizes only the selected transfer requests', async () => {
     const collateralizeTransfer = vi.fn((transferId: string) => ({ kind: 'collateralizeTransfer', transferId }));
-    const batch = vi.fn(txs => ({ kind: 'batch', txs }));
+    const batchAll = vi.fn(txs => ({ kind: 'batchAll', txs }));
     const submitAndWatch = vi.fn(async (args: { metadata: unknown; tx: unknown }) => ({
       tx: { metadataJson: args.metadata },
       txResult: {},
@@ -440,10 +590,11 @@ describe('MintingAuthorities', () => {
       getMintingAuthorityEthereumHdPath(hdIndex: number): `m/44'/60'/${string}` {
         return getEthereumHdPath(DEFAULT_MEMORY_WALLET_KEYS_ETHEREUM_HD_PREFIXES.mintingAuthority, hdIndex);
       },
-      signEthereumPersonalMessage: vi
-        .fn()
-        .mockResolvedValueOnce(`0x${'11'.repeat(64)}1c`)
-        .mockResolvedValueOnce(`0x${'22'.repeat(64)}1c`),
+      signEthereumPersonalMessage: vi.fn(async (authorizationHash: string) => {
+        if (authorizationHash === `0x${'aa'.repeat(32)}`) return `0x${'11'.repeat(64)}1c`;
+        if (authorizationHash === `0x${'bb'.repeat(32)}`) return `0x${'22'.repeat(64)}1c`;
+        return `0x${'33'.repeat(64)}1c`;
+      }),
     };
     const pendingMintingAuthorizations = [
       {
@@ -462,6 +613,14 @@ describe('MintingAuthorities', () => {
         microgonCollateral: 0n,
         micronotCollateral: 20n,
       },
+      {
+        transferId: '0x' + '03'.repeat(32),
+        authorityIndex: 4,
+        authorizationHash: '0x' + 'cc'.repeat(32),
+        mintingAuthorityTip: 33n,
+        microgonCollateral: 30n,
+        micronotCollateral: 40n,
+      },
     ];
     const mintingAuthorities = {
       data: {
@@ -478,7 +637,7 @@ describe('MintingAuthorities', () => {
                   collateralizeTransfer,
                 },
                 utility: {
-                  batch,
+                  batchAll,
                 },
               },
             })),
@@ -490,45 +649,42 @@ describe('MintingAuthorities', () => {
       onAuthorize: vi.fn(async () => undefined),
     };
 
-    await MintingAuthorities.prototype.authorize.call(mintingAuthorities);
+    await MintingAuthorities.prototype.authorize.call(mintingAuthorities, [
+      pendingMintingAuthorizations[1].transferId,
+      pendingMintingAuthorizations[2].transferId,
+    ]);
 
+    expect(collateralizeTransfer).toHaveBeenCalledTimes(2);
     expect(collateralizeTransfer).toHaveBeenNthCalledWith(
       1,
-      pendingMintingAuthorizations[0].transferId,
-      `0x${'11'.repeat(64)}1c`,
-      pendingMintingAuthorizations[0].microgonCollateral,
-      pendingMintingAuthorizations[0].micronotCollateral,
-    );
-    expect(collateralizeTransfer).toHaveBeenNthCalledWith(
-      2,
       pendingMintingAuthorizations[1].transferId,
       `0x${'22'.repeat(64)}1c`,
       pendingMintingAuthorizations[1].microgonCollateral,
       pendingMintingAuthorizations[1].micronotCollateral,
     );
-    expect(batch).toHaveBeenCalledWith([
-      { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[0].transferId },
+    expect(collateralizeTransfer).toHaveBeenNthCalledWith(
+      2,
+      pendingMintingAuthorizations[2].transferId,
+      `0x${'33'.repeat(64)}1c`,
+      pendingMintingAuthorizations[2].microgonCollateral,
+      pendingMintingAuthorizations[2].micronotCollateral,
+    );
+    expect(batchAll).toHaveBeenCalledWith([
       { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[1].transferId },
+      { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[2].transferId },
     ]);
     expect(submitAndWatch).toHaveBeenCalledWith(
       expect.objectContaining({
         tx: {
-          kind: 'batch',
+          kind: 'batchAll',
           txs: [
-            { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[0].transferId },
             { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[1].transferId },
+            { kind: 'collateralizeTransfer', transferId: pendingMintingAuthorizations[2].transferId },
           ],
         },
         metadata: {
           actionType: 'authorizeTransfer',
           authorizations: [
-            {
-              authorityIndex: pendingMintingAuthorizations[0].authorityIndex,
-              transferId: pendingMintingAuthorizations[0].transferId,
-              mintingAuthorityTip: pendingMintingAuthorizations[0].mintingAuthorityTip,
-              microgonCollateral: pendingMintingAuthorizations[0].microgonCollateral,
-              micronotCollateral: pendingMintingAuthorizations[0].micronotCollateral,
-            },
             {
               authorityIndex: pendingMintingAuthorizations[1].authorityIndex,
               transferId: pendingMintingAuthorizations[1].transferId,
@@ -536,9 +692,44 @@ describe('MintingAuthorities', () => {
               microgonCollateral: pendingMintingAuthorizations[1].microgonCollateral,
               micronotCollateral: pendingMintingAuthorizations[1].micronotCollateral,
             },
+            {
+              authorityIndex: pendingMintingAuthorizations[2].authorityIndex,
+              transferId: pendingMintingAuthorizations[2].transferId,
+              mintingAuthorityTip: pendingMintingAuthorizations[2].mintingAuthorityTip,
+              microgonCollateral: pendingMintingAuthorizations[2].microgonCollateral,
+              micronotCollateral: pendingMintingAuthorizations[2].micronotCollateral,
+            },
           ],
         },
         useLatestNonce: true,
+      }),
+    );
+
+    vi.clearAllMocks();
+
+    await MintingAuthorities.prototype.authorize.call(mintingAuthorities);
+
+    expect(collateralizeTransfer).toHaveBeenCalledTimes(3);
+    expect(batchAll).toHaveBeenCalledWith(
+      pendingMintingAuthorizations.map(authorization => ({
+        kind: 'collateralizeTransfer',
+        transferId: authorization.transferId,
+      })),
+    );
+    expect(submitAndWatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          actionType: 'authorizeTransfer',
+          authorizations: pendingMintingAuthorizations.map(
+            ({ authorityIndex, transferId, mintingAuthorityTip, microgonCollateral, micronotCollateral }) => ({
+              authorityIndex,
+              transferId,
+              mintingAuthorityTip,
+              microgonCollateral,
+              micronotCollateral,
+            }),
+          ),
+        },
       }),
     );
   });
@@ -666,6 +857,18 @@ function noneAuthority() {
   };
 }
 
+function bigintValue(value: bigint) {
+  return { toBigInt: () => value };
+}
+
+function hexValue(value: string) {
+  return { toHex: () => value };
+}
+
+function accountValue(hex: string, address: string) {
+  return { toHex: () => hex, toString: () => address };
+}
+
 function someTransfer(transferId: string) {
   return {
     isNone: false,
@@ -674,7 +877,7 @@ function someTransfer(transferId: string) {
       microgonsPerArgonot: { toBigInt: () => 1_000_000n },
       mintingAuthorityCollateralBySigner: { keys: () => [] },
       asset: { isArgon: true },
-      argonAccountId: { toHex: () => '0x' + 'aa'.repeat(32) },
+      argonAccountId: accountValue('0x' + 'aa'.repeat(32), '5SourceAccount'),
       argonTransferNonce: { toBigInt: () => 1n },
       destinationAccount: { toHex: () => '0x' + 'bb'.repeat(20) },
       validUntilEthereumBlock: { toBigInt: () => 123n },

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -63,6 +63,66 @@ describe('MyVaultRecovery', () => {
   });
 });
 
+describe('MyVault crosschain queue history', () => {
+  it('returns approval work without mixing in registration or personal transfer transactions', () => {
+    const authorize = createTxInfo({ extrinsicType: ExtrinsicType.CrosschainTransferAuthorize });
+    const councilApproval = createTxInfo({ extrinsicType: ExtrinsicType.CrosschainTransferApproveCouncil });
+    const collectedCouncilApproval = createTxInfo({
+      extrinsicType: ExtrinsicType.VaultCollect,
+      metadataJson: { actionType: 'approveCouncil', councilApprovalCount: 2 },
+    });
+    const registration = createTxInfo({ extrinsicType: ExtrinsicType.CrosschainTransferRegisterMintingAuthority });
+    const personalTransfer = createTxInfo({ extrinsicType: ExtrinsicType.CrosschainTransferTransferOut });
+    const { myVault } = createVault({
+      txInfos: [authorize, councilApproval, collectedCouncilApproval, registration, personalTransfer],
+    });
+
+    expect(myVault.getCrosschainQueueTxInfos()).toEqual([authorize, councilApproval, collectedCouncilApproval]);
+  });
+
+  it('calculates finalized minting-authorization rewards net of their transaction fees', () => {
+    const finalizedAuthorization = createTxInfo({
+      id: 1,
+      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+      status: TransactionStatus.Finalized,
+      txFeePlusTip: 1_000_000n,
+      metadataJson: {
+        actionType: 'authorizeTransfer',
+        authorizations: [{ mintingAuthorityTip: 5_000_000n }, { mintingAuthorityTip: 3_000_000n }],
+      },
+    });
+    const partiallyCompletedAuthorization = createTxInfo({
+      id: 2,
+      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+      status: TransactionStatus.Finalized,
+      txFeePlusTip: 500_000n,
+      blockExtrinsicErrorJson: { message: 'Batch interrupted', batchInterruptedIndex: 2 },
+      metadataJson: {
+        actionType: 'authorizeTransfer',
+        authorizations: [
+          { mintingAuthorityTip: 3_000_000n },
+          { mintingAuthorityTip: 4_000_000n },
+          { mintingAuthorityTip: 5_000_000n },
+        ],
+      },
+    });
+    const pendingAuthorization = createTxInfo({
+      id: 3,
+      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
+      txFeePlusTip: 250_000n,
+      metadataJson: {
+        actionType: 'authorizeTransfer',
+        authorizations: [{ mintingAuthorityTip: 10_000_000n }],
+      },
+    });
+    const { myVault } = createVault({
+      txInfos: [finalizedAuthorization, partiallyCompletedAuthorization, pendingAuthorization],
+    });
+
+    expect(myVault.getCrosschainQueueNetEarnings()).toBe(13_500_000n);
+  });
+});
+
 describe('MyVault cosign recovery', () => {
   it('updates collect alert state from finalized data', async () => {
     const unsubscribe = vi.fn();

--- a/src-vue/__test__/TransactionInfo.test.ts
+++ b/src-vue/__test__/TransactionInfo.test.ts
@@ -96,6 +96,27 @@ it('treats a watched finalized tx result as finalized before the record is persi
   });
 });
 
+it('reports an included transaction as on chain before the finalized head catches up', async () => {
+  const txInfo = new TransactionInfo({
+    tx: {
+      blockHeight: 100,
+      isFinalized: false,
+      createdAt: new Date(),
+    } as ITransactionRecord,
+    txResult: {
+      isFinalized: false,
+    } as TxResult,
+  });
+  let unsubscribe: () => void = () => undefined;
+
+  const progressMessage = await new Promise<string>(resolve => {
+    unsubscribe = txInfo.subscribeToProgress(args => resolve(args.progressMessage));
+  });
+  unsubscribe();
+
+  expect(progressMessage).toBe('Included in Block #100 · Waiting for Finalization...');
+});
+
 it('rejects waitForPostProcessing when post-processing fails', async () => {
   const txInfo = new TransactionInfo({
     tx: {

--- a/src-vue/__test__/TransactionProgress.test.ts
+++ b/src-vue/__test__/TransactionProgress.test.ts
@@ -1,0 +1,83 @@
+import * as Vue from 'vue';
+import { TxResult } from '@argonprotocol/mainchain';
+import { describe, expect, it, vi } from 'vitest';
+import { getActiveTransactionInfos, trackTransactionProgress } from '../lib/TransactionProgress.ts';
+import { TransactionInfo } from '../lib/TransactionInfo.ts';
+import type { ITransactionRecord } from '../lib/db/TransactionsTable.ts';
+
+describe('TransactionProgress', () => {
+  it('tracks each active transaction once and restores the idle state after the batch finishes', () => {
+    const progressCallbacks = new Map<number, Parameters<TransactionInfo['subscribeToProgress']>[0]>();
+    const createPendingTransaction = (id: number, createdAt: Date) => {
+      const txInfo = new TransactionInfo({
+        tx: { id, createdAt } as ITransactionRecord,
+        txResult: {} as TxResult,
+      });
+      txInfo.createPostProcessor();
+      vi.spyOn(txInfo, 'subscribeToProgress').mockImplementation(callback => {
+        progressCallbacks.set(id, callback);
+        return vi.fn();
+      });
+      return txInfo;
+    };
+
+    const laterTransaction = createPendingTransaction(2, new Date('2026-08-15T12:01:00Z'));
+    const earlierTransaction = createPendingTransaction(1, new Date('2026-08-15T12:00:00Z'));
+    const activeTransactions = getActiveTransactionInfos([laterTransaction, earlierTransaction, laterTransaction]);
+    const isSubmitting = Vue.ref(false);
+    const progressPct = Vue.ref(0);
+    const progressLabel = Vue.ref('');
+    const activeTransactionCount = Vue.ref(0);
+    const error = Vue.ref('');
+    const onIdle = vi.fn();
+
+    expect(activeTransactions.map(({ tx }) => tx.id)).toEqual([1, 2]);
+
+    trackTransactionProgress({
+      txInfos: activeTransactions,
+      isSubmitting,
+      progressPct,
+      progressLabel,
+      activeTransactionCount,
+      error,
+      onIdle,
+      onCleanup: vi.fn(),
+    });
+    progressCallbacks.get(1)!({
+      progressPct: 80,
+      progressMessage: 'Waiting for finalization...',
+      confirmations: 3,
+      expectedConfirmations: 4,
+      isMaxed: false,
+    });
+    progressCallbacks.get(2)!({
+      progressPct: 30,
+      progressMessage: 'Waiting for inclusion...',
+      confirmations: -1,
+      expectedConfirmations: 4,
+      isMaxed: false,
+    });
+
+    expect(isSubmitting.value).toBe(true);
+    expect(activeTransactionCount.value).toBe(2);
+    expect(progressPct.value).toBe(30);
+    expect(progressLabel.value).toBe('Waiting for inclusion... (2 transactions in progress)');
+
+    trackTransactionProgress({
+      txInfos: [],
+      isSubmitting,
+      progressPct,
+      progressLabel,
+      activeTransactionCount,
+      error,
+      onIdle,
+      onCleanup: vi.fn(),
+    });
+
+    expect(isSubmitting.value).toBe(false);
+    expect(progressPct.value).toBe(0);
+    expect(progressLabel.value).toBe('');
+    expect(activeTransactionCount.value).toBe(0);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+});

--- a/src-vue/components/CopyableArgonAddress.vue
+++ b/src-vue/components/CopyableArgonAddress.vue
@@ -1,0 +1,23 @@
+<template>
+  <span class="inline-flex max-w-full min-w-0 items-center gap-x-1.5">
+    <span :title="address" class="min-w-0 truncate font-mono select-all">
+      {{ address }}
+    </span>
+    <CopyToClipboard
+      :content="address"
+      class="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-slate-400 hover:bg-slate-200/70 hover:text-slate-600"
+      title="Copy full Argon address"
+    >
+      <CopyIcon class="h-3.5 w-3.5" />
+      <template #copying><CheckIcon class="h-3.5 w-3.5 text-green-600" /></template>
+    </CopyToClipboard>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { CheckIcon } from '@heroicons/vue/24/outline';
+import CopyIcon from '../assets/copy.svg';
+import CopyToClipboard from './CopyToClipboard.vue';
+
+defineProps<{ address: string }>();
+</script>

--- a/src-vue/components/CrosschainActivityDetails.vue
+++ b/src-vue/components/CrosschainActivityDetails.vue
@@ -1,0 +1,95 @@
+<template>
+  <dl
+    class="grid gap-x-4 gap-y-2 text-sm"
+    :class="wide ? 'grid-cols-[120px_minmax(0,1fr)_120px_minmax(0,1fr)]' : 'grid-cols-[120px_minmax(0,1fr)]'"
+  >
+    <dt>Queue order</dt>
+    <dd>#{{ queueNonce }}</dd>
+
+    <template v-if="approvalProgress">
+      <dt>Council approval</dt>
+      <dd>
+        {{ approvalProgress.signatureCount }} of {{ approvalProgress.memberCount }} signers ·
+        {{ approvalWeightPercent }}% approval weight
+      </dd>
+    </template>
+
+    <template v-if="awaitingArgonConfirmation">
+      <dt>Argon confirmation</dt>
+      <dd v-if="ethereumBlocksUntilArgonConfirmation !== undefined">
+        {{ ethereumBlocksUntilArgonConfirmation }} Ethereum
+        {{ ethereumBlocksUntilArgonConfirmation === 1n ? 'block' : 'blocks' }} away
+      </dd>
+      <dd v-else>In progress</dd>
+    </template>
+
+    <template v-if="targetKind === 'globalIssuanceCouncilRotation'">
+      <dt>Proposed council</dt>
+      <dd v-if="councilChange" :title="`Council hash ${targetValue}`">
+        {{ councilChange.vaultCount }} vaults
+        <span class="text-slate-500">
+          ({{ councilChange.newVaultCount }} new · {{ councilChange.leavingVaultCount }} leaving)
+        </span>
+      </dd>
+      <dd v-else :title="`Council hash ${targetValue}`">Details unavailable</dd>
+
+      <dt>Proposed rate</dt>
+      <dd v-if="councilChange">
+        {{ microgonToArgonNm(councilChange.epochMicrogonsPerArgonot).format('0,0.[00]') }} ARGN per ARGNOT
+      </dd>
+      <dd v-else>Details unavailable</dd>
+    </template>
+
+    <template v-else>
+      <dt>Minting Authority</dt>
+      <dd :title="`Signing key ${targetValue}`" class="flex min-w-0 items-center gap-x-2">
+        <span v-if="authorityOwnerIdentity" class="shrink-0 font-medium">
+          {{ formatCrosschainSourceIdentity(authorityOwnerIdentity) }}
+        </span>
+        <CopyableArgonAddress v-if="authorityOwnerAccount" :address="authorityOwnerAccount" />
+        <span v-if="!authorityOwnerIdentity && !authorityOwnerAccount">Owner unavailable</span>
+      </dd>
+    </template>
+  </dl>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import CopyableArgonAddress from './CopyableArgonAddress.vue';
+import { formatCrosschainSourceIdentity, type ICrosschainSourceIdentity } from '../lib/CrosschainTransferView.ts';
+import type { IGlobalCouncilApproval, IGlobalCouncilChange, IGlobalCouncilQueueItem } from '../lib/GlobalCouncil.ts';
+import { createNumeralHelpers } from '../lib/numeral.ts';
+import { getCurrency } from '../stores/currency.ts';
+
+const props = defineProps<{
+  queueNonce: bigint;
+  targetKind: IGlobalCouncilApproval['targetKind'];
+  targetValue: string;
+  authorityOwnerAccount?: string;
+  authorityOwnerIdentity?: ICrosschainSourceIdentity;
+  approvalProgress?: IGlobalCouncilQueueItem['approvalProgress'];
+  awaitingArgonConfirmation?: boolean;
+  ethereumBlocksUntilArgonConfirmation?: bigint;
+  councilChange?: IGlobalCouncilChange;
+  wide?: boolean;
+}>();
+
+const { microgonToArgonNm } = createNumeralHelpers(getCurrency());
+
+const approvalWeightPercent = Vue.computed(() => {
+  if (!props.approvalProgress?.totalWeight) return 0;
+  return Number((props.approvalProgress.approvedWeight * 1_000n) / props.approvalProgress.totalWeight) / 10;
+});
+</script>
+
+<style scoped>
+@reference "../main.css";
+
+dt {
+  @apply text-slate-500;
+}
+
+dd {
+  @apply min-w-0 break-words text-slate-700;
+}
+</style>

--- a/src-vue/components/CrosschainHistoryRows.vue
+++ b/src-vue/components/CrosschainHistoryRows.vue
@@ -1,0 +1,191 @@
+<template>
+  <div v-if="records.length">
+    <details v-for="record in records" :key="record.id" class="group border-b border-slate-200 last:border-b-0">
+      <summary class="flex cursor-pointer list-none items-center gap-x-4 px-4 py-3 hover:bg-slate-50">
+        <div class="min-w-0 grow">
+          <div class="flex items-center gap-x-2">
+            <span class="font-semibold text-slate-800">{{ title(record) }}</span>
+            <span
+              v-if="sourceIdentity(record)"
+              class="max-w-48 truncate rounded bg-slate-200/70 px-2 py-0.5 text-xs font-medium text-slate-600"
+            >
+              {{ formatCrosschainSourceIdentity(sourceIdentity(record)!) }}
+            </span>
+          </div>
+          <div class="mt-0.5 text-sm text-slate-500">
+            Finalized · Argon block {{ record.blockNumber.toLocaleString() }} · {{ formatDate(record.blockTime) }}
+          </div>
+        </div>
+        <div v-if="record.details.kind === 'transferAuthorization'" class="shrink-0 text-right">
+          <div class="font-mono font-semibold text-slate-700">
+            {{ formatTokenAmount(record.details.amount, record.details.moveToken) }}
+          </div>
+          <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(record.details.reward) }} ARGN earned</div>
+        </div>
+        <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
+      </summary>
+
+      <div class="border-t border-dashed border-slate-200 bg-slate-50/70 px-10 py-4">
+        <dl
+          v-if="record.details.kind === 'transferAuthorization'"
+          class="grid grid-cols-[120px_minmax(0,1fr)_120px_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm"
+        >
+          <dt>Sender</dt>
+          <dd>
+            <div v-if="sourceIdentity(record)" class="font-medium">
+              {{ formatCrosschainSourceIdentity(sourceIdentity(record)!) }}
+            </div>
+            <CopyableArgonAddress :address="record.details.sourceAccount" />
+          </dd>
+          <dt>Recipient</dt>
+          <dd class="inline-flex max-w-full items-center gap-x-1.5">
+            <span :title="record.details.destinationAccount" class="font-mono select-all">
+              {{ abbreviateAddress(record.details.destinationAccount, 10) }}
+            </span>
+            <CopyToClipboard
+              :content="record.details.destinationAccount"
+              class="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-slate-400 hover:bg-slate-200/70 hover:text-slate-600"
+              title="Copy full Ethereum address"
+            >
+              <CopyIcon class="h-3.5 w-3.5" />
+              <template #copying><CheckIcon class="h-3.5 w-3.5 text-green-600" /></template>
+            </CopyToClipboard>
+          </dd>
+          <dt>Collateral supplied by</dt>
+          <dd :title="`Signing key ${record.details.authoritySigningKey}`">
+            <span v-if="authorityIdentity(record)" class="font-medium">
+              {{ formatCrosschainSourceIdentity(authorityIdentity(record)!) }}
+            </span>
+            <CopyableArgonAddress v-else :address="record.details.authorityOwnerAccount ?? record.accountId" />
+            <span class="text-slate-500">
+              · {{ formatArgon(record.details.microgonCollateral) }} ARGN +
+              {{ formatArgonot(record.details.micronotCollateral) }} ARGNOT
+            </span>
+          </dd>
+        </dl>
+
+        <CrosschainActivityDetails
+          v-else-if="record.details.kind === 'councilApproval'"
+          :queueNonce="record.details.queueNonce"
+          :targetKind="record.details.targetKind"
+          :targetValue="record.details.targetValue"
+          :authorityOwnerAccount="record.details.authorityOwnerAccount"
+          :authorityOwnerIdentity="ownerIdentity(record)"
+          :councilChange="record.details.councilChange"
+          wide
+        />
+
+        <dl v-else class="grid grid-cols-[120px_minmax(0,1fr)_120px_minmax(0,1fr)] gap-x-4 gap-y-2 text-sm">
+          <dt>Minting Authority</dt>
+          <dd :title="`Signing key ${record.details.authoritySigningKey}`">
+            <span v-if="recordIdentity(record)" class="font-medium">
+              {{ formatCrosschainSourceIdentity(recordIdentity(record)!) }}
+            </span>
+            <CopyableArgonAddress v-else :address="record.accountId" />
+          </dd>
+          <template v-if="record.details.queueNonce !== undefined">
+            <dt>Queue order</dt>
+            <dd>#{{ record.details.queueNonce }}</dd>
+          </template>
+        </dl>
+
+        <button
+          v-if="record.extrinsicIndex !== undefined"
+          type="button"
+          class="text-argon-600 hover:text-argon-700 mt-3 inline-flex items-center gap-x-1 text-sm underline decoration-transparent underline-offset-2 hover:decoration-current"
+          @click="openTransaction(record)"
+        >
+          Argon transaction
+          <ArrowTopRightOnSquareIcon class="h-4 w-4" />
+        </button>
+      </div>
+    </details>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MICROGONS_PER_ARGON, MICRONOTS_PER_ARGONOT, MoveToken } from '@argonprotocol/apps-core';
+import { ArrowTopRightOnSquareIcon, CheckIcon } from '@heroicons/vue/24/outline';
+import { open as tauriOpenUrl } from '@tauri-apps/plugin-shell';
+import CopyIcon from '../assets/copy.svg';
+import CrosschainActivityDetails from './CrosschainActivityDetails.vue';
+import CopyableArgonAddress from './CopyableArgonAddress.vue';
+import CopyToClipboard from './CopyToClipboard.vue';
+import type { ICrosschainSourceIdentity } from '../lib/CrosschainTransferView.ts';
+import { formatCrosschainSourceIdentity } from '../lib/CrosschainTransferView.ts';
+import type { ICrosschainHistoryRecord } from '../lib/CrosschainHistory.ts';
+import { abbreviateAddress } from '../lib/Utils.ts';
+import { createNumeralHelpers } from '../lib/numeral.ts';
+import { getCurrency } from '../stores/currency.ts';
+
+const props = defineProps<{
+  records: ICrosschainHistoryRecord[];
+  knownIdentities: Map<string, ICrosschainSourceIdentity>;
+}>();
+
+const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(getCurrency());
+
+function title(record: ICrosschainHistoryRecord) {
+  if (record.details.kind === 'transferAuthorization') return `Authorized ${record.details.moveToken} to Ethereum`;
+  if (record.details.kind === 'councilApproval') {
+    if (record.details.targetKind === 'mintingAuthorityActivation') return 'Signed minting authority activation';
+    if (record.details.targetKind === 'mintingAuthorityDeactivation') return 'Signed minting authority deactivation';
+    return 'Signed global issuance council rotation';
+  }
+  return 'Registered minting authority';
+}
+
+function sourceIdentity(record: ICrosschainHistoryRecord) {
+  if (record.details.kind !== 'transferAuthorization') return;
+  return props.knownIdentities.get(record.details.sourceAccount);
+}
+
+function ownerIdentity(record: ICrosschainHistoryRecord) {
+  if (record.details.kind !== 'councilApproval' || !record.details.authorityOwnerAccount) return;
+  return props.knownIdentities.get(record.details.authorityOwnerAccount);
+}
+
+function authorityIdentity(record: ICrosschainHistoryRecord) {
+  if (record.details.kind !== 'transferAuthorization') return;
+  return props.knownIdentities.get(record.details.authorityOwnerAccount ?? record.accountId);
+}
+
+function recordIdentity(record: ICrosschainHistoryRecord) {
+  return props.knownIdentities.get(record.accountId);
+}
+
+function openTransaction(record: ICrosschainHistoryRecord) {
+  if (record.extrinsicIndex === undefined) return;
+  void tauriOpenUrl(`https://argon.statescan.io/#/extrinsics/${record.blockNumber}-${record.extrinsicIndex}`);
+}
+
+function formatTokenAmount(amount: bigint, moveToken: MoveToken.ARGN | MoveToken.ARGNOT) {
+  return moveToken === MoveToken.ARGNOT ? `${formatArgonot(amount)} ARGNOT` : `${formatArgon(amount)} ARGN`;
+}
+
+function formatArgon(amount: bigint) {
+  if (amount > 0n && amount < BigInt(MICROGONS_PER_ARGON) / 100n) return '<0.01';
+  return microgonToArgonNm(amount).format('0,0.[00]');
+}
+
+function formatArgonot(amount: bigint) {
+  if (amount > 0n && amount < BigInt(MICRONOTS_PER_ARGONOT) / 100n) return '<0.01';
+  return micronotToArgonotNm(amount).format('0,0.[00]');
+}
+
+function formatDate(date: Date) {
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+</script>
+
+<style scoped>
+@reference "../main.css";
+
+dt {
+  @apply text-slate-500;
+}
+
+dd {
+  @apply min-w-0 break-words text-slate-700;
+}
+</style>

--- a/src-vue/components/CrosschainTransferDetails.vue
+++ b/src-vue/components/CrosschainTransferDetails.vue
@@ -1,0 +1,103 @@
+<template>
+  <dl
+    class="grid gap-x-4 gap-y-2 text-sm"
+    :class="wide ? 'grid-cols-[110px_minmax(0,1fr)_110px_minmax(0,1fr)]' : 'grid-cols-[110px_minmax(0,1fr)]'"
+  >
+    <dt>Sender</dt>
+    <dd>
+      <div v-if="sourceIdentity" class="font-medium">{{ formatCrosschainSourceIdentity(sourceIdentity) }}</div>
+      <CopyableArgonAddress :address="sourceAccount" />
+    </dd>
+
+    <dt>Lifetime sent to Ethereum</dt>
+    <dd v-if="sourceTotals">
+      {{ formatArgon(sourceTotals.microgonsOut) }} ARGN + {{ formatArgonot(sourceTotals.micronotsOut) }} ARGNOT across
+      {{ sourceTotals.transferOutCount }} transfer{{ sourceTotals.transferOutCount === 1 ? '' : 's' }}
+    </dd>
+    <dd v-else>Unavailable</dd>
+
+    <dt>Recipient</dt>
+    <dd>
+      <div class="inline-flex max-w-full items-center gap-x-1.5">
+        <span :title="recipient" class="font-mono select-all">{{ abbreviateAddress(recipient, 10) }}</span>
+        <CopyToClipboard
+          :content="recipient"
+          class="relative flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-slate-400 hover:bg-slate-200/70 hover:text-slate-600"
+          title="Copy full Ethereum address"
+        >
+          <CopyIcon class="h-3.5 w-3.5" />
+          <template #copying><CheckIcon class="h-3.5 w-3.5 text-green-600" /></template>
+        </CopyToClipboard>
+      </div>
+      <div v-if="recipientSeen !== undefined" class="mt-0.5 text-xs text-slate-500">
+        {{ recipientSeen ? 'Used by this sender before' : 'New Ethereum address for this sender' }}
+      </div>
+      <div v-else class="mt-0.5 text-xs text-slate-500">Recipient history is still syncing</div>
+    </dd>
+
+    <template v-if="progress">
+      <dt>Progress</dt>
+      <dd>{{ progress }}</dd>
+    </template>
+  </dl>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { MICROGONS_PER_ARGON, MICRONOTS_PER_ARGONOT } from '@argonprotocol/apps-core';
+import { CheckIcon } from '@heroicons/vue/24/outline';
+import CopyIcon from '../assets/copy.svg';
+import CopyableArgonAddress from './CopyableArgonAddress.vue';
+import CopyToClipboard from './CopyToClipboard.vue';
+import { formatCrosschainSourceIdentity, type ICrosschainSourceIdentity } from '../lib/CrosschainTransferView.ts';
+import type {
+  ICrosschainSourceTransferTotals,
+  IMintingAuthorityAuthorization,
+  IMintingAuthorityBackedTransfer,
+} from '../lib/MintingAuthorities.ts';
+import { abbreviateAddress } from '../lib/Utils.ts';
+import { createNumeralHelpers } from '../lib/numeral.ts';
+import { getCurrency } from '../stores/currency.ts';
+
+const props = defineProps<{
+  transfer: IMintingAuthorityAuthorization | IMintingAuthorityBackedTransfer;
+  sourceIdentity?: ICrosschainSourceIdentity;
+  sourceTotals?: ICrosschainSourceTransferTotals;
+  recipientSeen?: boolean;
+  progress?: string;
+  wide?: boolean;
+}>();
+
+const currency = getCurrency();
+const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
+
+const sourceAccount = Vue.computed(() => {
+  return props.transfer.sourceAccount;
+});
+const recipient = Vue.computed(() => {
+  return 'finalizeRequest' in props.transfer
+    ? props.transfer.finalizeRequest.recipient
+    : props.transfer.destinationAccount;
+});
+function formatArgon(value: bigint) {
+  if (value > 0n && value < BigInt(MICROGONS_PER_ARGON) / 100n) return '<0.01';
+  return microgonToArgonNm(value).format('0,0.[00]');
+}
+
+function formatArgonot(value: bigint) {
+  if (value > 0n && value < BigInt(MICRONOTS_PER_ARGONOT) / 100n) return '<0.01';
+  return micronotToArgonotNm(value).format('0,0.[00]');
+}
+</script>
+
+<style scoped>
+@reference "../main.css";
+
+dt {
+  @apply text-slate-500;
+}
+
+dd {
+  @apply min-w-0 break-words text-slate-700;
+}
+</style>

--- a/src-vue/components/Tooltip.vue
+++ b/src-vue/components/Tooltip.vue
@@ -13,7 +13,7 @@
           :style="[floatingZIndex, { width: width, maxWidth: maxWidth }]"
           class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-md pointer-events-none rounded-md border border-gray-800/20 bg-white px-4 py-3 text-left leading-5.5 text-gray-600 shadow-xl will-change-[transform,opacity] select-none"
         >
-          {{ content }}
+          <slot name="content">{{ content }}</slot>
           <TooltipArrow :width="24" :height="12" class="fill-white stroke-gray-400/30 shadow-xl/50" />
         </TooltipContent>
       </TooltipPortal>

--- a/src-vue/emitters/basicEmitter.ts
+++ b/src-vue/emitters/basicEmitter.ts
@@ -57,6 +57,7 @@ type IBasicEmitter = {
 
   openVaultsOverlay: void;
   openTransactionsOverlay: void;
+  openCrosschainHistoryOverlay: void;
 
   openVaultCollect: void;
   openTreasuryBondsOverlay: void;

--- a/src-vue/interfaces/IConfig.ts
+++ b/src-vue/interfaces/IConfig.ts
@@ -29,6 +29,7 @@ export enum TopTab {
 
   Mining = 'Mining',
   Vaulting = 'Vaulting',
+  CrosschainTransfers = 'CrosschainTransfers',
   Onboarding = 'Onboarding',
 }
 
@@ -212,6 +213,7 @@ export const ConfigSchema = z.object({
   wasImportedFromLegacy: z.boolean(),
   hasExtensionTreasury: z.boolean(),
   hasExtensionOperations: z.boolean(),
+  hasActivatedCrosschain: z.boolean(),
   selectedTab: z.nativeEnum(TopTab),
 
   serverAdd: ConfigServerAddSchema.optional(),
@@ -288,6 +290,7 @@ export interface IConfigDefaults {
   wasImportedFromLegacy: () => IConfig['wasImportedFromLegacy'];
   hasExtensionTreasury: () => IConfig['hasExtensionTreasury'];
   hasExtensionOperations: () => IConfig['hasExtensionOperations'];
+  hasActivatedCrosschain: () => IConfig['hasActivatedCrosschain'];
   selectedTab: () => IConfig['selectedTab'];
 
   serverAdd: () => IConfig['serverAdd'];

--- a/src-vue/lib/Config.ts
+++ b/src-vue/lib/Config.ts
@@ -85,6 +85,7 @@ export class Config implements IConfig {
       wasImportedFromLegacy: Config.getDefault(dbFields.wasImportedFromLegacy) as IConfig['wasImportedFromLegacy'],
       hasExtensionTreasury: Config.getDefault(dbFields.hasExtensionTreasury) as IConfig['hasExtensionTreasury'],
       hasExtensionOperations: Config.getDefault(dbFields.hasExtensionOperations) as IConfig['hasExtensionOperations'],
+      hasActivatedCrosschain: Config.getDefault(dbFields.hasActivatedCrosschain) as IConfig['hasActivatedCrosschain'],
       selectedTab: Config.getDefault(dbFields.selectedTab) as IConfig['selectedTab'],
       ethereumBeaconApiUrl: Config.getDefault(dbFields.ethereumBeaconApiUrl) as IConfig['ethereumBeaconApiUrl'],
       ethereumExecutionRpcUrl: Config.getDefault(
@@ -138,6 +139,7 @@ export class Config implements IConfig {
       'bootstrapDetails',
       'hasExtensionTreasury',
       'hasExtensionOperations',
+      'hasActivatedCrosschain',
       'serverAdd',
       'serverDetails',
       'isServerInstalled',
@@ -453,6 +455,14 @@ export class Config implements IConfig {
   }
   public set hasExtensionOperations(value: IConfig['hasExtensionOperations']) {
     this.setField('hasExtensionOperations', value);
+  }
+
+  public get hasActivatedCrosschain(): IConfig['hasActivatedCrosschain'] {
+    return this.getField('hasActivatedCrosschain');
+  }
+
+  public set hasActivatedCrosschain(value: IConfig['hasActivatedCrosschain']) {
+    this.setField('hasActivatedCrosschain', value);
   }
 
   public get selectedTab(): IConfig['selectedTab'] {
@@ -787,6 +797,7 @@ const dbFields = {
   wasImportedFromLegacy: 'wasImportedFromLegacy',
   hasExtensionTreasury: 'hasExtensionTreasury',
   hasExtensionOperations: 'hasExtensionOperations',
+  hasActivatedCrosschain: 'hasActivatedCrosschain',
   selectedTab: 'selectedTab',
 
   requiresPassword: 'requiresPassword',
@@ -828,6 +839,7 @@ const defaults: IConfigDefaults = {
   wasImportedFromLegacy: () => false,
   hasExtensionTreasury: () => false,
   hasExtensionOperations: () => false,
+  hasActivatedCrosschain: () => false,
   selectedTab: () => TopTab.Home,
 
   requiresPassword: () => false,

--- a/src-vue/lib/CrosschainHistory.ts
+++ b/src-vue/lib/CrosschainHistory.ts
@@ -1,0 +1,371 @@
+import {
+  AccountActivityKind,
+  type BlockWatch,
+  type IIndexerSpec,
+  MICRONOTS_PER_ARGONOT,
+  MoveToken,
+} from '@argonprotocol/apps-core';
+import type { FrameSystemEventRecord } from '@argonprotocol/mainchain';
+import { findAddressActivity } from './IndexerClient.ts';
+import type { IGlobalCouncilApproval, IGlobalCouncilChange } from './GlobalCouncil.ts';
+import type { WalletKeys } from './WalletKeys.ts';
+import { FinancialCacheTypes, type FinancialCacheTable } from './db/FinancialCacheTable.ts';
+
+export type ICrosschainHistoryDetails =
+  | {
+      kind: 'transferAuthorization';
+      transferId: string;
+      authoritySigningKey: string;
+      authorityOwnerAccount?: string;
+      sourceAccount: string;
+      destinationAccount: string;
+      moveToken: MoveToken.ARGN | MoveToken.ARGNOT;
+      amount: bigint;
+      reward: bigint;
+      microgonCollateral: bigint;
+      micronotCollateral: bigint;
+    }
+  | {
+      kind: 'councilApproval';
+      queueNonce: bigint;
+      targetKind: IGlobalCouncilApproval['targetKind'];
+      targetValue: string;
+      authorityOwnerAccount?: string;
+      councilChange?: IGlobalCouncilChange;
+    }
+  | {
+      kind: 'authorityLifecycle';
+      action: 'registered';
+      authoritySigningKey: string;
+      queueNonce: bigint;
+    };
+
+export type ICrosschainHistoryRecord = {
+  accountId: string;
+  id: string;
+  blockNumber: number;
+  blockTime: Date;
+  extrinsicIndex?: number;
+  eventIndex: number;
+  details: ICrosschainHistoryDetails;
+};
+
+type IFindAddressActivity = typeof findAddressActivity;
+type IIndexedActivity = IIndexerSpec['/v2/activity/:address']['responseType'];
+
+export class CrosschainHistory {
+  public data: {
+    records: ICrosschainHistoryRecord[];
+    isSyncing: boolean;
+    coverageComplete: boolean;
+    error?: string;
+  } = {
+    records: [],
+    isSyncing: false,
+    coverageComplete: false,
+  };
+
+  private refreshPromise?: Promise<void>;
+  private refreshRequested = false;
+  private refreshedThroughBlock = 0;
+  private definitionVersion?: number;
+  private readonly cacheRestorePromise: Promise<void>;
+
+  constructor(
+    private readonly walletKeys: Pick<WalletKeys, 'vaultingAddress'>,
+    private readonly blockWatch: Pick<
+      BlockWatch,
+      'start' | 'finalizedBlockHeader' | 'getHeader' | 'getEventsWithSpec' | 'getBlock'
+    >,
+    private readonly financialCache?: Promise<FinancialCacheTable>,
+    private readonly findActivity: IFindAddressActivity = findAddressActivity,
+  ) {
+    this.cacheRestorePromise = financialCache ? this.restoreCachedHistory() : Promise.resolve();
+  }
+
+  public refresh(): Promise<void> {
+    if (this.refreshPromise) {
+      this.refreshRequested = true;
+      return this.refreshPromise;
+    }
+
+    const refresh = async () => {
+      if (this.financialCache) await this.cacheRestorePromise;
+
+      do {
+        this.refreshRequested = false;
+        await this.refreshHistory();
+      } while (this.refreshRequested);
+    };
+    this.refreshPromise = refresh().finally(() => {
+      this.refreshPromise = undefined;
+    });
+    return this.refreshPromise;
+  }
+
+  public hasSeenRecipient(destinationAccount: string, excludeTransferId?: string): boolean | undefined {
+    if (!this.data.coverageComplete) return undefined;
+
+    const normalizedDestination = destinationAccount.toLowerCase();
+    return this.data.records.some(record => {
+      return (
+        record.details.kind === 'transferAuthorization' &&
+        record.details.destinationAccount.toLowerCase() === normalizedDestination &&
+        record.details.transferId.toLowerCase() !== excludeTransferId?.toLowerCase()
+      );
+    });
+  }
+
+  public getSponsoredTransferValue(microgonsPerArgonot: bigint) {
+    const transferIds = new Set<string>();
+
+    return this.data.records.reduce((total, record) => {
+      if (record.details.kind !== 'transferAuthorization') return total;
+
+      const transferId = record.details.transferId.toLowerCase();
+      if (transferIds.has(transferId)) return total;
+      transferIds.add(transferId);
+
+      if (record.details.moveToken === MoveToken.ARGN) return total + record.details.amount;
+      return total + (record.details.amount * microgonsPerArgonot) / BigInt(MICRONOTS_PER_ARGONOT);
+    }, 0n);
+  }
+
+  private async refreshHistory(): Promise<void> {
+    this.data.isSyncing = true;
+    this.data.error = undefined;
+
+    try {
+      await this.blockWatch.start();
+
+      const accountId = this.walletKeys.vaultingAddress;
+      const targetBlock = this.blockWatch.finalizedBlockHeader.blockNumber;
+      let afterBlock = this.refreshedThroughBlock;
+      let indexedHistory = await this.findActivity(accountId, {
+        afterBlock,
+        toBlock: targetBlock,
+        activityMask: AccountActivityKind.Fee,
+      });
+
+      const definitionChanged =
+        this.definitionVersion !== undefined && this.definitionVersion !== indexedHistory.definitionVersion;
+      if (definitionChanged) {
+        afterBlock = 0;
+        indexedHistory = await this.findActivity(accountId, {
+          afterBlock,
+          toBlock: targetBlock,
+          activityMask: AccountActivityKind.Fee,
+        });
+      }
+      if (indexedHistory.coverage.gaps.length) {
+        throw new Error('Crosschain history is incomplete because the activity index has a coverage gap');
+      }
+
+      const records = await this.replay(indexedHistory);
+      if (definitionChanged) this.data.records = [];
+
+      const recordsById = new Map(this.data.records.map(record => [record.id, record]));
+      for (const record of records) recordsById.set(record.id, record);
+      this.data.records = [...recordsById.values()].sort(
+        (left, right) => right.blockNumber - left.blockNumber || right.eventIndex - left.eventIndex,
+      );
+
+      const recoveredThroughBlock = Math.min(indexedHistory.asOfBlock, targetBlock);
+      this.data.coverageComplete = recoveredThroughBlock >= targetBlock;
+      this.refreshedThroughBlock = recoveredThroughBlock;
+      this.definitionVersion = indexedHistory.definitionVersion;
+      await this.cacheHistory(accountId);
+    } catch (error) {
+      this.data.coverageComplete = false;
+      this.data.error = error instanceof Error ? error.message : String(error);
+      console.warn('[CrosschainHistory] Unable to refresh indexed history', error);
+    } finally {
+      this.data.isSyncing = false;
+    }
+  }
+
+  private async restoreCachedHistory(): Promise<void> {
+    try {
+      const cache = await this.financialCache;
+      const accountId = this.walletKeys.vaultingAddress;
+      const cached = await cache?.get(FinancialCacheTypes.CrosschainHistory, accountId);
+      if (!cached) return;
+
+      this.data.records = cached.records;
+      this.refreshedThroughBlock = cached.refreshedThroughBlock;
+      this.definitionVersion = cached.definitionVersion;
+    } catch (error) {
+      console.warn('[CrosschainHistory] Unable to restore cached history', error);
+    }
+  }
+
+  private async cacheHistory(accountId: string): Promise<void> {
+    try {
+      const cache = await this.financialCache;
+      if (!cache || this.definitionVersion === undefined) return;
+
+      await cache.upsert(FinancialCacheTypes.CrosschainHistory, accountId, {
+        records: this.data.records,
+        definitionVersion: this.definitionVersion,
+        refreshedThroughBlock: this.refreshedThroughBlock,
+      });
+    } catch (error) {
+      console.warn('[CrosschainHistory] Unable to cache indexed history', error);
+    }
+  }
+
+  private async replay(indexedHistory: IIndexedActivity): Promise<ICrosschainHistoryRecord[]> {
+    const records: ICrosschainHistoryRecord[] = [];
+    const indexedBlocks = [...indexedHistory.blocks].sort((left, right) => left.blockNumber - right.blockNumber);
+
+    for (const indexedBlock of indexedBlocks) {
+      const block = await this.blockWatch.getHeader(indexedBlock.blockNumber);
+      if (block.blockHash.toLowerCase() !== indexedBlock.blockHash.toLowerCase()) {
+        throw new Error(`Crosschain history block hash mismatch at ${indexedBlock.blockNumber}`);
+      }
+
+      const { api, events, specVersion } = await this.blockWatch.getEventsWithSpec(block);
+      if (specVersion !== indexedBlock.specVersion) {
+        throw new Error(`Crosschain history runtime mismatch at ${indexedBlock.blockNumber}`);
+      }
+
+      const signedBlock = await this.blockWatch.getBlock(block);
+      for (const [eventIndex, eventRecord] of events.entries()) {
+        const details = await this.recoverOwnedEventDetails(api, signedBlock, eventRecord);
+        if (!details) continue;
+
+        const extrinsicIndex = eventRecord.phase.isApplyExtrinsic
+          ? eventRecord.phase.asApplyExtrinsic.toNumber()
+          : undefined;
+        records.push({
+          accountId: this.walletKeys.vaultingAddress,
+          id: `${block.blockHash}:${eventIndex}`,
+          blockNumber: block.blockNumber,
+          blockTime: new Date(block.blockTime),
+          extrinsicIndex,
+          eventIndex,
+          details,
+        });
+      }
+    }
+
+    return records;
+  }
+
+  private async recoverOwnedEventDetails(
+    api: Awaited<ReturnType<BlockWatch['getApi']>>,
+    signedBlock: Awaited<ReturnType<BlockWatch['getBlock']>>,
+    eventRecord: FrameSystemEventRecord,
+  ): Promise<ICrosschainHistoryDetails | undefined> {
+    const { event, phase } = eventRecord;
+    if (event.section !== 'crosschainTransfer') return;
+
+    if (api.events.crosschainTransfer.QueueEntryApprovalRecorded.is(event)) {
+      if (!phase.isApplyExtrinsic) return;
+      const extrinsic = signedBlock.block.extrinsics[phase.asApplyExtrinsic.toNumber()];
+      if (!extrinsic?.isSigned || extrinsic.signer.toString() !== this.walletKeys.vaultingAddress) return;
+
+      const { target, approvalQueueNonce } = event.data;
+      if (target.isMintingAuthorityActivation) {
+        const targetValue = target.asMintingAuthorityActivation.toHex();
+        const authorityOption = await api.query.crosschainTransfer.mintingAuthoritiesBySigner(targetValue);
+        return {
+          kind: 'councilApproval',
+          queueNonce: approvalQueueNonce.toBigInt(),
+          targetKind: 'mintingAuthorityActivation',
+          targetValue,
+          ...(authorityOption.isSome ? { authorityOwnerAccount: authorityOption.unwrap().accountId.toString() } : {}),
+        };
+      }
+      if (target.isMintingAuthorityDeactivation) {
+        const targetValue = target.asMintingAuthorityDeactivation.toHex();
+        const authorityOption = await api.query.crosschainTransfer.mintingAuthoritiesBySigner(targetValue);
+        return {
+          kind: 'councilApproval',
+          queueNonce: approvalQueueNonce.toBigInt(),
+          targetKind: 'mintingAuthorityDeactivation',
+          targetValue,
+          ...(authorityOption.isSome ? { authorityOwnerAccount: authorityOption.unwrap().accountId.toString() } : {}),
+        };
+      }
+      if (target.isGlobalIssuanceCouncilRotation) {
+        const targetValue = target.asGlobalIssuanceCouncilRotation.toHex();
+        const [activeCouncilHashOption, targetCouncilOption] = await Promise.all([
+          api.query.crosschainTransfer.activeGlobalIssuanceCouncilByDestinationChain('Ethereum'),
+          api.query.crosschainTransfer.globalIssuanceCouncilByHash(targetValue),
+        ]);
+        const activeCouncilOption = activeCouncilHashOption.isSome
+          ? await api.query.crosschainTransfer.globalIssuanceCouncilByHash(activeCouncilHashOption.unwrap())
+          : undefined;
+        const activeMemberAccounts = new Set(
+          activeCouncilOption?.isSome
+            ? [...activeCouncilOption.unwrap().members.values()].map(member => member.accountId.toString())
+            : [],
+        );
+        const targetCouncil = targetCouncilOption.isSome ? targetCouncilOption.unwrap() : undefined;
+        const targetMemberAccounts = new Set(
+          targetCouncil ? [...targetCouncil.members.values()].map(member => member.accountId.toString()) : [],
+        );
+        return {
+          kind: 'councilApproval',
+          queueNonce: approvalQueueNonce.toBigInt(),
+          targetKind: 'globalIssuanceCouncilRotation',
+          targetValue,
+          ...(targetCouncil
+            ? {
+                councilChange: {
+                  vaultCount: targetMemberAccounts.size,
+                  newVaultCount: [...targetMemberAccounts].filter(accountId => !activeMemberAccounts.has(accountId))
+                    .length,
+                  leavingVaultCount: [...activeMemberAccounts].filter(accountId => !targetMemberAccounts.has(accountId))
+                    .length,
+                  epochMicrogonsPerArgonot: targetCouncil.epochMicrogonsPerArgonot.toBigInt(),
+                },
+              }
+            : {}),
+        };
+      }
+      return;
+    }
+
+    if (api.events.crosschainTransfer.TransferCollateralized.is(event)) {
+      const transferId = event.data.transferId.toHex();
+      const authoritySigningKey = event.data.destinationSigningKey.toHex();
+
+      const authorityOption = await api.query.crosschainTransfer.mintingAuthoritiesBySigner(authoritySigningKey);
+      if (authorityOption.isNone) return;
+
+      const authorityOwnerAccount = authorityOption.unwrap().accountId.toString();
+      if (authorityOwnerAccount !== this.walletKeys.vaultingAddress) {
+        return;
+      }
+      const transferOption = await api.query.crosschainTransfer.transferOutById(transferId);
+      if (transferOption.isNone) return;
+
+      const transfer = transferOption.unwrap();
+      return {
+        kind: 'transferAuthorization',
+        transferId,
+        authoritySigningKey,
+        authorityOwnerAccount,
+        sourceAccount: transfer.argonAccountId.toString(),
+        destinationAccount: transfer.destinationAccount.toHex(),
+        moveToken: transfer.asset.isArgon ? MoveToken.ARGN : MoveToken.ARGNOT,
+        amount: transfer.amount.toBigInt(),
+        reward: transfer.mintingAuthorityTip.toBigInt(),
+        microgonCollateral: event.data.microgonCollateral.toBigInt(),
+        micronotCollateral: event.data.micronotCollateral.toBigInt(),
+      };
+    }
+
+    if (api.events.crosschainTransfer.MintingAuthorityRegistered.is(event)) {
+      if (event.data.accountId.toString() !== this.walletKeys.vaultingAddress) return;
+      return {
+        kind: 'authorityLifecycle',
+        action: 'registered',
+        authoritySigningKey: event.data.destinationSigningKey.toHex(),
+        queueNonce: event.data.approvalQueueNonce.toBigInt(),
+      };
+    }
+  }
+}

--- a/src-vue/lib/CrosschainTransferView.ts
+++ b/src-vue/lib/CrosschainTransferView.ts
@@ -1,0 +1,85 @@
+import { stripNetworkPrefix } from '@argonprotocol/apps-core';
+import type { Vault } from '@argonprotocol/mainchain';
+import type { IConnectedVault } from '../interfaces/IConfig.ts';
+import type { IGlobalCouncilQueueItem } from './GlobalCouncil.ts';
+
+export type ICrosschainSourceIdentity = {
+  name: string;
+  kind: 'vault' | 'upstream';
+};
+
+export function getCrosschainAccessState(args: {
+  hasActivatedCrosschain: boolean;
+  authorityCount: number;
+  councilSigner?: string;
+}) {
+  const hasMintingAuthority = args.authorityCount > 0;
+
+  return {
+    hasAccess: args.hasActivatedCrosschain || hasMintingAuthority || Boolean(args.councilSigner),
+    hasMintingAuthority,
+  };
+}
+
+export function createKnownCrosschainSourceIdentities(args: {
+  networkName: string;
+  createdVault?: Pick<Vault, 'name' | 'operatorAccountId'>;
+  vaultsById: Record<number, Pick<Vault, 'name' | 'operatorAccountId'>>;
+  localAccountIds: string[];
+  upstreamOperator?: IConnectedVault;
+  sourceUpstreamVaultAccountsByAccount?: ReadonlyMap<string, string>;
+}): Map<string, ICrosschainSourceIdentity> {
+  const identities = new Map<string, ICrosschainSourceIdentity>();
+  const addIdentity = (
+    accountId: string | undefined,
+    name: string | undefined,
+    kind: ICrosschainSourceIdentity['kind'],
+  ) => {
+    const trimmedName = stripNetworkPrefix(name?.trim() ?? '', args.networkName);
+    if (!accountId || !trimmedName) return;
+
+    identities.set(accountId, { name: trimmedName, kind });
+  };
+
+  for (const vault of Object.values(args.vaultsById)) {
+    addIdentity(vault.operatorAccountId, vault.name, 'vault');
+  }
+
+  if (args.createdVault?.name?.trim()) {
+    addIdentity(args.createdVault.operatorAccountId, args.createdVault.name, 'vault');
+    for (const accountId of args.localAccountIds) {
+      addIdentity(accountId, args.createdVault.name, 'vault');
+    }
+  } else {
+    for (const accountId of args.localAccountIds) {
+      addIdentity(accountId, args.upstreamOperator?.name, 'upstream');
+    }
+  }
+
+  const upstreamVault = args.vaultsById[args.upstreamOperator?.vaultId ?? -1];
+  if (args.upstreamOperator?.accountId && !identities.has(args.upstreamOperator.accountId)) {
+    addIdentity(args.upstreamOperator.accountId, args.upstreamOperator.name, 'upstream');
+  }
+  if (upstreamVault && !identities.has(upstreamVault.operatorAccountId)) {
+    addIdentity(upstreamVault.operatorAccountId, args.upstreamOperator?.name, 'upstream');
+  }
+
+  for (const [sourceAccount, upstreamVaultAccount] of args.sourceUpstreamVaultAccountsByAccount ?? []) {
+    const upstreamIdentity = identities.get(upstreamVaultAccount);
+    if (!identities.has(sourceAccount) && upstreamIdentity) {
+      identities.set(sourceAccount, { name: upstreamIdentity.name, kind: 'upstream' });
+    }
+  }
+
+  return identities;
+}
+
+export function formatCrosschainSourceIdentity(identity: ICrosschainSourceIdentity) {
+  return identity.kind === 'upstream' ? `Upstream: ${identity.name}` : identity.name;
+}
+
+export function formatCouncilTarget(targetKind: IGlobalCouncilQueueItem['targetKind']) {
+  if (targetKind === 'mintingAuthorityActivation') return 'Activate minting authority';
+  if (targetKind === 'mintingAuthorityDeactivation') return 'Deactivate minting authority';
+  return 'Rotate global issuance council';
+}

--- a/src-vue/lib/EthereumClient.ts
+++ b/src-vue/lib/EthereumClient.ts
@@ -308,6 +308,80 @@ export class EthereumClient {
     });
   }
 
+  public async getGatewayApprovalNonce(): Promise<bigint> {
+    const chainConfig = await this.loadChainConfig();
+    const { publicClient } = await this.createExecutionClient();
+    return await publicClient.readContract({
+      abi: EvmContracts.mintingGatewayAbi,
+      address: chainConfig.gatewayAddress,
+      functionName: 'argonApprovalsNonce',
+    });
+  }
+
+  public async getGatewayApprovalBlockNumbers(
+    queueNonces: bigint[],
+    afterExecutionBlockNumber?: bigint,
+  ): Promise<Map<bigint, bigint>> {
+    if (!queueNonces.length) return new Map();
+
+    const chainConfig = await this.loadChainConfig();
+    const { publicClient } = await this.createExecutionClient();
+    const latestLocatorIndex = await publicClient.readContract({
+      abi: EvmContracts.mintingGatewayAbi,
+      address: chainConfig.gatewayAddress,
+      functionName: 'latestActivityBlockLocatorIndex',
+    });
+    if (!latestLocatorIndex) return new Map();
+
+    const latestLocator = await publicClient.readContract({
+      abi: EvmContracts.mintingGatewayAbi,
+      address: chainConfig.gatewayAddress,
+      functionName: 'activityBlockLocators',
+      args: [latestLocatorIndex],
+    });
+    const latestActivityBlockNumber = latestLocator[0];
+    const fromBlock =
+      afterExecutionBlockNumber === undefined ? latestActivityBlockNumber : afterExecutionBlockNumber + 1n;
+    if (fromBlock > latestActivityBlockNumber) return new Map();
+
+    const requestedQueueNonces = new Set(queueNonces);
+    const blockNumbersByQueueNonce = new Map<bigint, bigint>();
+    const logs = await publicClient.getLogs({
+      address: chainConfig.gatewayAddress,
+      fromBlock,
+      toBlock: latestActivityBlockNumber,
+    });
+
+    for (const log of logs) {
+      if (log.blockNumber == null) continue;
+
+      let activity;
+      try {
+        activity = decodeEthereumGatewayActivityLog({
+          data: log.data,
+          topics: [...log.topics],
+        });
+      } catch {
+        continue;
+      }
+
+      if (
+        activity.kind !== EvmContracts.MintingGatewayEvents.GlobalIssuanceCouncilRotated.name &&
+        activity.kind !== EvmContracts.MintingGatewayEvents.MintingAuthorityActivated.name &&
+        activity.kind !== EvmContracts.MintingGatewayEvents.MintingAuthorityDeactivated.name
+      ) {
+        continue;
+      }
+
+      const queueNonce = activity.gatewayState.argonApprovalsNonce;
+      if (requestedQueueNonces.has(queueNonce)) {
+        blockNumbersByQueueNonce.set(queueNonce, log.blockNumber);
+      }
+    }
+
+    return blockNumbersByQueueNonce;
+  }
+
   public async getTransactionProgress(args: {
     txHash: Hash;
     blockNumber?: number;
@@ -1266,12 +1340,26 @@ function queueEntryHasQuorum(
     signedWeight += member.weight;
   }
 
-  if (signedWeight * 100n >= council.totalWeight * 90n) {
+  return hasGatewayApprovalQuorum({
+    approvedWeight: signedWeight,
+    totalWeight: council.totalWeight,
+    signatureCount: entry.signatures.size,
+    memberCount: council.members.length,
+  });
+}
+
+export function hasGatewayApprovalQuorum(args: {
+  approvedWeight: bigint;
+  totalWeight: bigint;
+  signatureCount: number;
+  memberCount: number;
+}) {
+  if (args.approvedWeight * 100n >= args.totalWeight * 90n) {
     return true;
   }
 
-  const unsignedMemberCount = council.members.length - entry.signatures.size;
-  return unsignedMemberCount <= 2 && signedWeight * 100n >= council.totalWeight * 80n;
+  const unsignedMemberCount = args.memberCount - args.signatureCount;
+  return unsignedMemberCount <= 2 && args.approvedWeight * 100n >= args.totalWeight * 80n;
 }
 
 function councilToSnapshot(council: LoadedCouncil): IEthereumGatewayCouncilSnapshot {

--- a/src-vue/lib/EthereumOutboundTransferTracker.ts
+++ b/src-vue/lib/EthereumOutboundTransferTracker.ts
@@ -1124,7 +1124,9 @@ export class EthereumOutboundTransferTracker {
       return false;
     };
 
-    let pendingTxInfo = this.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.get(transferId);
+    let pendingTxInfo = this.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.get(
+      transferId.toLowerCase(),
+    );
     if (!matchesLiveAuthorization(pendingTxInfo)) {
       pendingTxInfo = this.transactionTracker.findLatestTxInfo<IMintingAuthorityAuthorizeMetadata>(candidate =>
         matchesLiveAuthorization(candidate),
@@ -1155,7 +1157,7 @@ export class EthereumOutboundTransferTracker {
     });
 
     try {
-      const txInfo = await this.mintingAuthorities.authorize(transferId);
+      const txInfo = await this.mintingAuthorities.authorize([transferId]);
       await this.attachPendingArgonProgress({
         transferId,
         transfer,

--- a/src-vue/lib/GlobalCouncil.ts
+++ b/src-vue/lib/GlobalCouncil.ts
@@ -1,7 +1,12 @@
-import { bigIntMax, createDeferred, MiningFrames } from '@argonprotocol/apps-core';
+import { createDeferred, MiningFrames } from '@argonprotocol/apps-core';
 import { u8aToHex } from '@argonprotocol/mainchain';
 import type { IDeferred } from '@argonprotocol/apps-core';
-import type { ApiDecoration, ArgonClient, SubmittableExtrinsic } from '@argonprotocol/mainchain';
+import type {
+  ApiDecoration,
+  ArgonClient,
+  PalletCrosschainTransferCouncilApprovalQueueEntry,
+  SubmittableExtrinsic,
+} from '@argonprotocol/mainchain';
 import { u8aConcat } from '@polkadot/util';
 import type { Db } from './Db.ts';
 import type { WalletKeys } from './WalletKeys.ts';
@@ -11,13 +16,49 @@ import {
   EthereumClient,
   getEthereumExecutionRpcUrl,
   getEthereumFinalityMillis,
+  hasGatewayApprovalQuorum,
   type GatewayRelayOptions,
   type IEthereumGatewayRelayPreview,
 } from './EthereumClient.ts';
 const COUNCIL_SIGNER_REGISTRATION_MESSAGE_KEY = 'argon/council-signer/v2';
+const COUNCIL_APPROVAL_QUEUE_BATCH_SIZE = 32n;
+
+export type IGlobalCouncilChange = {
+  vaultCount: number;
+  newVaultCount: number;
+  leavingVaultCount: number;
+  epochMicrogonsPerArgonot: bigint;
+};
 
 export type IGlobalCouncilApproval = {
   approvalHash: string;
+  queueNonce: bigint;
+} & (
+  | {
+      targetKind: 'mintingAuthorityActivation';
+      targetSigningKey: string;
+      authorityOwnerAccount?: string;
+    }
+  | {
+      targetKind: 'mintingAuthorityDeactivation';
+      targetSigningKey: string;
+      authorityOwnerAccount?: string;
+    }
+  | {
+      targetKind: 'globalIssuanceCouncilRotation';
+      targetCouncilHash: string;
+      councilChange?: IGlobalCouncilChange;
+    }
+);
+
+export type IGlobalCouncilQueueItem = IGlobalCouncilApproval & {
+  approvalProgress: {
+    approvedWeight: bigint;
+    totalWeight: bigint;
+    signatureCount: number;
+    memberCount: number;
+  };
+  status: 'needsSignature' | 'awaitingCouncilQuorum' | 'readyForRelay';
 };
 
 export class GlobalCouncil {
@@ -25,6 +66,12 @@ export class GlobalCouncil {
     isReady: boolean;
     councilSigner?: string;
     pendingApprovals: IGlobalCouncilApproval[];
+    approvalQueue: IGlobalCouncilQueueItem[];
+    gatewayActivityCount: bigint;
+    activeEpochMicrogonsPerArgonot?: bigint;
+    transferOutMicrogonsPerArgonot?: bigint;
+    ethereumApprovalNonce?: bigint;
+    ethereumApprovalBlockNumbers: Map<bigint, bigint>;
   };
 
   #subscriptions: Array<() => void> = [];
@@ -35,6 +82,7 @@ export class GlobalCouncil {
   #lastRelayCheckAt = 0;
   #lastSharedRelayQueueKey?: string;
   #lastSharedRelayQueueSeenAt = 0;
+  #approvalBlockHydrationPromise?: Promise<void>;
 
   constructor(
     private readonly dbPromise: Promise<Db>,
@@ -46,6 +94,12 @@ export class GlobalCouncil {
       isReady: false,
       councilSigner: undefined,
       pendingApprovals: [],
+      approvalQueue: [],
+      gatewayActivityCount: 0n,
+      activeEpochMicrogonsPerArgonot: undefined,
+      transferOutMicrogonsPerArgonot: undefined,
+      ethereumApprovalNonce: undefined,
+      ethereumApprovalBlockNumbers: new Map(),
     };
   }
 
@@ -75,17 +129,36 @@ export class GlobalCouncil {
     updateSeq = ++this.#updateSeq,
   ): Promise<IGlobalCouncilApproval[]> {
     const db = await this.dbPromise;
-    const { councilSigner, pendingApprovals, hasSignedApprovalsAwaitingRelay, sharedRelayQueueKey } =
-      await getPendingCouncilApprovals(finalizedClient, this.walletKeys, db.walletHdKeysTable);
+    const {
+      councilSigner,
+      pendingApprovals,
+      approvalQueue,
+      gatewayActivityCount,
+      activeEpochMicrogonsPerArgonot,
+      transferOutMicrogonsPerArgonot,
+      hasReadyGatewayUpdates,
+      sharedRelayQueueKey,
+    } = await getPendingCouncilApprovals(finalizedClient, this.walletKeys, db.walletHdKeysTable);
     if (updateSeq !== this.#updateSeq) {
       return this.data.pendingApprovals;
     }
 
     this.data.councilSigner = councilSigner;
     this.data.pendingApprovals = pendingApprovals;
+    this.data.approvalQueue = approvalQueue;
+    this.data.gatewayActivityCount = gatewayActivityCount;
+    this.data.activeEpochMicrogonsPerArgonot = activeEpochMicrogonsPerArgonot;
+    this.data.transferOutMicrogonsPerArgonot = transferOutMicrogonsPerArgonot;
+    const liveQueueNonces = new Set(approvalQueue.map(({ queueNonce }) => queueNonce));
+    this.data.ethereumApprovalBlockNumbers = new Map(
+      [...this.data.ethereumApprovalBlockNumbers].filter(([queueNonce]) => liveQueueNonces.has(queueNonce)),
+    );
+    void this.refreshEthereumApprovalNonce(updateSeq).catch(error =>
+      console.error(`Error refreshing Ethereum gateway approval state`, error),
+    );
     void this.syncApprovedGatewayRelay({
       councilSigner,
-      hasSignedApprovalsAwaitingRelay,
+      hasReadyGatewayUpdates,
       sharedRelayQueueKey,
     }).catch(error => console.error(`Error relaying approved gateway updates`, error));
     return pendingApprovals;
@@ -194,7 +267,8 @@ export class GlobalCouncil {
     }
 
     const delegateAddress = await this.walletKeys.getVaultDelegateKeypair().then(x => x.address);
-    return await new EthereumClient(this.walletKeys, executionRpcUrl).applyReadyGatewayUpdates(
+    const ethereumClient = new EthereumClient(this.walletKeys, executionRpcUrl);
+    const receipt = await ethereumClient.applyReadyGatewayUpdates(
       finalizedClient,
       delegateAddress,
       {
@@ -203,6 +277,10 @@ export class GlobalCouncil {
       },
       options,
     );
+    if (receipt) {
+      await this.refreshEthereumApprovalNonce(this.#updateSeq, ethereumClient);
+    }
+    return receipt;
   }
 
   public async getReadyGatewayRelayPreview(options: GatewayRelayOptions = {}): Promise<IEthereumGatewayRelayPreview> {
@@ -226,16 +304,45 @@ export class GlobalCouncil {
     );
   }
 
+  public async hydrateEthereumApprovalBlockNumbers(
+    queueNonces: bigint[],
+    latestExecutionAnchorBlockNumber: bigint,
+  ): Promise<void> {
+    await this.#approvalBlockHydrationPromise;
+
+    const missingQueueNonces = queueNonces.filter(
+      queueNonce => !this.data.ethereumApprovalBlockNumbers.has(queueNonce),
+    );
+    if (!missingQueueNonces.length) return;
+
+    const executionRpcUrl = getEthereumExecutionRpcUrl(this.getConfiguredExecutionRpcUrl?.());
+    if (!executionRpcUrl) return;
+
+    const ethereumClient = new EthereumClient(this.walletKeys, executionRpcUrl);
+    const hydrationPromise = ethereumClient
+      .getGatewayApprovalBlockNumbers(missingQueueNonces, latestExecutionAnchorBlockNumber)
+      .then(blockNumbers => {
+        this.data.ethereumApprovalBlockNumbers = new Map([...this.data.ethereumApprovalBlockNumbers, ...blockNumbers]);
+      });
+    this.#approvalBlockHydrationPromise = hydrationPromise;
+
+    try {
+      await hydrationPromise;
+    } finally {
+      this.#approvalBlockHydrationPromise = undefined;
+    }
+  }
+
   private async syncApprovedGatewayRelay(args: {
     councilSigner?: string;
-    hasSignedApprovalsAwaitingRelay: boolean;
+    hasReadyGatewayUpdates: boolean;
     sharedRelayQueueKey?: string;
   }): Promise<void> {
-    const { councilSigner, hasSignedApprovalsAwaitingRelay, sharedRelayQueueKey } = args;
+    const { councilSigner, hasReadyGatewayUpdates, sharedRelayQueueKey } = args;
     if (!councilSigner || this.#pendingRelayPromise) {
       return;
     }
-    if (!hasSignedApprovalsAwaitingRelay && !sharedRelayQueueKey) {
+    if (!hasReadyGatewayUpdates && !sharedRelayQueueKey) {
       this.#lastSharedRelayQueueKey = undefined;
       this.#lastSharedRelayQueueSeenAt = 0;
       return;
@@ -249,7 +356,7 @@ export class GlobalCouncil {
     this.#lastRelayCheckAt = now;
 
     const relayPromise = (async () => {
-      if (hasSignedApprovalsAwaitingRelay) {
+      if (hasReadyGatewayUpdates) {
         const receipt = await this.relayApprovedGatewayUpdates({
           allowUncompensatedRelay: true,
           onlyThroughOwnedUpdate: true,
@@ -293,6 +400,19 @@ export class GlobalCouncil {
       this.#pendingRelayPromise = undefined;
     }
   }
+
+  private async refreshEthereumApprovalNonce(updateSeq: number, ethereumClient?: EthereumClient): Promise<void> {
+    if (!ethereumClient) {
+      const executionRpcUrl = getEthereumExecutionRpcUrl(this.getConfiguredExecutionRpcUrl?.());
+      if (!executionRpcUrl) return;
+      ethereumClient = new EthereumClient(this.walletKeys, executionRpcUrl);
+    }
+
+    const ethereumApprovalNonce = await ethereumClient.getGatewayApprovalNonce();
+    if (updateSeq === this.#updateSeq) {
+      this.data.ethereumApprovalNonce = ethereumApprovalNonce;
+    }
+  }
 }
 
 async function getPendingCouncilApprovals(
@@ -302,7 +422,11 @@ async function getPendingCouncilApprovals(
 ): Promise<{
   councilSigner?: string;
   pendingApprovals: IGlobalCouncilApproval[];
-  hasSignedApprovalsAwaitingRelay: boolean;
+  approvalQueue: IGlobalCouncilQueueItem[];
+  gatewayActivityCount: bigint;
+  activeEpochMicrogonsPerArgonot?: bigint;
+  transferOutMicrogonsPerArgonot?: bigint;
+  hasReadyGatewayUpdates: boolean;
   sharedRelayQueueKey?: string;
 }> {
   const [councilSignerAddress] = await walletKeys.getEthereumAddresses([walletKeys.councilSignerEthereumHdPath]);
@@ -315,7 +439,14 @@ async function getPendingCouncilApprovals(
     publicKeyHex: null,
   });
 
-  const [councilSignerOption, councilApprovalCursorOption, gatewayStateOption, nextQueueNonce] = await Promise.all([
+  const [
+    councilSignerOption,
+    councilApprovalCursorOption,
+    gatewayStateOption,
+    nextQueueNonce,
+    activeCouncilHashOption,
+    transferOutQuoteOption,
+  ] = await Promise.all([
     finalizeClient.query.crosschainTransfer.councilSignerByDestinationChainAndAccountId(
       'Ethereum',
       walletKeys.vaultingAddress,
@@ -326,40 +457,187 @@ async function getPendingCouncilApprovals(
     ),
     finalizeClient.query.crosschainTransfer.gatewayStateBySourceChain('Ethereum'),
     finalizeClient.query.crosschainTransfer.nextCouncilApprovalQueueNonceByDestinationChain('Ethereum'),
+    finalizeClient.query.crosschainTransfer.activeGlobalIssuanceCouncilByDestinationChain?.('Ethereum'),
+    finalizeClient.query.crosschainTransfer.transferOutQuoteMicrogonsPerArgonotByDestinationChain?.('Ethereum'),
   ]);
 
   const councilSigner = councilSignerOption.isSome ? councilSignerOption.unwrap().toHex() : undefined;
   const pendingApprovals: IGlobalCouncilApproval[] = [];
+  const approvalQueue: IGlobalCouncilQueueItem[] = [];
+  const approvalQueueCandidates: Array<{
+    approval: IGlobalCouncilApproval;
+    entry: PalletCrosschainTransferCouncilApprovalQueueEntry;
+    hasLocalSignature: boolean;
+  }> = [];
   const canSignCouncilApprovals = councilSigner?.toLowerCase() === councilSignerAddress.toLowerCase();
-  let hasSignedApprovalsAwaitingRelay = false;
   let sharedRelayQueueKey: string | undefined;
+  const gatewayActivityCount = gatewayStateOption.isSome
+    ? (gatewayStateOption.unwrap().gatewayActivityNonce?.toBigInt() ?? 0n)
+    : 0n;
 
   if (canSignCouncilApprovals && !councilApprovalCursorOption.isNone) {
     const lastSyncedNonce = gatewayStateOption.isSome ? gatewayStateOption.unwrap().argonApprovalsNonce.toBigInt() : 0n;
     const lastSignedNonce = councilApprovalCursorOption.unwrap().toBigInt();
     const nextPendingQueueNonce = nextQueueNonce.toBigInt();
-    hasSignedApprovalsAwaitingRelay = lastSignedNonce > lastSyncedNonce;
+    let reachedQueueEnd = false;
     for (
-      let queueNonce = bigIntMax(lastSyncedNonce, lastSignedNonce) + 1n;
-      queueNonce <= nextPendingQueueNonce;
-      queueNonce += 1n
+      let batchStartNonce = lastSyncedNonce + 1n;
+      batchStartNonce <= nextPendingQueueNonce && !reachedQueueEnd;
+      batchStartNonce += COUNCIL_APPROVAL_QUEUE_BATCH_SIZE
     ) {
-      const entryOption = await finalizeClient.query.crosschainTransfer.councilApprovalQueueByDestinationChainAndNonce(
-        'Ethereum',
-        queueNonce,
-      );
-      if (entryOption.isNone) {
-        break;
+      const batchEndNonce = batchStartNonce + COUNCIL_APPROVAL_QUEUE_BATCH_SIZE - 1n;
+      const batchNonces: bigint[] = [];
+      for (
+        let queueNonce = batchStartNonce;
+        queueNonce <= nextPendingQueueNonce && queueNonce <= batchEndNonce;
+        queueNonce += 1n
+      ) {
+        batchNonces.push(queueNonce);
       }
+      const entryOptions =
+        await finalizeClient.query.crosschainTransfer.councilApprovalQueueByDestinationChainAndNonce.multi(
+          batchNonces.map(queueNonce => ['Ethereum', queueNonce]),
+        );
+      for (const [index, entryOption] of entryOptions.entries()) {
+        if (entryOption.isNone) {
+          reachedQueueEnd = true;
+          break;
+        }
 
-      const entry = entryOption.unwrap();
-      pendingApprovals.push({ approvalHash: entry.approvalHash.toHex() });
+        const queueNonce = batchNonces[index];
+        const entry = entryOption.unwrap();
+        const approvalHash = entry.approvalHash.toHex();
+        let approval: IGlobalCouncilApproval;
+        if (entry.target.isMintingAuthorityActivation) {
+          approval = {
+            approvalHash,
+            queueNonce,
+            targetKind: 'mintingAuthorityActivation',
+            targetSigningKey: entry.target.asMintingAuthorityActivation.toHex(),
+          };
+        } else if (entry.target.isMintingAuthorityDeactivation) {
+          approval = {
+            approvalHash,
+            queueNonce,
+            targetKind: 'mintingAuthorityDeactivation',
+            targetSigningKey: entry.target.asMintingAuthorityDeactivation.toHex(),
+          };
+        } else if (entry.target.isGlobalIssuanceCouncilRotation) {
+          approval = {
+            approvalHash,
+            queueNonce,
+            targetKind: 'globalIssuanceCouncilRotation',
+            targetCouncilHash: entry.target.asGlobalIssuanceCouncilRotation.toHex(),
+          };
+        } else {
+          throw new Error(`Unsupported approval queue target ${entry.target.type}`);
+        }
+
+        approvalQueueCandidates.push({ approval, entry, hasLocalSignature: queueNonce <= lastSignedNonce });
+      }
     }
 
-    if (pendingApprovals.length === 0 && nextPendingQueueNonce > lastSyncedNonce) {
+    const approvingCouncilHashes = [
+      ...new Set(approvalQueueCandidates.map(({ entry }) => entry.approvingCouncilHash.toHex())),
+    ];
+    const approvingCouncilOptions = approvingCouncilHashes.length
+      ? await finalizeClient.query.crosschainTransfer.globalIssuanceCouncilByHash.multi(approvingCouncilHashes)
+      : [];
+    const approvingCouncilsByHash = new Map(
+      approvingCouncilHashes.map((hash, index) => [hash, approvingCouncilOptions[index]]),
+    );
+
+    for (const { approval, entry, hasLocalSignature } of approvalQueueCandidates) {
+      const approvingCouncilHash = entry.approvingCouncilHash.toHex();
+      const approvingCouncilOption = approvingCouncilsByHash.get(approvingCouncilHash);
+      if (!approvingCouncilOption?.isSome) {
+        throw new Error(`GlobalIssuanceCouncil ${approvingCouncilHash} not found.`);
+      }
+
+      const approvingCouncil = approvingCouncilOption.unwrap();
+      const approvalProgress = {
+        approvedWeight: entry.approvedTotalWeight.toBigInt(),
+        totalWeight: approvingCouncil.totalWeight.toBigInt(),
+        signatureCount: entry.signatures.size,
+        memberCount: approvingCouncil.members.size,
+      };
+      const isReadyForRelay = hasGatewayApprovalQuorum(approvalProgress);
+      const status = isReadyForRelay ? 'readyForRelay' : hasLocalSignature ? 'awaitingCouncilQuorum' : 'needsSignature';
+
+      approvalQueue.push({ ...approval, approvalProgress, status });
+      if (status === 'needsSignature') pendingApprovals.push(approval);
+    }
+
+    if (approvalQueue.some(({ status }) => status === 'readyForRelay')) {
       sharedRelayQueueKey = `${lastSyncedNonce}:${nextPendingQueueNonce}`;
     }
   }
 
-  return { councilSigner, pendingApprovals, hasSignedApprovalsAwaitingRelay, sharedRelayQueueKey };
+  const hasReadyGatewayUpdates = approvalQueue.some(({ status }) => status === 'readyForRelay');
+
+  const authorityApprovals = approvalQueue.filter(approval => approval.targetKind !== 'globalIssuanceCouncilRotation');
+  const authorityOptions = authorityApprovals.length
+    ? await finalizeClient.query.crosschainTransfer.mintingAuthoritiesBySigner.multi(
+        authorityApprovals.map(approval => approval.targetSigningKey),
+      )
+    : [];
+  for (const [index, approval] of authorityApprovals.entries()) {
+    const authorityOption = authorityOptions[index];
+    if (authorityOption.isSome) approval.authorityOwnerAccount = authorityOption.unwrap().accountId.toString();
+  }
+
+  const councilApprovals = approvalQueue.filter(approval => approval.targetKind === 'globalIssuanceCouncilRotation');
+  const councilHashes = [
+    ...(activeCouncilHashOption?.isSome ? [activeCouncilHashOption.unwrap().toHex()] : []),
+    ...councilApprovals.map(approval => approval.targetCouncilHash),
+  ];
+  const councilOptions = councilHashes.length
+    ? await finalizeClient.query.crosschainTransfer.globalIssuanceCouncilByHash.multi(councilHashes)
+    : [];
+  const activeCouncil = activeCouncilHashOption?.isSome ? councilOptions[0]?.unwrap() : undefined;
+  const activeMemberAccounts = new Set(
+    activeCouncil ? [...activeCouncil.members.values()].map(member => member.accountId.toString()) : [],
+  );
+  const targetOffset = activeCouncilHashOption?.isSome ? 1 : 0;
+  for (const [index, approval] of councilApprovals.entries()) {
+    const councilOption = councilOptions[index + targetOffset];
+    if (!councilOption?.isSome) continue;
+
+    const council = councilOption.unwrap();
+    const targetMemberAccounts = new Set([...council.members.values()].map(member => member.accountId.toString()));
+    approval.councilChange = {
+      vaultCount: targetMemberAccounts.size,
+      newVaultCount: [...targetMemberAccounts].filter(accountId => !activeMemberAccounts.has(accountId)).length,
+      leavingVaultCount: [...activeMemberAccounts].filter(accountId => !targetMemberAccounts.has(accountId)).length,
+      epochMicrogonsPerArgonot: council.epochMicrogonsPerArgonot.toBigInt(),
+    };
+  }
+  for (const pendingApproval of pendingApprovals) {
+    const queueItem = approvalQueue.find(item => item.queueNonce === pendingApproval.queueNonce);
+    if (!queueItem || queueItem.targetKind !== pendingApproval.targetKind) continue;
+    if (
+      pendingApproval.targetKind === 'globalIssuanceCouncilRotation' &&
+      queueItem.targetKind === 'globalIssuanceCouncilRotation'
+    ) {
+      pendingApproval.councilChange = queueItem.councilChange;
+    } else if (
+      pendingApproval.targetKind !== 'globalIssuanceCouncilRotation' &&
+      queueItem.targetKind !== 'globalIssuanceCouncilRotation'
+    ) {
+      pendingApproval.authorityOwnerAccount = queueItem.authorityOwnerAccount;
+    }
+  }
+
+  return {
+    councilSigner,
+    pendingApprovals,
+    approvalQueue,
+    gatewayActivityCount,
+    activeEpochMicrogonsPerArgonot: activeCouncil?.epochMicrogonsPerArgonot.toBigInt(),
+    transferOutMicrogonsPerArgonot: transferOutQuoteOption?.isSome
+      ? transferOutQuoteOption.unwrap().toBigInt()
+      : activeCouncil?.epochMicrogonsPerArgonot.toBigInt(),
+    hasReadyGatewayUpdates,
+    sharedRelayQueueKey,
+  };
 }

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -53,10 +53,18 @@ export default class Importer {
       importWalletKeys.vaultingAddress,
       importWalletKeys.operationalAddress,
     ];
-    const [balances, operationalAccount, ownedVault] = await Promise.all([
+    const mintingAuthorityCouncilSigner = finalizedApi.query.crosschainTransfer
+      ?.councilSignerByDestinationChainAndAccountId
+      ? finalizedApi.query.crosschainTransfer.councilSignerByDestinationChainAndAccountId(
+          'Ethereum',
+          importWalletKeys.vaultingAddress,
+        )
+      : undefined;
+    const [balances, operationalAccount, ownedVault, councilSigner] = await Promise.all([
       readArgonWalletBalanceValues(finalizedApi, addresses),
       finalizedApi.query.operationalAccounts.operationalAccounts(importWalletKeys.operationalAddress),
       getVaultByOperator({ client: finalizedApi, operatorAddress: importWalletKeys.vaultingAddress }),
+      mintingAuthorityCouncilSigner,
     ]);
 
     const hasExistingWalletValue = balances.some(balance => {
@@ -84,6 +92,7 @@ export default class Importer {
     // Member Bitcoin events also carry VaultPosition because they affect vault capital. Only the runtime's operator
     // index proves that this account owns a vault and should regain Operations.
     const hasVaultActivity = operationalProgress.hasVault || !!ownedVault;
+    const hasActivatedCrosschain = councilSigner?.isSome ?? false;
     let hasTreasuryHistory = false;
     if (!operationalProgress.hasOperationalAccount) {
       const treasuryActivity = await findAddressActivity(importWalletKeys.defaultArgonAddress, {
@@ -101,7 +110,8 @@ export default class Importer {
       }
     }
 
-    const hasOperationsHistory = operationalProgress.hasOperationalAccount || hasMiningActivity || hasVaultActivity;
+    const hasOperationsHistory =
+      operationalProgress.hasOperationalAccount || hasMiningActivity || hasVaultActivity || hasActivatedCrosschain;
     hasTreasuryHistory ||= hasOperationsHistory;
 
     const usesOperationalProfile = usesOperationalProfileNameRuntime(mainchainClient);
@@ -145,6 +155,7 @@ export default class Importer {
       walletPreviousLifeRecovered: JsonExt.stringify(!hasPreviousLife, 2),
       hasExtensionTreasury: JsonExt.stringify(hasTreasuryHistory, 2),
       hasExtensionOperations: JsonExt.stringify(hasOperationsHistory, 2),
+      hasActivatedCrosschain: JsonExt.stringify(hasActivatedCrosschain, 2),
       certificationDetails: JsonExt.stringify({ hasSavedMnemonic: true }, 2),
       miningSetupStatus: JsonExt.stringify(miningSetupStatus, 2),
       vaultingSetupStatus: JsonExt.stringify(

--- a/src-vue/lib/MintingAuthorities.ts
+++ b/src-vue/lib/MintingAuthorities.ts
@@ -34,6 +34,7 @@ export type IMintingAuthorityAuthorization = {
   transferId: string;
   authorityIndex: number;
   moveToken: MoveToken.ARGN | MoveToken.ARGNOT;
+  sourceAccount: string;
   destinationSigningKey: string;
   finalizeRequest: EvmContracts.MintingGatewayTransferOutOfArgonRequest;
   authorizationHash: string;
@@ -41,6 +42,28 @@ export type IMintingAuthorityAuthorization = {
   microgonCollateral: bigint;
   micronotCollateral: bigint;
   securityAmountMicrogons: bigint;
+};
+
+export type IMintingAuthorityBackedTransfer = {
+  transferId: string;
+  status: 'waitingForAuthorizations' | 'readyForEthereum';
+  moveToken: MoveToken.ARGN | MoveToken.ARGNOT;
+  sourceAccount: string;
+  sourceTransferNonce: bigint;
+  destinationAccount: string;
+  amount: bigint;
+  validUntilEthereumBlock: bigint;
+  mintingAuthorityTip: bigint;
+  totalAttachedCollateral: bigint;
+  ownedMicrogonCollateral: bigint;
+  ownedMicronotCollateral: bigint;
+  authoritySigners: string[];
+};
+
+export type ICrosschainSourceTransferTotals = {
+  microgonsOut: bigint;
+  micronotsOut: bigint;
+  transferOutCount: number;
 };
 
 export type IMintingAuthorityAuthorizeMetadata = {
@@ -53,6 +76,33 @@ export type IMintingAuthorityAuthorizeMetadata = {
     micronotCollateral: bigint;
   }>;
 };
+
+export function getActiveMintingAuthorityRemaining(
+  authorities: IEthereumMintingAuthority[],
+  microgonsPerArgonot: bigint,
+): { microgons: bigint; micronots: bigint; valueMicrogons: bigint } {
+  const remaining = authorities.reduce(
+    (total, authority) => {
+      if (!authority.isActive) return total;
+
+      total.microgons += bigIntMax(
+        0n,
+        authority.gatewayRemainingMicrogonCollateral - authority.pendingReservedMicrogonCollateral,
+      );
+      total.micronots += bigIntMax(
+        0n,
+        authority.gatewayRemainingMicronotCollateral - authority.pendingReservedMicronotCollateral,
+      );
+      return total;
+    },
+    { microgons: 0n, micronots: 0n },
+  );
+
+  return {
+    ...remaining,
+    valueMicrogons: remaining.microgons + (remaining.micronots * microgonsPerArgonot) / BigInt(MICROGONS_PER_ARGON),
+  };
+}
 
 export type IMintingAuthorityRegisterMetadata = {
   actionType: 'registerMintingAuthority';
@@ -69,6 +119,10 @@ export class MintingAuthorities {
     isReady: boolean;
     authorities: IEthereumMintingAuthority[];
     pendingMintingAuthorizations: IMintingAuthorityAuthorization[];
+    backedTransfers: IMintingAuthorityBackedTransfer[];
+    backedTransfersError?: string;
+    sourceTotalsByAccount: Map<string, ICrosschainSourceTransferTotals>;
+    sourceUpstreamVaultAccountsByAccount: Map<string, string>;
     pendingMintingAuthorizeTxInfosByTransferId: Map<string, TransactionInfo<IMintingAuthorityAuthorizeMetadata>>;
   };
   #subscriptions: VoidFunction[] = [];
@@ -93,6 +147,9 @@ export class MintingAuthorities {
       isReady: false,
       authorities: [],
       pendingMintingAuthorizations: [],
+      backedTransfers: [],
+      sourceTotalsByAccount: new Map(),
+      sourceUpstreamVaultAccountsByAccount: new Map(),
       pendingMintingAuthorizeTxInfosByTransferId: new Map(),
     };
   }
@@ -110,6 +167,12 @@ export class MintingAuthorities {
       await this.miningFrames.blockWatch.start();
       const finalizedClient = await this.miningFrames.blockWatch.getFinalizedApi();
       await this.refresh(finalizedClient);
+      if (!this.data.authorities.length) {
+        const restoredAuthorities = await this.restoreSignerIndexes(finalizedClient);
+        if (restoredAuthorities.length) {
+          await this.refresh(finalizedClient);
+        }
+      }
       for (const txInfo of this.transactionTracker.pendingBlockTxInfosAtLoad) {
         if (txInfo.tx.extrinsicType === ExtrinsicType.CrosschainTransferAuthorize) {
           void this.onAuthorize(txInfo as TransactionInfo<IMintingAuthorityAuthorizeMetadata>);
@@ -138,21 +201,118 @@ export class MintingAuthorities {
       this.walletKeys,
       db.walletHdKeysTable,
     );
-    const pendingMintingAuthorizations = await getPendingMintingAuthorizations(
-      finalizedClient,
-      authorities,
-      getPendingLocalAuthorizations(this.transactionTracker.data.txInfos),
-    );
+    let backedTransfersError: string | undefined;
+    const [pendingMintingAuthorizations, backedTransfers] = await Promise.all([
+      getPendingMintingAuthorizations(
+        finalizedClient,
+        authorities,
+        getPendingLocalAuthorizations(this.transactionTracker.data.txInfos),
+      ),
+      getMintingAuthorityBackedTransfers(finalizedClient, authorities).catch(error => {
+        console.warn('[MintingAuthorities] Unable to refresh transfers backed by owned authorities', error);
+        backedTransfersError = error instanceof Error ? error.message : `${error}`;
+        return this.data.backedTransfers;
+      }),
+    ]);
     if (updateSeq !== this.#updateSeq) {
       return this.data.pendingMintingAuthorizations;
     }
 
+    const sourceAccounts = [
+      ...new Set([
+        ...pendingMintingAuthorizations.map(authorization => authorization.sourceAccount),
+        ...backedTransfers.map(transfer => transfer.sourceAccount),
+      ]),
+    ];
+    const [sourceTotals, sourceUpstreamVaultAccountsByAccount] = await Promise.all([
+      sourceAccounts.length
+        ? finalizedClient.query.crosschainTransfer.transferTotalsByAccount.multi(sourceAccounts)
+        : [],
+      this.loadSourceUpstreamVaultAccounts(finalizedClient, sourceAccounts),
+    ]);
+
     this.data.authorities = authorities;
     this.data.pendingMintingAuthorizations = pendingMintingAuthorizations;
+    this.data.backedTransfers = backedTransfers;
+    this.data.backedTransfersError = backedTransfersError;
+    this.data.sourceTotalsByAccount = new Map(
+      sourceAccounts.map((accountId, index) => {
+        const totals = sourceTotals[index];
+        return [
+          accountId,
+          {
+            microgonsOut: totals.microgonsOut.toBigInt(),
+            micronotsOut: totals.micronotsOut.toBigInt(),
+            transferOutCount: totals.argonTransfersOutCount.toNumber() + totals.argonotTransfersOutCount.toNumber(),
+          },
+        ];
+      }),
+    );
+    this.data.sourceUpstreamVaultAccountsByAccount = sourceUpstreamVaultAccountsByAccount;
     void this.syncPendingActivationRelay(authorities).catch(error =>
       console.error(`Error requesting pending minting-authority activation relay`, error),
     );
     return pendingMintingAuthorizations;
+  }
+
+  private async loadSourceUpstreamVaultAccounts(
+    finalizedClient: ApiDecoration<'promise'>,
+    sourceAccounts: string[],
+  ): Promise<Map<string, string>> {
+    if (!sourceAccounts.length) return new Map();
+
+    try {
+      const sourceOperationalAccountIds =
+        await finalizedClient.query.operationalAccounts.operationalAccountBySubAccount.multi(sourceAccounts);
+      const operationalAccountIds = [
+        ...new Set(
+          sourceOperationalAccountIds.flatMap(accountId => (accountId.isSome ? [accountId.unwrap().toString()] : [])),
+        ),
+      ];
+      if (!operationalAccountIds.length) return new Map();
+
+      const operationalAccountOptions =
+        await finalizedClient.query.operationalAccounts.operationalAccounts.multi(operationalAccountIds);
+      const operationalAccountsById = new Map(
+        operationalAccountOptions.flatMap((account, index) =>
+          account.isSome ? [[operationalAccountIds[index], account.unwrap()] as const] : [],
+        ),
+      );
+      const upstreamAccountIds = [
+        ...new Set(
+          [...operationalAccountsById.values()].flatMap(account =>
+            account.upstreamAccount.isSome ? [account.upstreamAccount.unwrap().toString()] : [],
+          ),
+        ),
+      ];
+      if (!upstreamAccountIds.length) return new Map();
+
+      const upstreamAccountOptions =
+        await finalizedClient.query.operationalAccounts.operationalAccounts.multi(upstreamAccountIds);
+      const upstreamVaultAccountsById = new Map(
+        upstreamAccountOptions.flatMap((account, index) =>
+          account.isSome ? [[upstreamAccountIds[index], account.unwrap().vaultAccount.toString()] as const] : [],
+        ),
+      );
+      const sourceUpstreamVaultAccounts = new Map<string, string>();
+
+      for (const [index, sourceAccount] of sourceAccounts.entries()) {
+        const operationalAccountId = sourceOperationalAccountIds[index];
+        if (!operationalAccountId?.isSome) continue;
+
+        const operationalAccount = operationalAccountsById.get(operationalAccountId.unwrap().toString());
+        const upstreamAccountId = operationalAccount?.upstreamAccount;
+        if (!upstreamAccountId?.isSome) continue;
+
+        const upstreamVaultAccount = upstreamVaultAccountsById.get(upstreamAccountId.unwrap().toString());
+        if (upstreamVaultAccount) sourceUpstreamVaultAccounts.set(sourceAccount, upstreamVaultAccount);
+      }
+
+      return sourceUpstreamVaultAccounts;
+    } catch (error) {
+      console.warn('[MintingAuthorities] Unable to resolve transfer source sponsors', error);
+      return new Map();
+    }
   }
 
   public async restoreSignerIndexes(
@@ -179,6 +339,10 @@ export class MintingAuthorities {
 
     this.data.authorities = authorities;
     this.data.pendingMintingAuthorizations = [];
+    this.data.backedTransfers = [];
+    this.data.backedTransfersError = undefined;
+    this.data.sourceTotalsByAccount = new Map();
+    this.data.sourceUpstreamVaultAccountsByAccount = new Map();
     void this.syncPendingActivationRelay(authorities).catch(error =>
       console.error(`Error requesting restored minting-authority activation relay`, error),
     );
@@ -319,8 +483,16 @@ export class MintingAuthorities {
     }
   }
 
-  public async authorize(transferId?: string): Promise<TransactionInfo<IMintingAuthorityAuthorizeMetadata>> {
-    if (transferId) {
+  public async authorize(transferIds?: string[]): Promise<TransactionInfo<IMintingAuthorityAuthorizeMetadata>> {
+    const selectedTransferIds = transferIds
+      ? [...new Set(transferIds.map(transferId => transferId.toLowerCase()))]
+      : undefined;
+    if (selectedTransferIds && !selectedTransferIds.length) {
+      throw new Error('Select at least one minting authorization.');
+    }
+
+    if (selectedTransferIds?.length === 1) {
+      const transferId = selectedTransferIds[0];
       const pendingTxInfo = this.data.pendingMintingAuthorizeTxInfosByTransferId.get(transferId);
       if (pendingTxInfo && !pendingTxInfo.isPostProcessed) {
         return pendingTxInfo;
@@ -329,36 +501,50 @@ export class MintingAuthorities {
     }
 
     await this.load();
-    let nextAuthorization = transferId
-      ? this.data.pendingMintingAuthorizations.find(x => x.transferId === transferId)
-      : this.data.pendingMintingAuthorizations[0];
-    if (!nextAuthorization) {
+    const getAvailableAuthorizations = () => {
+      if (!selectedTransferIds) return [...this.data.pendingMintingAuthorizations];
+
+      const authorizationByTransferId = new Map(
+        this.data.pendingMintingAuthorizations.map(authorization => [
+          authorization.transferId.toLowerCase(),
+          authorization,
+        ]),
+      );
+      return selectedTransferIds
+        .map(transferId => authorizationByTransferId.get(transferId))
+        .filter(authorization => authorization !== undefined);
+    };
+
+    let authorizations = getAvailableAuthorizations();
+    if (!authorizations.length || (selectedTransferIds && authorizations.length !== selectedTransferIds.length)) {
       const finalizedClient = await this.miningFrames.blockWatch.getFinalizedApi();
       await this.refresh(finalizedClient);
-      nextAuthorization = transferId
-        ? this.data.pendingMintingAuthorizations.find(x => x.transferId === transferId)
-        : this.data.pendingMintingAuthorizations[0];
-      if (!nextAuthorization && transferId) {
-        nextAuthorization = (
-          await getPendingMintingAuthorizations(
-            finalizedClient,
-            this.data.authorities,
-            getPendingLocalAuthorizations(this.transactionTracker.data.txInfos),
-            transferId,
-          )
-        )[0];
+      authorizations = getAvailableAuthorizations();
+      if (!authorizations.length && selectedTransferIds?.length === 1) {
+        authorizations = await getPendingMintingAuthorizations(
+          finalizedClient,
+          this.data.authorities,
+          getPendingLocalAuthorizations(this.transactionTracker.data.txInfos),
+          selectedTransferIds[0],
+        );
       }
     }
-    if (!nextAuthorization) {
-      if (transferId) {
-        throw new Error(`Transfer ${transferId} is not currently available to authorize.`);
+    if (!authorizations.length) {
+      if (selectedTransferIds) {
+        throw new Error('The selected transfers are not currently available to authorize.');
       }
       throw new Error('No pending minting authorizations are currently available.');
+    }
+    if (selectedTransferIds && authorizations.length !== selectedTransferIds.length) {
+      const availableTransferIds = new Set(authorizations.map(authorization => authorization.transferId.toLowerCase()));
+      const unavailableTransferIds = selectedTransferIds.filter(transferId => !availableTransferIds.has(transferId));
+      throw new Error(
+        `The following transfers are not currently available to authorize: ${unavailableTransferIds.join(', ')}`,
+      );
     }
 
     const client = await this.miningFrames.blockWatch.clients.get(false);
     const txSigner = await this.walletKeys.getVaultingKeypair();
-    const authorizations = transferId ? [nextAuthorization] : [...this.data.pendingMintingAuthorizations];
     const txs = await Promise.all(
       authorizations.map(async authorization =>
         client.tx.crosschainTransfer.collateralizeTransfer(
@@ -374,7 +560,7 @@ export class MintingAuthorities {
       ),
     );
     const txInfo = await this.transactionTracker.submitAndWatch({
-      tx: txs.length === 1 ? txs[0] : client.tx.utility.batch(txs),
+      tx: txs.length === 1 ? txs[0] : client.tx.utility.batchAll(txs),
       txSigner,
       extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
       metadata: {
@@ -432,7 +618,7 @@ export class MintingAuthorities {
   public async onAuthorize(txInfo: TransactionInfo<IMintingAuthorityAuthorizeMetadata>): Promise<void> {
     const { authorizations } = txInfo.tx.metadataJson;
     for (const { transferId } of authorizations) {
-      this.data.pendingMintingAuthorizeTxInfosByTransferId.set(transferId, txInfo);
+      this.data.pendingMintingAuthorizeTxInfosByTransferId.set(transferId.toLowerCase(), txInfo);
     }
     const postProcessor = txInfo.createPostProcessor();
 
@@ -448,8 +634,9 @@ export class MintingAuthorities {
       throw error;
     } finally {
       for (const { transferId } of authorizations) {
-        if (this.data.pendingMintingAuthorizeTxInfosByTransferId.get(transferId)?.tx.id === txInfo.tx.id) {
-          this.data.pendingMintingAuthorizeTxInfosByTransferId.delete(transferId);
+        const normalizedTransferId = transferId.toLowerCase();
+        if (this.data.pendingMintingAuthorizeTxInfosByTransferId.get(normalizedTransferId)?.tx.id === txInfo.tx.id) {
+          this.data.pendingMintingAuthorizeTxInfosByTransferId.delete(normalizedTransferId);
         }
       }
     }
@@ -724,6 +911,7 @@ export async function getPendingMintingAuthorizations(
         transferId,
         authorityIndex: authority.authorityIndex,
         moveToken: transfer.asset.isArgon ? MoveToken.ARGN : MoveToken.ARGNOT,
+        sourceAccount: transfer.argonAccountId.toString(),
         destinationSigningKey: authority.signer,
         finalizeRequest,
         authorizationHash: EvmContracts.hashMintingGatewayMintingAuthorization(
@@ -751,6 +939,56 @@ export async function getPendingMintingAuthorizations(
   }
 
   return authorizations;
+}
+
+export async function getMintingAuthorityBackedTransfers(
+  finalizedClient: ApiDecoration<'promise'>,
+  authorities: IEthereumMintingAuthority[],
+): Promise<IMintingAuthorityBackedTransfer[]> {
+  const authoritySigners = new Set(authorities.map(authority => authority.signer.toLowerCase()));
+  const transferIds = [...new Set(authorities.flatMap(authority => authority.activePendingTransferIds))];
+  if (transferIds.length === 0) return [];
+
+  const transferOptions = await finalizedClient.query.crosschainTransfer.transferOutById.multi(transferIds);
+  const backedTransfers: IMintingAuthorityBackedTransfer[] = [];
+
+  for (const [index, transferOption] of transferOptions.entries()) {
+    if (transferOption.isNone) continue;
+
+    const transfer = transferOption.unwrap();
+    let ownedMicrogonCollateral = 0n;
+    let ownedMicronotCollateral = 0n;
+    const ownedAuthoritySigners: string[] = [];
+
+    for (const [signer, collateral] of transfer.mintingAuthorityCollateralBySigner.entries()) {
+      const signerAddress = signer.toHex();
+      if (!authoritySigners.has(signerAddress.toLowerCase())) continue;
+
+      ownedAuthoritySigners.push(signerAddress);
+      ownedMicrogonCollateral += collateral.microgonCollateral.toBigInt();
+      ownedMicronotCollateral += collateral.micronotCollateral.toBigInt();
+    }
+
+    if (ownedAuthoritySigners.length === 0) continue;
+
+    backedTransfers.push({
+      transferId: transferIds[index],
+      status: transfer.state.isReady ? 'readyForEthereum' : 'waitingForAuthorizations',
+      moveToken: transfer.asset.isArgon ? MoveToken.ARGN : MoveToken.ARGNOT,
+      sourceAccount: transfer.argonAccountId.toString(),
+      sourceTransferNonce: transfer.argonTransferNonce.toBigInt(),
+      destinationAccount: transfer.destinationAccount.toHex(),
+      amount: transfer.amount.toBigInt(),
+      validUntilEthereumBlock: transfer.validUntilEthereumBlock.toBigInt(),
+      mintingAuthorityTip: transfer.mintingAuthorityTip.toBigInt(),
+      totalAttachedCollateral: transfer.totalAttachedCollateral.toBigInt(),
+      ownedMicrogonCollateral,
+      ownedMicronotCollateral,
+      authoritySigners: ownedAuthoritySigners,
+    });
+  }
+
+  return backedTransfers;
 }
 
 function createActiveAuthorities(

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -55,7 +55,7 @@ import { ExtrinsicType } from './db/TransactionsTable.ts';
 import { computeCollectDeadline } from './VaultDeadlineWatcher.ts';
 import { WalletKeys } from './WalletKeys.ts';
 import { GlobalCouncil } from './GlobalCouncil.ts';
-import { MintingAuthorities } from './MintingAuthorities.ts';
+import { MintingAuthorities, type IMintingAuthorityAuthorizeMetadata } from './MintingAuthorities.ts';
 import { Config } from './Config.ts';
 import { ICollectOrphanCosignMetadata, IVaultCollectMetadata, VaultCollectBuilder } from './VaultCollectBuilder.ts';
 import { getSpendableDefaultArgonMicrogons } from './WalletForArgon.ts';
@@ -373,6 +373,41 @@ export class MyVault {
 
   public getTxInfoByType(extrinsicType: ExtrinsicType): TransactionInfo<any> | undefined {
     return this.#transactionTracker.data.txInfosByType[extrinsicType];
+  }
+
+  public getCrosschainQueueTxInfos(): TransactionInfo[] {
+    return this.#transactionTracker.data.txInfos.filter(({ tx }) => {
+      if (
+        tx.extrinsicType === ExtrinsicType.CrosschainTransferAuthorize ||
+        tx.extrinsicType === ExtrinsicType.CrosschainTransferApproveCouncil
+      ) {
+        return true;
+      }
+
+      const metadata = tx.metadataJson as Partial<IVaultCollectMetadata>;
+      return (
+        tx.extrinsicType === ExtrinsicType.VaultCollect &&
+        (metadata.actionType === 'approveCouncil' || (metadata.councilApprovalCount ?? 0) > 0)
+      );
+    });
+  }
+
+  public getCrosschainQueueNetEarnings(): bigint {
+    return this.getCrosschainQueueTxInfos().reduce((netEarnings, { tx }) => {
+      if (!tx.isFinalized || tx.extrinsicType !== ExtrinsicType.CrosschainTransferAuthorize) {
+        return netEarnings;
+      }
+
+      const metadata = tx.metadataJson as IMintingAuthorityAuthorizeMetadata;
+      const completedAuthorizationCount = tx.blockExtrinsicErrorJson
+        ? (tx.blockExtrinsicErrorJson.batchInterruptedIndex ?? 0)
+        : metadata.authorizations.length;
+      const earnedRewards = metadata.authorizations
+        .slice(0, completedAuthorizationCount)
+        .reduce((total, authorization) => total + authorization.mintingAuthorityTip, 0n);
+
+      return netEarnings + earnedRewards - (tx.txFeePlusTip ?? 0n);
+    }, 0n);
   }
 
   public getBitcoinReleaseRequestTxInfo(utxoId: number): TransactionInfo<any> | undefined {

--- a/src-vue/lib/TransactionInfo.ts
+++ b/src-vue/lib/TransactionInfo.ts
@@ -170,6 +170,9 @@ export class TransactionInfo<MetadataType = unknown> {
     }
 
     if (confirmations === -1) {
+      if (this.tx.blockHeight) {
+        return `Included in Block #${this.tx.blockHeight} · Waiting for Finalization...`;
+      }
       return 'Waiting for 1st Block...';
     } else if (confirmations === 0 && expectedConfirmations > 0) {
       return 'Waiting for 2nd Block...';

--- a/src-vue/lib/TransactionProgress.ts
+++ b/src-vue/lib/TransactionProgress.ts
@@ -1,0 +1,76 @@
+import type * as Vue from 'vue';
+import type { TransactionInfo } from './TransactionInfo.ts';
+
+export function getActiveTransactionInfos(txInfos: TransactionInfo[]) {
+  const uniqueTxInfos = new Map<number, TransactionInfo>();
+  for (const txInfo of txInfos) {
+    if (txInfo.isPostProcessed) continue;
+
+    uniqueTxInfos.set(txInfo.tx.id, txInfo);
+  }
+
+  return [...uniqueTxInfos.values()].sort((left, right) => left.tx.createdAt.getTime() - right.tx.createdAt.getTime());
+}
+
+export function trackTransactionProgress(args: {
+  txInfos: TransactionInfo[];
+  isSubmitting: Vue.Ref<boolean>;
+  progressPct: Vue.Ref<number>;
+  progressLabel: Vue.Ref<string>;
+  activeTransactionCount?: Vue.Ref<number>;
+  error: Vue.Ref<string>;
+  onIdle?: () => void;
+  onCleanup: (cleanupFn: () => void) => void;
+}) {
+  const { txInfos, isSubmitting, progressPct, progressLabel, activeTransactionCount, error, onIdle, onCleanup } = args;
+
+  if (txInfos.length > 0) {
+    const progressByTxId = new Map(
+      txInfos.map(txInfo => [
+        txInfo.tx.id,
+        {
+          progressPct: 0,
+          progressMessage: 'Preparing transaction...',
+        },
+      ]),
+    );
+
+    error.value = '';
+    isSubmitting.value = true;
+    if (activeTransactionCount) activeTransactionCount.value = txInfos.length;
+
+    for (const txInfo of txInfos) {
+      const unsubscribe = txInfo.subscribeToProgress((progressArgs, progressError) => {
+        progressByTxId.set(txInfo.tx.id, {
+          progressPct: progressArgs.progressPct,
+          progressMessage: progressArgs.progressMessage,
+        });
+
+        const slowestProgress = Array.from(progressByTxId.values()).reduce((slowest, current) => {
+          if (!slowest || current.progressPct < slowest.progressPct) return current;
+
+          return slowest;
+        });
+
+        progressPct.value = slowestProgress?.progressPct ?? 0;
+        progressLabel.value =
+          txInfos.length > 1
+            ? `${slowestProgress?.progressMessage ?? 'Preparing transaction...'} (${txInfos.length} transactions in progress)`
+            : (slowestProgress?.progressMessage ?? '');
+
+        if (progressError) error.value = progressError.message;
+      });
+      onCleanup(unsubscribe);
+    }
+
+    return;
+  }
+
+  if (activeTransactionCount) activeTransactionCount.value = 0;
+  if (!isSubmitting.value) return;
+
+  isSubmitting.value = false;
+  progressPct.value = 0;
+  progressLabel.value = '';
+  onIdle?.();
+}

--- a/src-vue/lib/db/FinancialCacheTable.ts
+++ b/src-vue/lib/db/FinancialCacheTable.ts
@@ -1,8 +1,10 @@
 import type { IWallet } from '../Wallet.ts';
+import type { ICrosschainHistoryRecord } from '../CrosschainHistory.ts';
 import { BaseTable, type IFieldTypes } from './BaseTable.ts';
 import { convertFromSqliteFields, logStartupTiming, toSqlParams } from '../Utils.ts';
 
 export enum FinancialCacheTypes {
+  CrosschainHistory = 'CrosschainHistory',
   ExternalWalletBalance = 'ExternalWalletBalance',
 }
 
@@ -17,7 +19,14 @@ export type IExternalWalletBalanceCacheRecord = Pick<
   observedAt: Date;
 };
 
+export type ICrosschainHistoryCacheRecord = {
+  records: ICrosschainHistoryRecord[];
+  definitionVersion: number;
+  refreshedThroughBlock: number;
+};
+
 export interface IFinancialCacheSchemas {
+  [FinancialCacheTypes.CrosschainHistory]: ICrosschainHistoryCacheRecord;
   [FinancialCacheTypes.ExternalWalletBalance]: IExternalWalletBalanceCacheRecord;
 }
 

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -326,6 +326,31 @@
                 </div>
               </div>
             </article>
+            <div Selector :LastSelector="!showCrosschainNavigation" />
+          </li>
+          <li
+            v-if="showCrosschainNavigation"
+            data-testid="LeftBar.goto(TopTab.CrosschainTransfers)"
+            @click="goto(TopTab.CrosschainTransfers)"
+            :class="{ Selected: controller.selectedTab === TopTab.CrosschainTransfers }"
+          >
+            <article class="flex flex-col">
+              <div class="relative flex flex-row items-center">
+                <div class="flex grow flex-row items-center">
+                  <div class="mr-1 w-6 text-center">
+                    <ArrowsRightLeftIcon class="relative inline-block w-5.5 opacity-70" />
+                  </div>
+                  <div>Crosschain</div>
+                  <div v-if="hasCrosschainAction" class="ml-2 flex items-center" title="Crosschain action required">
+                    <span class="bg-argon-800/50 h-2 w-2 rounded-full" />
+                    <span class="sr-only">Action required</span>
+                  </div>
+                </div>
+                <div v-if="currency.isLoaded" class="opacity-60">
+                  {{ currency.symbol }}{{ microgonToMoneyNm(crosschainNetEarnings).format('0,0.00') }}
+                </div>
+              </div>
+            </article>
             <div Selector LastSelector />
           </li>
         </ul>
@@ -526,6 +551,9 @@ import {
 import WalletSelector from '../wallets/components/WalletSelector.vue';
 import WalletActions from '../wallets/components/WalletActions.vue';
 import CertificationIcon from '../assets/certification.svg';
+import { ArrowsRightLeftIcon } from '@heroicons/vue/24/outline';
+import { getMyVault } from '../stores/vaults.ts';
+import { getCrosschainAccessState } from '../lib/CrosschainTransferView.ts';
 
 const controller = useCertificationController();
 const basics = useBasics();
@@ -536,6 +564,7 @@ const currency = getCurrency();
 const financials = useFinancials();
 const miningAssets = useMiningAssetBreakdown();
 const vaultingAssets = useVaultingAssetBreakdown();
+const myVault = getMyVault();
 const { microgonToArgonNm, microgonToMoneyNm, micronotToArgonotNm, micronotToMoneyNm, satToMoneyNm } =
   createNumeralHelpers(currency);
 
@@ -591,6 +620,23 @@ const selectedWalletBalance = Vue.computed(() => {
 
   const wallet = selectedWalletData.value;
   return getWalletTotalValue(wallet, currency);
+});
+
+const hasCrosschainAction = Vue.computed(() => {
+  return (
+    myVault.mintingAuthorities.data.pendingMintingAuthorizations.length > 0 ||
+    myVault.globalCouncil.data.pendingApprovals.length > 0
+  );
+});
+
+const crosschainNetEarnings = Vue.computed(() => myVault.getCrosschainQueueNetEarnings());
+
+const showCrosschainNavigation = Vue.computed(() => {
+  return getCrosschainAccessState({
+    hasActivatedCrosschain: config.hasActivatedCrosschain,
+    authorityCount: myVault.mintingAuthorities.data.isReady ? myVault.mintingAuthorities.data.authorities.length : 0,
+    councilSigner: myVault.globalCouncil.data.councilSigner,
+  }).hasAccess;
 });
 
 function selectWallet(wallet: IWalletSelection) {

--- a/src-vue/overlays/CrosschainHistoryOverlay.vue
+++ b/src-vue/overlays/CrosschainHistoryOverlay.vue
@@ -1,0 +1,71 @@
+<!-- prettier-ignore -->
+<template>
+  <OverlayBase :isOpen="isOpen" @close="closeOverlay" @pressEsc="closeOverlay" class="w-8/12" overflowScroll>
+    <template #title>
+      <div class="grow text-2xl font-bold">Crosschain History</div>
+    </template>
+
+    <div class="min-h-0 max-h-[calc(100vh-10rem)] overflow-y-auto px-5 pb-5">
+      <div class="flex items-center gap-x-2 border-b border-slate-200 px-4 py-3 text-sm text-slate-500">
+        <span
+          v-if="crosschainHistory.data.isSyncing"
+          class="border-argon-500 h-3.5 w-3.5 animate-spin rounded-full border-2 border-r-transparent"
+        />
+        <span v-if="crosschainHistory.data.isSyncing">Downloading newer indexed history</span>
+        <span v-else-if="crosschainHistory.data.coverageComplete">Indexed history is caught up</span>
+        <span v-else>{{ crosschainHistory.data.error ?? 'Indexed history is not complete yet' }}</span>
+      </div>
+
+      <CrosschainHistoryRows
+        v-if="crosschainHistory.data.records.length"
+        :records="crosschainHistory.data.records"
+        :knownIdentities="knownSourceIdentities"
+      />
+      <div
+        v-else-if="crosschainHistory.data.isSyncing"
+        class="flex min-h-56 items-center justify-center text-sm font-semibold text-slate-500">
+        Downloading crosschain history...
+      </div>
+      <div v-else class="flex min-h-56 items-center justify-center text-sm text-slate-500">
+        No completed crosschain activity was found.
+      </div>
+    </div>
+  </OverlayBase>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import CrosschainHistoryRows from '../components/CrosschainHistoryRows.vue';
+import basicEmitter from '../emitters/basicEmitter.ts';
+import { useBasics } from '../stores/basics.ts';
+import { getCrosschainHistory, getKnownCrosschainSourceIdentities } from '../stores/vaults.ts';
+import OverlayBase from './OverlayBase.vue';
+
+const basics = useBasics();
+const crosschainHistory = getCrosschainHistory();
+
+const isOpen = Vue.ref(false);
+
+const knownSourceIdentities = Vue.computed(() => {
+  return getKnownCrosschainSourceIdentities();
+});
+
+function openOverlay(): void {
+  isOpen.value = true;
+  basics.overlayIsOpen = true;
+  void crosschainHistory.refresh();
+}
+
+function closeOverlay(): void {
+  isOpen.value = false;
+  basics.overlayIsOpen = false;
+}
+
+Vue.onMounted(() => {
+  basicEmitter.on('openCrosschainHistoryOverlay', openOverlay);
+});
+
+Vue.onBeforeUnmount(() => {
+  basicEmitter.off('openCrosschainHistoryOverlay', openOverlay);
+});
+</script>

--- a/src-vue/overlays/EthereumSyncPopover.vue
+++ b/src-vue/overlays/EthereumSyncPopover.vue
@@ -66,10 +66,10 @@
             <div class="text-gray-500">Ethereum Block</div>
             <div class="font-mono font-light">{{ formatBigInt(ethereumSyncState?.latestEthereumBlockNumber) }}</div>
 
-            <div class="text-gray-500">Execution Anchor Gap</div>
+            <div class="text-gray-500">Execution Anchor Lag</div>
             <div class="font-mono font-light">{{ formatBigInt(executionBlockLag) }}</div>
 
-            <div class="text-gray-500">Gateway Nonce Gap</div>
+            <div class="text-gray-500">Gateway Activity Lag</div>
             <div class="font-mono font-light">{{ formatBigInt(ethereumSyncState?.gatewayActivityNonceGap) }}</div>
 
             <div class="text-gray-500">Last Error</div>

--- a/src-vue/overlays/GatewayRelayOverlay.vue
+++ b/src-vue/overlays/GatewayRelayOverlay.vue
@@ -7,7 +7,7 @@
     @pressEsc="closeOverlay"
     class="w-[620px]">
     <template #title>
-      <div class="grow text-2xl font-bold">Relay Pending Gateway Activities</div>
+      <div class="grow text-2xl font-bold">Relay Gateway Updates</div>
     </template>
 
     <div class="px-6 py-5 text-slate-700">
@@ -16,7 +16,7 @@
       </div>
 
       <div v-else-if="loadError" class="space-y-4">
-        <div class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ loadError }}
         </div>
 
@@ -32,15 +32,21 @@
 
       <div v-else-if="preview" class="space-y-5">
         <p class="text-sm leading-6 text-slate-500">
-          This sends ready Ethereum gateway updates using your Ethereum wallet. Collect still records council approvals and collateralizes transfers separately; this step is only for the outbound Ethereum relay.
+          This publishes signed minting-authority and council updates to the Ethereum gateway. Transfers that are ready on Argon are submitted separately by their sending wallets.
         </p>
 
-        <div v-if="submitSuccessHash" class="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+        <div v-if="readyTransferCount" class="rounded-md border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          {{ readyTransferCount }} outbound transfer{{ readyTransferCount === 1 ? ' is' : 's are' }} ready on Argon and waiting for
+          {{ readyTransferCount === 1 ? 'its' : 'their' }} sending wallet{{ readyTransferCount === 1 ? '' : 's' }} to submit
+          {{ readyTransferCount === 1 ? 'it' : 'them' }} on Ethereum. {{ readyTransferCount === 1 ? 'It is' : 'They are' }} not a gateway update relayed by this action.
+        </div>
+
+        <div v-if="submitSuccessHash" class="border-argon-100 bg-argon-20 text-argon-800 rounded-md border px-4 py-3 text-sm">
           Gateway activities were relayed to Ethereum in transaction
           <span class="font-mono">{{ submitSuccessHash }}</span>.
         </div>
 
-        <div v-if="submitError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div v-if="submitError" class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ submitError }}
         </div>
 
@@ -58,14 +64,21 @@
             <div class="flex items-center justify-between gap-4 px-4 py-3">
               <dt class="text-sm text-slate-500">Current ETH balance</dt>
               <dd class="text-sm font-semibold text-slate-800">
-                {{ formatEth(preview.ethereumBalanceWei) }} ETH
+                {{ formatEvmNativeFeeWei(preview.ethereumBalanceWei) }} ETH
               </dd>
             </div>
 
             <div class="flex items-center justify-between gap-4 px-4 py-3">
-              <dt class="text-sm text-slate-500">Ready gateway activities</dt>
+              <dt class="text-sm text-slate-500">Ready gateway updates</dt>
               <dd class="text-sm font-semibold text-slate-800">
                 {{ preview.updateCount }}
+              </dd>
+            </div>
+
+            <div v-if="awaitingCouncilQuorumCount" class="flex items-center justify-between gap-4 px-4 py-3">
+              <dt class="text-sm text-slate-500">Waiting for council quorum</dt>
+              <dd class="text-sm font-semibold text-slate-800">
+                {{ awaitingCouncilQuorumCount }}
               </dd>
             </div>
 
@@ -97,21 +110,25 @@
             <div class="flex items-center justify-between gap-4 px-4 py-3">
               <dt class="text-sm text-slate-500">Estimated network fee</dt>
               <dd class="text-sm font-semibold text-slate-800">
-                {{ preview.feeEstimateWei != null ? `${formatEth(preview.feeEstimateWei)} ETH` : 'Not available' }}
+                {{
+                  preview.feeEstimateWei != null
+                    ? `${formatEvmNativeFeeWei(preview.feeEstimateWei)} ETH`
+                    : 'Not available'
+                }}
               </dd>
             </div>
 
             <div class="flex items-center justify-between gap-4 px-4 py-3">
               <dt class="text-sm text-slate-500">Expected repayment on Argon</dt>
               <dd class="text-sm font-semibold text-slate-800">
-                {{ microgonToArgonNm(preview.expectedRepaymentMicrogons).format('0,0.[000000]') }} ARGN
+                {{ microgonToArgonNm(preview.expectedRepaymentMicrogons).format('0,0.[00]') }} ARGN
               </dd>
             </div>
 
             <div v-if="estimatedFeeMicrogons != null" class="flex items-center justify-between gap-4 px-4 py-3">
               <dt class="text-sm text-slate-500">Fee at current repayment pricing</dt>
               <dd class="text-sm font-semibold text-slate-800">
-                {{ microgonToArgonNm(estimatedFeeMicrogons).format('0,0.[000000]') }} ARGN
+                {{ microgonToArgonNm(estimatedFeeMicrogons).format('0,0.[00]') }} ARGN
               </dd>
             </div>
           </dl>
@@ -119,7 +136,7 @@
 
         <div
           class="rounded-md px-4 py-3 text-sm"
-          :class="preview.canRelay ? 'border border-emerald-200 bg-emerald-50 text-emerald-800' : 'border border-amber-200 bg-amber-50 text-amber-800'">
+          :class="preview.canRelay ? 'border border-argon-100 bg-argon-20 text-argon-800' : 'border border-slate-300 bg-slate-50 text-slate-700'">
           {{ previewMessage }}
         </div>
 
@@ -199,7 +216,11 @@ const previewMessage = Vue.computed(() => {
   }
 
   if (preview.value.reason === 'noReadyUpdates') {
-    return 'No pending gateway activities are ready to relay right now.';
+    if (awaitingCouncilQuorumCount.value) {
+      return `${awaitingCouncilQuorumCount.value} gateway proposal${awaitingCouncilQuorumCount.value === 1 ? ' has' : 's have'} your signature but ${awaitingCouncilQuorumCount.value === 1 ? 'is' : 'are'} still waiting for council quorum.`;
+    }
+
+    return 'No signed gateway updates are ready to publish to Ethereum right now.';
   }
 
   if (preview.value.reason === 'uncompensatedSharedBatch') {
@@ -208,14 +229,24 @@ const previewMessage = Vue.computed(() => {
 
   if (preview.value.reason === 'insufficientBalance') {
     const missingWei = (preview.value.feeEstimateWei ?? 0n) - preview.value.ethereumBalanceWei;
-    return `This wallet needs about ${formatEth(missingWei)} more ETH to cover this relay.`;
+    return `This wallet needs about ${formatEvmNativeFeeWei(missingWei)} more ETH to cover this relay.`;
   }
 
   if (preview.value.reason === 'repaymentTooLow') {
     return 'At current repayment pricing, this relay would cost more in Ethereum fees than the expected Argon repayment.';
   }
 
-  return 'No pending gateway activities are ready to relay right now.';
+  return 'No signed gateway updates are ready to publish to Ethereum right now.';
+});
+
+const readyTransferCount = Vue.computed(() => {
+  return myVault.mintingAuthorities.data.backedTransfers.filter(transfer => transfer.status === 'readyForEthereum')
+    .length;
+});
+
+const awaitingCouncilQuorumCount = Vue.computed(() => {
+  return myVault.globalCouncil.data.approvalQueue.filter(approval => approval.status === 'awaitingCouncilQuorum')
+    .length;
 });
 
 async function loadPreview() {
@@ -262,10 +293,6 @@ async function submitRelay() {
 
 function closeOverlay() {
   isOpen.value = false;
-}
-
-function formatEth(valueWei: bigint) {
-  return formatEvmNativeFeeWei(valueWei);
 }
 
 basicEmitter.on('openGatewayRelayOverlay', () => {

--- a/src-vue/overlays/MintingAuthorityRequestOverlay.vue
+++ b/src-vue/overlays/MintingAuthorityRequestOverlay.vue
@@ -32,7 +32,7 @@
           {{ progressMessage }}
         </div>
 
-        <div v-if="progressError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div v-if="progressError" class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ progressError }}
         </div>
 
@@ -54,7 +54,7 @@
       </div>
 
       <div v-else-if="loadError" class="space-y-4">
-        <div class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ loadError }}
         </div>
 
@@ -76,33 +76,33 @@
 
         <div
           v-if="relayDelegateNeedsSetup"
-          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
+          class="rounded-lg border border-slate-300 bg-slate-50 px-4 py-4">
           <div class="flex items-start justify-between gap-4">
             <div class="grow">
-              <div class="text-sm font-semibold text-amber-900">Relay Delegate Needs Setup</div>
-              <div class="mt-1 text-sm leading-6 text-amber-800">
+              <div class="text-sm font-semibold text-slate-800">Relay Delegate Needs Setup</div>
+              <div class="mt-1 text-sm leading-6 text-slate-600">
                 Your server can't send Ethereum relays for this vault yet because the relay delegate isn't set up.
               </div>
 
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Current Balance</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Current Balance</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
 
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Minimum Balance</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Minimum Balance</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
 
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Setup Funding</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(targetVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Setup Funding</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(targetVaultDelegateBalance).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
               </div>
@@ -122,34 +122,34 @@
 
         <div
           v-else-if="relayDelegateTopUpAmount > 0n"
-          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-4">
+          class="rounded-lg border border-slate-300 bg-slate-50 px-4 py-4">
           <div class="flex items-start justify-between gap-4">
             <div class="grow">
-              <div class="text-sm font-semibold text-amber-900">Relay Delegate Needs Funds</div>
-              <div class="mt-1 text-sm leading-6 text-amber-800">
+              <div class="text-sm font-semibold text-slate-800">Relay Delegate Needs Funds</div>
+              <div class="mt-1 text-sm leading-6 text-slate-600">
                 Your server's relay delegate is low on funds. Top it up here so your server can keep sending Ethereum
                 relays for this vault.
               </div>
 
               <div class="mt-4 grid grid-cols-3 gap-3 text-sm">
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Current Balance</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Current Balance</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(relayDelegateBalance).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
 
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Minimum Balance</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Minimum Balance</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(minimumVaultDelegateBalance).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
 
-                <div class="rounded-md border border-amber-200 bg-white/70 px-3 py-2">
-                  <div class="text-xs font-semibold uppercase tracking-wide text-amber-700">Top-Up Needed</div>
-                  <div class="mt-1 font-semibold text-amber-950">
-                    {{ microgonToArgonNm(relayDelegateTopUpAmount).format('0,0.[000000]') }} ARGN
+                <div class="rounded-md border border-slate-200 bg-white px-3 py-2">
+                  <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">Top-Up Needed</div>
+                  <div class="mt-1 font-semibold text-slate-800">
+                    {{ microgonToArgonNm(relayDelegateTopUpAmount).format('0,0.[00]') }} ARGN
                   </div>
                 </div>
               </div>
@@ -175,12 +175,12 @@
             </div>
           </div>
 
-          <div class="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
-            <div class="text-xs font-semibold uppercase tracking-wide text-emerald-700">New authority signing key</div>
-            <div class="mt-1 text-sm font-semibold text-emerald-900">
+          <div class="border-argon-100 bg-argon-20 rounded-lg border px-4 py-3">
+            <div class="text-argon-700 text-xs font-semibold uppercase tracking-wide">New authority signing key</div>
+            <div class="text-argon-900 mt-1 text-sm font-semibold">
               {{ nextAuthorityIndex != null ? `Signer #${nextAuthorityIndex}` : 'Preparing signer...' }}
             </div>
-            <div class="mt-2 break-all font-mono text-sm text-emerald-800">
+            <div class="text-argon-800 mt-2 break-all font-mono text-sm">
               {{ nextAuthoritySigner || 'Loading a fresh minting-authority signer...' }}
             </div>
           </div>
@@ -228,14 +228,14 @@
                 <div>
                   <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">ARGN</div>
                   <div class="mt-1 font-semibold text-slate-800">
-                    {{ microgonToArgonNm(authority.microgonCollateral).format('0,0.[000000]') }}
+                    {{ microgonToArgonNm(authority.microgonCollateral).format('0,0.[00]') }}
                   </div>
                 </div>
 
                 <div>
                   <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">ARGNOT</div>
                   <div class="mt-1 font-semibold text-slate-800">
-                    {{ micronotToArgonotNm(authority.micronotCollateral).format('0,0.[000000]') }}
+                    {{ micronotToArgonotNm(authority.micronotCollateral).format('0,0.[00]') }}
                   </div>
                 </div>
               </div>
@@ -247,28 +247,36 @@
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Epoch Argonot Conversion</div>
             <div class="mt-1 text-lg font-semibold text-slate-800">
-              {{ microgonToArgonNm(epochMicrogonsPerArgonot).format('0,0.[000000]') }} ARGN / ARGNOT
+              {{ microgonToArgonNm(epochMicrogonsPerArgonot).format('0,0.[00]') }} ARGN / ARGNOT
             </div>
           </div>
 
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Minimum request value</div>
             <div class="mt-1 text-lg font-semibold text-slate-800">
-              {{ microgonToArgonNm(minimumRequiredMicrogons).format('0,0.[000000]') }} ARGN
+              {{ microgonToArgonNm(minimumRequiredMicrogons).format('0,0.[00]') }} ARGN
             </div>
           </div>
 
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Bond-backed ARGN available</div>
             <div class="mt-1 text-lg font-semibold text-slate-800">
-              {{ microgonToArgonNm(remainingBondMicrogons).format('0,0.[000000]') }} ARGN
+              {{ microgonToArgonNm(remainingBondMicrogons).format('0,0.[00]') }} ARGN
             </div>
           </div>
 
           <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Committed ARGNOT available</div>
-            <div class="mt-1 text-lg font-semibold text-slate-800">
-              {{ micronotToArgonotNm(remainingCommittedMicronots).format('0,0.[000000]') }} ARGNOT
+            <div class="mt-1 flex items-end justify-between gap-3">
+              <div class="text-lg font-semibold text-slate-800">
+                {{ micronotToArgonotNm(remainingCommittedMicronots).format('0,0.[00]') }} ARGNOT
+              </div>
+              <button
+                type="button"
+                class="text-argon-600 hover:text-argon-800 cursor-pointer text-xs font-semibold"
+                @click="openCommitment">
+                Manage
+              </button>
             </div>
           </div>
         </div>
@@ -314,7 +322,7 @@
           <div class="mt-4 rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
             <div class="text-xs font-semibold uppercase tracking-wide text-slate-400">Total request value</div>
             <div class="mt-1 text-2xl font-semibold text-slate-800">
-              {{ microgonToArgonNm(requestValueMicrogons).format('0,0.[000000]') }} ARGN
+              {{ microgonToArgonNm(requestValueMicrogons).format('0,0.[00]') }} ARGN
             </div>
             <div class="mt-1 text-xs text-slate-500">
               This combines your direct bond-backed ARGN with committed ARGNOT converted at the current council value.
@@ -322,17 +330,17 @@
           </div>
         </div>
 
-        <div v-if="validationMessage" class="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+        <div v-if="validationMessage" class="border-argon-100 bg-argon-20 text-argon-800 rounded-md border px-4 py-3 text-sm">
           {{ validationMessage }}
         </div>
 
         <div
           v-if="activationRelayError"
-          class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ activationRelayError }}
         </div>
 
-        <div v-if="submitError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div v-if="submitError" class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ submitError }}
         </div>
 
@@ -460,19 +468,24 @@ const validationMessage = Vue.computed(() => {
     return 'No bond-backed Argons or committed Argonots are currently available for a minting authority request.';
   }
   if (maximumRequestValueMicrogons.value < minimumRequiredMicrogons.value) {
-    return `Available collateral totals ${microgonToArgonNm(maximumRequestValueMicrogons.value).format('0,0.[000000]')} ARGN, which is below the ${microgonToArgonNm(minimumRequiredMicrogons.value).format('0,0.[000000]')} ARGN minimum.`;
+    return `Available collateral totals ${microgonToArgonNm(maximumRequestValueMicrogons.value).format('0,0.[00]')} ARGN, which is below the ${microgonToArgonNm(minimumRequiredMicrogons.value).format('0,0.[00]')} ARGN minimum.`;
   }
   if (requestValueMicrogons.value <= 0n) {
     return 'Add bond-backed ARGN, committed ARGNOT, or both.';
   }
   if (requestValueMicrogons.value < minimumRequiredMicrogons.value) {
-    return `Minting authority collateral must be at least ${microgonToArgonNm(minimumRequiredMicrogons.value).format('0,0.[000000]')} ARGN in total value.`;
+    return `Minting authority collateral must be at least ${microgonToArgonNm(minimumRequiredMicrogons.value).format('0,0.[00]')} ARGN in total value.`;
   }
   return '';
 });
 
 function closeOverlay() {
   isOpen.value = false;
+}
+
+function openCommitment() {
+  closeOverlay();
+  basicEmitter.emit('openArgonotCommitmentOverlay');
 }
 
 function resetProgress() {

--- a/src-vue/overlays/OverlayBase.vue
+++ b/src-vue/overlays/OverlayBase.vue
@@ -67,7 +67,7 @@
                 </span>
               </h2>
               <div :class="props.overflowScroll ? 'min-h-0 overflow-y-auto overflow-x-hidden' : ''" class="grow flex flex-col">
-                <slot />
+                <slot :floatingZIndex="getFloatingZIndex(overlayZIndex.contentZIndex)" />
               </div>
             </div>
           </Motion>
@@ -85,7 +85,7 @@ import { AnimatePresence, Motion, MotionGlobalConfig } from 'motion-v';
 import { ChevronLeftIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import BgOverlay from '../components/BgOverlay.vue';
 import Draggable from './helpers/Draggable.ts';
-import { provideOverlayContentZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
+import { getFloatingZIndex, provideOverlayContentZIndex, useOverlayZIndex } from './helpers/OverlayZIndex.ts';
 
 defineOptions({
   inheritAttrs: false,

--- a/src-vue/overlays/TransactionsOverlay.vue
+++ b/src-vue/overlays/TransactionsOverlay.vue
@@ -164,6 +164,7 @@ function transactionLabel(transaction: ITransactionRecord): string {
       const metadata = transaction.metadataJson as IVaultCollectMetadata;
       if (metadata.actionType === 'collectRevenue') return 'Collected Vault Revenue';
       if (metadata.actionType === 'cosignBitcoin') return 'Cosigned Bitcoin Locks';
+      if (metadata.actionType === 'approveCouncil') return 'Approved Gateway Changes';
       return 'Processed Vault Actions';
     }
     case ExtrinsicType.VaultSetCommittedArgonots:
@@ -212,7 +213,7 @@ function transactionLabel(transaction: ITransactionRecord): string {
     case ExtrinsicType.CrosschainTransferTransferOut:
       return 'Sent to Ethereum';
     case ExtrinsicType.CrosschainTransferApproveCouncil:
-      return 'Approved Ethereum Transfer';
+      return 'Approved Gateway Change';
     case ExtrinsicType.CrosschainTransferAuthorize:
       return 'Authorized Ethereum Transfer';
     case ExtrinsicType.CrosschainTransferRegisterMintingAuthority:

--- a/src-vue/overlays/VaultCollectOverlay.vue
+++ b/src-vue/overlays/VaultCollectOverlay.vue
@@ -6,7 +6,8 @@
     :title="overlayTitle"
     @close="closeOverlay"
     class="">
-    <div box class="flex flex-col gap-y-6 px-5 py-3">
+    <template #default="{ floatingZIndex }">
+      <div box class="flex flex-col gap-y-6 px-5 py-3">
       <div
         v-if="!showCollectSection && !showMintingAuthorizeSection"
         class="rounded-md border border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-600">
@@ -74,14 +75,67 @@
           <p>
             <template v-if="collectRevenue || manualPendingCosignCount">This transaction will also record </template>
             <template v-else>The next transaction will record </template>
-            <strong>
+            <PopoverRoot v-if="myVault.globalCouncil.data.pendingApprovals.length" as="span">
+              <PopoverTrigger as-child>
+                <button
+                  type="button"
+                  class="focus-visible:ring-argon-500 inline cursor-pointer appearance-none rounded-sm bg-transparent p-0 text-left text-inherit underline decoration-dotted underline-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1">
+                  <strong>
+                    {{ councilApprovalCount }} council approval{{ councilApprovalCount === 1 ? '' : 's' }}
+                  </strong>
+                </button>
+              </PopoverTrigger>
+              <PopoverPortal>
+                <PopoverContent
+                  side="top"
+                  align="center"
+                  :sideOffset="10"
+                  :collisionPadding="24"
+                  :avoidCollisions="true"
+                  :style="{ zIndex: floatingZIndex }"
+                  class="relative w-[min(520px,calc(100vw-2rem))] rounded-lg border border-gray-300 bg-white text-left text-sm text-slate-700 shadow-lg">
+                  <PopoverPanelArrow />
+                  <div class="max-h-[min(420px,calc(100vh-3rem))] overflow-y-auto px-5 py-4">
+                    <h2 class="mb-3 text-lg font-bold text-slate-800">Pending Ethereum Gateway Updates</h2>
+                    <div class="flex flex-col gap-3">
+                      <div
+                        v-for="approval in myVault.globalCouncil.data.pendingApprovals"
+                        :key="approval.approvalHash"
+                        class="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+                        <div class="font-semibold text-slate-800">
+                          {{ formatCouncilTarget(approval.targetKind) }}
+                        </div>
+                        <CrosschainActivityDetails
+                          class="mt-3"
+                          :queueNonce="approval.queueNonce"
+                          :targetKind="approval.targetKind"
+                          :targetValue="approval.targetKind === 'globalIssuanceCouncilRotation'
+                            ? approval.targetCouncilHash
+                            : approval.targetSigningKey"
+                          :authorityOwnerAccount="approval.targetKind === 'globalIssuanceCouncilRotation'
+                            ? undefined
+                            : approval.authorityOwnerAccount"
+                          :authorityOwnerIdentity="approval.targetKind === 'globalIssuanceCouncilRotation' || !approval.authorityOwnerAccount
+                            ? undefined
+                            : getSourceIdentity(approval.authorityOwnerAccount)"
+                          :councilChange="approval.targetKind === 'globalIssuanceCouncilRotation'
+                            ? approval.councilChange
+                            : undefined"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </PopoverPortal>
+            </PopoverRoot>
+            <strong v-else>
               {{ councilApprovalCount }} council approval{{ councilApprovalCount === 1 ? '' : 's' }}
             </strong>
             for pending Ethereum gateway updates.
           </p>
         </div>
 
-        <div v-if="collectError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div v-if="collectError" class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ collectError }}
         </div>
 
@@ -131,7 +185,50 @@
 
           <p v-else-if="mintingAuthorizeOpportunityCount > 0" class="mt-2 text-sm text-slate-600">
             You have
-            <strong>
+            <PopoverRoot v-if="myVault.mintingAuthorities.data.pendingMintingAuthorizations.length" as="span">
+              <PopoverTrigger as-child>
+                <button
+                  type="button"
+                  class="focus-visible:ring-argon-500 inline cursor-pointer appearance-none rounded-sm bg-transparent p-0 text-left text-inherit underline decoration-dotted underline-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1">
+                  <strong>
+                    {{ mintingAuthorizeOpportunityCount }} crosschain authorization{{ mintingAuthorizeOpportunityCount === 1 ? '' : 's' }}
+                  </strong>
+                </button>
+              </PopoverTrigger>
+              <PopoverPortal>
+                <PopoverContent
+                  side="top"
+                  align="center"
+                  :sideOffset="10"
+                  :collisionPadding="24"
+                  :avoidCollisions="true"
+                  :style="{ zIndex: floatingZIndex }"
+                  class="relative w-[min(560px,calc(100vw-2rem))] rounded-lg border border-gray-300 bg-white text-left text-sm text-slate-700 shadow-lg">
+                  <PopoverPanelArrow />
+                  <div class="max-h-[min(480px,calc(100vh-3rem))] overflow-y-auto px-5 py-4">
+                    <h2 class="mb-3 text-lg font-bold text-slate-800">Crosschain Authorizations</h2>
+                    <div class="flex flex-col gap-3">
+                      <div
+                        v-for="authorization in myVault.mintingAuthorities.data.pendingMintingAuthorizations"
+                        :key="authorization.transferId"
+                        class="rounded-md border border-slate-200 bg-slate-50 px-4 py-3">
+                        <CrosschainTransferDetails
+                          :transfer="authorization"
+                          :sourceIdentity="getSourceIdentity(authorization.sourceAccount)"
+                          :sourceTotals="getSourceTotals(authorization.sourceAccount)"
+                          :recipientSeen="crosschainHistory.hasSeenRecipient(
+                            authorization.finalizeRequest.recipient,
+                            authorization.transferId,
+                          )"
+                          progress="Waiting for your minting-authority signature"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </PopoverPortal>
+            </PopoverRoot>
+            <strong v-else>
               {{ mintingAuthorizeOpportunityCount }} crosschain authorization{{ mintingAuthorizeOpportunityCount === 1 ? '' : 's' }}
             </strong>
             ready on Argon
@@ -150,11 +247,11 @@
 
         <div
           v-if="mintingAuthorizeUpdateMessage"
-          class="rounded-md border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-700">
+          class="border-argon-100 bg-argon-20 text-argon-800 rounded-md border px-4 py-3 text-sm">
           {{ mintingAuthorizeUpdateMessage }}
         </div>
 
-        <div v-if="mintingAuthorizeError" class="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div v-if="mintingAuthorizeError" class="border-argon-error/30 bg-argon-error/5 text-argon-error rounded-md border px-4 py-3 text-sm">
           {{ mintingAuthorizeError }}
         </div>
 
@@ -181,7 +278,8 @@
           </div>
         </div>
       </section>
-    </div>
+      </div>
+    </template>
   </OverlayBase>
 </template>
 
@@ -189,14 +287,20 @@
 import * as Vue from 'vue';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import { MoveTo } from '@argonprotocol/apps-core';
+import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui';
 import CountdownClock from '../components/CountdownClock.vue';
-import { getMyVault } from '../stores/vaults.ts';
+import CrosschainActivityDetails from '../components/CrosschainActivityDetails.vue';
+import CrosschainTransferDetails from '../components/CrosschainTransferDetails.vue';
+import PopoverPanelArrow from '../components/PopoverPanelArrow.vue';
+import { getCrosschainHistory, getKnownCrosschainSourceIdentities, getMyVault } from '../stores/vaults.ts';
 import { getCurrency } from '../stores/currency.ts';
 import { createNumeralHelpers } from '../lib/numeral.ts';
+import { formatCouncilTarget } from '../lib/CrosschainTransferView.ts';
 import ProgressBar from '../components/ProgressBar.vue';
 import OverlayBase from './OverlayBase.vue';
-import { MoveTo } from '@argonprotocol/apps-core';
-import { TransactionInfo } from '../lib/TransactionInfo.ts';
+import { getActiveTransactionInfos, trackTransactionProgress } from '../lib/TransactionProgress.ts';
+import type { TransactionInfo } from '../lib/TransactionInfo.ts';
 import type { IMintingAuthorityAuthorizeMetadata } from '../lib/MintingAuthorities.ts';
 import type { IVaultCollectMetadata } from '../lib/VaultCollectBuilder.ts';
 
@@ -207,10 +311,19 @@ const emit = defineEmits<{
 }>();
 
 const myVault = getMyVault();
+const crosschainHistory = getCrosschainHistory();
 const currency = getCurrency();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 
+const knownSourceIdentities = Vue.computed(() => {
+  return getKnownCrosschainSourceIdentities();
+});
+
 const isOpen = Vue.ref(true);
+
+Vue.onMounted(() => {
+  void crosschainHistory.refresh();
+});
 
 const collectRevenue = Vue.ref(0n);
 const councilApprovalCount = Vue.ref(0);
@@ -253,11 +366,11 @@ const activeCollectTxInfos = Vue.computed(() => {
     txInfos.push(pendingBitcoinCosignTxInfo);
   }
 
-  return getUniqueTransactionInfos(txInfos);
+  return getActiveTransactionInfos(txInfos);
 });
 
 const activeMintingAuthorizeTxInfos = Vue.computed(() => {
-  return getUniqueTransactionInfos([
+  return getActiveTransactionInfos([
     ...myVault.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.values(),
   ]) as TransactionInfo<IMintingAuthorityAuthorizeMetadata>[];
 });
@@ -361,6 +474,14 @@ const mintingAuthorizeButtonLabel = Vue.computed(() => {
 function closeOverlay() {
   isOpen.value = false;
   emit('close');
+}
+
+function getSourceIdentity(accountId: string) {
+  return knownSourceIdentities.value.get(accountId);
+}
+
+function getSourceTotals(accountId: string) {
+  return myVault.mintingAuthorities.data.sourceTotalsByAccount.get(accountId);
 }
 
 function syncNoticeState() {
@@ -499,86 +620,6 @@ function maybeCloseOverlay() {
   ) {
     closeOverlay();
   }
-}
-
-function trackTransactionProgress(args: {
-  txInfos: TransactionInfo[];
-  isSubmitting: Vue.Ref<boolean>;
-  progressPct: Vue.Ref<number>;
-  progressLabel: Vue.Ref<string>;
-  activeTransactionCount: Vue.Ref<number>;
-  error: Vue.Ref<string>;
-  onIdle: () => void;
-  onCleanup: (cleanupFn: () => void) => void;
-}) {
-  const { txInfos, isSubmitting, progressPct, progressLabel, activeTransactionCount, error, onIdle, onCleanup } = args;
-
-  if (txInfos.length > 0) {
-    const progressByTxId = new Map(
-      txInfos.map(txInfo => [
-        txInfo.tx.id,
-        {
-          progressPct: 0,
-          progressMessage: 'Preparing transaction...',
-        },
-      ]),
-    );
-
-    error.value = '';
-    isSubmitting.value = true;
-    activeTransactionCount.value = txInfos.length;
-
-    for (const txInfo of txInfos) {
-      const unsubscribe = txInfo.subscribeToProgress((progressArgs, progressError) => {
-        progressByTxId.set(txInfo.tx.id, {
-          progressPct: progressArgs.progressPct,
-          progressMessage: progressArgs.progressMessage,
-        });
-
-        const slowestProgress = Array.from(progressByTxId.values()).reduce((slowest, current) => {
-          if (!slowest || current.progressPct < slowest.progressPct) {
-            return current;
-          }
-          return slowest;
-        });
-
-        progressPct.value = slowestProgress?.progressPct ?? 0;
-        progressLabel.value =
-          txInfos.length > 1
-            ? `${slowestProgress?.progressMessage ?? 'Preparing transaction...'} (${txInfos.length} transactions in progress)`
-            : (slowestProgress?.progressMessage ?? '');
-
-        if (progressError) {
-          error.value = progressError.message;
-        }
-      });
-      onCleanup(unsubscribe);
-    }
-
-    return;
-  }
-
-  activeTransactionCount.value = 0;
-  if (!isSubmitting.value) {
-    return;
-  }
-
-  isSubmitting.value = false;
-  progressPct.value = 0;
-  progressLabel.value = '';
-  onIdle();
-}
-
-function getUniqueTransactionInfos(txInfos: TransactionInfo[]) {
-  const uniqueTxInfos = new Map<number, TransactionInfo>();
-  for (const txInfo of txInfos) {
-    if (txInfo.isPostProcessed) {
-      continue;
-    }
-    uniqueTxInfos.set(txInfo.tx.id, txInfo);
-  }
-
-  return [...uniqueTxInfos.values()].sort((left, right) => left.tx.createdAt.getTime() - right.tx.createdAt.getTime());
 }
 
 function getCollectActionTitle(actionType?: IVaultCollectMetadata['actionType']) {

--- a/src-vue/overlays/helpers/OverlayZIndex.ts
+++ b/src-vue/overlays/helpers/OverlayZIndex.ts
@@ -72,11 +72,15 @@ export function provideOverlayContentZIndex(contentZIndex: Vue.Ref<number> | Vue
   Vue.provide(overlayContentZIndexKey, contentZIndex);
 }
 
+export function getFloatingZIndex(parentOverlayContentZIndex?: number, offset = 1) {
+  const rootFloatingZIndex = ROOT_FLOATING_Z_INDEX + Math.max(offset - 1, 0);
+  return parentOverlayContentZIndex ? parentOverlayContentZIndex + offset : rootFloatingZIndex;
+}
+
 export function useFloatingZIndex(offset = 1) {
   const parentOverlayContentZIndex = Vue.inject(overlayContentZIndexKey, undefined);
-  const rootFloatingZIndex = ROOT_FLOATING_Z_INDEX + Math.max(offset - 1, 0);
 
   return Vue.computed(() => ({
-    zIndex: parentOverlayContentZIndex ? parentOverlayContentZIndex.value + offset : rootFloatingZIndex,
+    zIndex: getFloatingZIndex(parentOverlayContentZIndex?.value, offset),
   }));
 }

--- a/src-vue/screens/CrosschainTransfers.vue
+++ b/src-vue/screens/CrosschainTransfers.vue
@@ -1,0 +1,37 @@
+<!-- prettier-ignore -->
+<template>
+  <div data-testid="CrosschainTransfersScreen" class="h-full">
+    <Dashboard v-if="accessState.hasAccess" />
+    <div v-else class="flex h-full flex-col items-center justify-center">
+      <div class="text-2xl font-bold text-slate-600/40 uppercase">Loading...</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { TopTab } from '../interfaces/IConfig.ts';
+import { getCrosschainAccessState } from '../lib/CrosschainTransferView.ts';
+import { useCertificationController } from '../stores/certificationController.ts';
+import { getConfig } from '../stores/config.ts';
+import { getMyVault } from '../stores/vaults.ts';
+import Dashboard from './crosschain-transfers-screen/Dashboard.vue';
+
+const controller = useCertificationController();
+const config = getConfig();
+const myVault = getMyVault();
+const accessState = Vue.computed(() =>
+  getCrosschainAccessState({
+    hasActivatedCrosschain: config.hasActivatedCrosschain,
+    authorityCount: myVault.mintingAuthorities.data.authorities.length,
+    councilSigner: myVault.globalCouncil.data.councilSigner,
+  }),
+);
+
+Vue.onMounted(async () => {
+  await myVault.load();
+  if (!accessState.value.hasAccess) {
+    controller.setTab(TopTab.Vaulting);
+  }
+});
+</script>

--- a/src-vue/screens/crosschain-transfers-screen/Dashboard.vue
+++ b/src-vue/screens/crosschain-transfers-screen/Dashboard.vue
@@ -1,0 +1,950 @@
+<!-- prettier-ignore -->
+<template>
+  <div data-testid="CrosschainTransfersDashboard" class="flex h-full min-h-0 grow flex-col gap-y-2 overflow-y-auto pr-2.5">
+    <section class="flex h-[14%] min-h-24 shrink-0 flex-row gap-x-2">
+      <Tooltip :asChild="true">
+        <div box stat-box class="flex w-1/5 cursor-help flex-col">
+          <span>₳{{ formatCapacity(remainingMintingAuthority.valueMicrogons) }}</span>
+          <label>Remaining Minting Authority</label>
+        </div>
+        <template #content>
+          <div class="space-y-1">
+            <div>{{ formatArgon(remainingMintingAuthority.microgons) }} ARGN remaining</div>
+            <div>{{ formatArgonot(remainingMintingAuthority.micronots) }} ARGNOT remaining</div>
+            <div class="text-xs text-slate-500">
+              {{ formatArgon(mintingAuthorityValuationRate) }} ARGN per ARGNOT transfer-out quote
+            </div>
+          </div>
+        </template>
+      </Tooltip>
+      <Tooltip
+        :asChild="true"
+        content="Deduplicated ARGN-equivalent value of transfer requests you authorized, using the current transfer-out quote."
+      >
+        <div box stat-box class="flex w-1/5 cursor-help flex-col">
+          <span>₳{{ formatCapacity(sponsoredTransferValue) }}</span>
+          <label>Transfer Value Sponsored</label>
+        </div>
+      </Tooltip>
+      <Tooltip :asChild="true" content="Transfer authorizations and council approvals recovered for this wallet.">
+        <div box stat-box class="flex w-1/5 cursor-help flex-col">
+          <span>{{ totalSigned.toLocaleString() }}</span>
+          <label>Total Signed</label>
+        </div>
+      </Tooltip>
+      <Tooltip :asChild="true" content="Transfer-authorization rewards recovered from your signing history, before fees.">
+        <div box stat-box class="flex w-1/5 cursor-help flex-col">
+          <span>₳{{ formatArgon(historicalRewardsEarned) }}</span>
+          <label>Rewards Earned</label>
+        </div>
+      </Tooltip>
+      <Tooltip :asChild="true" content="Rewards offered by transfer requests currently available to your minting authorities.">
+        <div box stat-box class="flex w-1/5 cursor-help flex-col">
+          <span>₳{{ formatArgon(availableRewards) }}</span>
+          <label>Rewards Available</label>
+        </div>
+      </Tooltip>
+    </section>
+
+    <section box class="flex shrink-0 flex-col px-2">
+      <header class="flex items-center border-b border-slate-400/30 px-2 py-2">
+        <div class="grow">
+          <div class="text-xl font-bold text-slate-900/80">Crosschain Transfers</div>
+        </div>
+
+        <div class="flex items-center gap-x-3 text-base font-light text-slate-700">
+          <button
+            type="button"
+            class="cursor-pointer hover:opacity-80"
+            @click="basicEmitter.emit('openMintingAuthorityRequestOverlay')">
+            Add Authority
+          </button>
+          <div class="h-5 w-px bg-slate-600/30" />
+          <EthereumSyncPopover position="top">
+            <span class="cursor-pointer hover:opacity-80">Sync Status</span>
+          </EthereumSyncPopover>
+        </div>
+      </header>
+
+      <div v-if="fundingError" class="border-argon-error/30 bg-argon-error/5 text-argon-error border-b px-4 py-2 text-sm">
+        {{ fundingError }}
+      </div>
+      <div
+        v-if="myVault.mintingAuthorities.data.backedTransfersError"
+        class="border-argon-error/30 bg-argon-error/5 text-argon-error border-b px-4 py-2 text-sm">
+        Current backed-transfer status could not be refreshed. Previously loaded rows may be out of date.
+      </div>
+
+      <div v-if="transferQueueRows.length">
+        <section>
+          <header class="flex items-center border-b border-slate-300/70 px-4 py-3">
+            <div class="grow">
+              <h2 class="font-semibold text-slate-800">Transfer Requests</h2>
+              <p class="text-sm text-slate-500">Choose which requests to fund with your minting authority.</p>
+            </div>
+            <button
+              v-if="fundableRows.length > 1"
+              type="button"
+              role="checkbox"
+              :aria-checked="selectedTransferIds.length > 0 && !allFundableRowsSelected ? 'mixed' : allFundableRowsSelected"
+              class="flex cursor-pointer items-center gap-x-2 text-sm text-slate-600 hover:text-slate-800"
+              @click="toggleAllFundableRows">
+              <Checkbox
+                :isChecked="allFundableRowsSelected"
+                :isPartiallyChecked="selectedTransferIds.length > 0 && !allFundableRowsSelected"
+                :size="4"
+              />
+              Select all
+            </button>
+          </header>
+
+          <details
+            v-for="row in transferQueueRows"
+            :key="row.key"
+            class="group border-b border-slate-200 last:border-b-0">
+            <summary class="flex cursor-pointer list-none items-center gap-x-4 px-4 py-3 hover:bg-slate-50">
+              <button
+                v-if="row.needsAction && row.transferId"
+                type="button"
+                role="checkbox"
+                :aria-checked="selectedTransferIds.includes(row.transferId)"
+                class="cursor-pointer"
+                title="Select this transfer request to fund"
+                @click.stop="toggleTransferSelection(row.transferId)">
+                <Checkbox :isChecked="selectedTransferIds.includes(row.transferId)" :size="4" />
+                <span class="sr-only">Select transfer {{ row.transferId }} to fund</span>
+              </button>
+              <div v-else class="flex w-4 shrink-0 justify-center" title="Your authorization is recorded">
+                <CheckCircleIcon class="-m-0.5 h-5 w-5 text-slate-400" />
+                <span class="sr-only">Your authorization is recorded</span>
+              </div>
+              <div class="min-w-0 grow">
+                <div class="flex items-center gap-x-2">
+                  <span class="font-semibold text-slate-800">{{ row.title }}</span>
+                  <span
+                    v-if="row.sourceIdentity"
+                    class="max-w-48 truncate rounded bg-slate-200/70 px-2 py-0.5 text-xs font-medium text-slate-600">
+                    {{ formatCrosschainSourceIdentity(row.sourceIdentity) }}
+                  </span>
+                </div>
+                <div class="mt-0.5 flex min-w-0 items-center gap-x-2 text-sm">
+                  <span class="text-slate-600">{{ row.status }}</span>
+                  <span class="text-slate-400">·</span>
+                  <span class="truncate text-slate-500">Waiting for {{ row.waitingFor }}</span>
+                </div>
+              </div>
+              <div v-if="row.amount !== undefined" class="shrink-0 text-right">
+                <div class="font-mono font-semibold text-slate-700">{{ formatTokenAmount(row.amount, row.moveToken) }}</div>
+                <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(row.reward ?? 0n) }} ARGN reward</div>
+              </div>
+              <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
+            </summary>
+
+            <div class="border-t border-dashed border-slate-200 bg-slate-50/70 px-10 py-4">
+              <CrosschainTransferDetails
+                v-if="row.transferDetails"
+                :transfer="row.transferDetails"
+                :sourceIdentity="row.sourceIdentity"
+                :sourceTotals="getSourceTotals(row.sourceAccount)"
+                :recipientSeen="getRecipientSeen(row)"
+                :progress="getTransferProgress(row)"
+                wide
+              />
+              <div v-else class="text-sm text-slate-600">Waiting for {{ row.waitingFor }}.</div>
+            </div>
+          </details>
+
+          <div
+            v-if="fundableRows.length || showFundingProgress"
+            class="flex items-center gap-x-4 border-t border-slate-300/70 px-4 py-2">
+            <template v-if="showFundingProgress">
+              <div class="grow text-sm font-medium text-slate-700">
+                Funding {{ fundingTransferCount }} selected transfer{{ fundingTransferCount === 1 ? '' : 's' }} on Argon...
+              </div>
+              <div
+                role="status"
+                aria-live="polite"
+                class="w-72 shrink-0">
+                <div :class="fundingError ? 'text-argon-error' : 'text-slate-500'" class="mb-1 truncate text-xs">
+                  {{ fundingError || fundingProgressLabel || 'Preparing transaction...' }}
+                </div>
+                <ProgressBar :progress="fundingProgressPct" :showLabel="false" class="h-4" />
+              </div>
+            </template>
+            <template v-else>
+              <div class="grow text-sm text-slate-500">
+                <template v-if="selectedAuthorizations.length">
+                  {{ formatArgon(selectedMicrogonCollateral) }} ARGN +
+                  {{ formatArgonot(selectedMicronotCollateral) }} ARGNOT collateral for
+                  {{ formatArgon(selectedRewardMicrogons) }} ARGN reward
+                </template>
+                <template v-else>Select one or more transfer requests to fund.</template>
+              </div>
+              <button
+                type="button"
+                class="bg-argon-button enabled:hover:bg-argon-button-hover rounded px-3 py-1.5 text-sm font-semibold whitespace-nowrap text-white enabled:cursor-pointer disabled:cursor-default disabled:opacity-40"
+                :disabled="!selectedAuthorizations.length"
+                @click="fundSelectedTransfers">
+                Fund Selected ({{ selectedAuthorizations.length }})
+              </button>
+            </template>
+          </div>
+        </section>
+
+      </div>
+
+      <div
+        v-else-if="!accessState.hasMintingAuthority"
+        class="flex min-h-32 flex-col items-center justify-center px-8 text-center text-slate-500">
+        <div class="text-lg font-semibold text-slate-600">No minting authority is registered</div>
+        <p class="mt-1 max-w-2xl text-sm">
+          A minting authority is required to fund transfer requests and earn authorization rewards. Use Add Authority
+          above to register one.
+        </p>
+      </div>
+
+      <div v-else class="flex min-h-32 flex-col items-center justify-center px-8 text-center text-slate-500">
+        <div class="text-lg font-semibold text-slate-600">No transfers are in progress</div>
+        <p class="mt-1 max-w-lg text-sm">
+          New transfer requests will appear here when they need funding or are still moving to Ethereum.
+        </p>
+      </div>
+    </section>
+
+    <section v-if="councilQueueRows.length" box class="shrink-0 px-2">
+      <header class="flex items-center border-b border-slate-300/70 px-4 py-3">
+        <div class="grow">
+          <h2 class="font-semibold text-slate-800">Global Council Approval Queue</h2>
+          <p class="text-sm text-slate-500">Gateway updates waiting for signatures, quorum, or Ethereum relay.</p>
+        </div>
+      </header>
+
+      <details
+        v-for="row in councilQueueRows"
+        :key="row.key"
+        class="group border-b border-slate-200 last:border-b-0">
+        <summary class="flex cursor-pointer list-none items-center gap-x-4 px-4 py-3 hover:bg-slate-50">
+          <div
+            v-if="row.needsAction"
+            role="checkbox"
+            aria-checked="true"
+            aria-disabled="true"
+            class="cursor-default opacity-40"
+            title="Included in this approval batch">
+            <Checkbox :isChecked="true" :size="4" />
+            <span class="sr-only">Included in this approval batch</span>
+          </div>
+          <div v-else class="flex w-4 shrink-0 justify-center" title="Your approval is recorded">
+            <CheckCircleIcon class="-m-0.5 h-5 w-5 text-slate-400" />
+            <span class="sr-only">Your approval is recorded</span>
+          </div>
+          <div class="min-w-0 grow">
+            <div class="flex items-center gap-x-2">
+              <span class="font-semibold text-slate-800">{{ row.title }}</span>
+              <span
+                v-if="row.authorityOwnerIdentity"
+                class="max-w-48 truncate rounded bg-slate-200/70 px-2 py-0.5 text-xs font-medium text-slate-600">
+                {{ formatCrosschainSourceIdentity(row.authorityOwnerIdentity) }}
+              </span>
+            </div>
+            <div class="mt-0.5 flex min-w-0 items-center gap-x-2 text-sm">
+              <span class="text-slate-600">{{ row.status }}</span>
+              <span class="text-slate-400">·</span>
+              <span class="truncate text-slate-500">Waiting for {{ row.waitingFor }}</span>
+            </div>
+          </div>
+          <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
+        </summary>
+
+        <div class="border-t border-dashed border-slate-200 bg-slate-50/70 px-10 py-4">
+          <CrosschainActivityDetails
+            :queueNonce="row.queueNonce"
+            :targetKind="row.targetKind"
+            :targetValue="row.targetValue"
+            :authorityOwnerAccount="row.authorityOwnerAccount"
+            :authorityOwnerIdentity="row.authorityOwnerIdentity"
+            :approvalProgress="row.approvalProgress"
+            :councilChange="row.councilChange"
+            :awaitingArgonConfirmation="isCouncilUpdateRelayed(row.queueNonce)"
+            :ethereumBlocksUntilArgonConfirmation="getEthereumBlocksUntilArgonConfirmation(row.queueNonce)"
+            wide
+          />
+        </div>
+      </details>
+
+      <div
+        v-if="
+          pendingCouncilApprovalCount ||
+          relayableCouncilUpdateCount ||
+          relayedCouncilUpdateCount ||
+          showCouncilApprovalProgress
+        "
+        class="flex items-center gap-x-4 border-t border-slate-300/70 px-4 py-2">
+        <template v-if="showCouncilApprovalProgress">
+          <div class="grow text-sm text-slate-500">
+            Approving {{ councilApprovalProgressItemCount }} gateway update{{ councilApprovalProgressItemCount === 1 ? '' : 's' }} on Argon.
+          </div>
+          <div
+            role="status"
+            aria-live="polite"
+            class="w-72 shrink-0">
+            <div
+              :class="councilApprovalError ? 'text-argon-error' : 'text-slate-500'"
+              class="mb-1 truncate text-xs">
+              {{ councilApprovalError || councilApprovalProgressLabel || 'Preparing transaction...' }}
+            </div>
+            <ProgressBar :progress="councilApprovalProgressPct" :showLabel="false" class="h-4" />
+          </div>
+        </template>
+        <template v-else>
+          <div class="grow text-sm text-slate-500">
+            <template v-if="pendingCouncilApprovalCount">
+              {{ pendingCouncilApprovalCount }} gateway update{{ pendingCouncilApprovalCount === 1 ? '' : 's' }} waiting
+              for your council signature.
+            </template>
+            <template v-else-if="relayableCouncilUpdateCount">
+              {{ relayableCouncilUpdateCount }} gateway update{{ relayableCouncilUpdateCount === 1 ? '' : 's' }} ready
+              for Ethereum relay.
+            </template>
+            <template v-else>
+              {{ relayedCouncilUpdateCount }} gateway update{{ relayedCouncilUpdateCount === 1 ? '' : 's' }} applied
+              on Ethereum and waiting for Argon confirmation.
+            </template>
+          </div>
+          <button
+            v-if="relayableCouncilUpdateCount"
+            type="button"
+            class="cursor-pointer rounded border border-slate-300 px-3 py-1.5 text-sm font-semibold whitespace-nowrap text-slate-600 hover:bg-slate-50"
+            @click="basicEmitter.emit('openGatewayRelayOverlay')">
+            Relay Gateway Updates ({{ relayableCouncilUpdateCount }})
+          </button>
+          <button
+            v-if="pendingCouncilApprovalCount"
+            type="button"
+            class="bg-argon-button hover:bg-argon-button-hover cursor-pointer rounded px-3 py-1.5 text-sm font-semibold whitespace-nowrap text-white"
+            @click="basicEmitter.emit('openVaultCollect')">
+            Approve Updates ({{ pendingCouncilApprovalCount }})
+          </button>
+        </template>
+      </div>
+    </section>
+
+    <section box class="shrink-0 px-2">
+      <header class="flex items-center border-b border-slate-300/70 px-4 py-3">
+        <div class="grow">
+          <div class="flex items-center gap-x-2">
+            <h2 class="font-semibold text-slate-800">History</h2>
+            <span
+              v-if="crosschainHistory.data.isSyncing"
+              class="border-argon-500 h-3.5 w-3.5 animate-spin rounded-full border-2 border-r-transparent"
+              title="Downloading crosschain history"
+            />
+          </div>
+          <p class="text-sm text-slate-500">Your transfer authorizations, council signatures, and authority changes.</p>
+        </div>
+        <button
+          type="button"
+          class="text-argon-600 hover:text-argon-800 cursor-pointer text-sm"
+          @click="basicEmitter.emit('openCrosschainHistoryOverlay')">
+          View all
+        </button>
+      </header>
+
+      <CrosschainHistoryRows
+        v-if="recentHistory.length"
+        :records="recentHistory"
+        :knownIdentities="knownSourceIdentities"
+      />
+      <div v-else-if="crosschainHistory.data.isSyncing" class="px-6 py-6 text-center text-sm text-slate-500">
+        Downloading history. The live queue remains available.
+      </div>
+      <div v-else-if="crosschainHistory.data.error" class="px-6 py-6 text-center text-sm text-slate-500">
+        {{ crosschainHistory.data.error }}. Cached history will appear here when available.
+      </div>
+      <div v-else class="px-6 py-6 text-center text-sm text-slate-500">
+        No completed crosschain activity was found.
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import { MICROGONS_PER_ARGON, MICRONOTS_PER_ARGONOT, MoveToken } from '@argonprotocol/apps-core';
+import { CheckCircleIcon } from '@heroicons/vue/24/outline';
+import basicEmitter from '../../emitters/basicEmitter.ts';
+import { ExtrinsicType, type ITransactionRecord, TransactionStatus } from '../../interfaces/ITransactionRecord.ts';
+import {
+  formatCouncilTarget,
+  formatCrosschainSourceIdentity,
+  getCrosschainAccessState,
+  type ICrosschainSourceIdentity,
+} from '../../lib/CrosschainTransferView.ts';
+import type { IGlobalCouncilChange, IGlobalCouncilQueueItem } from '../../lib/GlobalCouncil.ts';
+import type {
+  ICrosschainSourceTransferTotals,
+  IMintingAuthorityAuthorization,
+  IMintingAuthorityAuthorizeMetadata,
+  IMintingAuthorityBackedTransfer,
+} from '../../lib/MintingAuthorities.ts';
+import { getActiveMintingAuthorityRemaining } from '../../lib/MintingAuthorities.ts';
+import type { TransactionInfo } from '../../lib/TransactionInfo.ts';
+import { getActiveTransactionInfos, trackTransactionProgress } from '../../lib/TransactionProgress.ts';
+import type { IVaultCollectMetadata } from '../../lib/VaultCollectBuilder.ts';
+import type { ICrosschainOutboundTransferRecord } from '../../lib/db/CrosschainOutboundTransfersTable.ts';
+import { createNumeralHelpers } from '../../lib/numeral.ts';
+import Checkbox from '../../components/Checkbox.vue';
+import CrosschainActivityDetails from '../../components/CrosschainActivityDetails.vue';
+import CrosschainHistoryRows from '../../components/CrosschainHistoryRows.vue';
+import CrosschainTransferDetails from '../../components/CrosschainTransferDetails.vue';
+import ProgressBar from '../../components/ProgressBar.vue';
+import Tooltip from '../../components/Tooltip.vue';
+import EthereumSyncPopover from '../../overlays/EthereumSyncPopover.vue';
+import { getBot } from '../../stores/bot.ts';
+import { getConfig } from '../../stores/config.ts';
+import { getCurrency } from '../../stores/currency.ts';
+import { getEthereumOutboundTransferTracker } from '../../stores/moveToEthereum.ts';
+import { getCrosschainHistory, getKnownCrosschainSourceIdentities, getMyVault } from '../../stores/vaults.ts';
+
+type ITransferQueueRow = {
+  key: string;
+  title: string;
+  status: string;
+  waitingFor: string;
+  needsAction: boolean;
+  transferId: string;
+  moveToken?: MoveToken.ARGN | MoveToken.ARGNOT;
+  amount?: bigint;
+  reward?: bigint;
+  sourceAccount?: string;
+  sourceIdentity?: ICrosschainSourceIdentity;
+  destinationAccount?: string;
+  validUntilEthereumBlock?: bigint;
+  microgonCollateral?: bigint;
+  micronotCollateral?: bigint;
+  argonBlockHeight?: number;
+  ethereumBlockNumber?: number;
+  transferDetails?: IMintingAuthorityAuthorization | IMintingAuthorityBackedTransfer;
+};
+
+type ICouncilQueueRow = {
+  key: string;
+  title: string;
+  status: string;
+  waitingFor: string;
+  needsAction: boolean;
+  queueNonce: bigint;
+  targetKind: IGlobalCouncilQueueItem['targetKind'];
+  targetValue: string;
+  authorityOwnerAccount?: string;
+  authorityOwnerIdentity?: ICrosschainSourceIdentity;
+  approvalProgress: IGlobalCouncilQueueItem['approvalProgress'];
+  councilChange?: IGlobalCouncilChange;
+};
+
+const myVault = getMyVault();
+const crosschainHistory = getCrosschainHistory();
+const bot = getBot();
+const config = getConfig();
+const currency = getCurrency();
+const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
+
+const accessState = Vue.computed(() =>
+  getCrosschainAccessState({
+    hasActivatedCrosschain: config.hasActivatedCrosschain,
+    authorityCount: myVault.mintingAuthorities.data.authorities.length,
+    councilSigner: myVault.globalCouncil.data.councilSigner,
+  }),
+);
+
+let outboundTracker: ReturnType<typeof getEthereumOutboundTransferTracker> | undefined;
+try {
+  outboundTracker = getEthereumOutboundTransferTracker();
+} catch {
+  // Transfer rows remain authoritative without optional local Ethereum provenance.
+}
+
+const remainingMintingAuthority = Vue.computed(() => {
+  return getActiveMintingAuthorityRemaining(
+    myVault.mintingAuthorities.data.authorities,
+    mintingAuthorityValuationRate.value,
+  );
+});
+const mintingAuthorityValuationRate = Vue.computed(() => {
+  return (
+    myVault.globalCouncil.data.transferOutMicrogonsPerArgonot ??
+    myVault.globalCouncil.data.activeEpochMicrogonsPerArgonot ??
+    currency.microgonsPer.ARGNOT ??
+    0n
+  );
+});
+const crosschainQueueTxInfos = Vue.computed(() => myVault.getCrosschainQueueTxInfos());
+const selectedTransferIds = Vue.ref<string[]>([]);
+const isFundingSelected = Vue.ref(false);
+const fundingProgressPct = Vue.ref(0);
+const fundingProgressLabel = Vue.ref('');
+const fundingError = Vue.ref('');
+
+const isSubmittingCouncilApproval = Vue.ref(false);
+const councilApprovalProgressPct = Vue.ref(0);
+const councilApprovalProgressLabel = Vue.ref('');
+const activeCouncilApprovalTransactionCount = Vue.ref(0);
+const councilApprovalError = Vue.ref('');
+
+const activeFundingTxInfos = Vue.computed(() => {
+  return getActiveTransactionInfos([
+    ...myVault.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.values(),
+  ]) as TransactionInfo<IMintingAuthorityAuthorizeMetadata>[];
+});
+const showFundingProgress = Vue.computed(() => {
+  return isFundingSelected.value || activeFundingTxInfos.value.length > 0;
+});
+
+const activeCouncilApprovalTxInfos = Vue.computed(() => {
+  return getActiveTransactionInfos(
+    crosschainQueueTxInfos.value.filter(({ tx }) => {
+      if (tx.extrinsicType === ExtrinsicType.CrosschainTransferApproveCouncil) return true;
+
+      const metadata = tx.metadataJson as Partial<IVaultCollectMetadata>;
+      return (
+        tx.extrinsicType === ExtrinsicType.VaultCollect &&
+        (metadata.actionType === 'approveCouncil' || (metadata.councilApprovalCount ?? 0) > 0)
+      );
+    }),
+  ) as TransactionInfo<IVaultCollectMetadata>[];
+});
+const showCouncilApprovalProgress = Vue.computed(() => {
+  return isSubmittingCouncilApproval.value || activeCouncilApprovalTxInfos.value.length > 0;
+});
+const councilApprovalProgressItemCount = Vue.computed(() => {
+  const updateCount = activeCouncilApprovalTxInfos.value.reduce(
+    (total, { tx }) => total + (tx.metadataJson.councilApprovalCount ?? 0),
+    0,
+  );
+  return updateCount || activeCouncilApprovalTransactionCount.value;
+});
+
+const localAuthorizationTxByTransferId = Vue.computed(() => {
+  const txByTransferId = new Map<string, ITransactionRecord>();
+  for (const txInfo of crosschainQueueTxInfos.value) {
+    if (txInfo.tx.extrinsicType !== ExtrinsicType.CrosschainTransferAuthorize) continue;
+
+    const metadata = txInfo.tx.metadataJson as Partial<IMintingAuthorityAuthorizeMetadata>;
+    for (const authorization of metadata.authorizations ?? []) {
+      txByTransferId.set(authorization.transferId.toLowerCase(), txInfo.tx);
+    }
+  }
+  return txByTransferId;
+});
+
+const localOutboundByTransferId = Vue.computed(() => {
+  const transfersById = new Map<string, ICrosschainOutboundTransferRecord>();
+  for (const transfer of Object.values(outboundTracker?.data.transfersById ?? {})) {
+    const record = transfer.persistedRecord;
+    if (record?.transferId) {
+      transfersById.set(record.transferId.toLowerCase(), record);
+    }
+  }
+  return transfersById;
+});
+
+const knownSourceIdentities = Vue.computed(() => {
+  return getKnownCrosschainSourceIdentities();
+});
+
+const transferQueueRows = Vue.computed<ITransferQueueRow[]>(() => {
+  const finalizedTransferIds = new Set(
+    myVault.mintingAuthorities.data.backedTransfers.map(transfer => transfer.transferId.toLowerCase()),
+  );
+  const pendingSubmissionIds = new Set(
+    [...myVault.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.keys()].map(transferId =>
+      transferId.toLowerCase(),
+    ),
+  );
+  const actionableAuthorizations = myVault.mintingAuthorities.data.pendingMintingAuthorizations.filter(
+    authorization => !pendingSubmissionIds.has(authorization.transferId.toLowerCase()),
+  );
+  const actionableTransferIds = new Set(actionableAuthorizations.map(transfer => transfer.transferId.toLowerCase()));
+  const rows = [
+    ...actionableAuthorizations.map(toPendingAuthorizationRow),
+    ...[...myVault.mintingAuthorities.data.pendingMintingAuthorizeTxInfosByTransferId.entries()]
+      .filter(([transferId]) => {
+        const normalizedTransferId = transferId.toLowerCase();
+        return !finalizedTransferIds.has(normalizedTransferId) && !actionableTransferIds.has(normalizedTransferId);
+      })
+      .map(toPendingSubmissionRow),
+    ...myVault.mintingAuthorities.data.backedTransfers.map(toBackedTransferRow),
+  ];
+
+  return rows.sort((left, right) => Number(right.needsAction) - Number(left.needsAction));
+});
+
+const councilQueueRows = Vue.computed<ICouncilQueueRow[]>(() => {
+  return myVault.globalCouncil.data.approvalQueue
+    .map(toCouncilRow)
+    .sort((left, right) => Number(right.needsAction) - Number(left.needsAction));
+});
+const pendingCouncilApprovalCount = Vue.computed(() => myVault.globalCouncil.data.pendingApprovals.length);
+const relayableCouncilUpdateCount = Vue.computed(() => {
+  return myVault.globalCouncil.data.approvalQueue.filter(
+    ({ queueNonce, status }) => status === 'readyForRelay' && !isCouncilUpdateRelayed(queueNonce),
+  ).length;
+});
+const relayedCouncilUpdateCount = Vue.computed(() => {
+  return myVault.globalCouncil.data.approvalQueue.filter(
+    ({ queueNonce, status }) => status === 'readyForRelay' && isCouncilUpdateRelayed(queueNonce),
+  ).length;
+});
+const relayedCouncilQueueNonces = Vue.computed(() => {
+  return myVault.globalCouncil.data.approvalQueue
+    .filter(({ queueNonce, status }) => status === 'readyForRelay' && isCouncilUpdateRelayed(queueNonce))
+    .map(({ queueNonce }) => queueNonce);
+});
+const latestExecutionAnchorBlockNumber = Vue.computed(() => {
+  return bot.state?.ethereumSync?.latestExecutionAnchorBlockNumber;
+});
+
+Vue.watch(
+  [relayedCouncilQueueNonces, latestExecutionAnchorBlockNumber],
+  ([queueNonces, executionAnchorBlockNumber]) => {
+    if (!queueNonces.length || executionAnchorBlockNumber === undefined) return;
+
+    void myVault.globalCouncil
+      .hydrateEthereumApprovalBlockNumbers(queueNonces, executionAnchorBlockNumber)
+      .catch(error => console.error('[CrosschainTransfers] Unable to hydrate live Ethereum approval activity', error));
+  },
+  { immediate: true },
+);
+
+const fundableRows = Vue.computed(() => transferQueueRows.value.filter(row => row.needsAction));
+const allFundableRowsSelected = Vue.computed(() => {
+  return (
+    fundableRows.value.length > 0 && fundableRows.value.every(row => selectedTransferIds.value.includes(row.transferId))
+  );
+});
+const selectedAuthorizations = Vue.computed(() => {
+  const selectedIds = new Set(selectedTransferIds.value.map(transferId => transferId.toLowerCase()));
+  const fundableIds = new Set(fundableRows.value.map(row => row.transferId.toLowerCase()));
+  return myVault.mintingAuthorities.data.pendingMintingAuthorizations.filter(authorization => {
+    const transferId = authorization.transferId.toLowerCase();
+    return selectedIds.has(transferId) && fundableIds.has(transferId);
+  });
+});
+const selectedMicrogonCollateral = Vue.computed(() => {
+  return selectedAuthorizations.value.reduce((total, authorization) => total + authorization.microgonCollateral, 0n);
+});
+const selectedMicronotCollateral = Vue.computed(() => {
+  return selectedAuthorizations.value.reduce((total, authorization) => total + authorization.micronotCollateral, 0n);
+});
+const selectedRewardMicrogons = Vue.computed(() => {
+  return selectedAuthorizations.value.reduce((total, authorization) => total + authorization.mintingAuthorityTip, 0n);
+});
+const fundingTransferCount = Vue.computed(() => {
+  if (!activeFundingTxInfos.value.length) return selectedAuthorizations.value.length;
+
+  return new Set(
+    activeFundingTxInfos.value.flatMap(({ tx }) => tx.metadataJson.authorizations.map(({ transferId }) => transferId)),
+  ).size;
+});
+const historicalRewardsEarned = Vue.computed(() => {
+  return crosschainHistory.data.records.reduce((total, record) => {
+    return record.details.kind === 'transferAuthorization' ? total + record.details.reward : total;
+  }, 0n);
+});
+const availableRewards = Vue.computed(() => {
+  return myVault.mintingAuthorities.data.pendingMintingAuthorizations.reduce(
+    (total, authorization) => total + authorization.mintingAuthorityTip,
+    0n,
+  );
+});
+const totalSigned = Vue.computed(() => {
+  return crosschainHistory.data.records.filter(record => record.details.kind !== 'authorityLifecycle').length;
+});
+const sponsoredTransferValue = Vue.computed(() => {
+  return crosschainHistory.getSponsoredTransferValue(mintingAuthorityValuationRate.value);
+});
+const recentHistory = Vue.computed(() => crosschainHistory.data.records.slice(0, 3));
+
+Vue.onMounted(async () => {
+  void crosschainHistory.refresh();
+});
+
+Vue.watch(
+  () => myVault.globalCouncil.data.gatewayActivityCount,
+  (gatewayActivityCount, previousCount) => {
+    if (previousCount === undefined || gatewayActivityCount === previousCount) return;
+    void crosschainHistory.refresh();
+  },
+);
+
+Vue.watch(
+  activeFundingTxInfos,
+  (txInfos, _, onCleanup) => {
+    trackTransactionProgress({
+      txInfos,
+      isSubmitting: isFundingSelected,
+      progressPct: fundingProgressPct,
+      progressLabel: fundingProgressLabel,
+      error: fundingError,
+      onCleanup,
+    });
+  },
+  { immediate: true },
+);
+
+Vue.watch(
+  activeCouncilApprovalTxInfos,
+  (txInfos, _, onCleanup) => {
+    trackTransactionProgress({
+      txInfos,
+      isSubmitting: isSubmittingCouncilApproval,
+      progressPct: councilApprovalProgressPct,
+      progressLabel: councilApprovalProgressLabel,
+      activeTransactionCount: activeCouncilApprovalTransactionCount,
+      error: councilApprovalError,
+      onCleanup,
+    });
+  },
+  { immediate: true },
+);
+
+Vue.watch(
+  () => fundableRows.value.map(row => row.transferId),
+  availableTransferIds => {
+    const availableIds = new Set(availableTransferIds.map(transferId => transferId.toLowerCase()));
+    const validSelectedTransferIds = selectedTransferIds.value.filter(transferId =>
+      availableIds.has(transferId.toLowerCase()),
+    );
+    if (validSelectedTransferIds.length !== selectedTransferIds.value.length) {
+      selectedTransferIds.value = validSelectedTransferIds;
+    }
+  },
+  { immediate: true },
+);
+
+function toggleAllFundableRows() {
+  selectedTransferIds.value = allFundableRowsSelected.value ? [] : fundableRows.value.map(row => row.transferId);
+}
+
+function toggleTransferSelection(transferId: string) {
+  selectedTransferIds.value = selectedTransferIds.value.includes(transferId)
+    ? selectedTransferIds.value.filter(selectedTransferId => selectedTransferId !== transferId)
+    : [...selectedTransferIds.value, transferId];
+}
+
+async function fundSelectedTransfers() {
+  if (!selectedAuthorizations.value.length || isFundingSelected.value) return;
+
+  isFundingSelected.value = true;
+  fundingError.value = '';
+  fundingProgressPct.value = 0;
+  fundingProgressLabel.value = 'Preparing transaction...';
+
+  try {
+    await myVault.mintingAuthorities.authorize(
+      selectedAuthorizations.value.map(authorization => authorization.transferId),
+    );
+    selectedTransferIds.value = [];
+  } catch (error) {
+    fundingError.value = error instanceof Error ? error.message : `${error}`;
+  } finally {
+    if (!activeFundingTxInfos.value.length) isFundingSelected.value = false;
+  }
+}
+
+function toPendingAuthorizationRow(authorization: IMintingAuthorityAuthorization): ITransferQueueRow {
+  const transferId = authorization.transferId.toLowerCase();
+  const localArgonTx = localAuthorizationTxByTransferId.value.get(transferId);
+  const localOutbound = localOutboundByTransferId.value.get(transferId);
+
+  return {
+    key: `authorize-${authorization.transferId}`,
+    title: `Transfer ${authorization.moveToken} to Ethereum`,
+    status: 'Available to fund',
+    waitingFor: 'minting-authority funding',
+    needsAction: true,
+    moveToken: authorization.moveToken,
+    amount: authorization.finalizeRequest.amount,
+    reward: authorization.mintingAuthorityTip,
+    transferId: authorization.transferId,
+    sourceAccount: authorization.sourceAccount,
+    sourceIdentity: knownSourceIdentities.value.get(authorization.sourceAccount),
+    destinationAccount: authorization.finalizeRequest.recipient,
+    validUntilEthereumBlock: authorization.finalizeRequest.validUntilBlock,
+    microgonCollateral: authorization.microgonCollateral,
+    micronotCollateral: authorization.micronotCollateral,
+    argonBlockHeight: localArgonTx?.blockHeight,
+    ethereumBlockNumber: localOutbound?.targetBlockNumber,
+    transferDetails: authorization,
+  };
+}
+
+function toBackedTransferRow(transfer: IMintingAuthorityBackedTransfer): ITransferQueueRow {
+  const transferId = transfer.transferId.toLowerCase();
+  const localArgonTx = localAuthorizationTxByTransferId.value.get(transferId);
+  const localOutbound = localOutboundByTransferId.value.get(transferId);
+  const isReady = transfer.status === 'readyForEthereum';
+
+  return {
+    key: `backed-${transfer.transferId}`,
+    title: `Transfer ${transfer.moveToken} to Ethereum`,
+    status: isReady ? 'Ready on Argon' : 'Partially funded on Argon',
+    waitingFor: isReady ? 'the sender to submit on Ethereum' : 'another minting authority',
+    needsAction: false,
+    moveToken: transfer.moveToken,
+    amount: transfer.amount,
+    reward: transfer.mintingAuthorityTip,
+    transferId: transfer.transferId,
+    sourceAccount: transfer.sourceAccount,
+    sourceIdentity: knownSourceIdentities.value.get(transfer.sourceAccount),
+    destinationAccount: transfer.destinationAccount,
+    validUntilEthereumBlock: transfer.validUntilEthereumBlock,
+    microgonCollateral: transfer.ownedMicrogonCollateral,
+    micronotCollateral: transfer.ownedMicronotCollateral,
+    argonBlockHeight: localArgonTx?.blockHeight,
+    ethereumBlockNumber: localOutbound?.targetBlockNumber,
+    transferDetails: transfer,
+  };
+}
+
+function toPendingSubmissionRow(
+  entry: [string, TransactionInfo<IMintingAuthorityAuthorizeMetadata>],
+): ITransferQueueRow {
+  const [transferId, txInfo] = entry;
+  const metadata = txInfo.tx.metadataJson as IMintingAuthorityAuthorizeMetadata;
+  const authorization = metadata.authorizations.find(
+    item => item.transferId.toLowerCase() === transferId.toLowerCase(),
+  );
+  const isInBlock = txInfo.tx.status === TransactionStatus.InBlock;
+
+  return {
+    key: `submitted-${transferId}`,
+    title: 'Transfer authorization to Ethereum',
+    status: isInBlock ? 'Authorization included on Argon' : 'Authorization submitted',
+    waitingFor: 'Argon finalization',
+    needsAction: false,
+    transferId,
+    reward: authorization?.mintingAuthorityTip,
+    microgonCollateral: authorization?.microgonCollateral,
+    micronotCollateral: authorization?.micronotCollateral,
+    argonBlockHeight: txInfo.tx.blockHeight,
+  };
+}
+
+function toCouncilRow(approval: IGlobalCouncilQueueItem): ICouncilQueueRow {
+  const needsAction = approval.status === 'needsSignature';
+  const isRelayedToEthereum = isCouncilUpdateRelayed(approval.queueNonce);
+  const authorityOwnerAccount =
+    approval.targetKind === 'globalIssuanceCouncilRotation' ? undefined : approval.authorityOwnerAccount;
+  const approvalWeightPercent = approval.approvalProgress.totalWeight
+    ? Number((approval.approvalProgress.approvedWeight * 1_000n) / approval.approvalProgress.totalWeight) / 10
+    : 0;
+  const approvalProgressLabel = `${approval.approvalProgress.signatureCount} of ${approval.approvalProgress.memberCount} signers · ${approvalWeightPercent}% approval weight`;
+  let status = isRelayedToEthereum ? 'Applied on Ethereum' : 'Council quorum reached';
+  let waitingFor = isRelayedToEthereum ? 'Argon confirmation' : 'Ethereum relay';
+  if (approval.status === 'needsSignature') {
+    status = 'Your council approval is needed';
+    waitingFor = `your council signature (${approvalProgressLabel})`;
+  } else if (approval.status === 'awaitingCouncilQuorum') {
+    status = 'Your signature is recorded';
+    waitingFor = `council quorum (${approvalProgressLabel})`;
+  }
+
+  return {
+    key: `council-${approval.queueNonce}`,
+    title: formatCouncilTarget(approval.targetKind),
+    status,
+    waitingFor,
+    needsAction,
+    approvalProgress: approval.approvalProgress,
+    queueNonce: approval.queueNonce,
+    targetKind: approval.targetKind,
+    targetValue:
+      approval.targetKind === 'globalIssuanceCouncilRotation' ? approval.targetCouncilHash : approval.targetSigningKey,
+    ...(authorityOwnerAccount
+      ? {
+          authorityOwnerAccount,
+          authorityOwnerIdentity: knownSourceIdentities.value.get(authorityOwnerAccount),
+        }
+      : {}),
+    ...(approval.targetKind === 'globalIssuanceCouncilRotation' && approval.councilChange
+      ? { councilChange: approval.councilChange }
+      : {}),
+  };
+}
+
+function isCouncilUpdateRelayed(queueNonce: bigint): boolean {
+  return queueNonce <= (myVault.globalCouncil.data.ethereumApprovalNonce ?? -1n);
+}
+
+function getEthereumBlocksUntilArgonConfirmation(queueNonce: bigint): bigint | undefined {
+  const activityBlockNumber = myVault.globalCouncil.data.ethereumApprovalBlockNumbers.get(queueNonce);
+  const executionAnchorBlockNumber = latestExecutionAnchorBlockNumber.value;
+  if (activityBlockNumber === undefined || executionAnchorBlockNumber === undefined) return;
+
+  return activityBlockNumber > executionAnchorBlockNumber ? activityBlockNumber - executionAnchorBlockNumber : 0n;
+}
+
+function getSourceTotals(sourceAccount?: string): ICrosschainSourceTransferTotals | undefined {
+  return sourceAccount ? myVault.mintingAuthorities.data.sourceTotalsByAccount.get(sourceAccount) : undefined;
+}
+
+function getRecipientSeen(row: ITransferQueueRow): boolean | undefined {
+  if (!row.destinationAccount) return;
+  return crosschainHistory.hasSeenRecipient(row.destinationAccount, row.transferId);
+}
+
+function formatTokenAmount(amount: bigint, moveToken?: MoveToken.ARGN | MoveToken.ARGNOT) {
+  return moveToken === MoveToken.ARGNOT ? `${formatArgonot(amount)} ARGNOT` : `${formatArgon(amount)} ARGN`;
+}
+
+function formatArgon(amount: bigint) {
+  if (amount > 0n && amount < BigInt(MICROGONS_PER_ARGON) / 100n) return '<0.01';
+  return microgonToArgonNm(amount).format('0,0.[00]');
+}
+
+function formatArgonot(amount: bigint) {
+  if (amount > 0n && amount < BigInt(MICRONOTS_PER_ARGONOT) / 100n) return '<0.01';
+  return micronotToArgonotNm(amount).format('0,0.[00]');
+}
+
+function formatCapacity(amount: bigint) {
+  return microgonToArgonNm(amount).formatIfElse('< 1_000', '0,0.[00]', '0,0');
+}
+
+function getTransferProgress(row: ITransferQueueRow) {
+  const blocks = [];
+  if (row.argonBlockHeight) blocks.push(`Argon block ${row.argonBlockHeight}`);
+  if (row.ethereumBlockNumber) blocks.push(`Ethereum block ${row.ethereumBlockNumber}`);
+  if (blocks.length) return blocks.join(' · ');
+  return `Waiting for ${row.waitingFor}`;
+}
+</script>
+
+<style scoped>
+@reference "../../main.css";
+
+[box] {
+  @apply min-h-20 rounded border-[1px] border-slate-400/30 bg-white py-2 shadow;
+}
+
+[stat-box] {
+  @apply text-argon-600 flex flex-col items-center justify-center;
+
+  span {
+    @apply font-mono text-3xl font-bold;
+  }
+
+  label {
+    @apply mt-1 text-sm text-gray-500;
+  }
+}
+
+dt {
+  @apply text-slate-500;
+}
+
+dd {
+  @apply min-w-0 break-words text-slate-700;
+}
+</style>

--- a/src-vue/screens/stable-swaps-screen/Dashboard.vue
+++ b/src-vue/screens/stable-swaps-screen/Dashboard.vue
@@ -172,7 +172,12 @@ import { getCurrency } from '../../stores/currency.ts';
 import { useStableSwaps } from '../../stores/stableSwaps.ts';
 import EthereumIcon from '../../assets/networks/ethereum.svg';
 import ArgonIcon from '../../assets/networks/argon.svg';
-import { ICurrencyKey, NetworkConfig, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import {
+  getEthereumTransactionExplorerUrl,
+  ICurrencyKey,
+  NetworkConfig,
+  UnitOfMeasurement,
+} from '@argonprotocol/apps-core';
 import { ArrowTopRightOnSquareIcon, CheckIcon } from '@heroicons/vue/24/outline';
 import FormattedMoney from '../../components/FormattedMoney.vue';
 import { useFinancials } from '../../stores/financials.ts';
@@ -196,7 +201,8 @@ const totalSwapReturn = Vue.computed(() => {
 });
 
 async function openPurchaseTx(txHash: string) {
-  await tauriOpenUrl(`https://etherscan.io/tx/${txHash}`);
+  const explorerUrl = getEthereumTransactionExplorerUrl(txHash);
+  if (explorerUrl) await tauriOpenUrl(explorerUrl);
 }
 
 const currencyFadeClass = Vue.ref('');

--- a/src-vue/stores/vaults.ts
+++ b/src-vue/stores/vaults.ts
@@ -1,7 +1,7 @@
 import { Vaults } from '../lib/Vaults';
 import { getDbPromise } from './helpers/dbPromise';
 import { MyVault } from '../lib/MyVault.ts';
-import { reactive } from 'vue';
+import { reactive, watch } from 'vue';
 import { getConfig, NETWORK_NAME } from './config.ts';
 import { getMiningFrames } from './mainchain.ts';
 import { getCurrency } from './currency.ts';
@@ -12,11 +12,14 @@ import { GlobalCouncil } from '../lib/GlobalCouncil.ts';
 import { MintingAuthorities } from '../lib/MintingAuthorities.ts';
 import { getServerApiClient } from './server.ts';
 import { getUpstreamOperatorClient } from './upstreamOperator.ts';
+import { CrosschainHistory } from '../lib/CrosschainHistory.ts';
+import { createKnownCrosschainSourceIdentities, getCrosschainAccessState } from '../lib/CrosschainTransferView.ts';
 
 export { type Vaults };
 
 let vaults: Vaults;
 let myVault: MyVault;
+let crosschainHistory: CrosschainHistory;
 
 export function getVaults(): Vaults {
   if (!vaults) {
@@ -46,6 +49,32 @@ export function getMyVault(): MyVault {
       };
     });
     mintingAuthorities.data = reactive(mintingAuthorities.data) as any;
+    watch(
+      () => [mintingAuthorities.data.authorities.length, globalCouncil.data.councilSigner] as const,
+      ([authorityCount, councilSigner]) => {
+        if (
+          !getCrosschainAccessState({
+            hasActivatedCrosschain: config.hasActivatedCrosschain,
+            authorityCount,
+            councilSigner,
+          }).hasAccess
+        ) {
+          return;
+        }
+
+        void config.isLoadedPromise
+          .then(async () => {
+            if (config.hasActivatedCrosschain) return;
+
+            config.hasActivatedCrosschain = true;
+            config.hasExtensionTreasury = true;
+            config.hasExtensionOperations = true;
+            await config.save();
+          })
+          .catch(error => console.error('[CrosschainTransfers] Unable to preserve navigation access', error));
+      },
+      { immediate: true },
+    );
 
     myVault = new MyVault(
       dbPromise,
@@ -61,4 +90,29 @@ export function getMyVault(): MyVault {
   }
 
   return myVault;
+}
+
+export function getCrosschainHistory(): CrosschainHistory {
+  if (!crosschainHistory) {
+    const financialCache = getDbPromise().then(db => db.financialCacheTable);
+    crosschainHistory = new CrosschainHistory(getWalletKeys(), getMiningFrames().blockWatch, financialCache);
+    crosschainHistory.data = reactive(crosschainHistory.data) as typeof crosschainHistory.data;
+  }
+
+  return crosschainHistory;
+}
+
+export function getKnownCrosschainSourceIdentities() {
+  const config = getConfig();
+  const vault = getMyVault();
+  const walletKeys = getWalletKeys();
+
+  return createKnownCrosschainSourceIdentities({
+    networkName: NETWORK_NAME,
+    createdVault: vault.createdVault ?? undefined,
+    vaultsById: vault.vaults.vaultsById,
+    localAccountIds: [walletKeys.defaultArgonAddress, walletKeys.vaultingAddress, walletKeys.operationalAddress],
+    upstreamOperator: config.upstreamOperator,
+    sourceUpstreamVaultAccountsByAccount: vault.mintingAuthorities.data.sourceUpstreamVaultAccountsByAccount,
+  });
 }


### PR DESCRIPTION
## Summary

Minting authorities and global council signers now have one Crosschain workspace for funding selected transfer requests, approving and relaying gateway updates, monitoring live Argon-to-Ethereum progress, and reviewing their own indexed activity.

The screen keeps the existing collect workflow intact. Collect alerts use the same compact transfer and council details, while the dedicated workspace adds selective actions, persistent history, capacity and earnings statistics, operator context, and sync status.

## Design decisions

- Live transfer and council rows come from the existing `MintingAuthorities` and `GlobalCouncil` state. The page does not create a parallel queue or intermediate approval state.
- Transfer funding accepts explicit transfer IDs, so an authority can fund only the requests it chooses. Existing bulk collection behavior remains available.
- Personal history uses the activity index to find candidate blocks, then replays authoritative mainchain events and caches the validated result locally. Cached history remains visible during refreshes or indexer failures.
- Gateway updates expose quorum, relay readiness, Ethereum application, and the remaining Ethereum blocks before Argon confirms the update.
- The Crosschain entry remains hidden until the account has activated crosschain access, owns a minting authority, or is a council signer. Once activated on an installation, access stays enabled.

## Validation

- `yarn vitest --run --project src-vue --project core` — 812 tests passed
- `yarn typecheck`
- `yarn lint:check`
