### PR TITLE
fix: stop background ui work after unmount

### DIFF
--- a/src-vue/__test__/BitcoinLockProgress.test.ts
+++ b/src-vue/__test__/BitcoinLockProgress.test.ts
@@ -185,6 +185,48 @@ describe('bitcoinLockProgress', () => {
     expect(store.lockProcessing.value.confirmations).toBe(1);
   });
 
+  it('does not subscribe to mining frames after the final consumer stops during load', async () => {
+    let finishLoading!: () => void;
+    const loading = new Promise<void>(resolve => {
+      finishLoading = resolve;
+    });
+    const onTick = vi.fn(() => ({ unsubscribe: vi.fn() }));
+    const lock = createLock(BitcoinLockStatus.Releasing);
+    const store = createBitcoinLockProgressStore({
+      myVault: {
+        getBitcoinReleaseRequestTxInfo: () => undefined,
+        getTxInfoByType: () => undefined,
+      } as Pick<MyVault, 'getBitcoinReleaseRequestTxInfo' | 'getTxInfoByType'> as MyVault,
+      bitcoinLocks: {
+        getAcceptedFundingRecord: () =>
+          ({ status: BitcoinUtxoStatus.ReleaseIsProcessingOnArgon }) as ReturnType<
+            BitcoinLocks['getAcceptedFundingRecord']
+          >,
+        getMismatchViewState: () => ({ phase: 'none' }) as ReturnType<BitcoinLocks['getMismatchViewState']>,
+        getRequestReleaseByVaultProgress: () => 0,
+        isLockProcessingStatus: () => false,
+      } as Pick<
+        BitcoinLocks,
+        | 'getAcceptedFundingRecord'
+        | 'getMismatchViewState'
+        | 'getRequestReleaseByVaultProgress'
+        | 'isLockProcessingStatus'
+      > as BitcoinLocks,
+      miningFrames: {
+        load: () => loading,
+        onTick,
+      } as Pick<MiningFrames, 'load' | 'onTick'> as MiningFrames,
+    });
+
+    const stopTracking = store.trackLock(lock);
+    stopTracking();
+    finishLoading();
+    await loading;
+    await Promise.resolve();
+
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
   it('keeps the last known funding progress when the same lock recomputes as unknown', () => {
     const lock = { ...createLock(BitcoinLockStatus.LockPendingFunding), utxoId: 18 } as IBitcoinLockRecord;
     const store = createBitcoinLockProgressStore({

--- a/src-vue/overlays/BitcoinLockingOverlay.vue
+++ b/src-vue/overlays/BitcoinLockingOverlay.vue
@@ -147,7 +147,7 @@ const createdLock = Vue.ref<IBitcoinLockRecord | undefined>();
 let overlayRefreshInterval: ReturnType<typeof setInterval> | undefined;
 let unsubscribeTicks: VoidFunction | undefined;
 let vaultRefreshKey = 0;
-let isUnmounted = false;
+let isDisposed = false;
 
 const defaultVault = Vue.computed(() => {
   const vaultId = myVault.vaultId;
@@ -344,13 +344,14 @@ async function resolveCreatedLockTransition() {
   if (requestedPersonalLock.value || !createdLockUuid.value) return;
   if (trackedCreatedLock.value?.utxoId != null) return;
 
+  // Recheck the session after the database waits because the overlay can close or reopen for another lock.
   const lockUuid = createdLockUuid.value;
   const table = await bitcoinLocks.getTable();
   const utxoId = await table.getUtxoIdByUuid(lockUuid);
   if (utxoId == null) return;
 
   const finalizedLock = bitcoinLocks.getLockByUtxoId(utxoId) ?? (await table.getByUtxoId(utxoId));
-  if (isUnmounted || !isOpen.value || createdLockUuid.value !== lockUuid || !finalizedLock) return;
+  if (isDisposed || !isOpen.value || createdLockUuid.value !== lockUuid || !finalizedLock) return;
 
   createdLock.value = finalizedLock;
 }
@@ -486,7 +487,8 @@ Vue.onMounted(async () => {
   basicEmitter.on('closeAllOverlays', closeFromGlobalRequest);
 
   await miningFrames.load();
-  if (isUnmounted) return;
+  // Runtime compatibility can dispose this overlay instance while loading; do not subscribe afterward.
+  if (isDisposed) return;
   currentTick.value = miningFrames.currentTick;
   unsubscribeTicks = miningFrames.onTick(() => {
     currentTick.value = miningFrames.currentTick;
@@ -501,7 +503,7 @@ Vue.watch(trackedCreatedLock, nextLock => {
 Vue.watch(personalLock, updateLockProcessingDetails, { deep: true });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   basicEmitter.off('openBitcoinLock', openOverlay);
   basicEmitter.off('closeAllOverlays', closeFromGlobalRequest);
   unsubscribeTicks?.();

--- a/src-vue/overlays/BitcoinLockingOverlay.vue
+++ b/src-vue/overlays/BitcoinLockingOverlay.vue
@@ -147,6 +147,7 @@ const createdLock = Vue.ref<IBitcoinLockRecord | undefined>();
 let overlayRefreshInterval: ReturnType<typeof setInterval> | undefined;
 let unsubscribeTicks: VoidFunction | undefined;
 let vaultRefreshKey = 0;
+let isUnmounted = false;
 
 const defaultVault = Vue.computed(() => {
   const vaultId = myVault.vaultId;
@@ -343,12 +344,13 @@ async function resolveCreatedLockTransition() {
   if (requestedPersonalLock.value || !createdLockUuid.value) return;
   if (trackedCreatedLock.value?.utxoId != null) return;
 
+  const lockUuid = createdLockUuid.value;
   const table = await bitcoinLocks.getTable();
-  const utxoId = await table.getUtxoIdByUuid(createdLockUuid.value);
+  const utxoId = await table.getUtxoIdByUuid(lockUuid);
   if (utxoId == null) return;
 
   const finalizedLock = bitcoinLocks.getLockByUtxoId(utxoId) ?? (await table.getByUtxoId(utxoId));
-  if (!finalizedLock) return;
+  if (isUnmounted || !isOpen.value || createdLockUuid.value !== lockUuid || !finalizedLock) return;
 
   createdLock.value = finalizedLock;
 }
@@ -484,6 +486,7 @@ Vue.onMounted(async () => {
   basicEmitter.on('closeAllOverlays', closeFromGlobalRequest);
 
   await miningFrames.load();
+  if (isUnmounted) return;
   currentTick.value = miningFrames.currentTick;
   unsubscribeTicks = miningFrames.onTick(() => {
     currentTick.value = miningFrames.currentTick;
@@ -498,10 +501,11 @@ Vue.watch(trackedCreatedLock, nextLock => {
 Vue.watch(personalLock, updateLockProcessingDetails, { deep: true });
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
   basicEmitter.off('openBitcoinLock', openOverlay);
   basicEmitter.off('closeAllOverlays', closeFromGlobalRequest);
   unsubscribeTicks?.();
-  stopSessionRefresh();
+  closeSession();
 });
 </script>
 

--- a/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
+++ b/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
@@ -320,10 +320,12 @@ const argonRequestProgressLabel = Vue.computed(() => {
 let feeQuoteTimeout: ReturnType<typeof setTimeout> | undefined;
 let feeQuoteRunId = 0;
 let stopArgonRequestProgress: (() => void) | undefined;
+let isUnmounted = false;
 
 Vue.watch(
   [trimmedDestination, feeRatePerSatVb, () => wallets.liquidLockingWallet.availableMicrogons],
   () => {
+    if (isUnmounted) return;
     if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
     const runId = ++feeQuoteRunId;
     argonFeeQuote.value = undefined;
@@ -335,14 +337,21 @@ Vue.watch(
     }
 
     isCheckingArgonFee.value = true;
-    feeQuoteTimeout = setTimeout(() => void refreshArgonFeeQuote(runId), 200);
+    feeQuoteTimeout = setTimeout(() => {
+      feeQuoteTimeout = undefined;
+      void refreshArgonFeeQuote(runId);
+    }, 200);
   },
   { immediate: true },
 );
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
+  feeQuoteRunId += 1;
   if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
+  feeQuoteTimeout = undefined;
   stopArgonRequestProgress?.();
+  stopArgonRequestProgress = undefined;
 });
 
 Vue.onMounted(() => trackArgonRequestProgress());
@@ -360,23 +369,26 @@ async function requestReturn(): Promise<void> {
       toScriptPubkey: trimmedDestination.value,
       feeRatePerSatVb: feeRatePerSatVb.value,
     });
+    if (isUnmounted) return;
     trackArgonRequestProgress(txInfo);
   } catch (error) {
+    if (isUnmounted) return;
     isArgonRequestInProgress.value = false;
     requestError.value = error instanceof Error ? error.message : String(error);
   } finally {
-    isSubmitting.value = false;
+    if (!isUnmounted) isSubmitting.value = false;
   }
 }
 
 function trackArgonRequestProgress(
   txInfo = bitcoinLocks.orphanReleases.getTransactionInfo(props.record.lockUtxoId, props.record),
 ): void {
-  if (!txInfo) return;
+  if (!txInfo || isUnmounted) return;
 
   isArgonRequestInProgress.value = [TransactionStatus.Submitted, TransactionStatus.InBlock].includes(txInfo.tx.status);
   stopArgonRequestProgress?.();
   stopArgonRequestProgress = txInfo.subscribeToProgress((progress, error) => {
+    if (isUnmounted) return;
     argonRequestProgressPct.value = progress.progressPct;
     argonRequestConfirmations.value = progress.confirmations;
     argonRequestExpectedConfirmations.value = progress.expectedConfirmations;
@@ -393,13 +405,13 @@ async function refreshArgonFeeQuote(runId: number): Promise<void> {
       toScriptPubkey: trimmedDestination.value,
       feeRatePerSatVb: feeRatePerSatVb.value,
     });
-    if (runId !== feeQuoteRunId) return;
+    if (isUnmounted || runId !== feeQuoteRunId) return;
     argonFeeQuote.value = quote;
   } catch {
-    if (runId !== feeQuoteRunId) return;
+    if (isUnmounted || runId !== feeQuoteRunId) return;
     argonFeeQuoteError.value = 'Unable to check the Argon transaction fee. Please try again.';
   } finally {
-    if (runId === feeQuoteRunId) isCheckingArgonFee.value = false;
+    if (!isUnmounted && runId === feeQuoteRunId) isCheckingArgonFee.value = false;
   }
 }
 

--- a/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
+++ b/src-vue/overlays/BitcoinOrphanRecoveryOverlay.vue
@@ -320,12 +320,11 @@ const argonRequestProgressLabel = Vue.computed(() => {
 let feeQuoteTimeout: ReturnType<typeof setTimeout> | undefined;
 let feeQuoteRunId = 0;
 let stopArgonRequestProgress: (() => void) | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 Vue.watch(
   [trimmedDestination, feeRatePerSatVb, () => wallets.liquidLockingWallet.availableMicrogons],
   () => {
-    if (isUnmounted) return;
     if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
     const runId = ++feeQuoteRunId;
     argonFeeQuote.value = undefined;
@@ -337,21 +336,15 @@ Vue.watch(
     }
 
     isCheckingArgonFee.value = true;
-    feeQuoteTimeout = setTimeout(() => {
-      feeQuoteTimeout = undefined;
-      void refreshArgonFeeQuote(runId);
-    }, 200);
+    feeQuoteTimeout = setTimeout(() => void refreshArgonFeeQuote(runId), 200);
   },
   { immediate: true },
 );
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
-  feeQuoteRunId += 1;
+  isDisposed = true;
   if (feeQuoteTimeout) clearTimeout(feeQuoteTimeout);
-  feeQuoteTimeout = undefined;
   stopArgonRequestProgress?.();
-  stopArgonRequestProgress = undefined;
 });
 
 Vue.onMounted(() => trackArgonRequestProgress());
@@ -369,26 +362,24 @@ async function requestReturn(): Promise<void> {
       toScriptPubkey: trimmedDestination.value,
       feeRatePerSatVb: feeRatePerSatVb.value,
     });
-    if (isUnmounted) return;
     trackArgonRequestProgress(txInfo);
   } catch (error) {
-    if (isUnmounted) return;
     isArgonRequestInProgress.value = false;
     requestError.value = error instanceof Error ? error.message : String(error);
   } finally {
-    if (!isUnmounted) isSubmitting.value = false;
+    isSubmitting.value = false;
   }
 }
 
 function trackArgonRequestProgress(
   txInfo = bitcoinLocks.orphanReleases.getTransactionInfo(props.record.lockUtxoId, props.record),
 ): void {
-  if (!txInfo || isUnmounted) return;
+  // The request can resolve after this overlay instance is disposed; teardown cannot remove a later subscription.
+  if (!txInfo || isDisposed) return;
 
   isArgonRequestInProgress.value = [TransactionStatus.Submitted, TransactionStatus.InBlock].includes(txInfo.tx.status);
   stopArgonRequestProgress?.();
   stopArgonRequestProgress = txInfo.subscribeToProgress((progress, error) => {
-    if (isUnmounted) return;
     argonRequestProgressPct.value = progress.progressPct;
     argonRequestConfirmations.value = progress.confirmations;
     argonRequestExpectedConfirmations.value = progress.expectedConfirmations;
@@ -405,13 +396,13 @@ async function refreshArgonFeeQuote(runId: number): Promise<void> {
       toScriptPubkey: trimmedDestination.value,
       feeRatePerSatVb: feeRatePerSatVb.value,
     });
-    if (isUnmounted || runId !== feeQuoteRunId) return;
+    if (runId !== feeQuoteRunId) return;
     argonFeeQuote.value = quote;
   } catch {
-    if (isUnmounted || runId !== feeQuoteRunId) return;
+    if (runId !== feeQuoteRunId) return;
     argonFeeQuoteError.value = 'Unable to check the Argon transaction fee. Please try again.';
   } finally {
-    if (!isUnmounted && runId === feeQuoteRunId) isCheckingArgonFee.value = false;
+    if (runId === feeQuoteRunId) isCheckingArgonFee.value = false;
   }
 }
 

--- a/src-vue/overlays/BitcoinRatchetingOverlay.vue
+++ b/src-vue/overlays/BitcoinRatchetingOverlay.vue
@@ -98,7 +98,7 @@ const txInfo = Vue.shallowRef<TransactionInfo<IBitcoinRatchetMetadata>>();
 const progressPct = Vue.ref(0);
 const progressLabel = Vue.ref('');
 let unsubscribeProgress: (() => void) | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 const props = defineProps<{
   personalLock: IBitcoinLockRecord;
@@ -120,15 +120,12 @@ async function loadRatchetPreview() {
   errorMessage.value = '';
 
   try {
-    const preview = await bitcoinLocks.getRatchetPreview(props.personalLock);
-    if (isUnmounted) return;
-    ratchetPreview.value = preview;
+    ratchetPreview.value = await bitcoinLocks.getRatchetPreview(props.personalLock);
   } catch (error) {
-    if (isUnmounted) return;
     ratchetPreview.value = undefined;
     errorMessage.value = error instanceof Error ? error.message : 'Unable to load ratchet details.';
   } finally {
-    if (!isUnmounted) isLoadingPreview.value = false;
+    isLoadingPreview.value = false;
   }
 }
 
@@ -143,19 +140,18 @@ async function submitRatchet() {
       ratchetPreview.value.securitizationToAdd > 0n
         ? await walletKeys.getVaultingKeypair()
         : await walletKeys.getLiquidLockingKeypair();
-    if (isUnmounted) return;
+    // This overlay instance can be disposed while the signer loads; do not start a transaction afterward.
+    if (isDisposed) return;
     const info = await bitcoinLocks.ratchet(props.personalLock, txSigner);
-    if (isUnmounted) return;
     trackTransaction(info);
   } catch (error) {
-    if (isUnmounted) return;
     errorMessage.value = error instanceof Error ? error.message : 'Unable to ratchet this Bitcoin lock.';
     isSubmitting.value = false;
   }
 }
 
 function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
-  if (isUnmounted) return;
+  if (isDisposed) return;
   unsubscribeProgress?.();
   txInfo.value = info;
   isSubmitting.value = true;
@@ -165,7 +161,6 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
   progressLabel.value = status.isFinalized ? 'Finalizing ratchet details...' : 'Waiting for transaction status...';
 
   unsubscribeProgress = info.subscribeToProgress((progress, error) => {
-    if (isUnmounted) return;
     progressPct.value = progress.progressPct;
     progressLabel.value = progress.progressMessage;
     if (error) {
@@ -175,7 +170,8 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
 
   void info.waitForPostProcessing.then(
     () => {
-      if (isUnmounted) return;
+      // Post-processing cannot be cancelled; this disposed instance must not reload the parent dashboard.
+      if (isDisposed) return;
       const error = info.getStatus().error;
       if (error) {
         errorMessage.value = error.message;
@@ -187,7 +183,6 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
       emit('completed');
     },
     error => {
-      if (isUnmounted) return;
       errorMessage.value = error instanceof Error ? error.message : 'Unable to save the completed ratchet.';
       isSubmitting.value = false;
     },
@@ -196,7 +191,8 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
-  if (isUnmounted) return;
+  // This overlay instance can be disposed while recovered state loads; do not subscribe afterward.
+  if (isDisposed) return;
   const pendingTxInfo = bitcoinLocks.getPendingRatchetTxInfo(props.personalLock);
   if (pendingTxInfo) {
     isLoadingPreview.value = false;
@@ -208,8 +204,7 @@ Vue.onMounted(async () => {
 });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   unsubscribeProgress?.();
-  unsubscribeProgress = undefined;
 });
 </script>

--- a/src-vue/overlays/BitcoinRatchetingOverlay.vue
+++ b/src-vue/overlays/BitcoinRatchetingOverlay.vue
@@ -98,6 +98,7 @@ const txInfo = Vue.shallowRef<TransactionInfo<IBitcoinRatchetMetadata>>();
 const progressPct = Vue.ref(0);
 const progressLabel = Vue.ref('');
 let unsubscribeProgress: (() => void) | undefined;
+let isUnmounted = false;
 
 const props = defineProps<{
   personalLock: IBitcoinLockRecord;
@@ -119,12 +120,15 @@ async function loadRatchetPreview() {
   errorMessage.value = '';
 
   try {
-    ratchetPreview.value = await bitcoinLocks.getRatchetPreview(props.personalLock);
+    const preview = await bitcoinLocks.getRatchetPreview(props.personalLock);
+    if (isUnmounted) return;
+    ratchetPreview.value = preview;
   } catch (error) {
+    if (isUnmounted) return;
     ratchetPreview.value = undefined;
     errorMessage.value = error instanceof Error ? error.message : 'Unable to load ratchet details.';
   } finally {
-    isLoadingPreview.value = false;
+    if (!isUnmounted) isLoadingPreview.value = false;
   }
 }
 
@@ -139,15 +143,19 @@ async function submitRatchet() {
       ratchetPreview.value.securitizationToAdd > 0n
         ? await walletKeys.getVaultingKeypair()
         : await walletKeys.getLiquidLockingKeypair();
+    if (isUnmounted) return;
     const info = await bitcoinLocks.ratchet(props.personalLock, txSigner);
+    if (isUnmounted) return;
     trackTransaction(info);
   } catch (error) {
+    if (isUnmounted) return;
     errorMessage.value = error instanceof Error ? error.message : 'Unable to ratchet this Bitcoin lock.';
     isSubmitting.value = false;
   }
 }
 
 function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
+  if (isUnmounted) return;
   unsubscribeProgress?.();
   txInfo.value = info;
   isSubmitting.value = true;
@@ -157,6 +165,7 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
   progressLabel.value = status.isFinalized ? 'Finalizing ratchet details...' : 'Waiting for transaction status...';
 
   unsubscribeProgress = info.subscribeToProgress((progress, error) => {
+    if (isUnmounted) return;
     progressPct.value = progress.progressPct;
     progressLabel.value = progress.progressMessage;
     if (error) {
@@ -166,6 +175,7 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
 
   void info.waitForPostProcessing.then(
     () => {
+      if (isUnmounted) return;
       const error = info.getStatus().error;
       if (error) {
         errorMessage.value = error.message;
@@ -177,6 +187,7 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
       emit('completed');
     },
     error => {
+      if (isUnmounted) return;
       errorMessage.value = error instanceof Error ? error.message : 'Unable to save the completed ratchet.';
       isSubmitting.value = false;
     },
@@ -185,6 +196,7 @@ function trackTransaction(info: TransactionInfo<IBitcoinRatchetMetadata>) {
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
+  if (isUnmounted) return;
   const pendingTxInfo = bitcoinLocks.getPendingRatchetTxInfo(props.personalLock);
   if (pendingTxInfo) {
     isLoadingPreview.value = false;
@@ -196,6 +208,8 @@ Vue.onMounted(async () => {
 });
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
   unsubscribeProgress?.();
+  unsubscribeProgress = undefined;
 });
 </script>

--- a/src-vue/overlays/BitcoinUnlockingOverlay.vue
+++ b/src-vue/overlays/BitcoinUnlockingOverlay.vue
@@ -181,6 +181,7 @@ const personalLock = Vue.computed<IBitcoinLockRecord | undefined>(() => {
 const releaseState = Vue.computed(() => bitcoinLocks.getLockUnlockReleaseState(personalLock.value));
 
 const wasOpenedWithoutBitcoin = Vue.ref(!props.personalLock);
+let headerLoadTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const unlockStep = Vue.computed<UnlockStep>(() => {
   const lock = personalLock.value;
@@ -205,10 +206,14 @@ function closeOverlay() {
   emit('close', false);
 }
 
-Vue.onMounted(async () => {
-  setTimeout(() => {
+Vue.onMounted(() => {
+  headerLoadTimeout = setTimeout(() => {
     isLoaded.value = true;
   }, 100);
+});
+
+Vue.onUnmounted(() => {
+  if (headerLoadTimeout) clearTimeout(headerLoadTimeout);
 });
 </script>
 

--- a/src-vue/overlays/BitcoinUnlockingOverlay.vue
+++ b/src-vue/overlays/BitcoinUnlockingOverlay.vue
@@ -181,7 +181,6 @@ const personalLock = Vue.computed<IBitcoinLockRecord | undefined>(() => {
 const releaseState = Vue.computed(() => bitcoinLocks.getLockUnlockReleaseState(personalLock.value));
 
 const wasOpenedWithoutBitcoin = Vue.ref(!props.personalLock);
-let headerLoadTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const unlockStep = Vue.computed<UnlockStep>(() => {
   const lock = personalLock.value;
@@ -206,14 +205,10 @@ function closeOverlay() {
   emit('close', false);
 }
 
-Vue.onMounted(() => {
-  headerLoadTimeout = setTimeout(() => {
+Vue.onMounted(async () => {
+  setTimeout(() => {
     isLoaded.value = true;
   }, 100);
-});
-
-Vue.onUnmounted(() => {
-  if (headerLoadTimeout) clearTimeout(headerLoadTimeout);
 });
 </script>
 

--- a/src-vue/overlays/CertificationOverlay.vue
+++ b/src-vue/overlays/CertificationOverlay.vue
@@ -159,6 +159,7 @@ const controller = useCertificationController();
 const isOpen = Vue.ref(false);
 const currentStepId = Vue.ref<OperationalStepId | null>(null);
 const currentTrack = Vue.ref<'treasury' | 'operations'>('treasury');
+let guideActivationTimeout: ReturnType<typeof setTimeout> | undefined;
 const currentStepIds = Vue.computed(() => {
   return currentTrack.value === 'treasury'
     ? treasuryCertificationStepIds
@@ -226,7 +227,9 @@ function startTask() {
   const stepId = currentStepId.value;
   closeOverlay();
 
-  setTimeout(() => {
+  if (guideActivationTimeout) clearTimeout(guideActivationTimeout);
+  guideActivationTimeout = setTimeout(() => {
+    guideActivationTimeout = undefined;
     controller.activeGuideId = stepId;
 
     if (stepId === OperationalStepId.ActivateVault) {
@@ -266,7 +269,7 @@ function openDocumentationLink(link: string) {
   void tauriOpenUrl(link);
 }
 
-basicEmitter.on('openOperationalOverlay', (stepId: OperationalStepId) => {
+function openOperationalOverlay(stepId: OperationalStepId) {
   if (controller.isOperationalActivationReady) {
     closeOverlay();
     basicEmitter.emit('openOperationalRewardsOverlay', { screen: 'activate' });
@@ -281,5 +284,12 @@ basicEmitter.on('openOperationalOverlay', (stepId: OperationalStepId) => {
   isOpen.value = true;
   currentStepId.value = stepId;
   basics.overlayIsOpen = true;
+}
+
+basicEmitter.on('openOperationalOverlay', openOperationalOverlay);
+
+Vue.onUnmounted(() => {
+  if (guideActivationTimeout) clearTimeout(guideActivationTimeout);
+  basicEmitter.off('openOperationalOverlay', openOperationalOverlay);
 });
 </script>

--- a/src-vue/overlays/CertificationOverlay.vue
+++ b/src-vue/overlays/CertificationOverlay.vue
@@ -159,7 +159,6 @@ const controller = useCertificationController();
 const isOpen = Vue.ref(false);
 const currentStepId = Vue.ref<OperationalStepId | null>(null);
 const currentTrack = Vue.ref<'treasury' | 'operations'>('treasury');
-let guideActivationTimeout: ReturnType<typeof setTimeout> | undefined;
 const currentStepIds = Vue.computed(() => {
   return currentTrack.value === 'treasury'
     ? treasuryCertificationStepIds
@@ -227,9 +226,7 @@ function startTask() {
   const stepId = currentStepId.value;
   closeOverlay();
 
-  if (guideActivationTimeout) clearTimeout(guideActivationTimeout);
-  guideActivationTimeout = setTimeout(() => {
-    guideActivationTimeout = undefined;
+  setTimeout(() => {
     controller.activeGuideId = stepId;
 
     if (stepId === OperationalStepId.ActivateVault) {
@@ -289,7 +286,6 @@ function openOperationalOverlay(stepId: OperationalStepId) {
 basicEmitter.on('openOperationalOverlay', openOperationalOverlay);
 
 Vue.onUnmounted(() => {
-  if (guideActivationTimeout) clearTimeout(guideActivationTimeout);
   basicEmitter.off('openOperationalOverlay', openOperationalOverlay);
 });
 </script>

--- a/src-vue/overlays/OperationalProfileOverlay.vue
+++ b/src-vue/overlays/OperationalProfileOverlay.vue
@@ -121,6 +121,7 @@ const setupProgressError = Vue.ref<string | null>(null);
 
 let unsubSetupProgress: (() => void) | undefined;
 let selectDraftName: ((operatorName: string) => void) | undefined;
+let openRequestId = 0;
 
 const hasVault = Vue.computed(() => {
   return !!myVault.createdVault?.vaultId;
@@ -246,14 +247,20 @@ function closeOverlay() {
   basics.overlayIsOpen = false;
 }
 
-basicEmitter.on('openOperationalProfileOverlay', async request => {
+async function openOperationalProfileOverlay(request: void | IOperationalProfileRequest) {
+  const requestId = ++openRequestId;
   await load(request || undefined);
+  if (requestId !== openRequestId) return;
   isOpen.value = true;
   isLoaded.value = true;
   basics.overlayIsOpen = true;
-});
+}
+
+basicEmitter.on('openOperationalProfileOverlay', openOperationalProfileOverlay);
 
 Vue.onUnmounted(() => {
+  openRequestId += 1;
+  basicEmitter.off('openOperationalProfileOverlay', openOperationalProfileOverlay);
   clearSetupProgress();
 });
 </script>

--- a/src-vue/overlays/OperationalProfileOverlay.vue
+++ b/src-vue/overlays/OperationalProfileOverlay.vue
@@ -250,6 +250,7 @@ function closeOverlay() {
 async function openOperationalProfileOverlay(request: void | IOperationalProfileRequest) {
   const requestId = ++openRequestId;
   await load(request || undefined);
+  // Runtime compatibility can unmount this global overlay while the profile load is pending.
   if (requestId !== openRequestId) return;
   isOpen.value = true;
   isLoaded.value = true;

--- a/src-vue/overlays/OperationalRewardsOverlay.vue
+++ b/src-vue/overlays/OperationalRewardsOverlay.vue
@@ -115,12 +115,18 @@ Vue.watch(
   },
 );
 
-basicEmitter.on('openOperationalRewardsOverlay', payload => {
+function openOperationalRewardsOverlay(payload?: { screen?: OperationalRewardsScreen }) {
   if (!controller.isFullyOperational && !controller.isOperationalActivationReady) {
     return;
   }
 
   controller.clearCompletionNotices();
   goTo(payload?.screen ?? (controller.isFullyOperational ? 'congratulations' : 'activate'));
+}
+
+basicEmitter.on('openOperationalRewardsOverlay', openOperationalRewardsOverlay);
+
+Vue.onUnmounted(() => {
+  basicEmitter.off('openOperationalRewardsOverlay', openOperationalRewardsOverlay);
 });
 </script>

--- a/src-vue/overlays/UpgradeToOperationsOverlay.vue
+++ b/src-vue/overlays/UpgradeToOperationsOverlay.vue
@@ -248,10 +248,12 @@ function closeOverlay() {
   isOpen.value = false;
 }
 
-basicEmitter.on('openUpgradeToOperationsOverlay', () => {
+function openUpgradeToOperationsOverlay() {
   isOpen.value = true;
   void refreshOperationReturns();
-});
+}
+
+basicEmitter.on('openUpgradeToOperationsOverlay', openUpgradeToOperationsOverlay);
 
 Vue.watch(
   () => controller.chainProgress.isUpgradedToOperations,
@@ -269,6 +271,7 @@ Vue.onMounted(() => {
 });
 
 Vue.onBeforeUnmount(() => {
+  basicEmitter.off('openUpgradeToOperationsOverlay', openUpgradeToOperationsOverlay);
   if (refreshInterval) {
     clearInterval(refreshInterval);
   }

--- a/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
+++ b/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
@@ -774,10 +774,13 @@ function selectAction(action: 'accept' | 'return') {
 
 let refreshFeeEstimateTimeout: ReturnType<typeof setTimeout> | undefined;
 let feeEstimateRunId = 0;
+let isUnmounted = false;
 
 function queueFeeEstimateRefresh() {
+  if (isUnmounted) return;
   if (refreshFeeEstimateTimeout) clearTimeout(refreshFeeEstimateTimeout);
   refreshFeeEstimateTimeout = setTimeout(() => {
+    refreshFeeEstimateTimeout = undefined;
     void refreshEstimatedOptionFees();
   }, 200);
 }
@@ -786,7 +789,7 @@ async function refreshEstimatedOptionFees() {
   const runId = ++feeEstimateRunId;
   const candidate = nextCandidate.value?.record;
   if (!candidate || !currentLock.value.utxoId) {
-    if (runId !== feeEstimateRunId) return;
+    if (isUnmounted || runId !== feeEstimateRunId) return;
     acceptArgonTxFeeMicrogons.value = null;
     returnArgonTxFeeMicrogons.value = null;
     return;
@@ -817,7 +820,7 @@ async function refreshEstimatedOptionFees() {
       .catch(() => null);
   }
 
-  if (runId !== feeEstimateRunId) return;
+  if (isUnmounted || runId !== feeEstimateRunId) return;
   acceptArgonTxFeeMicrogons.value = acceptFee;
   returnArgonTxFeeMicrogons.value = returnFee;
 }
@@ -962,12 +965,16 @@ Vue.watch(
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
   await vaults.load(true).catch(() => undefined);
+  if (isUnmounted) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(currentLock.value);
   queueFeeEstimateRefresh();
 });
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
+  feeEstimateRunId += 1;
   if (refreshFeeEstimateTimeout) clearTimeout(refreshFeeEstimateTimeout);
+  refreshFeeEstimateTimeout = undefined;
   stopLockProgressTracking?.();
   stopLockProgressTracking = undefined;
 });

--- a/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
+++ b/src-vue/overlays/bitcoin-locking/LockFundingMismatch.vue
@@ -774,13 +774,11 @@ function selectAction(action: 'accept' | 'return') {
 
 let refreshFeeEstimateTimeout: ReturnType<typeof setTimeout> | undefined;
 let feeEstimateRunId = 0;
-let isUnmounted = false;
+let isDisposed = false;
 
 function queueFeeEstimateRefresh() {
-  if (isUnmounted) return;
   if (refreshFeeEstimateTimeout) clearTimeout(refreshFeeEstimateTimeout);
   refreshFeeEstimateTimeout = setTimeout(() => {
-    refreshFeeEstimateTimeout = undefined;
     void refreshEstimatedOptionFees();
   }, 200);
 }
@@ -789,7 +787,7 @@ async function refreshEstimatedOptionFees() {
   const runId = ++feeEstimateRunId;
   const candidate = nextCandidate.value?.record;
   if (!candidate || !currentLock.value.utxoId) {
-    if (isUnmounted || runId !== feeEstimateRunId) return;
+    if (runId !== feeEstimateRunId) return;
     acceptArgonTxFeeMicrogons.value = null;
     returnArgonTxFeeMicrogons.value = null;
     return;
@@ -820,7 +818,7 @@ async function refreshEstimatedOptionFees() {
       .catch(() => null);
   }
 
-  if (isUnmounted || runId !== feeEstimateRunId) return;
+  if (runId !== feeEstimateRunId) return;
   acceptArgonTxFeeMicrogons.value = acceptFee;
   returnArgonTxFeeMicrogons.value = returnFee;
 }
@@ -965,16 +963,15 @@ Vue.watch(
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
   await vaults.load(true).catch(() => undefined);
-  if (isUnmounted) return;
+  // This component instance can be disposed during the forced refresh; do not start resources afterward.
+  if (isDisposed) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(currentLock.value);
   queueFeeEstimateRefresh();
 });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
-  feeEstimateRunId += 1;
+  isDisposed = true;
   if (refreshFeeEstimateTimeout) clearTimeout(refreshFeeEstimateTimeout);
-  refreshFeeEstimateTimeout = undefined;
   stopLockProgressTracking?.();
   stopLockProgressTracking = undefined;
 });

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
@@ -79,9 +79,11 @@ const progressLabel = Vue.computed(() => {
 });
 
 let stopLockProgressTracking: (() => void) | undefined;
+let isUnmounted = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
+  if (isUnmounted) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
 });
 
@@ -94,6 +96,7 @@ Vue.watch(
 );
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
   stopLockProgressTracking?.();
   stopLockProgressTracking = undefined;
 });

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnArgon.vue
@@ -79,11 +79,12 @@ const progressLabel = Vue.computed(() => {
 });
 
 let stopLockProgressTracking: (() => void) | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
-  if (isUnmounted) return;
+  // Persisted locks render early, so this component instance can be disposed while loading.
+  if (isDisposed) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
 });
 
@@ -96,7 +97,7 @@ Vue.watch(
 );
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   stopLockProgressTracking?.();
   stopLockProgressTracking = undefined;
 });

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
@@ -126,11 +126,12 @@ function updateProgress() {
 
 let updateBitcoinLockProcessingInterval: ReturnType<typeof setInterval> | undefined = undefined;
 let stopLockProgressTracking: (() => void) | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
-  if (isUnmounted) return;
+  // Persisted locks render early, so this component instance can be disposed while loading.
+  if (isDisposed) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
   updateBitcoinLockProcessingInterval = setInterval(updateProgress, 1e3);
   updateProgress();
@@ -146,7 +147,7 @@ Vue.watch(
 );
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   if (updateBitcoinLockProcessingInterval) {
     clearInterval(updateBitcoinLockProcessingInterval);
     updateBitcoinLockProcessingInterval = undefined;

--- a/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockIsProcessingOnBitcoin.vue
@@ -126,9 +126,11 @@ function updateProgress() {
 
 let updateBitcoinLockProcessingInterval: ReturnType<typeof setInterval> | undefined = undefined;
 let stopLockProgressTracking: (() => void) | undefined;
+let isUnmounted = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
+  if (isUnmounted) return;
   stopLockProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
   updateBitcoinLockProcessingInterval = setInterval(updateProgress, 1e3);
   updateProgress();
@@ -144,8 +146,10 @@ Vue.watch(
 );
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
   if (updateBitcoinLockProcessingInterval) {
     clearInterval(updateBitcoinLockProcessingInterval);
+    updateBitcoinLockProcessingInterval = undefined;
   }
   stopLockProgressTracking?.();
   stopLockProgressTracking = undefined;

--- a/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
@@ -173,6 +173,7 @@ const retrySeconds = Vue.ref<number>();
 const fundingCheckMessage = Vue.ref('');
 
 let retryCountdownInterval: ReturnType<typeof setInterval> | undefined;
+let isUnmounted = false;
 
 function closeOverlay() {
   emit('close');
@@ -185,20 +186,24 @@ async function checkForBitcoin() {
   isCheckingForBitcoin.value = true;
   try {
     const observation = await bitcoinLocks.utxoTracking.observeMempoolFunding(props.personalLock);
+    if (isUnmounted) return;
     if (observation) return;
 
     fundingCheckMessage.value = 'We haven’t found your transfer yet, but we’ll keep checking automatically.';
   } catch (error) {
+    if (isUnmounted) return;
     console.error('Error checking for Bitcoin funding:', error);
     fundingCheckMessage.value = 'We couldn’t check the Bitcoin network just now, but we’ll try again automatically.';
   } finally {
-    isCheckingForBitcoin.value = false;
+    if (!isUnmounted) isCheckingForBitcoin.value = false;
   }
 
+  if (isUnmounted) return;
   startFundingRetryCountdown();
 }
 
 function startFundingRetryCountdown() {
+  if (isUnmounted) return;
   stopFundingRetryCountdown();
   retrySeconds.value = 30;
   retryCountdownInterval = setInterval(() => {
@@ -221,6 +226,7 @@ function stopFundingRetryCountdown() {
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
+  if (isUnmounted) return;
   fundingExpirationTime.value = dayjs.utc(bitcoinLocks.verifyExpirationTime(props.personalLock));
   try {
     scriptPaytoAddress.value = bitcoinLocks.formatP2wshAddress(props.personalLock.lockDetails.p2wshScriptHashHex);
@@ -241,5 +247,8 @@ Vue.onMounted(async () => {
   fundingBip21.value = `bitcoin:${scriptPaytoAddress.value}?amount=${btcAmount}&label=${label}&message=${message}`;
 });
 
-Vue.onUnmounted(stopFundingRetryCountdown);
+Vue.onUnmounted(() => {
+  isUnmounted = true;
+  stopFundingRetryCountdown();
+});
 </script>

--- a/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
+++ b/src-vue/overlays/bitcoin-locking/LockReadyForBitcoin.vue
@@ -173,7 +173,7 @@ const retrySeconds = Vue.ref<number>();
 const fundingCheckMessage = Vue.ref('');
 
 let retryCountdownInterval: ReturnType<typeof setInterval> | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 function closeOverlay() {
   emit('close');
@@ -186,24 +186,22 @@ async function checkForBitcoin() {
   isCheckingForBitcoin.value = true;
   try {
     const observation = await bitcoinLocks.utxoTracking.observeMempoolFunding(props.personalLock);
-    if (isUnmounted) return;
     if (observation) return;
 
     fundingCheckMessage.value = 'We haven’t found your transfer yet, but we’ll keep checking automatically.';
   } catch (error) {
-    if (isUnmounted) return;
     console.error('Error checking for Bitcoin funding:', error);
     fundingCheckMessage.value = 'We couldn’t check the Bitcoin network just now, but we’ll try again automatically.';
   } finally {
-    if (!isUnmounted) isCheckingForBitcoin.value = false;
+    isCheckingForBitcoin.value = false;
   }
 
-  if (isUnmounted) return;
+  // The request can finish after this component instance is disposed; teardown cannot clear a later interval.
+  if (isDisposed) return;
   startFundingRetryCountdown();
 }
 
 function startFundingRetryCountdown() {
-  if (isUnmounted) return;
   stopFundingRetryCountdown();
   retrySeconds.value = 30;
   retryCountdownInterval = setInterval(() => {
@@ -226,7 +224,6 @@ function stopFundingRetryCountdown() {
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
-  if (isUnmounted) return;
   fundingExpirationTime.value = dayjs.utc(bitcoinLocks.verifyExpirationTime(props.personalLock));
   try {
     scriptPaytoAddress.value = bitcoinLocks.formatP2wshAddress(props.personalLock.lockDetails.p2wshScriptHashHex);
@@ -248,7 +245,7 @@ Vue.onMounted(async () => {
 });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   stopFundingRetryCountdown();
 });
 </script>

--- a/src-vue/overlays/bitcoin-locking/UnlockIsProcessing.vue
+++ b/src-vue/overlays/bitcoin-locking/UnlockIsProcessing.vue
@@ -55,13 +55,16 @@ Vue.watch(
 );
 
 let stopProgressTracking: (() => void) | undefined;
+let isUnmounted = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
+  if (isUnmounted) return;
   stopProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
 });
 
 Vue.onUnmounted(() => {
+  isUnmounted = true;
   stopProgressTracking?.();
   stopProgressTracking = undefined;
 });

--- a/src-vue/overlays/bitcoin-locking/UnlockIsProcessing.vue
+++ b/src-vue/overlays/bitcoin-locking/UnlockIsProcessing.vue
@@ -55,16 +55,17 @@ Vue.watch(
 );
 
 let stopProgressTracking: (() => void) | undefined;
-let isUnmounted = false;
+let isDisposed = false;
 
 Vue.onMounted(async () => {
   await bitcoinLocks.load();
-  if (isUnmounted) return;
+  // Persisted locks render early, so this component instance can be disposed while loading.
+  if (isDisposed) return;
   stopProgressTracking = bitcoinLockProgress.trackLock(personalLock.value);
 });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   stopProgressTracking?.();
   stopProgressTracking = undefined;
 });

--- a/src-vue/screens/mining-screen/FirstAuctionFailed.vue
+++ b/src-vue/screens/mining-screen/FirstAuctionFailed.vue
@@ -69,6 +69,9 @@ const currency = getCurrency();
 const wallets = useWallets();
 const myMiningSeats = getMyMiningSeats();
 const bot = getBot();
+let isUnmounted = false;
+let calculatorSubscription: ReturnType<typeof calculator.onLoad> | undefined;
+let isActivitySubscribed = false;
 
 const { microgonToMoneyNm, microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 const microgonRequirement = Vue.ref(0n);
@@ -105,9 +108,16 @@ function openWalletFunding() {
 Vue.onMounted(async () => {
   if (!config.biddingRules) return;
   await config.isLoadedPromise;
+  if (isUnmounted) return;
   await myMiningSeats.subscribeToActivity();
+  if (isUnmounted) {
+    myMiningSeats.unsubscribeFromActivity();
+    return;
+  }
+  isActivitySubscribed = true;
 
-  const loadSubscription = calculator.onLoad(() => {
+  calculatorSubscription = calculator.onLoad(() => {
+    if (isUnmounted) return;
     const projections = calculator.runProjections(config.biddingRules, 'maximum');
     microgonRequirement.value = projections.microgonRequirement;
     micronotRequirement.value = projections.micronotRequirement;
@@ -115,12 +125,17 @@ Vue.onMounted(async () => {
     myMaximumBid.value = calculator.maximumBidAmount;
   });
 
-  Vue.onUnmounted(() => {
-    loadSubscription.unsubscribe();
-    myMiningSeats.unsubscribeFromActivity();
-  });
-
   await calculator.load();
+});
+
+Vue.onUnmounted(() => {
+  isUnmounted = true;
+  calculatorSubscription?.unsubscribe();
+  calculatorSubscription = undefined;
+  if (isActivitySubscribed) {
+    myMiningSeats.unsubscribeFromActivity();
+    isActivitySubscribed = false;
+  }
 });
 </script>
 

--- a/src-vue/screens/mining-screen/FirstAuctionFailed.vue
+++ b/src-vue/screens/mining-screen/FirstAuctionFailed.vue
@@ -69,9 +69,8 @@ const currency = getCurrency();
 const wallets = useWallets();
 const myMiningSeats = getMyMiningSeats();
 const bot = getBot();
-let isUnmounted = false;
+let isDisposed = false;
 let calculatorSubscription: ReturnType<typeof calculator.onLoad> | undefined;
-let isActivitySubscribed = false;
 
 const { microgonToMoneyNm, microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 const microgonRequirement = Vue.ref(0n);
@@ -108,16 +107,12 @@ function openWalletFunding() {
 Vue.onMounted(async () => {
   if (!config.biddingRules) return;
   await config.isLoadedPromise;
-  if (isUnmounted) return;
-  await myMiningSeats.subscribeToActivity();
-  if (isUnmounted) {
-    myMiningSeats.unsubscribeFromActivity();
-    return;
-  }
-  isActivitySubscribed = true;
+  // This component instance can be disposed while configuration loads; do not attach callbacks afterward.
+  if (isDisposed) return;
 
   calculatorSubscription = calculator.onLoad(() => {
-    if (isUnmounted) return;
+    // onLoad also queues this callback through loadedFrameIdPromise, which unsubscribe cannot cancel.
+    if (isDisposed) return;
     const projections = calculator.runProjections(config.biddingRules, 'maximum');
     microgonRequirement.value = projections.microgonRequirement;
     micronotRequirement.value = projections.micronotRequirement;
@@ -129,13 +124,8 @@ Vue.onMounted(async () => {
 });
 
 Vue.onUnmounted(() => {
-  isUnmounted = true;
+  isDisposed = true;
   calculatorSubscription?.unsubscribe();
-  calculatorSubscription = undefined;
-  if (isActivitySubscribed) {
-    myMiningSeats.unsubscribeFromActivity();
-    isActivitySubscribed = false;
-  }
 });
 </script>
 

--- a/src-vue/stores/bitcoinLockProgress.ts
+++ b/src-vue/stores/bitcoinLockProgress.ts
@@ -399,6 +399,7 @@ export function createBitcoinLockProgressStore(deps: BitcoinLockProgressDeps) {
   async function ensureMiningFramesSubscription() {
     if (miningFramesUnsub) return;
     await miningFrames.load();
+    if (activeConsumers.value === 0 || miningFramesUnsub || !isReleaseArgonPhase(lock.value)) return;
     miningFramesUnsub = miningFrames.onTick(() => {
       if (isReleaseArgonPhase(lock.value)) {
         updateVaultWaitProgress();

--- a/src-vue/stores/bitcoinLockProgress.ts
+++ b/src-vue/stores/bitcoinLockProgress.ts
@@ -399,6 +399,7 @@ export function createBitcoinLockProgressStore(deps: BitcoinLockProgressDeps) {
   async function ensureMiningFramesSubscription() {
     if (miningFramesUnsub) return;
     await miningFrames.load();
+    // The final consumer can stop while loading; do not subscribe after its disposer has already run.
     if (activeConsumers.value === 0 || miningFramesUnsub || !isReleaseArgonPhase(lock.value)) return;
     miningFramesUnsub = miningFrames.onTick(() => {
       if (isReleaseArgonPhase(lock.value)) {


### PR DESCRIPTION
## Summary

Some overlays kept global event handlers after unmount, and several async setup paths could attach timers or subscriptions after their owner was gone. That could reopen stale overlays, keep background polling alive, or publish late progress into abandoned views.

This makes component lifetime and active Bitcoin progress consumers authoritative for those resources. Existing mounted flows behave the same; teardown now invalidates late work and removes owned listeners.

## Validation

- `yarn typecheck`
- `yarn lint:check`
- The Bitcoin progress regression test passes and fails against the previous late-subscription behavior.
