### PR TITLE
fix: preserve dashboards and records through server upgrades

### DIFF
--- a/.storybook/scenarios/setupAppScenario.ts
+++ b/.storybook/scenarios/setupAppScenario.ts
@@ -64,6 +64,7 @@ export function setupAppScenario({ selectedTab, config: configOverrides = {} }: 
   const config = Vue.reactive({
     isLoaded: true,
     isLoadedPromise: Promise.resolve(),
+    selectedTab,
     hasExtensionOperations: true,
     hasExtensionTreasury: false,
     miningSetupStatus: MiningSetupStatus.None,

--- a/.storybook/scenarios/setupCertificationScenario.ts
+++ b/.storybook/scenarios/setupCertificationScenario.ts
@@ -134,6 +134,7 @@ export async function setupCertificationMenuScenario(state: CertificationMenuSce
     config.hasExtensionTreasury = true;
     config.hasExtensionOperations = true;
     config.setCertificationDetails({ hasSavedMnemonic: true });
+    controller.hasLoadedInitialOperationalProgress = true;
     controller.chainProgress = {
       ...controller.chainProgress,
       hasOperationalAccount: true,

--- a/.storybook/stories/certification/CertificationMenu.stories.ts
+++ b/.storybook/stories/certification/CertificationMenu.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import * as Vue from 'vue';
-import { within } from 'storybook/test';
+import { expect, within } from 'storybook/test';
 import AppScreen from '../../components/AppScreen.vue';
 import { expectEventuallyVisible } from '../../support/expectEventuallyVisible.ts';
 import { setupCertificationMenuScenario } from '../../scenarios/setupCertificationScenario.ts';
@@ -8,6 +8,8 @@ import basicEmitter from '../../../src-vue/emitters/basicEmitter.ts';
 import UpgradeToOperationsOverlay from '../../../src-vue/overlays/UpgradeToOperationsOverlay.vue';
 import Home from '../../../src-vue/screens/Home.vue';
 import CertificationMenu from '../../../src-vue/navigation/CertificationMenu.vue';
+import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
+import { TopTab } from '../../../src-vue/interfaces/IConfig.ts';
 
 const meta = {
   title: 'Certification/Top bar',
@@ -39,6 +41,26 @@ export const TreasuryChecklist: Story = {
     await expectEventuallyVisible(canvas.findByText(/Complete the following steps to unlock/));
     await expectEventuallyVisible(canvas.findByText(/Liquid Lock/));
     await expectEventuallyVisible(canvas.findByText(/Acquire .*Argon Bonds/));
+  },
+};
+
+export const OperationalProgressLoading: Story = {
+  beforeEach: () => {
+    const { controller } = setupAppScenario({
+      selectedTab: TopTab.Home,
+      config: {
+        hasExtensionTreasury: true,
+        hasExtensionOperations: true,
+      },
+    });
+    controller.isLoaded = true;
+    controller.hasLoadedInitialOperationalProgress = false;
+  },
+  render: () => renderCertificationOverview(false),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.queryByRole('button', { name: /Treasury Certification/ })).not.toBeInTheDocument();
   },
 };
 

--- a/.storybook/stories/mining/Mining.stories.ts
+++ b/.storybook/stories/mining/Mining.stories.ts
@@ -1,14 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { MICROGONS_PER_ARGON, MICRONOTS_PER_ARGONOT, MINING_BID_PROXY_FEE_FLOAT } from '@argonprotocol/apps-core';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, fn, mocked, userEvent, within } from 'storybook/test';
 import AppScreen from '../../components/AppScreen.vue';
 import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
 import { setupMiningAuctionScenario } from '../../scenarios/setupMiningAuctionScenario.ts';
 import { setupMiningPortfolioScenario } from '../../scenarios/setupMiningPortfolioScenario.ts';
 import { setCertificationGuide } from '../../scenarios/setupCertificationScenario.ts';
-import { MiningSetupStatus, TopTab, type IConfig } from '../../../src-vue/interfaces/IConfig.ts';
+import { InstallStepErrorType, MiningSetupStatus, TopTab, type IConfig } from '../../../src-vue/interfaces/IConfig.ts';
 import { Config } from '../../../src-vue/lib/Config.ts';
+import { getBot } from '../../../src-vue/stores/bot.ts';
 import { getConfig } from '../../../src-vue/stores/config.ts';
+import { getInstaller } from '../../../src-vue/stores/installer.ts';
 import { OperationalStepId } from '../../../src-vue/stores/certificationController.ts';
 import Mining from '../../../src-vue/screens/Mining.vue';
 
@@ -98,6 +100,61 @@ export const ServerInstalling: Story = {
 
     await expect(canvas.getByText('INSTALLING')).toBeVisible();
     await expect(canvas.getByText(/This local computer will be used to run your mining software/)).toBeVisible();
+  },
+};
+
+export const ServerUpdatingWithoutBotApi: Story = {
+  beforeEach: () => {
+    setupMiningPortfolioScenario();
+    Object.assign(getBot(), { isReady: false });
+    getConfig().isServerInstalling = true;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('heading', { name: 'Updating Your Server' })).toBeVisible();
+    await expect(canvas.getByText(/Mining will reconnect automatically/)).toBeVisible();
+  },
+};
+
+export const ServerUpdatingWithBotApi: Story = {
+  beforeEach: () => {
+    setupMiningPortfolioScenario();
+    getConfig().isServerInstalling = true;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('MiningDashboard')).toBeVisible();
+    await expect(canvas.queryByRole('heading', { name: 'Updating Your Server' })).not.toBeInTheDocument();
+  },
+};
+
+export const ServerUpdateFailed: Story = {
+  beforeEach: () => {
+    setupMiningPortfolioScenario();
+    Object.assign(getBot(), { isReady: false });
+
+    const config = getConfig();
+    config.isServerInstalling = true;
+    config.serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+    config.serverInstaller.errorType = InstallStepErrorType.ArgonInstall;
+    config.serverInstaller.errorMessage = 'Argon syncstatus returned error JSON too many times';
+
+    mocked(getInstaller, { partial: true }).mockReturnValue({
+      runFailedStep: fn(async () => undefined),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('LeftBar.goto(TopTab.Mining)')).toHaveClass('Selected');
+    await expect(canvas.getByText('Server Update Failed')).toBeVisible();
+    await expect(canvas.getByText(/Failed to Install Argon/)).toBeVisible();
+    await expect(canvas.getByText('Argon syncstatus returned error JSON too many times')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Retry' }));
+    await expect(getInstaller().runFailedStep).toHaveBeenCalledWith('all');
   },
 };
 

--- a/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
+++ b/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
@@ -4,10 +4,7 @@ import type {
   IBitcoinLockCouponUseRecord,
   ICertificationProgress,
 } from '@argonprotocol/apps-core';
-import type {
-  IBitcoinLockCouponStatus,
-  IMemberInvite,
-} from '@argonprotocol/apps-router';
+import type { IBitcoinLockCouponStatus, IMemberInvite } from '@argonprotocol/apps-router';
 import { MiningFrames, NetworkConfig } from '@argonprotocol/apps-core';
 import { Keyring } from '@polkadot/keyring';
 import { TypeRegistry } from '@polkadot/types';
@@ -188,14 +185,20 @@ export const BalancesUnavailable: Story = {
 export const PreviousRuntimeFeeWaiver: Story = {
   beforeEach: () => {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
+    const currentTick = MiningFrames.calculateCurrentTickFromSystemTime();
     selectedInvite = createInvite(8, {
       lastClickedAt: new Date('2026-08-16T16:00:00.000Z'),
-      bitcoinLockCoupon: createFeeWaiver('previousRuntime'),
+      bitcoinLockCoupon: createFeeWaiver('previousRuntime', currentTick),
     });
     controller.setOperationalInvites([selectedInvite]);
   },
   play: async () => {
-    await expectEventuallyVisible(within(document.body).findByText('This waiver covers one eligible Bitcoin lock.'));
+    const canvas = within(document.body);
+    const heading = await canvas.findByText('Bitcoin Fee Waiver');
+
+    await expect(heading.nextElementSibling).toHaveTextContent(/₳68\s*fee waiver\s*· Unused\s*· expired\s*now/);
+    await expect(heading.nextElementSibling).not.toHaveTextContent('$');
+    await expect(canvas.findByRole('button', { name: 'now' })).resolves.toBeEnabled();
   },
 };
 
@@ -210,7 +213,7 @@ export const FeeWaiverPending: Story = {
     controller.setOperationalInvites([selectedInvite]);
   },
   play: async () => {
-    await expectEventuallyVisible(within(document.body).findByText(/₳20\.40 pending/));
+    await expectEventuallyVisible(within(document.body).findByText(/₳20 pending/));
   },
 };
 
@@ -225,8 +228,10 @@ export const FeeWaiverUsed: Story = {
     controller.setOperationalInvites([selectedInvite]);
   },
   play: async () => {
-    await expectEventuallyVisible(within(document.body).findByText('Bitcoin Fee Waiver'));
-    await expect(within(document.body).findAllByText('₳68')).resolves.toHaveLength(2);
+    const canvas = within(document.body);
+    const heading = await canvas.findByText('Bitcoin Fee Waiver');
+
+    await expect(heading.nextElementSibling).toHaveTextContent(/₳68\s*fee waiver\s*· Used\s*.* ago/);
   },
 };
 
@@ -241,7 +246,11 @@ export const FeeWaiverExpired: Story = {
     controller.setOperationalInvites([selectedInvite]);
   },
   play: async () => {
-    await expectEventuallyVisible(within(document.body).findByRole('button', { name: '2 days ago' }));
+    const canvas = within(document.body);
+    const heading = await canvas.findByText('Bitcoin Fee Waiver');
+
+    await expect(heading.nextElementSibling).toHaveTextContent(/₳68\s*fee waiver\s*· Unused\s*· expired\s*2 days ago/);
+    await expectEventuallyVisible(canvas.findByRole('button', { name: '2 days ago' }));
   },
 };
 
@@ -306,14 +315,14 @@ function createFeeWaiver(
   state: 'available' | 'partiallyUsed' | 'previousRuntime' | 'pending' | 'used' | 'expired' = 'available',
   currentTick = MiningFrames.calculateCurrentTickFromSystemTime(),
 ): IBitcoinLockCouponStatus {
-  const originalFeeCreditMicrogons = 68_000_000n;
+  const originalFeeCreditMicrogons = 68_400_000n;
   let uses: IBitcoinLockCouponUseRecord[] = [];
   if (state === 'partiallyUsed') {
     uses = [createFeeWaiverUse(1, 'Finalized', 40_800_000n)];
   } else if (state === 'pending') {
     uses = [createFeeWaiverUse(1, 'Finalized', 20_400_000n), createFeeWaiverUse(2, 'InBlock', 20_400_000n)];
   } else if (state === 'used') {
-    uses = [createFeeWaiverUse(1, 'Finalized', 68_000_000n)];
+    uses = [createFeeWaiverUse(1, 'Finalized', originalFeeCreditMicrogons)];
   }
 
   let expirationTick: number | undefined;
@@ -336,12 +345,47 @@ function createFeeWaiver(
     expiresAfterTicks: 7 * NetworkConfig.rewardTicksPerFrame,
     createdAt: new Date('2026-08-14T16:00:00.000Z'),
     updatedAt: new Date('2026-08-16T16:00:00.000Z'),
-    ...(state === 'previousRuntime' ? {} : { feeCreditMicrogons: originalFeeCreditMicrogons }),
+    feeCreditMicrogons: originalFeeCreditMicrogons,
     ...(expirationTick == null ? {} : { expirationTick }),
     ...(uses.length ? { accountId: memberAccountId } : {}),
   };
 
-  if (state === 'previousRuntime') return { status: 'Open', coupon };
+  if (state === 'previousRuntime') {
+    return {
+      status: 'Expired',
+      coupon: { ...coupon, expirationTick: currentTick },
+      relay: {
+        id: 1,
+        requestId: 'legacy-relay-failed',
+        status: 'Failed',
+        requestedSatoshis: 25_000_000n,
+        securitizationUsedMicrogons: 20_400_000n,
+        ownerAccountId: memberAccountId,
+        ownerBitcoinPubkey: `02${'44'.repeat(32)}`,
+        microgonsAtTargetPerBtc: 6_800_000_000n,
+        error: 'The delegated initialization expired before it finalized.',
+        delegateAddress: scenarioKeyring.addFromUri('//StorybookDelegate').address,
+        extrinsicHash: `0x${'12'.repeat(32)}`,
+        extrinsicMethodJson: { section: 'bitcoinLocks', method: 'initializeFor' },
+        txNonce: 1,
+        txSubmittedAtBlockHeight: 100,
+        txSubmittedAtTime: new Date('2026-08-15T16:00:00.000Z'),
+        txExpiresAtBlockHeight: 164,
+        txInBlockHeight: null,
+        txInBlockHash: null,
+        txFinalizedHeight: null,
+        txFeePlusTip: null,
+        txTip: null,
+        utxoId: null,
+        createdAt: new Date('2026-08-15T16:00:00.000Z'),
+        updatedAt: new Date('2026-08-15T16:15:00.000Z'),
+      },
+      originalFeeCreditMicrogons,
+      usedFeeCreditMicrogons: 0n,
+      pendingFeeCreditMicrogons: 0n,
+      remainingFeeCreditMicrogons: originalFeeCreditMicrogons,
+    };
+  }
 
   // Derive the visible state from the durable use history consumed by BitcoinLockCouponService.getStatus.
   const usedFeeCreditMicrogons = uses

--- a/.storybook/stories/onboarding/Onboarding.stories.ts
+++ b/.storybook/stories/onboarding/Onboarding.stories.ts
@@ -3,18 +3,27 @@ import type { ICertificationProgress } from '@argonprotocol/apps-core';
 import type { IMemberInvite } from '@argonprotocol/apps-router';
 import { Keyring } from '@polkadot/keyring';
 import * as Vue from 'vue';
-import { fn, mocked } from 'storybook/test';
+import { expect, fn, mocked, within } from 'storybook/test';
 import AppScreen from '../../components/AppScreen.vue';
 import { createScenarioVault } from '../../scenarios/createScenarioVault.ts';
 import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
-import { OnboardingSetupStatus, TopTab } from '../../../src-vue/interfaces/IConfig.ts';
+import {
+  type IConfig,
+  InstallStepErrorType,
+  OnboardingSetupStatus,
+  TopTab,
+} from '../../../src-vue/interfaces/IConfig.ts';
+import { Config } from '../../../src-vue/lib/Config.ts';
 import {
   activateOperationalAccountSetup,
   usesOperationalProfileNameRuntime,
 } from '../../../src-vue/lib/OperationalAccount.ts';
 import { useCertificationController } from '../../../src-vue/stores/certificationController.ts';
+import { getConfig } from '../../../src-vue/stores/config.ts';
+import { getInstaller } from '../../../src-vue/stores/installer.ts';
 import { getMainchainClient } from '../../../src-vue/stores/mainchain.ts';
 import { getMyVault } from '../../../src-vue/stores/vaults.ts';
+import { getServerApiClient } from '../../../src-vue/stores/server.ts';
 import Onboarding from '../../../src-vue/screens/Onboarding.vue';
 
 const meta = {
@@ -85,6 +94,124 @@ export const InviteLoading: Story = {
   },
 };
 
+export const ServerUpdatingWithoutInviteApi: Story = {
+  beforeEach: () => {
+    setupOnboardingScenario(OnboardingSetupStatus.Finished, {
+      hasOperation: true,
+      serverInstalled: true,
+      serverInstalling: true,
+    });
+    mocked(getServerApiClient, { partial: true }).mockReturnValue({
+      getInvites: fn(async () => {
+        throw new Error('Server API unavailable');
+      }),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole('heading', { name: 'Updating Your Server' })).toBeVisible();
+    await expect(canvas.getByText(/Member onboarding will reconnect automatically/)).toBeVisible();
+  },
+};
+
+export const ServerUpdateFailed: Story = {
+  beforeEach: () => {
+    setupOnboardingScenario(OnboardingSetupStatus.Finished, {
+      hasOperation: true,
+      serverInstalled: true,
+      serverInstalling: true,
+    });
+
+    const config = getConfig();
+    config.serverInstaller = Config.getDefault('serverInstaller') as IConfig['serverInstaller'];
+    config.serverInstaller.errorType = InstallStepErrorType.ArgonInstall;
+    config.serverInstaller.errorMessage = 'Argon syncstatus returned error JSON too many times';
+
+    mocked(getServerApiClient, { partial: true }).mockReturnValue({
+      getInvites: fn(async () => {
+        throw new Error('Server API unavailable');
+      }),
+    });
+    mocked(getInstaller, { partial: true }).mockReturnValue({
+      runFailedStep: fn(async () => undefined),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('LeftBar.goto(TopTab.Onboarding)')).toHaveClass('Selected');
+    await expect(await canvas.findByText('Server Update Failed')).toBeVisible();
+    await expect(canvas.getByText(/Failed to Install Argon/)).toBeVisible();
+    await expect(canvas.getByText('Argon syncstatus returned error JSON too many times')).toBeVisible();
+  },
+};
+
+export const ServerUpdatingWithInviteApi: Story = {
+  beforeEach: () => {
+    setupOnboardingScenario(OnboardingSetupStatus.Finished, {
+      hasOperation: true,
+      serverInstalled: true,
+      serverInstalling: true,
+    });
+    mocked(getServerApiClient, { partial: true }).mockReturnValue({
+      getInvites: fn(async () => createMemberInvites()),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Server Update in Progress')).toBeVisible();
+    await expect(await canvas.findByText('Morgan')).toBeVisible();
+    await expect(canvas.getByTestId('SendMemberInvite')).not.toBeDisabled();
+  },
+};
+
+export const ServerUpdatingWithCachedInvites: Story = {
+  beforeEach: async () => {
+    const controller = setupOnboardingScenario(OnboardingSetupStatus.Finished, {
+      hasOperation: true,
+      serverInstalled: true,
+      serverInstalling: true,
+    });
+    await Vue.nextTick();
+    controller.setOperationalInvites(createMemberInvites());
+    controller.hasLoadedOperationalInvites = true;
+    mocked(getServerApiClient, { partial: true }).mockReturnValue({
+      getInvites: fn(async () => {
+        throw new Error('Server API unavailable');
+      }),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Server Update in Progress')).toBeVisible();
+    await expect(canvas.getByText('Morgan')).toBeVisible();
+    await expect(canvas.getByTestId('SendMemberInvite')).toBeDisabled();
+  },
+};
+
+export const ServerUnavailableWithoutInviteApi: Story = {
+  beforeEach: () => {
+    setupOnboardingScenario(OnboardingSetupStatus.Finished, {
+      hasOperation: true,
+      serverInstalled: true,
+    });
+    mocked(getServerApiClient, { partial: true }).mockReturnValue({
+      getInvites: fn(async () => {
+        throw new Error('Server API unavailable');
+      }),
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole('heading', { name: 'Server Unavailable' })).toBeVisible();
+    await expect(canvas.getByText(/Member onboarding cannot reach your server right now/)).toBeVisible();
+  },
+};
+
 export const EmptyDashboard: Story = {
   beforeEach: () => {
     const controller = setupOnboardingScenario(OnboardingSetupStatus.Finished, {
@@ -116,15 +243,31 @@ export const MemberStates: Story = {
 
 function setupOnboardingScenario(
   onboardingSetupStatus: OnboardingSetupStatus,
-  options: { hasOperation?: boolean; serverAdded?: boolean; serverInstalled?: boolean } = {},
+  options: {
+    hasOperation?: boolean;
+    serverAdded?: boolean;
+    serverInstalled?: boolean;
+    serverInstalling?: boolean;
+  } = {},
 ) {
-  const { controller } = setupAppScenario({
+  const { config, controller } = setupAppScenario({
     selectedTab: TopTab.Onboarding,
     config: {
       onboardingSetupStatus,
       isServerAdded: options.serverAdded ?? options.serverInstalled ?? false,
       isServerInstalled: options.serverInstalled ?? false,
+      isServerInstalling: options.serverInstalling ?? false,
     },
+  });
+
+  if (options.serverInstalled) {
+    config.serverDetails = {
+      ...config.serverDetails,
+      ipAddress: '192.0.2.10',
+    };
+  }
+  mocked(getServerApiClient, { partial: true }).mockReturnValue({
+    getInvites: fn(async () => controller.operationalInvites),
   });
   const createdVault = options.hasOperation ? createScenarioVault() : null;
   const currentMyVault = getMyVault();

--- a/e2e/actors/AppVaultOperator.ts
+++ b/e2e/actors/AppVaultOperator.ts
@@ -236,12 +236,15 @@ export class AppVaultOperator {
       this.config.vaultingRules.baseMicrogonCommitment +
       rewardConfig.treasuryMinimumBonds +
       20n * BigInt(MICROGONS_PER_ARGON);
+    const existingTreasuryMicronots = (
+      await client.query.ownership.account(this.walletKeys.treasuryAddress)
+    ).free.toBigInt();
 
     await sudoFundWallet({
       client,
       address: this.walletKeys.treasuryAddress,
       microgons: requiredVaultingBalance,
-      micronots: 0n,
+      micronots: existingTreasuryMicronots,
     });
 
     await this.ensureVaultReady();

--- a/e2e/scripts/devUpstreamServer.ts
+++ b/e2e/scripts/devUpstreamServer.ts
@@ -204,6 +204,10 @@ export async function startDevUpstreamServer(args: {
   };
   const fundingClient = await getClient(args.archiveUrl);
   try {
+    const existingTreasuryMicronots = (
+      await fundingClient.query.ownership.account(walletKeys.defaultArgonAddress)
+    ).free.toBigInt();
+
     await sudoFundWallet({
       client: fundingClient,
       address: miningBotKeypair.address,
@@ -214,7 +218,7 @@ export async function startDevUpstreamServer(args: {
       client: fundingClient,
       address: walletKeys.defaultArgonAddress,
       microgons: 10n * BigInt(MICROGONS_PER_ARGON),
-      micronots: 0n,
+      micronots: existingTreasuryMicronots,
     });
   } finally {
     await fundingClient.disconnect();

--- a/router/__test__/BitcoinLockCouponService.test.ts
+++ b/router/__test__/BitcoinLockCouponService.test.ts
@@ -124,7 +124,7 @@ describe('BitcoinLockCouponService', () => {
     await expect(service.getByOfferCode(created.coupon.offerCode)).resolves.toMatchObject({ status: 'Expired' });
   });
 
-  it('backfills an unused legacy coupon without changing its offer code', async () => {
+  it('recovers an unused legacy coupon after its delegated relay failed', async () => {
     const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'router-coupon-backfill-'));
     tempDirs.push(tempDir);
 
@@ -134,6 +134,7 @@ describe('BitcoinLockCouponService', () => {
 
     const member = routerDb.usersTable.insertUser({ role: UserRole.Member, name: 'Casey' });
     routerDb.userInvitesTable.insertInvite(member.id, 'invite-code', 'Operator One');
+    const now = new Date();
     routerDb.bitcoinLockCouponsTable.restore({
       userId: member.id,
       sequence: 1,
@@ -143,15 +144,65 @@ describe('BitcoinLockCouponService', () => {
       estimatedGiftUsd: 16.25,
       btcPctFee: 2.5,
       expiresAfterTicks: 60,
+      expirationTick: 100,
       accountId: 'member-account',
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      relayRequestId: 'failed-legacy-relay',
+      relay: {
+        id: 1,
+        requestId: 'failed-legacy-relay',
+        status: 'Failed',
+        requestedSatoshis: 25_000n,
+        securitizationUsedMicrogons: 100n,
+        ownerAccountId: 'member-account',
+        ownerBitcoinPubkey: '0x1234',
+        microgonsAtTargetPerBtc: 75_000_000n,
+        error: 'Relay expired before it was included in a block.',
+        delegateAddress: 'delegate-account',
+        extrinsicHash: '0xrelay',
+        extrinsicMethodJson: {},
+        txNonce: 1,
+        txSubmittedAtBlockHeight: 8,
+        txSubmittedAtTime: now,
+        txExpiresAtBlockHeight: 16,
+        txInBlockHeight: null,
+        txInBlockHash: null,
+        txFinalizedHeight: null,
+        txFeePlusTip: null,
+        txTip: null,
+        utxoId: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const botClient = new BotUpstreamClient('http://127.0.0.1:1');
+    vi.spyOn(botClient, 'listBitcoinLockRelays').mockRejectedValue(new Error('Bot is offline'));
+    vi.spyOn(botClient, 'signBitcoinLockFeeCoupon').mockResolvedValue({
+      feeDiscount: 100_000n,
+      securitizationSpaceToUnreserve: 0n,
+      expiresAtFrame: 1_000n,
+      nonce: 1n,
+      signature: '0xsignature',
+    });
+    vi.spyOn(MiningFrames, 'calculateCurrentTickFromSystemTime').mockReturnValue(100);
+
+    const unavailableService = new BitcoinLockCouponService({
+      db: routerDb,
+      botClient,
+      getMainchainClient: unavailableMainchainClient,
+    });
+    await unavailableService.reconcile();
+    await expect(unavailableService.getByOfferCode('legacy-offer')).resolves.toMatchObject({
+      coupon: { feeCreditMicrogons: null },
+      relay: { status: 'Failed' },
+      status: 'Failed',
     });
 
     const priceIndex = new PriceIndex();
     vi.spyOn(PriceIndex.prototype, 'load').mockResolvedValue(priceIndex);
     vi.spyOn(BitcoinLock, 'calculateRedemptionAmountFromSatoshis').mockReturnValue(4_000_000n);
-    const botClient = new BotUpstreamClient('http://127.0.0.1:1');
     const service = new BitcoinLockCouponService({
       db: routerDb,
       botClient,
@@ -159,12 +210,144 @@ describe('BitcoinLockCouponService', () => {
     });
 
     await service.reconcile();
+    const restartedService = new BitcoinLockCouponService({
+      db: routerDb,
+      botClient,
+      getMainchainClient: unavailableMainchainClient,
+    });
 
-    await expect(service.getByOfferCode('legacy-offer')).resolves.toMatchObject({
+    await expect(restartedService.getByOfferCode('legacy-offer')).resolves.toMatchObject({
       coupon: { offerCode: 'legacy-offer', feeCreditMicrogons: 100_000n },
+      relay: { requestId: 'failed-legacy-relay', status: 'Failed' },
       originalFeeCreditMicrogons: 100_000n,
       remainingFeeCreditMicrogons: 100_000n,
+      status: 'Expired',
+    });
+
+    const reopened = await restartedService.updateExpiration('legacy-offer', 60);
+    expect(reopened).toMatchObject({
+      coupon: { expirationTick: 160 },
+      relay: { requestId: 'failed-legacy-relay', status: 'Failed' },
+      remainingFeeCreditMicrogons: 100_000n,
       status: 'Open',
+    });
+
+    await expect(
+      service.initialize('legacy-offer', {
+        requestedSatoshis: 25_000n,
+        ownerAccountId: 'member-account',
+        ownerBitcoinPubkey: '0x1234',
+        microgonsAtTargetPerBtc: 75_000_000n,
+      }),
+    ).rejects.toMatchObject({ status: 426, code: 'DESKTOP_UPGRADE_REQUIRED' });
+
+    await expect(
+      restartedService.authorizeInitialization('legacy-offer', {
+        requestId: 'new-fee-coupon-use',
+        execution: 'FeeCoupon',
+        requestedSatoshis: 25_000n,
+        feeCreditMicrogons: 100_000n,
+        ownerAccountId: 'member-account',
+        ownerBitcoinPubkey: '0x1234',
+        microgonsAtTargetPerBtc: 75_000_000n,
+      }),
+    ).resolves.toMatchObject({
+      status: { status: 'Prepared', pendingFeeCreditMicrogons: 100_000n },
+      use: { requestId: 'new-fee-coupon-use', status: 'Prepared' },
+    });
+  });
+
+  it('recovers the fee used by a finalized legacy coupon from its stored Bitcoin lock', async () => {
+    const tempDir = Fs.mkdtempSync(Path.join(os.tmpdir(), 'router-finalized-coupon-backfill-'));
+    tempDirs.push(tempDir);
+
+    const routerDb = new Db(Path.join(tempDir, 'router.sqlite'));
+    routerDb.migrate();
+    databases.push(routerDb);
+
+    const member = routerDb.usersTable.insertUser({ role: UserRole.Member, name: 'Casey' });
+    routerDb.userInvitesTable.insertInvite(member.id, 'invite-code', 'Operator One');
+    const now = new Date();
+    routerDb.bitcoinLockCouponsTable.restore({
+      userId: member.id,
+      sequence: 1,
+      offerCode: 'finalized-legacy-offer',
+      vaultId: 10,
+      maxSatoshis: 8_156_469n,
+      estimatedGiftUsd: 266.61,
+      btcPctFee: 5,
+      expiresAfterTicks: 14_400,
+      expirationTick: 29_757_770,
+      accountId: 'member-account',
+      relayRequestId: 'finalized-legacy-relay',
+      relay: {
+        id: 1,
+        requestId: 'finalized-legacy-relay',
+        status: 'Finalized',
+        requestedSatoshis: 8_155_496n,
+        securitizationUsedMicrogons: 4_985_000_240n,
+        ownerAccountId: 'member-account',
+        ownerBitcoinPubkey: '0x1234',
+        microgonsAtTargetPerBtc: 61_678_355_325n,
+        error: null,
+        delegateAddress: 'delegate-account',
+        extrinsicHash: '0xrelay',
+        extrinsicMethodJson: {},
+        txNonce: 1,
+        txSubmittedAtBlockHeight: 832_570,
+        txSubmittedAtTime: now,
+        txExpiresAtBlockHeight: 832_600,
+        txInBlockHeight: 832_575,
+        txInBlockHash: '0xblock',
+        txFinalizedHeight: 832_575,
+        txFeePlusTip: 14n,
+        txTip: 2n,
+        utxoId: 61,
+        createdAt: now,
+        updatedAt: now,
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    vi.spyOn(BitcoinLock, 'get').mockResolvedValue({ couponFeesPaid: 249_250_012n } as BitcoinLock);
+    const botClient = new BotUpstreamClient('http://127.0.0.1:1');
+    vi.spyOn(botClient, 'listBitcoinLockRelays').mockRejectedValue(new Error('Bot is offline'));
+    const unavailableService = new BitcoinLockCouponService({
+      db: routerDb,
+      botClient,
+      getMainchainClient: unavailableMainchainClient,
+    });
+    await unavailableService.reconcile();
+    expect(routerDb.bitcoinLockCouponsTable.fetchByOfferCode('finalized-legacy-offer')).toMatchObject({
+      feeCreditMicrogons: null,
+    });
+
+    const service = new BitcoinLockCouponService({
+      db: routerDb,
+      botClient,
+      getMainchainClient: async () =>
+        ({
+          at: vi.fn(async () => ({})),
+        }) as unknown as ArgonClient,
+    });
+
+    await service.reconcile();
+
+    expect(routerDb.bitcoinLockCouponsTable.fetchByOfferCode('finalized-legacy-offer')).toMatchObject({
+      feeCreditMicrogons: 249_250_012n,
+    });
+
+    const restartedService = new BitcoinLockCouponService({
+      db: routerDb,
+      botClient,
+      getMainchainClient: unavailableMainchainClient,
+    });
+    await expect(restartedService.getByOfferCode('finalized-legacy-offer')).resolves.toMatchObject({
+      originalFeeCreditMicrogons: 249_250_012n,
+      usedFeeCreditMicrogons: 249_250_012n,
+      remainingFeeCreditMicrogons: 0n,
+      status: 'Used',
     });
   });
 

--- a/router/src/BitcoinLockCouponService.ts
+++ b/router/src/BitcoinLockCouponService.ts
@@ -144,6 +144,14 @@ export class BitcoinLockCouponService {
     if (microgonsAtTargetPerBtc == null || microgonsAtTargetPerBtc <= 0n) {
       throw new RouterError('A current bitcoin price quote is required to initialize this bitcoin lock.', 400);
     }
+    if (coupon.relay?.status === 'Failed' && coupon.feeCreditMicrogons) {
+      throw new RouterError(
+        `This failed delegated initialization can be retried with Argon Desktop ${BITCOIN_FEE_COUPON_MINIMUM_DESKTOP_VERSION} or newer. Update Argon Desktop and try again. Your Bitcoin fee waiver remains available.`,
+        426,
+        'DESKTOP_UPGRADE_REQUIRED',
+        BITCOIN_FEE_COUPON_MINIMUM_DESKTOP_VERSION,
+      );
+    }
     if (coupon.relay) {
       this.assertMatchingRelay(coupon.relay, request);
       return this.getStatus(coupon);
@@ -192,7 +200,7 @@ export class BitcoinLockCouponService {
     if (microgonsAtTargetPerBtc == null || microgonsAtTargetPerBtc <= 0n) {
       throw new RouterError('A current bitcoin price quote is required to initialize this bitcoin lock.', 400);
     }
-    if (coupon.relay) {
+    if (coupon.relay && coupon.relay.status !== 'Failed') {
       throw new RouterError('This older Bitcoin gift is already being used through delegated initialization.', 409);
     }
     if (!coupon.feeCreditMicrogons) {
@@ -346,7 +354,9 @@ export class BitcoinLockCouponService {
     let status: IBitcoinLockCouponStatus['status'] = 'Open';
     if (coupon.relay?.status === 'Finalized') {
       status = 'Used';
-    } else if (coupon.relay) {
+    } else if (coupon.relay?.status === 'Failed' && originalFeeCreditMicrogons == null) {
+      status = 'Failed';
+    } else if (coupon.relay?.status === 'Submitted' || coupon.relay?.status === 'InBlock') {
       status = coupon.relay.status;
     } else if (activeUse) {
       status = activeUse.status;
@@ -448,20 +458,44 @@ export class BitcoinLockCouponService {
   }
 
   private async backfillLegacyFeeCredits(): Promise<void> {
-    const coupons = this.db.bitcoinLockCouponsTable.fetchAll().filter(coupon => {
-      return coupon.feeCreditMicrogons == null && !coupon.relayRequestId && !coupon.relay;
-    });
+    const coupons = this.db.bitcoinLockCouponsTable.fetchAll().filter(coupon => coupon.feeCreditMicrogons == null);
     if (!coupons.length) return;
 
+    let client: ArgonClient;
     try {
-      const priceIndex = await new PriceIndex().load(await this.getMainchainClient());
-      for (const coupon of coupons) {
-        const maximumLockValue = BitcoinLock.calculateRedemptionAmountFromSatoshis(priceIndex, coupon.maxSatoshis);
-        const feeCreditMicrogons = percentOf(maximumLockValue, coupon.btcPctFee, true);
-        this.db.bitcoinLockCouponsTable.setFeeCredit(coupon.id, feeCreditMicrogons);
-      }
+      client = await this.getMainchainClient();
     } catch {
       // The legacy coupon remains readable and can be upgraded on a later client poll.
+      return;
+    }
+
+    const unusedCoupons = coupons.filter(coupon => {
+      return (!coupon.relayRequestId && !coupon.relay) || coupon.relay?.status === 'Failed';
+    });
+    if (unusedCoupons.length) {
+      try {
+        const priceIndex = await new PriceIndex().load(client);
+        for (const coupon of unusedCoupons) {
+          const maximumLockValue = BitcoinLock.calculateRedemptionAmountFromSatoshis(priceIndex, coupon.maxSatoshis);
+          const feeCreditMicrogons = percentOf(maximumLockValue, coupon.btcPctFee, true);
+          this.db.bitcoinLockCouponsTable.setFeeCredit(coupon.id, feeCreditMicrogons);
+        }
+      } catch {
+        // Unused legacy coupons can be upgraded from a later price index.
+      }
+    }
+
+    for (const coupon of coupons) {
+      const relay = coupon.relay;
+      if (relay?.status !== 'Finalized' || relay.utxoId == null || !relay.txInBlockHash) continue;
+
+      try {
+        const historicalClient = await client.at(relay.txInBlockHash);
+        const lock = await BitcoinLock.get(historicalClient, relay.utxoId);
+        if (lock) this.db.bitcoinLockCouponsTable.setFeeCredit(coupon.id, lock.couponFeesPaid);
+      } catch {
+        // A finalized coupon can retry its archived lock read on a later client poll.
+      }
     }
   }
 

--- a/src-vue/__test__/BitcoinLocks.history.test.ts
+++ b/src-vue/__test__/BitcoinLocks.history.test.ts
@@ -7,9 +7,13 @@ import { BitcoinLockStatus, type IBitcoinLockRecord } from '../lib/db/BitcoinLoc
 import { BitcoinUtxoStatus } from '../lib/db/BitcoinUtxosTable.ts';
 import { bigintCodec, numberCodec, optionCodec } from '../../core/__test__/helpers/codecs.ts';
 import { createLock, createStore, createHistoricalLock, historyBlock, historyEvent } from './helpers/bitcoin.ts';
+import * as BitcoinLockHistory from '../lib/recovery/BitcoinLockHistory.ts';
 
 vi.mock('../stores/mainchain.ts', () => ({
   getMainchainClient: vi.fn(async () => ({})),
+}));
+vi.mock('../lib/recovery/BitcoinLockHistory.ts', () => ({
+  getHistoricalBitcoinLock: vi.fn(),
 }));
 
 describe('BitcoinLocks historical event replay', () => {
@@ -97,11 +101,10 @@ describe('BitcoinLocks historical event replay', () => {
     };
     vi.spyOn(store, 'getTable').mockResolvedValue(table as never);
     vi.spyOn(store.recovery, 'recoverLock').mockResolvedValue(record);
-    vi.spyOn(BitcoinLock, 'get')
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock)
       .mockResolvedValueOnce(createdLock)
-      .mockResolvedValueOnce(verifiedLock)
-      .mockResolvedValueOnce(ratchetedLock)
-      .mockResolvedValueOnce(twiceRatchetedLock);
+      .mockResolvedValueOnce(verifiedLock);
+    vi.spyOn(BitcoinLock, 'get').mockResolvedValueOnce(ratchetedLock).mockResolvedValueOnce(twiceRatchetedLock);
     vi.spyOn(BitcoinLock.prototype, 'getFundingUtxoRef')
       .mockResolvedValueOnce(undefined)
       .mockResolvedValue({ txid: 'funding-txid', bitcoinTxid: 'funding-txid', vout: 0 });
@@ -289,7 +292,7 @@ describe('BitcoinLocks historical event replay', () => {
       saveRecoveredHistory: vi.fn(async () => undefined),
     };
     vi.spyOn(store, 'getTable').mockResolvedValue(table as never);
-    vi.spyOn(BitcoinLock, 'get')
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock)
       .mockResolvedValueOnce(
         new BitcoinLock({
           ...createHistoricalLock({ accountId, liquidityPromised: 1_100n, lockedTargetPrice: 1_100n }),
@@ -367,7 +370,7 @@ describe('BitcoinLocks historical event replay', () => {
         lock.status = BitcoinLockStatus.LockExpiredWaitingForFunding;
       }),
     } as never);
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(undefined);
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(undefined);
 
     await store.recovery.recoverBlock(historyBlock(157), [
       historyEvent(157, 'bitcoinUtxos', 'UtxoUnwatched', { utxoId: 7 }),
@@ -420,7 +423,7 @@ describe('BitcoinLocks historical event replay', () => {
     store.data.locksByUtxoId[7] = record;
     const saveRecoveredHistory = vi.fn(async () => undefined);
     vi.spyOn(store, 'getTable').mockResolvedValue({ saveRecoveredHistory } as never);
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(
       new BitcoinLock({
         ...createHistoricalLock({ accountId, liquidityPromised: recoveredLiquidity }),
         isFlexible: isBackfill,
@@ -579,7 +582,7 @@ describe('BitcoinLocks historical event replay', () => {
       ownerBitcoinPubkey: hexToU8a(chainLock.ownerPubkey),
     });
     vi.spyOn(store, 'trackDerivedBitcoinLockKey').mockResolvedValue();
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(chainLock);
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(chainLock);
     const block = historyBlock(151);
     const events = [
       historyEvent(151, 'bitcoinLocks', 'BitcoinLockCreated', {

--- a/src-vue/__test__/BitcoinLocks.recovery.test.ts
+++ b/src-vue/__test__/BitcoinLocks.recovery.test.ts
@@ -13,8 +13,13 @@ import { getBitcoinAlertNotices } from '../lib/Alerts.ts';
 import { BitcoinFinancials } from '../lib/financials/BitcoinLocks.ts';
 import { createTestDb } from './helpers/db.ts';
 import { bitcoinRecoveryEventPolicies } from '../lib/recovery/BitcoinLocks.ts';
+import * as BitcoinLockHistory from '../lib/recovery/BitcoinLockHistory.ts';
 import { createLock, createStore, createHistoricalLock, historyBlock, historyEvent } from './helpers/bitcoin.ts';
 import { nextTick, reactive, watchEffect } from 'vue';
+
+vi.mock('../lib/recovery/BitcoinLockHistory.ts', () => ({
+  getHistoricalBitcoinLock: vi.fn(),
+}));
 
 vi.mock('../stores/mainchain.ts', () => ({
   getMainchainClient: vi.fn(async () => ({})),
@@ -973,7 +978,7 @@ describe('BitcoinLocks history replay publication', () => {
       walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(
       new BitcoinLock({ ...createHistoricalLock({ accountId, liquidityPromised: 1_000n }), isFlexible: true }),
     );
     const block = historyBlock(200);
@@ -1046,7 +1051,7 @@ describe('BitcoinLocks history replay publication', () => {
       walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(
       new BitcoinLock({ ...createHistoricalLock({ accountId, liquidityPromised: 1_000n }), isFlexible: true }),
     );
 
@@ -1092,7 +1097,7 @@ describe('BitcoinLocks history replay publication', () => {
       walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(
       new BitcoinLock({ ...createHistoricalLock({ accountId, liquidityPromised: 1_200n }), isFlexible: true }),
     );
     const liveRatchetStarted = createDeferred<void>();
@@ -1159,7 +1164,7 @@ describe('BitcoinLocks history replay publication', () => {
       walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     store.data.locksByUtxoId[7] = record;
-    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+    vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock).mockResolvedValue(
       new BitcoinLock({ ...createHistoricalLock({ accountId, liquidityPromised: 1_000n }), isFlexible: true }),
     );
 

--- a/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
+++ b/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
@@ -3,6 +3,7 @@ import { getOfflineRegistry } from '@argonprotocol/mainchain';
 import { describe, expect, it, vi } from 'vitest';
 import { ArgonBonds } from '../lib/ArgonBonds.ts';
 import { FinancialHistoryImporter } from '../lib/recovery/index.ts';
+import { getHistoricalBitcoinLock } from '../lib/recovery/BitcoinLockHistory.ts';
 import { VaultHistory } from '../lib/recovery/MyVault.ts';
 import { createTestDb } from './helpers/db.ts';
 import { createHistoricalEventData } from '../../indexer/__test__/helpers/historicalEvents.ts';
@@ -13,6 +14,37 @@ const registry = getOfflineRegistry();
 const accountId = encodeAddress(new Uint8Array(32).fill(0x33));
 
 describe('financial history spec boundaries', () => {
+  it.each([
+    { specVersion: 130, priceField: 'peggedPrice' },
+    { specVersion: 146, priceField: 'lockedMarketRate' },
+    { specVersion: 150, priceField: 'lockedMarketRate' },
+    { specVersion: 154, priceField: 'lockedTargetPrice' },
+    { specVersion: 157, priceField: 'lockedTargetPrice' },
+  ] as const)('decodes the complete spec $specVersion Bitcoin lock storage shape', async variant => {
+    const client = createBitcoinLockClient(variant);
+
+    const lock = await getHistoricalBitcoinLock(client as never, 10);
+
+    expect(lock).toMatchObject({
+      utxoId: 10,
+      vaultId: 3,
+      lockedTargetPrice: 516_350_021n,
+      liquidityPromised: 499_433_743n,
+      ownerAccount: accountId,
+      securitizationRatio: 1,
+      satoshis: 488_274n,
+      vaultClaimHeight: 975_911,
+      openClaimHeight: 980_231,
+      createdAtHeight: 923_351,
+      isFunded: true,
+      isFlexible: variant.specVersion === 157,
+      couponFeesPaid: variant.specVersion >= 146 ? 2_000_000n : 0n,
+      createdAtArgonBlock: variant.specVersion >= 146 ? 472_519 : 0,
+    });
+    expect(lock?.utxoSatoshis).toBe(variant.specVersion >= 146 ? 488_275n : undefined);
+    expect(client.query.bitcoinLocks.locksByUtxoId).toHaveBeenCalledOnce();
+  });
+
   it('passes spec 137 Bitcoin activity to recovery while rejecting bond history before spec 151', async () => {
     const recoverBitcoin = vi.fn(async () => undefined);
     const importBondHistory = vi.fn(async () => undefined);
@@ -319,4 +351,69 @@ function createBondLot(specVersion: number) {
     ...value,
     program: { Vault: { vaultId: 4, sharingPercent: 300_000, bonusPercent: 150_000 } },
   });
+}
+
+function createBitcoinLockClient({
+  specVersion,
+  priceField,
+}: {
+  specVersion: number;
+  priceField: 'peggedPrice' | 'lockedMarketRate' | 'lockedTargetPrice';
+}) {
+  const commonFields = {
+    vaultId: 'Compact<u32>',
+    liquidityPromised: specVersion >= 150 ? 'Compact<u128>' : 'u128',
+    [priceField]: specVersion >= 150 ? 'Compact<u128>' : 'u128',
+    ownerAccount: 'AccountId32',
+    ...(specVersion >= 150 ? { securitizationRatio: 'u128' } : {}),
+    securityFees: specVersion >= 150 ? 'Compact<u128>' : 'u128',
+    ...(specVersion >= 146 ? { couponPaidFees: specVersion >= 150 ? 'Compact<u128>' : 'u128' } : {}),
+    satoshis: 'Compact<u64>',
+    ...(specVersion >= 146 ? { utxoSatoshis: 'Option<u64>' } : {}),
+    vaultPubkey: 'ArgonPrimitivesBitcoinCompressedBitcoinPubkey',
+    vaultClaimPubkey: 'ArgonPrimitivesBitcoinCompressedBitcoinPubkey',
+    vaultXpubSources: '([u8;4],u32,u32)',
+    ownerPubkey: 'ArgonPrimitivesBitcoinCompressedBitcoinPubkey',
+    vaultClaimHeight: 'Compact<u64>',
+    openClaimHeight: 'Compact<u64>',
+    createdAtHeight: 'Compact<u64>',
+    utxoScriptPubkey: 'ArgonPrimitivesBitcoinBitcoinCosignScriptPubkey',
+    [specVersion >= 150 ? 'isFunded' : 'isVerified']: 'bool',
+    ...(specVersion < 146 ? { isRejectedNeedsRelease: 'bool' } : {}),
+    ...(specVersion === 157 ? { isBackfill: 'bool' } : {}),
+    fundHoldExtensions: 'BTreeMap<u64,u128>',
+    ...(specVersion >= 146 ? { createdAtArgonBlock: specVersion >= 150 ? 'Compact<u32>' : 'u32' } : {}),
+  };
+  const lockType = `AppBitcoinLockSpec${specVersion}`;
+  registry.register({ [lockType]: commonFields });
+
+  const lock = registry.createType(lockType, {
+    vaultId: 3,
+    liquidityPromised: 499_433_743n,
+    [priceField]: 516_350_021n,
+    ownerAccount: accountId,
+    ...(specVersion >= 150 ? { securitizationRatio: 1_000_000_000_000_000_000n } : {}),
+    securityFees: 0,
+    ...(specVersion >= 146 ? { couponPaidFees: 2_000_000n } : {}),
+    satoshis: 488_274,
+    ...(specVersion >= 146 ? { utxoSatoshis: 488_275 } : {}),
+    vaultPubkey: `0x02${'11'.repeat(32)}`,
+    vaultClaimPubkey: `0x02${'22'.repeat(32)}`,
+    vaultXpubSources: ['0x01020304', 1, 2],
+    ownerPubkey: `0x03${'33'.repeat(32)}`,
+    vaultClaimHeight: 975_911,
+    openClaimHeight: 980_231,
+    createdAtHeight: 923_351,
+    utxoScriptPubkey: { P2WSH: { wscriptHash: `0x${'44'.repeat(32)}` } },
+    [specVersion >= 150 ? 'isFunded' : 'isVerified']: true,
+    ...(specVersion < 146 ? { isRejectedNeedsRelease: false } : {}),
+    ...(specVersion === 157 ? { isBackfill: true } : {}),
+    fundHoldExtensions: {},
+    ...(specVersion >= 146 ? { createdAtArgonBlock: 472_519 } : {}),
+  });
+  return {
+    query: {
+      bitcoinLocks: { locksByUtxoId: vi.fn(async () => optionCodec(lock)) },
+    },
+  };
 }

--- a/src-vue/components/ServerConnectionStatus.vue
+++ b/src-vue/components/ServerConnectionStatus.vue
@@ -1,0 +1,136 @@
+<!-- prettier-ignore -->
+<template>
+  <div
+    v-if="isBlocking"
+    class="absolute inset-0 z-20 flex h-full w-full flex-col items-center justify-center bg-slate-50 px-[15%] pb-[10%] text-center"
+  >
+    <div v-if="errorMessage" class="text-argon-600 mx-auto mb-3 h-16 w-16">
+      <AlertIcon class="h-full w-full" />
+    </div>
+    <div v-else :class="isUpdating ? 'pulse-animation' : ''" class="text-argon-800/80 mx-auto mb-3 h-28 w-28">
+      <slot name="icon" />
+    </div>
+    <h1 class="text-argon-600 mt-5 text-5xl font-bold">
+      <template v-if="errorMessage">Server Update Failed</template>
+      <template v-else-if="isUpdating">Updating Your Server</template>
+      <template v-else>Server Unavailable</template>
+    </h1>
+    <div v-if="errorMessage" class="mx-auto mt-4 max-w-2xl text-lg leading-7 font-light text-slate-600">
+      <p v-if="failedStepLabel" class="font-semibold text-slate-700">Failed to {{ failedStepLabel }}</p>
+      <p :class="failedStepLabel ? 'mt-1' : ''">{{ errorMessage }}</p>
+    </div>
+    <p v-else class="mx-auto mt-4 max-w-2xl text-lg leading-7 font-light text-slate-600">
+      <template v-if="isUpdating">
+        {{ featureName }} will reconnect automatically when the server update finishes.
+      </template>
+      <template v-else>
+        {{ featureName }} cannot reach your server right now. It will retry automatically.
+      </template>
+    </p>
+    <button
+      v-if="errorMessage"
+      @click="retryServerUpdate"
+      :disabled="isRetryingServerUpdate"
+      class="border-argon-button text-argon-button hover:border-argon-button-hover hover:text-argon-button-hover mt-6 cursor-pointer rounded border px-4 py-1 font-bold disabled:pointer-events-none disabled:opacity-50"
+    >
+      {{ isRetryingServerUpdate ? 'Retrying...' : 'Retry' }}
+    </button>
+  </div>
+
+  <div
+    v-else
+    class="border-argon-300/40 bg-argon-50/70 text-argon-800 mb-2 flex min-h-16 items-center rounded border px-5 py-3 shadow-sm"
+  >
+    <div v-if="errorMessage" class="mr-4 h-7 w-7 shrink-0">
+      <AlertIcon class="h-full w-full" />
+    </div>
+    <div v-else :class="isUpdating ? 'pulse-animation' : ''" class="mr-4 h-10 w-10 shrink-0 opacity-70">
+      <slot name="icon" />
+    </div>
+    <div class="min-w-0 grow">
+      <div class="text-base font-bold">
+        <template v-if="errorMessage">Server Update Failed</template>
+        <template v-else-if="isUpdating">Server Update in Progress</template>
+        <template v-else>Server Unavailable</template>
+      </div>
+      <div v-if="errorMessage" class="mt-0.5 text-sm font-light text-slate-600">
+        <p v-if="failedStepLabel" class="font-semibold text-slate-700">Failed to {{ failedStepLabel }}</p>
+        <p :class="failedStepLabel ? 'mt-0.5' : ''">{{ errorMessage }}</p>
+      </div>
+      <p v-else class="mt-0.5 text-sm font-light text-slate-600">
+        <template v-if="isUnavailable">
+          Showing the last known {{ featureName.toLowerCase() }} data. Server actions will return automatically after
+          the connection recovers.
+        </template>
+        <template v-else>
+          The server is still available but may be interrupted briefly during the update.
+        </template>
+      </p>
+    </div>
+    <button
+      v-if="errorMessage"
+      @click="retryServerUpdate"
+      :disabled="isRetryingServerUpdate"
+      class="border-argon-button text-argon-button hover:border-argon-button-hover hover:text-argon-button-hover ml-5 shrink-0 cursor-pointer rounded border px-4 py-1 font-bold disabled:pointer-events-none disabled:opacity-50"
+    >
+      {{ isRetryingServerUpdate ? 'Retrying...' : 'Retry' }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import * as Vue from 'vue';
+import AlertIcon from '../assets/alert.svg?component';
+import { stepLabels } from '../lib/InstallerStep.ts';
+import { getConfig } from '../stores/config.ts';
+import { getInstaller } from '../stores/installer.ts';
+
+defineProps<{
+  featureName: string;
+  isBlocking?: boolean;
+  isUnavailable?: boolean;
+}>();
+
+const config = getConfig();
+
+const isRetryingServerUpdate = Vue.ref(false);
+const errorMessage = Vue.computed(() => {
+  if (!config.serverInstaller?.errorType) return;
+  return config.serverInstaller.errorMessage || 'The server could not finish updating.';
+});
+const failedStepLabel = Vue.computed(() => {
+  const errorType = config.serverInstaller?.errorType;
+  return stepLabels.find(({ key }) => key.valueOf() === errorType?.valueOf())?.options[0];
+});
+const isUpdating = Vue.computed(() => config.isServerInstalling && !errorMessage.value);
+
+async function retryServerUpdate() {
+  if (isRetryingServerUpdate.value) return;
+
+  isRetryingServerUpdate.value = true;
+  try {
+    await getInstaller().runFailedStep('all');
+  } finally {
+    isRetryingServerUpdate.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.pulse-animation {
+  animation: pulse 1.5s ease-in-out infinite;
+  transform-origin: center bottom;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.8;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.05);
+  }
+}
+</style>

--- a/src-vue/lib/recovery/BitcoinLockHistory.ts
+++ b/src-vue/lib/recovery/BitcoinLockHistory.ts
@@ -1,0 +1,54 @@
+import {
+  BitcoinLock,
+  FIXED_U128_DECIMALS,
+  fromFixedNumber,
+  getBigIntFallback,
+  type ApiDecoration,
+  type bool,
+} from '@argonprotocol/mainchain';
+
+// Mirrors BitcoinLock.get for archived storage, including fields that changed names before the current client.
+export async function getHistoricalBitcoinLock(
+  client: ApiDecoration<'promise'>,
+  utxoId: number,
+): Promise<BitcoinLock | undefined> {
+  const rawLock = await client.query.bitcoinLocks.locksByUtxoId(utxoId);
+  if (!rawLock.isSome) return;
+
+  const lock = rawLock.unwrap();
+  const wscriptHash = lock.utxoScriptPubkey.asP2wsh.wscriptHash.toHex().replace('0x', '');
+  const [fingerprint, cosignHdIndex, claimHdIndex] = lock.vaultXpubSources;
+  const securitizationRatio = lock.securitizationRatio?.toBigInt();
+
+  return new BitcoinLock({
+    utxoId,
+    p2wshScriptHashHex: `0x0020${wscriptHash}`,
+    vaultId: lock.vaultId.toNumber(),
+    lockedTargetPrice: getBigIntFallback(lock.lockedTargetPrice, lock, ['lockedMarketRate', 'peggedPrice']),
+    liquidityPromised: lock.liquidityPromised.toBigInt(),
+    ownerAccount: lock.ownerAccount.toHuman(),
+    securitizationRatio:
+      securitizationRatio == null ? 1 : fromFixedNumber(securitizationRatio, FIXED_U128_DECIMALS).toNumber(),
+    satoshis: lock.satoshis.toBigInt(),
+    utxoSatoshis: lock.utxoSatoshis?.isSome ? lock.utxoSatoshis.value.toBigInt() : undefined,
+    vaultPubkey: lock.vaultPubkey.toHex(),
+    vaultClaimPubkey: lock.vaultClaimPubkey.toHex(),
+    ownerPubkey: lock.ownerPubkey.toHex(),
+    vaultXpubSources: {
+      parentFingerprint: new Uint8Array(fingerprint),
+      cosignHdIndex: cosignHdIndex.toNumber(),
+      claimHdIndex: claimHdIndex.toNumber(),
+    },
+    vaultClaimHeight: lock.vaultClaimHeight.toNumber(),
+    openClaimHeight: lock.openClaimHeight.toNumber(),
+    createdAtHeight: lock.createdAtHeight.toNumber(),
+    securityFees: lock.securityFees.toBigInt(),
+    isFunded: lock.isFunded?.isTrue ?? lock.getT<bool>('isVerified')?.isTrue ?? false,
+    isFlexible: lock.isFlexible?.isTrue ?? lock.getT<bool>('isBackfill')?.isTrue ?? false,
+    couponFeesPaid: lock.couponPaidFees?.toBigInt() ?? 0n,
+    fundHoldExtensionsByBitcoinExpirationHeight: Object.fromEntries(
+      [...lock.fundHoldExtensions.entries()].map(([height, amount]) => [height.toNumber(), amount.toBigInt()]),
+    ),
+    createdAtArgonBlock: lock.createdAtArgonBlock?.toNumber() ?? 0,
+  });
+}

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -35,6 +35,7 @@ import type { Db } from '../Db.ts';
 import type { IBitcoinRequestLockMetadata } from '../BitcoinLocks.ts';
 import { ExtrinsicType } from '../db/TransactionsTable.ts';
 import { readRequiredEventBigInt, readRequiredEventField } from './index.ts';
+import { getHistoricalBitcoinLock } from './BitcoinLockHistory.ts';
 
 type BitcoinRecoveryUtxoTracking = Pick<
   BitcoinUtxoTracking,
@@ -376,7 +377,7 @@ export class BitcoinLockRecovery {
       if (liveRecord) await this.prepareHistoryRecoveryLock(liveRecord, options.lockQueueOwnerUuid);
 
       if (event.method === 'BitcoinLockCreated') {
-        const chainLock = await BitcoinLock.get(api, utxoId);
+        const chainLock = await getHistoricalBitcoinLock(api, utxoId);
         if (!chainLock) throw new Error(`Bitcoin lock ${utxoId} is unavailable at its creation block`);
         chainLock.couponFeesPaid = bigIntMax(chainLock.couponFeesPaid, this.readUnchargedSecurityFee(event, block));
 
@@ -482,7 +483,7 @@ export class BitcoinLockRecovery {
         event.method === 'UtxoFundedFromCandidate' ||
         (isUnknownBitcoinLockEvent && record.status === BitcoinLockStatus.LockPendingFunding);
       if (restoresPreFundingState) {
-        const chainLock = await BitcoinLock.get(api, utxoId);
+        const chainLock = await getHistoricalBitcoinLock(api, utxoId);
         if (!chainLock) throw new Error(`Bitcoin lock ${utxoId} is unavailable after ${event.method}`);
 
         const recovered = this.createDetachedRecord(record);
@@ -515,7 +516,7 @@ export class BitcoinLockRecovery {
       } else if (isBitcoinUtxoUnwatched) {
         if (record.status !== BitcoinLockStatus.LockPendingFunding) continue;
 
-        const chainLock = await BitcoinLock.get(api, utxoId);
+        const chainLock = await getHistoricalBitcoinLock(api, utxoId);
         if (chainLock) continue;
 
         const recovered = this.createDetachedRecord(record);
@@ -523,7 +524,7 @@ export class BitcoinLockRecovery {
         else await table.setLockExpiredWaitingForFunding(recovered);
         this.applyRecoveredRecord(recovered);
       } else if (event.method === 'BitcoinLockBackfillChanged' || isUnknownBitcoinLockEvent) {
-        const chainLock = await BitcoinLock.get(api, utxoId);
+        const chainLock = await getHistoricalBitcoinLock(api, utxoId);
         if (!chainLock) {
           throw new Error(
             `bitcoinLocks.${event.method} requires an explicit recovery handler because it removed the lock`,

--- a/src-vue/navigation/CertificationMenu.vue
+++ b/src-vue/navigation/CertificationMenu.vue
@@ -292,7 +292,7 @@ const isUnlockTrack = Vue.computed(() => {
   return !controller.chainProgress.isUpgradedToOperations;
 });
 const isCertificationMenuVisible = Vue.computed(() => {
-  return !controller.isOperationalRewardsFlowActive;
+  return controller.hasLoadedInitialOperationalProgress && !controller.isOperationalRewardsFlowActive;
 });
 const hasRequestedOperationsUpgrade = Vue.computed(() => {
   return hasOperationsUpgradeRequest({

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -359,7 +359,7 @@
 
     <section DashBox class="flex w-full grow flex-col justify-end px-1">
       <div
-        v-if="config.isLoaded && !config.hasExtensionTreasury"
+        v-if="config.isLoaded && controller.hasLoadedInitialOperationalProgress && !config.hasExtensionTreasury"
         class="relative flex grow flex-col items-center justify-center text-center"
       >
         <DiamondsIcon class="text-argon-600/80 mb-2 w-20" />
@@ -391,6 +391,7 @@
       <div
         v-else-if="
           config.isLoaded &&
+          controller.hasLoadedInitialOperationalProgress &&
           config.hasExtensionTreasury &&
           !controller.chainProgress.isUpgradedToOperations &&
           controller.completedTreasuryCertificationStepCount !== treasuryCertificationStepIds.length

--- a/src-vue/overlays/MemberDetailsOverlay.vue
+++ b/src-vue/overlays/MemberDetailsOverlay.vue
@@ -63,34 +63,35 @@
         </button>
       </div>
 
-      <div v-if="invite.bitcoinLockCoupon" class="mt-8">
+      <div v-if="invite.bitcoinLockCoupon?.originalFeeCreditMicrogons != null" class="mt-8">
         <div class="border-b border-slate-200 pb-1 font-semibold text-slate-800">Bitcoin Fee Waiver</div>
         <div class="mt-3 text-sm text-slate-500">
           <div class="flex items-center">
-            <div v-if="invite.bitcoinLockCoupon.status === 'Used' && bitcoinFeeWaiverAppliedAt">
-              Used
-              <span class="ml-1">
-                {{ formatMemberDate(bitcoinFeeWaiverAppliedAt) }}
-              </span>
-            </div>
-            <div v-else-if="invite.bitcoinLockCoupon.originalFeeCreditMicrogons != null">
-              <span class="font-mono text-slate-700">
-                ₳{{ formatArgonTokenAmount(invite.bitcoinLockCoupon.usedFeeCreditMicrogons ?? 0n) }}
-              </span>
-              of
-              <span class="font-mono text-slate-700">
-                ₳{{ formatArgonTokenAmount(invite.bitcoinLockCoupon.originalFeeCreditMicrogons) }}
-              </span>
-              used
+            <span class="font-mono text-slate-700">
+              ₳{{ formatFeeWaiverAmount(invite.bitcoinLockCoupon.originalFeeCreditMicrogons) }}
+            </span>
+            <span class="ml-1">fee waiver</span>
+            <template v-if="invite.bitcoinLockCoupon.status === 'Used'">
+              <span class="mr-1 ml-2">· Used</span>
+              <span v-if="bitcoinFeeWaiverAppliedAt">{{ formatMemberDate(bitcoinFeeWaiverAppliedAt) }}</span>
+            </template>
+            <template v-else>
               <span
-                v-if="(invite.bitcoinLockCoupon.pendingFeeCreditMicrogons ?? 0n) > 0n"
-                class="font-mono text-slate-700"
+                v-if="
+                  (invite.bitcoinLockCoupon.usedFeeCreditMicrogons ?? 0n) === 0n &&
+                  (invite.bitcoinLockCoupon.pendingFeeCreditMicrogons ?? 0n) === 0n
+                "
+                class="ml-2"
               >
-                (₳{{ formatArgonTokenAmount(invite.bitcoinLockCoupon.pendingFeeCreditMicrogons ?? 0n) }}
-                pending)
+                · Unused
               </span>
-            </div>
-            <div v-else>This waiver covers one eligible Bitcoin lock.</div>
+              <span v-if="(invite.bitcoinLockCoupon.usedFeeCreditMicrogons ?? 0n) > 0n" class="ml-2">
+                · ₳{{ formatFeeWaiverAmount(invite.bitcoinLockCoupon.usedFeeCreditMicrogons ?? 0n) }} used
+              </span>
+              <span v-if="(invite.bitcoinLockCoupon.pendingFeeCreditMicrogons ?? 0n) > 0n" class="ml-2">
+                · ₳{{ formatFeeWaiverAmount(invite.bitcoinLockCoupon.pendingFeeCreditMicrogons ?? 0n) }} pending
+              </span>
+            </template>
             <template
               v-if="
                 invite.bitcoinLockCoupon.status !== 'Used' && isBitcoinFeeWaiverExpired && expirationDaysAgo != null
@@ -393,17 +394,31 @@ const certificationCompletedCount = Vue.computed(() => {
 const canUpdateBitcoinFeeWaiverExpiration = Vue.computed(() => {
   const coupon = invite.value?.bitcoinLockCoupon;
   return (
+    !controller.operationalInviteLoadError &&
     !!coupon &&
     (coupon.status === 'Open' || coupon.status === 'Expired') &&
-    (coupon.remainingFeeCreditMicrogons ?? 1n) > 0n
+    (coupon.remainingFeeCreditMicrogons ?? 0n) > 0n
   );
 });
 const bitcoinFeeWaiverAppliedAt = Vue.computed(() => {
   const coupon = invite.value?.bitcoinLockCoupon;
   if (coupon?.status !== 'Used') return;
-  return coupon.relay?.updatedAt ?? coupon.coupon.usedAt;
+  return (
+    coupon.relay?.updatedAt ??
+    coupon.coupon.usedAt ??
+    coupon.uses?.filter(use => use.status === 'Finalized').at(-1)?.updatedAt
+  );
 });
-const isBitcoinFeeWaiverExpired = Vue.computed(() => invite.value?.bitcoinLockCoupon?.status === 'Expired');
+const isBitcoinFeeWaiverExpired = Vue.computed(() => {
+  const coupon = invite.value?.bitcoinLockCoupon;
+  if (!coupon) return false;
+
+  return (
+    coupon.status === 'Expired' ||
+    (coupon.coupon.expirationTick != null &&
+      MiningFrames.calculateCurrentTickFromSystemTime() >= coupon.coupon.expirationTick)
+  );
+});
 const availabilityDays = Vue.computed(() => {
   const coupon = invite.value?.bitcoinLockCoupon?.coupon;
   if (!coupon || coupon.expirationTick != null) return;
@@ -436,6 +451,8 @@ const availableOperationsUpgradeCodeCount = Vue.computed(() => {
   return Math.max(controller.chainProgress.availableAccessCodes - outstandingAccessProofCount, 0);
 });
 const canUpgradeMemberToOperations = Vue.computed(() => {
+  if (controller.operationalInviteLoadError) return false;
+
   const member = invite.value;
   if (!member) return false;
 
@@ -628,6 +645,10 @@ Vue.onUnmounted(() => {
 function formatArgonTokenAmount(amount: bigint) {
   const format = amount % BigInt(MICROGONS_PER_ARGON) === 0n ? '0,0' : '0,0.00';
   return microgonToArgonNm(amount).format(format);
+}
+
+function formatFeeWaiverAmount(amount: bigint) {
+  return microgonToArgonNm(amount).format('0,0');
 }
 
 function formatMemberDate(date: Date) {

--- a/src-vue/screens/Mining.vue
+++ b/src-vue/screens/Mining.vue
@@ -5,8 +5,8 @@
     <SetupChecklist v-else-if="config.miningSetupStatus === MiningSetupStatus.Checklist" />
     <SetupInstalling v-else-if="config.miningSetupStatus === MiningSetupStatus.Installing" />
     <template v-else-if="config.miningSetupStatus === MiningSetupStatus.Finished">
-      <StartingBot v-if="!bot.isReady && !config.isServerInstalling" />
-      <Dashboard v-else-if="config.hasMiningSeats" />
+      <Dashboard v-if="config.hasMiningSeats && (bot.isReady || config.isServerInstalling)" />
+      <StartingBot v-else-if="!bot.isReady" />
       <FirstAuction v-else />
     </template>
     <SyncingOverlay v-if="bot.isSyncing" />

--- a/src-vue/screens/Onboarding.vue
+++ b/src-vue/screens/Onboarding.vue
@@ -11,13 +11,6 @@
         @activate="activateOnboarding"
       />
       <BlankSlate v-else-if="config.onboardingSetupStatus === OnboardingSetupStatus.None" />
-      <div v-else-if="inviteLoadError" class="flex h-full items-center justify-center text-red-600">
-        {{ inviteLoadError }}
-      </div>
-
-      <div v-else-if="!controller.hasLoadedOperationalInvites" class="flex h-full items-center justify-center">
-        <div class="text-2xl font-bold text-slate-600/40 uppercase">Loading...</div>
-      </div>
       <Dashboard v-else />
     </template>
 
@@ -40,7 +33,6 @@
 </template>
 
 <script setup lang="ts">
-import * as Vue from 'vue';
 import { NetworkConfig } from '@argonprotocol/apps-core';
 import LockedIcon from '../assets/locked.svg?component';
 import { OnboardingSetupStatus } from '../interfaces/IConfig.ts';
@@ -54,34 +46,11 @@ import SetupInstalling from './onboarding-screen/SetupInstalling.vue';
 const config = getConfig();
 const controller = useCertificationController();
 
-const inviteLoadError = Vue.ref('');
 function activateOnboarding(operatorName: string) {
   controller.onboardingOperatorNameDraft = operatorName;
   config.onboardingSetupStatus = OnboardingSetupStatus.Installing;
   void config.save();
 }
-
-Vue.watch(
-  [
-    () => config.hasExtensionOperations,
-    () => config.onboardingSetupStatus,
-    () => config.isServerInstalled,
-    () => config.serverDetails.ipAddress,
-  ],
-  async ([hasExtensionOperations, setupStatus, isServerInstalled, ipAddress]) => {
-    if (!hasExtensionOperations || setupStatus !== OnboardingSetupStatus.Finished || !isServerInstalled || !ipAddress) {
-      return;
-    }
-
-    inviteLoadError.value = '';
-    try {
-      await controller.loadOperationalInvites();
-    } catch {
-      inviteLoadError.value = 'Unable to load member invites right now.';
-    }
-  },
-  { immediate: true },
-);
 </script>
 
 <style scoped>

--- a/src-vue/screens/mining-screen/Dashboard.vue
+++ b/src-vue/screens/mining-screen/Dashboard.vue
@@ -1,6 +1,10 @@
 <!-- prettier-ignore -->
 <template>
   <TooltipProvider :disableHoverableContent="true" class="flex flex-col h-full">
+    <ServerConnectionStatus v-if="!bot.isReady && config.isServerInstalling" featureName="Mining" isBlocking>
+      <template #icon><MiningIcon class="h-full w-full" /></template>
+    </ServerConnectionStatus>
+
     <div data-testid="MiningDashboard" :class="myMiningSeats.isLoaded ? '' : 'opacity-30 pointer-events-none'" class="flex min-w-0 flex-col h-full pr-2.5 gap-y-2 justify-stretch grow">
       <span data-testid="TotalBlocksMined" :data-value="totalBlocksMined" class="sr-only">{{ totalBlocksMined }}</span>
 
@@ -248,12 +252,16 @@ import MiningSeats from './components/MiningSeats.vue';
 import { getBlockWatch, getMainchainClient, getMining, getMiningFrames } from '../../stores/mainchain.ts';
 import { botEmitter } from '../../lib/Bot.ts';
 import { getBot } from '../../stores/bot.ts';
+import { getConfig } from '../../stores/config.ts';
 import { useWallets } from '../../stores/wallets.ts';
 import { useFinancials } from '../../stores/financials.ts';
+import MiningIcon from '../../assets/mining.svg?component';
+import ServerConnectionStatus from '../../components/ServerConnectionStatus.vue';
 
 const myMiningSeats = getMyMiningSeats();
 const currency = getCurrency();
 const bot = getBot();
+const config = getConfig();
 const blockWatch = getBlockWatch();
 const mining = getMining();
 const miningFrames = getMiningFrames();

--- a/src-vue/screens/onboarding-screen/Dashboard.vue
+++ b/src-vue/screens/onboarding-screen/Dashboard.vue
@@ -1,6 +1,27 @@
 <!-- prettier-ignore -->
 <template>
-  <div class="flex h-full grow flex-col">
+  <ServerConnectionStatus
+    v-if="controller.operationalInviteLoadError && !controller.operationalInvites.length"
+    featureName="Member onboarding"
+    isBlocking
+    isUnavailable
+  >
+    <template #icon><OnboardingIcon class="h-full w-full" /></template>
+  </ServerConnectionStatus>
+
+  <div v-else-if="!controller.hasLoadedOperationalInvites" class="flex h-full items-center justify-center">
+    <div class="text-2xl font-bold text-slate-600/40 uppercase">Loading...</div>
+  </div>
+
+  <div v-else class="flex h-full grow flex-col">
+    <ServerConnectionStatus
+      v-if="config.isServerInstalling || controller.operationalInviteLoadError"
+      featureName="Member onboarding"
+      :isUnavailable="!!controller.operationalInviteLoadError"
+    >
+      <template #icon><OnboardingIcon class="h-full w-full" /></template>
+    </ServerConnectionStatus>
+
     <TooltipProvider :disableHoverableContent="true">
       <section class="flex h-[14%] flex-row gap-x-2">
         <TooltipRoot>
@@ -187,6 +208,7 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
+import { NetworkConfig } from '@argonprotocol/apps-core';
 import { TooltipArrow, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui';
 import OnboardingIcon from '../../assets/onboarding.svg?component';
 import ArrowCalloutButton from '../../components/ArrowCalloutButton.vue';
@@ -197,6 +219,7 @@ import { getConfig } from '../../stores/config.ts';
 import { getCurrency } from '../../stores/currency.ts';
 import { getMyVault } from '../../stores/vaults.ts';
 import MemberInvites from './components/MemberInvites.vue';
+import ServerConnectionStatus from '../../components/ServerConnectionStatus.vue';
 
 const config = getConfig();
 const controller = useCertificationController();
@@ -205,6 +228,7 @@ const myVault = getMyVault();
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 
 const showCreateInviteGuidance = Vue.ref(false);
+let loadInvitesPromise: Promise<unknown> | undefined;
 
 const canViewRewards = Vue.computed(() => {
   return (
@@ -213,7 +237,12 @@ const canViewRewards = Vue.computed(() => {
 });
 
 const canSendInvite = Vue.computed(() => {
-  return config.isServerInstalled && controller.hasLoadedOperationalInvites && !!myVault.createdVault;
+  return (
+    config.isServerInstalled &&
+    controller.hasLoadedOperationalInvites &&
+    !controller.operationalInviteLoadError &&
+    !!myVault.createdVault
+  );
 });
 
 const showInviteBlankSlate = Vue.computed(() => {
@@ -230,6 +259,39 @@ function openRewards() {
     basicEmitter.emit('openOperationalRewardsOverlay', { screen: 'claim' });
   }
 }
+
+function loadInvites(): Promise<unknown> {
+  if (loadInvitesPromise) return loadInvitesPromise;
+
+  const promise = controller
+    .loadOperationalInvites()
+    .catch(() => undefined)
+    .finally(() => {
+      loadInvitesPromise = undefined;
+    });
+  loadInvitesPromise = promise;
+
+  return promise;
+}
+
+Vue.watch(
+  [() => config.isLoaded, () => config.isServerInstalled, () => config.serverDetails.ipAddress],
+  ([isConfigLoaded, isServerInstalled, ipAddress], _previous, onCleanup) => {
+    if (!isConfigLoaded || !isServerInstalled || !ipAddress) return;
+
+    void loadInvites();
+    const interval = setInterval(
+      () => {
+        if (document.visibilityState !== 'visible') return;
+        void loadInvites();
+      },
+      Math.max(NetworkConfig.tickMillis, 5_000),
+    );
+
+    onCleanup(() => clearInterval(interval));
+  },
+  { immediate: true },
+);
 </script>
 
 <style scoped>

--- a/src-vue/screens/onboarding-screen/components/MemberInvites.vue
+++ b/src-vue/screens/onboarding-screen/components/MemberInvites.vue
@@ -11,12 +11,6 @@
     </div>
 
     <div class="flex min-h-0 grow flex-col">
-      <div v-if="errorMessage" class="mt-3 space-y-2">
-        <div v-if="errorMessage" class="text-sm text-red-600">
-          {{ errorMessage }}
-        </div>
-      </div>
-
       <div class="mt-4 min-h-0 grow overflow-auto">
         <table class="w-full min-w-[760px] text-left">
           <thead
@@ -129,7 +123,6 @@
 </template>
 
 <script setup lang="ts">
-import * as Vue from 'vue';
 import type { IMemberInvite } from '@argonprotocol/apps-router';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -138,27 +131,21 @@ import { ChevronRightIcon } from '@heroicons/vue/24/outline';
 import {
   countCompletedOperationalCertificationRequirements,
   countCompletedTreasuryCertificationRequirements,
-  NetworkConfig,
   operationalCertificationRequirementCount,
   treasuryCertificationRequirementCount,
 } from '@argonprotocol/apps-core';
 import basicEmitter from '../../../emitters/basicEmitter.ts';
 import { createNumeralHelpers } from '../../../lib/numeral.ts';
-import { getConfig } from '../../../stores/config.ts';
 import { getCurrency } from '../../../stores/currency.ts';
 import { useCertificationController } from '../../../stores/certificationController.ts';
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
-const config = getConfig();
 const controller = useCertificationController();
 const currency = getCurrency();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
-const errorMessage = Vue.ref<string | null>(null);
-let loadInvitesPromise: Promise<void> | undefined;
-
 function inviteStatus(invite: IMemberInvite) {
   return (
     controller.operationalInviteStatusesByCode[invite.inviteCode] ?? {
@@ -192,47 +179,4 @@ function certificationRequirementCount(invite: IMemberInvite) {
     (showOperationsCertification(invite) ? operationalCertificationRequirementCount : 0)
   );
 }
-
-function loadInvites(): Promise<void> {
-  if (loadInvitesPromise) {
-    return loadInvitesPromise;
-  }
-
-  errorMessage.value = null;
-  loadInvitesPromise = (async () => {
-    try {
-      await controller.loadOperationalInvites();
-    } catch (error) {
-      errorMessage.value =
-        error instanceof Error
-          ? `Unable to refresh member invites: ${error.message}`
-          : 'Unable to refresh member invites right now. Please try again.';
-    }
-  })().finally(() => {
-    loadInvitesPromise = undefined;
-  });
-
-  return loadInvitesPromise;
-}
-
-Vue.watch(
-  [() => config.isServerInstalled, () => config.serverDetails.ipAddress],
-  ([isServerInstalled, ipAddress], _previous, onCleanup) => {
-    if (!isServerInstalled || !ipAddress) return;
-
-    if (!controller.hasLoadedOperationalInvites) {
-      void loadInvites();
-    }
-    const interval = setInterval(
-      () => {
-        if (document.visibilityState !== 'visible') return;
-        void loadInvites();
-      },
-      Math.max(NetworkConfig.tickMillis, 5_000),
-    );
-
-    onCleanup(() => clearInterval(interval));
-  },
-  { immediate: true },
-);
 </script>

--- a/src-vue/stores/certificationController.ts
+++ b/src-vue/stores/certificationController.ts
@@ -228,25 +228,13 @@ export const useCertificationController = defineStore('certificationController',
   const completionNoticeQueue = Vue.ref<OperationalStepId[]>([]);
   const operationalInvites = Vue.shallowRef<IMemberInvite[]>([]);
   const hasLoadedOperationalInvites = Vue.ref(false);
+  const operationalInviteLoadError = Vue.ref('');
   const operationalInviteStatusesByCode = Vue.ref<Record<string, IOperationalInviteStatus>>({});
   const operationalInviteServerKey = Vue.computed(() => {
-    if (!config.isLoaded) return '';
-
     const { type, ipAddress, gatewayPort } = config.serverDetails;
     return ipAddress ? `${type}:${ipAddress}:${gatewayPort ?? 443}` : '';
   });
   let operationalInviteLoadVersion = 0;
-
-  Vue.watch(
-    operationalInviteServerKey,
-    serverKey => {
-      operationalInviteLoadVersion += 1;
-      operationalInvites.value = [];
-      operationalInviteStatusesByCode.value = {};
-      hasLoadedOperationalInvites.value = !serverKey;
-    },
-    { immediate: true },
-  );
 
   const certificationStepCount = allCertificationStepIds.length;
   const hasBitcoinFundingSeenOnBitcoin = Vue.computed(() => {
@@ -593,6 +581,18 @@ export const useCertificationController = defineStore('certificationController',
     if (operationalAccountUnsubscribe) return;
 
     Vue.watch(
+      operationalInviteServerKey,
+      serverKey => {
+        operationalInviteLoadVersion += 1;
+        operationalInvites.value = [];
+        operationalInviteStatusesByCode.value = {};
+        operationalInviteLoadError.value = '';
+        hasLoadedOperationalInvites.value = !serverKey;
+      },
+      { immediate: true },
+    );
+
+    Vue.watch(
       [() => config.hasExtensionTreasury, () => wallets.defaultArgonWallet.availableMicrogons],
       () => {
         void refreshTreasuryTransferTotals().catch(error => {
@@ -784,10 +784,13 @@ export const useCertificationController = defineStore('certificationController',
   }
 
   async function loadOperationalInvites() {
+    await config.isLoadedPromise;
+
     const serverKey = operationalInviteServerKey.value;
     if (!serverKey) {
       operationalInvites.value = [];
       operationalInviteStatusesByCode.value = {};
+      operationalInviteLoadError.value = '';
       hasLoadedOperationalInvites.value = true;
       return [];
     }
@@ -800,8 +803,15 @@ export const useCertificationController = defineStore('certificationController',
       }
 
       setOperationalInvites(invites);
+      operationalInviteLoadError.value = '';
 
       return invites;
+    } catch (error) {
+      if (requestVersion === operationalInviteLoadVersion && serverKey === operationalInviteServerKey.value) {
+        operationalInviteLoadError.value =
+          error instanceof Error ? error.message : 'Unable to reach the member onboarding API.';
+      }
+      throw error;
     } finally {
       if (requestVersion === operationalInviteLoadVersion && serverKey === operationalInviteServerKey.value) {
         hasLoadedOperationalInvites.value = true;
@@ -967,6 +977,7 @@ export const useCertificationController = defineStore('certificationController',
     pendingRewardsAmount,
     operationalInvites,
     hasLoadedOperationalInvites,
+    operationalInviteLoadError,
     operationalInviteStatusesByCode,
     activeOperationalInvites,
     activeOperationalInviteCount,


### PR DESCRIPTION
## Summary

Server upgrades now keep onboarding and mining usable while their APIs respond, and show a clear blocking or retry state only when the required service is unavailable.

- Member invites refresh after configuration loads and remain visible from cached data during a brief outage.
- Certification actions no longer flash before their authoritative progress is loaded.
- Legacy fee waivers recover their original amount and usage state, while archived Bitcoin locks decode across the supported runtime history.

## Validation

- Storybook covers connected updates, unavailable APIs, cached invites, server failure and retry, and fee-waiver states.
- Recovery tests cover failed archive reads, later repair, restart durability, and historical runtime storage shapes.
