### PR TITLE
fix: harden installer and bitcoin failure handling

### DIFF
--- a/e2e/flows/operations/Mining.op.finalizeSetup.ts
+++ b/e2e/flows/operations/Mining.op.finalizeSetup.ts
@@ -210,6 +210,10 @@ export default new Operation<IMiningFlowContext, IFinalizeSetupState>(import.met
       INSTALL_PROGRESS_POLL_MS,
       async () => {
         if (await didFinishInstall()) return true;
+        const miningInstallError = await getMiningInstallError(flow);
+        if (miningInstallError) {
+          throw new Error(`${flowName}: mining setup failed: ${miningInstallError}`);
+        }
 
         const [installProgressVisible, miningInstallingVisible, startingBotVisible] = await Promise.all([
           flow.isVisible({ selector: '.InstallProgress' }),
@@ -384,6 +388,15 @@ async function getFailedInstallStepNames(flow: IE2EFlowRuntime, stepCount: numbe
   return failedSteps;
 }
 
+async function getMiningInstallError(flow: IE2EFlowRuntime): Promise<string | null> {
+  const errorTarget = 'MiningIsInstalling.errorMessage';
+  const errorState = await flow.isVisible(errorTarget);
+  if (!errorState.visible) return null;
+
+  const message = (await flow.getText(errorTarget, { timeoutMs: 1_000 })).trim();
+  return message.length > 0 ? message : 'Unknown mining setup error';
+}
+
 async function tryGetTotalBlocksMined(flow: IE2EFlowRuntime, flowName: string): Promise<number | null> {
   const value = await getAttributeOrNull(flow, 'TotalBlocksMined', 'data-value', 2_000);
   if (value == null || value.trim().length === 0) return null;
@@ -398,6 +411,11 @@ async function waitForServerInstallToReachLaunchableState(flow: IE2EFlowRuntime,
   await pollEvery(
     2_000,
     async () => {
+      const miningInstallError = await getMiningInstallError(flow);
+      if (miningInstallError) {
+        throw new Error(`${flowName}: mining setup failed: ${miningInstallError}`);
+      }
+
       const [dashboard, firstAuction, startingBot, launchBot, installProgress] = await Promise.all([
         flow.isVisible('MiningDashboard'),
         flow.isVisible('FirstAuction'),
@@ -475,6 +493,11 @@ async function waitForPostLaunchReadyState(flow: IE2EFlowRuntime, flowName: stri
   await pollEvery(
     2_000,
     async () => {
+      const miningInstallError = await getMiningInstallError(flow);
+      if (miningInstallError) {
+        throw new Error(`${flowName}: mining setup failed: ${miningInstallError}`);
+      }
+
       const dashboardVisible = await flow.isVisible('MiningDashboard');
       return dashboardVisible.visible;
     },

--- a/src-vue/__test__/BitcoinLocks.integration.test.ts
+++ b/src-vue/__test__/BitcoinLocks.integration.test.ts
@@ -265,8 +265,8 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
           );
 
           const expirationConfig = await BitcoinLock.getConfig(await clients.get(false));
-          const expirationBitcoinHeight =
-            observed.lock.lockDetails.createdAtHeight + expirationConfig.pendingConfirmationExpirationBlocks;
+          const orphaningBitcoinHeight =
+            observed.lock.lockDetails.createdAtHeight + expirationConfig.pendingConfirmationExpirationBlocks + 1;
 
           const preExpiryClient = await clients.get(false);
           const preExpiryBitcoinHeight = await BitcoinLock.getBitcoinConfirmedBlockHeight(preExpiryClient);
@@ -281,7 +281,7 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
             );
           });
 
-          expect(preExpiryBitcoinHeight).toBeLessThan(expirationBitcoinHeight);
+          expect(preExpiryBitcoinHeight).toBeLessThan(orphaningBitcoinHeight);
           expect(preExpiryChainLock).toBeTruthy();
           expect(candidateWasRecordedBeforeExpiry).toBe(true);
 
@@ -291,8 +291,8 @@ describe.skipIf(skipE2E).sequential('BitcoinLocks integration', { timeout: 240e3
             async () => {
               const chainClient = await clients.get(false);
               const currentBitcoinHeight = await BitcoinLock.getBitcoinConfirmedBlockHeight(chainClient);
-              if (currentBitcoinHeight >= expirationBitcoinHeight) return true;
-              mineBitcoinBlocks(expirationBitcoinHeight - currentBitcoinHeight, minerAddress);
+              if (currentBitcoinHeight >= orphaningBitcoinHeight) return true;
+              mineBitcoinBlocks(orphaningBitcoinHeight - currentBitcoinHeight, minerAddress);
               return;
             },
             { pollMs: 1e3 },
@@ -930,16 +930,16 @@ async function returnExpiredMismatchAndWaitForChainRestore(
 }> {
   const observed = await observeMismatchCandidate(harness, lock, getMismatchFundingSatoshis(lock.satoshis), progress);
   const expirationConfig = await BitcoinLock.getConfig(await clients.get(false));
-  const expirationBitcoinHeight =
-    observed.lock.lockDetails.createdAtHeight + expirationConfig.pendingConfirmationExpirationBlocks;
+  const orphaningBitcoinHeight =
+    observed.lock.lockDetails.createdAtHeight + expirationConfig.pendingConfirmationExpirationBlocks + 1;
   await waitFor(
     60e3,
     'bitcoin lock expiration height',
     async () => {
       const chainClient = await clients.get(false);
       const currentBitcoinHeight = await BitcoinLock.getBitcoinConfirmedBlockHeight(chainClient);
-      if (currentBitcoinHeight >= expirationBitcoinHeight) return true;
-      mineBitcoinBlocks(expirationBitcoinHeight - currentBitcoinHeight, minerAddress);
+      if (currentBitcoinHeight >= orphaningBitcoinHeight) return true;
+      mineBitcoinBlocks(orphaningBitcoinHeight - currentBitcoinHeight, minerAddress);
       return;
     },
     { pollMs: 1e3 },

--- a/src-vue/__test__/BitcoinUtxoTracking.test.ts
+++ b/src-vue/__test__/BitcoinUtxoTracking.test.ts
@@ -257,6 +257,7 @@ describe('BitcoinUtxoTracking', () => {
   });
 
   it('still records mempool funding when Argon candidate refresh fails', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const db = await createTestDb();
     const tracking = createTracking(db, {
       mempool: {
@@ -291,6 +292,58 @@ describe('BitcoinUtxoTracking', () => {
     expect(candidates[0].txid).toBe('d'.repeat(64));
     expect(candidates[0].status).toBe(BitcoinUtxoStatus.SeenOnMempool);
     expect(candidates[0].mempoolObservation?.isConfirmed).toBe(true);
+    expect(warning).toHaveBeenCalledWith(
+      '[BitcoinUtxoTracking] Failed to refresh Argon funding candidates',
+      expect.objectContaining({ message: 'rpc timeout' }),
+    );
+    warning.mockRestore();
+  });
+
+  it('still records Argon funding when mempool observation fails', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const db = await createTestDb();
+    const tracking = createTracking(db, {
+      mempool: {
+        getAddressUtxos: vi.fn().mockRejectedValue(new Error('esplora unavailable')),
+      },
+    });
+    const lock = createLock({ status: BitcoinLockStatus.LockPendingFunding, satoshis: 10_000n });
+    const chainTxid = 'e'.repeat(64);
+    const preferredClient = Object.assign(Object.create(null), {
+      query: Object.assign(Object.create(null), {
+        bitcoinUtxos: Object.assign(Object.create(null), {
+          candidateUtxoRefsByUtxoId: vi.fn().mockResolvedValue({
+            entries: () =>
+              [
+                [
+                  {
+                    txid: { toHex: () => chainTxid },
+                    outputIndex: { toNumber: () => 1 },
+                  },
+                  { toBigInt: () => 10_100n },
+                ],
+              ][Symbol.iterator](),
+          }),
+        }),
+        bitcoinLocks: Object.assign(Object.create(null), {
+          orphanedUtxosByAccount: Object.assign(Object.create(null), {
+            entries: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }) as ArgonClient;
+
+    const hasSignals = await tracking.syncPendingFundingSignals(lock, preferredClient);
+
+    expect(hasSignals).toBe(true);
+    expect(tracking.getFundingCandidateRecords(lock)).toEqual([
+      expect.objectContaining({ txid: chainTxid, status: BitcoinUtxoStatus.FundingCandidate }),
+    ]);
+    expect(warning).toHaveBeenCalledWith(
+      '[BitcoinUtxoTracking] Failed to observe mempool funding',
+      expect.objectContaining({ message: 'esplora unavailable' }),
+    );
+    warning.mockRestore();
   });
 
   it('does not downgrade an Argon funding candidate when mempool observation arrives later', async () => {

--- a/src-vue/__test__/BitcoinUtxoTracking.test.ts
+++ b/src-vue/__test__/BitcoinUtxoTracking.test.ts
@@ -293,7 +293,7 @@ describe('BitcoinUtxoTracking', () => {
     expect(candidates[0].status).toBe(BitcoinUtxoStatus.SeenOnMempool);
     expect(candidates[0].mempoolObservation?.isConfirmed).toBe(true);
     expect(warning).toHaveBeenCalledWith(
-      '[BitcoinUtxoTracking] Failed to refresh Argon funding candidates',
+      '[BitcoinUtxoTracking] Failed to refresh Argon funding candidates for lock lock-1 (utxoId 1)',
       expect.objectContaining({ message: 'rpc timeout' }),
     );
     warning.mockRestore();
@@ -340,7 +340,7 @@ describe('BitcoinUtxoTracking', () => {
       expect.objectContaining({ txid: chainTxid, status: BitcoinUtxoStatus.FundingCandidate }),
     ]);
     expect(warning).toHaveBeenCalledWith(
-      '[BitcoinUtxoTracking] Failed to observe mempool funding',
+      '[BitcoinUtxoTracking] Failed to observe mempool funding for lock lock-1 (utxoId 1)',
       expect.objectContaining({ message: 'esplora unavailable' }),
     );
     warning.mockRestore();

--- a/src-vue/__test__/SSHConnection.test.ts
+++ b/src-vue/__test__/SSHConnection.test.ts
@@ -3,11 +3,12 @@ import { ServerType } from '../interfaces/IConfig.ts';
 import { SSHConnection } from '../lib/SSHConnection.ts';
 import { InvokeTimeout } from '../lib/tauriApi.ts';
 
-const { invokeWithTimeout, MockInvokeTimeout } = vi.hoisted(() => {
+const { invokeWithTimeout, listen, MockInvokeTimeout } = vi.hoisted(() => {
   class MockInvokeTimeout extends Error {}
 
   return {
     invokeWithTimeout: vi.fn(),
+    listen: vi.fn(),
     MockInvokeTimeout,
   };
 });
@@ -21,13 +22,15 @@ vi.mock('../lib/tauriApi.ts', () => {
 
 vi.mock('@tauri-apps/api/event', () => {
   return {
-    listen: vi.fn(),
+    listen,
   };
 });
 
 describe('SSHConnection', () => {
   beforeEach(() => {
     invokeWithTimeout.mockReset();
+    listen.mockReset();
+    listen.mockResolvedValue(vi.fn());
   });
 
   it('reconnects after a command timeout even if close times out', async () => {
@@ -86,5 +89,68 @@ describe('SSHConnection', () => {
       'open_ssh_connection',
       'ssh_run_command',
     ]);
+  });
+
+  it('retries an embedded upload after the transfer client times out', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    invokeWithTimeout
+      .mockRejectedValueOnce(new Error('SSH upload timed out after 120s'))
+      .mockResolvedValueOnce('success');
+
+    const connection = new SSHConnection({
+      type: ServerType.LocalComputer,
+      ipAddress: '127.0.0.1',
+      sshPort: 55404,
+      sshUser: 'root',
+      workDir: '/app',
+    });
+
+    await expect(
+      connection.uploadEmbeddedFileWithTimeout(
+        'resources/server-2.3.5.tar.gz',
+        '/app/server-2.3.5.tar.gz',
+        vi.fn(),
+        120_000,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(invokeWithTimeout.mock.calls.map(call => call[0] as string)).toEqual([
+      'ssh_upload_embedded_file',
+      'ssh_upload_embedded_file',
+    ]);
+    expect(warning).toHaveBeenCalledWith(
+      '[SSHConnection] Embedded upload to /app/server-2.3.5.tar.gz timed out at 0%; retrying with a fresh transfer connection',
+    );
+    warning.mockRestore();
+  });
+
+  it('reports upload progress when the final transfer attempt times out', async () => {
+    let emitProgress: ((event: { payload: number }) => void) | undefined;
+    listen.mockImplementation(async (_eventName, callback) => {
+      emitProgress = callback;
+      return vi.fn();
+    });
+    invokeWithTimeout.mockImplementationOnce(async () => {
+      emitProgress?.({ payload: 37 });
+      throw new Error('SSH upload timed out after 120s');
+    });
+
+    const connection = new SSHConnection({
+      type: ServerType.LocalComputer,
+      ipAddress: '127.0.0.1',
+      sshPort: 55404,
+      sshUser: 'root',
+      workDir: '/app',
+    });
+
+    await expect(
+      connection.uploadEmbeddedFileWithTimeout(
+        'resources/server-2.3.5.tar.gz',
+        '/app/server-2.3.5.tar.gz',
+        vi.fn(),
+        120_000,
+        0,
+      ),
+    ).rejects.toThrow('streaming, last progress 37%');
   });
 });

--- a/src-vue/lib/BitcoinUtxoTracking.ts
+++ b/src-vue/lib/BitcoinUtxoTracking.ts
@@ -298,12 +298,18 @@ export default class BitcoinUtxoTracking {
     ]);
 
     if (argonCandidatesResult.status === 'rejected') {
-      console.warn('[BitcoinUtxoTracking] Failed to refresh Argon funding candidates', argonCandidatesResult.reason);
+      console.warn(
+        `[BitcoinUtxoTracking] Failed to refresh Argon funding candidates for lock ${lock.uuid} (utxoId ${lock.utxoId})`,
+        argonCandidatesResult.reason,
+      );
     }
     if (mempoolObservationResult.status === 'fulfilled') {
       mempoolObservation = mempoolObservationResult.value;
     } else {
-      console.warn('[BitcoinUtxoTracking] Failed to observe mempool funding', mempoolObservationResult.reason);
+      console.warn(
+        `[BitcoinUtxoTracking] Failed to observe mempool funding for lock ${lock.uuid} (utxoId ${lock.utxoId})`,
+        mempoolObservationResult.reason,
+      );
     }
 
     const hasFundingRecord = !!this.getAcceptedFundingRecordForLock(lock);

--- a/src-vue/lib/BitcoinUtxoTracking.ts
+++ b/src-vue/lib/BitcoinUtxoTracking.ts
@@ -297,8 +297,13 @@ export default class BitcoinUtxoTracking {
       this.observeMempoolFunding(lock),
     ]);
 
+    if (argonCandidatesResult.status === 'rejected') {
+      console.warn('[BitcoinUtxoTracking] Failed to refresh Argon funding candidates', argonCandidatesResult.reason);
+    }
     if (mempoolObservationResult.status === 'fulfilled') {
       mempoolObservation = mempoolObservationResult.value;
+    } else {
+      console.warn('[BitcoinUtxoTracking] Failed to observe mempool funding', mempoolObservationResult.reason);
     }
 
     const hasFundingRecord = !!this.getAcceptedFundingRecordForLock(lock);

--- a/src-vue/lib/SSHConnection.ts
+++ b/src-vue/lib/SSHConnection.ts
@@ -112,11 +112,14 @@ export class SSHConnection {
     remotePath: string,
     progressCallback: (progress: number) => void,
     timeout: number,
+    retries = 1,
   ): Promise<void> {
     const eventProgressKey = localRelativePath.replace(/[^a-zA-Z0-9]/g, '_') + '_up_progress';
+    let lastProgress = 0;
     const unsub = await listen(eventProgressKey, event => {
-      progressCallback(event.payload as number);
-      if (event.payload === 100) {
+      lastProgress = event.payload as number;
+      progressCallback(lastProgress);
+      if (lastProgress === 100) {
         unsub(); // Unsubscribe when upload is complete
       }
     });
@@ -129,9 +132,28 @@ export class SSHConnection {
         timeoutMs: timeout,
       };
       await invokeWithTimeout('ssh_upload_embedded_file', payload, timeout + 5_000);
-    } catch (e) {
+    } catch (error) {
       unsub();
-      throw e;
+      const errorMessage = String(error).toLowerCase();
+      const transferTimedOut = error instanceof InvokeTimeout || errorMessage.includes('ssh upload timed out');
+      if (retries > 0 && !this.isDestroyed && transferTimedOut) {
+        console.warn(
+          `[SSHConnection] Embedded upload to ${remotePath} timed out at ${lastProgress}%; ` +
+            'retrying with a fresh transfer connection',
+        );
+        return await this.uploadEmbeddedFileWithTimeout(
+          localRelativePath,
+          remotePath,
+          progressCallback,
+          timeout,
+          retries - 1,
+        );
+      }
+      if (transferTimedOut) {
+        const phase = lastProgress >= 100 ? 'awaiting remote completion' : 'streaming';
+        throw new Error(`${String(error)} (${phase}, last progress ${lastProgress}%)`);
+      }
+      throw error;
     }
   }
 

--- a/src-vue/screens/mining-screen/SetupInstalling.vue
+++ b/src-vue/screens/mining-screen/SetupInstalling.vue
@@ -5,7 +5,11 @@
       <MiningIcon :class="errorMessage ? '' : 'pulse-animation'" class="mx-auto mb-3 block h-28 text-argon-800/80" />
       <h1 class="mt-5 text-5xl font-bold text-center text-argon-600">Initializing Your Miner</h1>
 
-      <p v-if="errorMessage != ''" class="mx-auto w-140 pt-3 text-center font-light">
+      <p
+        v-if="errorMessage != ''"
+        data-testid="MiningIsInstalling.errorMessage"
+        class="mx-auto w-140 pt-3 text-center font-light"
+      >
         There was an error setting up your miner: <span class="text-red-700">{{ errorMessage }}</span>
       </p>
 


### PR DESCRIPTION
## Summary

Installer bundle uploads now get one clean retry after a transfer timeout. If the retry fails, mining E2E reports the installer error and last upload progress instead of waiting for a generic readiness timeout.

Bitcoin mismatch-return coverage now crosses the runtime's actual orphaning boundary. Argon and mempool funding checks continue independently, but a rejected source is logged rather than silently ignored.

Ethereum sync behavior is unchanged because the failed run did not expose a confirmed root cause there.

## Validation

- `Mining.flow.onboarding` completed through the real SSH installer upload.
- `Bitcoin.flow.mismatchReturn` completed, and all seven Docker-backed Bitcoin lock integration scenarios passed.
- Targeted unit tests, typechecking, linting, formatting, and operation-rule checks passed.
