### PR TITLE
fix(storybook): stabilize Bitcoin fee snapshots

### DIFF
--- a/.storybook/scenarios/setupBitcoinOverlayScenario.ts
+++ b/.storybook/scenarios/setupBitcoinOverlayScenario.ts
@@ -74,6 +74,7 @@ export function setupBitcoinOverlayScenario() {
   const scenarioStartedAt = Date.now();
   const pendingResolvers = new Set<VoidFunction>();
   const cleanupTasks = new Set<VoidFunction>();
+  mocked(BitcoinLocks.getFeeRates).mockRestore?.();
   const getFeeRates = spyOn(BitcoinLocks, 'getFeeRates').mockResolvedValue({
     fast: { feeRate: 3n, estimatedMinutes: 10 },
     medium: { feeRate: 1n, estimatedMinutes: 30 },

--- a/.storybook/scenarios/setupBitcoinOverlayScenario.ts
+++ b/.storybook/scenarios/setupBitcoinOverlayScenario.ts
@@ -8,7 +8,7 @@ import { MockProvider } from '@polkadot/rpc-provider/mock';
 import { TypeRegistry } from '@polkadot/types';
 import type { u128, u64, Vec } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
-import { fn, mocked } from 'storybook/test';
+import { fn, mocked, spyOn } from 'storybook/test';
 import { createScenarioVault } from './createScenarioVault.ts';
 import { setupAppScenario } from './setupAppScenario.ts';
 import { TopTab } from '../../src-vue/interfaces/IConfig.ts';
@@ -74,6 +74,12 @@ export function setupBitcoinOverlayScenario() {
   const scenarioStartedAt = Date.now();
   const pendingResolvers = new Set<VoidFunction>();
   const cleanupTasks = new Set<VoidFunction>();
+  const getFeeRates = spyOn(BitcoinLocks, 'getFeeRates').mockResolvedValue({
+    fast: { feeRate: 3n, estimatedMinutes: 10 },
+    medium: { feeRate: 1n, estimatedMinutes: 30 },
+    slow: { feeRate: 1n, estimatedMinutes: 60 },
+  });
+  cleanupTasks.add(() => getFeeRates.mockRestore());
   const { config, wallets } = setupAppScenario({
     selectedTab: TopTab.BitcoinLocks,
     config: {

--- a/.storybook/scenarios/setupBitcoinOverlayScenario.ts
+++ b/.storybook/scenarios/setupBitcoinOverlayScenario.ts
@@ -526,6 +526,7 @@ function createScenarioTransactionInfo<Metadata>(options: {
   metadata: Metadata;
   status?: TransactionStatus;
   error?: Error;
+  progress?: { progressPct: number; confirmations: number; expectedConfirmations: number };
   onCleanup?: (cleanup: VoidFunction) => void;
 }): TransactionInfo<Metadata> {
   const status = options.status ?? (options.error ? TransactionStatus.Error : TransactionStatus.InBlock);
@@ -568,6 +569,13 @@ function createScenarioTransactionInfo<Metadata>(options: {
   if (options.error) txResult.submissionError = options.error;
 
   const info = new TransactionInfo<Metadata>({ tx, txResult });
+  const progress = options.progress;
+  if (progress) {
+    spyOn(info, 'subscribeToProgress').mockImplementation(callback => {
+      void callback({ ...progress, progressMessage: '', isMaxed: false });
+      return () => undefined;
+    });
+  }
   const finalize = () => {
     txResult.blockHash ??= new Uint8Array([1, 2, 3, 4]);
     txResult.blockNumber ??= 18_511;

--- a/.storybook/scenarios/setupMiningAuctionScenario.ts
+++ b/.storybook/scenarios/setupMiningAuctionScenario.ts
@@ -1,6 +1,8 @@
 import * as Vue from 'vue';
 import { type IWinningBid, NetworkConfig } from '@argonprotocol/apps-core';
-import { fn, mocked } from 'storybook/test';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { fn, mocked, spyOn } from 'storybook/test';
 import { MiningSetupStatus, TopTab } from '../../src-vue/interfaces/IConfig.ts';
 import { getBot } from '../../src-vue/stores/bot.ts';
 import { getConfig } from '../../src-vue/stores/config.ts';
@@ -8,6 +10,8 @@ import { getInstaller } from '../../src-vue/stores/installer.ts';
 import { getBiddingCalculator, getMining } from '../../src-vue/stores/mainchain.ts';
 import { getMyMiningSeats } from '../../src-vue/stores/myMiningSeats.ts';
 import { setupAppScenario } from './setupAppScenario.ts';
+
+dayjs.extend(utc);
 
 export type MiningAuctionScenario =
   | 'connecting'
@@ -22,6 +26,7 @@ export type MiningAuctionScenario =
 
 const tickAtStartOfNextCohort = Date.UTC(2030, 0, 1) / NetworkConfig.tickMillis;
 const tickAtStartOfAuctionClosing = Date.UTC(2030, 0, 2) / NetworkConfig.tickMillis;
+const auctionScenarioNow = dayjs.utc('2029-12-31T14:36:36.000Z');
 const microgonRequirement = 500_000_000n;
 const micronotRequirement = 250_000_000n;
 const zeroSeatScenarios = new Set<MiningAuctionScenario>([
@@ -31,7 +36,10 @@ const zeroSeatScenarios = new Set<MiningAuctionScenario>([
   'bidLimitExceeded',
 ]);
 
-export function setupMiningAuctionScenario(state: MiningAuctionScenario): void {
+export function setupMiningAuctionScenario(state: MiningAuctionScenario): VoidFunction {
+  mocked(dayjs.utc).mockRestore?.();
+  const utcNow = dayjs.utc;
+  const clock = spyOn(dayjs, 'utc').mockImplementation((...args) => (args.length ? utcNow(...args) : auctionScenarioNow));
   const { config, wallets } = setupAppScenario({
     selectedTab: TopTab.Mining,
     config: {
@@ -102,7 +110,7 @@ export function setupMiningAuctionScenario(state: MiningAuctionScenario): void {
 
   if (state === 'winningOne' || state === 'winningMany') {
     config.hasMiningBids = true;
-    return;
+    return () => clock.mockRestore();
   }
 
   if (state === 'argonShortage' || state === 'bothShortage') {
@@ -111,6 +119,8 @@ export function setupMiningAuctionScenario(state: MiningAuctionScenario): void {
   if (state === 'argonotShortage' || state === 'bothShortage') {
     Object.assign(wallets, { totalMiningMicronots: 0n });
   }
+
+  return () => clock.mockRestore();
 }
 
 function createWinningBids(count: number): IWinningBid[] {

--- a/.storybook/stories/bitcoin/BitcoinLockingOverlay.stories.ts
+++ b/.storybook/stories/bitcoin/BitcoinLockingOverlay.stories.ts
@@ -1,6 +1,6 @@
 import * as Vue from 'vue';
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
-import { fn, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 import { expectEventuallyVisible } from '../../support/expectEventuallyVisible.ts';
 import {
   createBitcoinUtxo,
@@ -212,9 +212,10 @@ export const FundingMismatch: Story = {
     scenario.replaceUtxoRecords([candidate]);
   },
   play: async () => {
-    await expectEventuallyVisible(
-      within(document.body).findByText(/Choose whether to keep or return this Bitcoin deposit/i),
-    );
+    const body = within(document.body);
+    await expectEventuallyVisible(body.findByText(/Choose whether to keep or return this Bitcoin deposit/i));
+    await expectEventuallyVisible(body.findByText('1 sat/vbyte'));
+    await expect(body.findByTestId('LockFundingMismatch.feeRate')).resolves.toHaveTextContent('Medium = ~30 min');
   },
 };
 

--- a/.storybook/stories/bitcoin/BitcoinOrphanRecoveryOverlay.stories.ts
+++ b/.storybook/stories/bitcoin/BitcoinOrphanRecoveryOverlay.stories.ts
@@ -184,6 +184,7 @@ export const ArgonRequest: Story = {
       scenario.createTransactionInfo({
         status: TransactionStatus.Submitted,
         extrinsicType: ExtrinsicType.BitcoinOrphanedUtxoRelease,
+        progress: { progressPct: 38, confirmations: 1, expectedConfirmations: 4 },
         metadata: {
           releaseKind: 'Orphan',
           utxoId: scenario.lock.utxoId!,
@@ -195,7 +196,9 @@ export const ArgonRequest: Story = {
     return () => scenario.cleanup();
   },
   play: async () => {
-    await expectEventuallyVisible(within(document.body).findByText(/Argon Block/));
+    const body = within(document.body);
+    await expectEventuallyVisible(body.findByText(/Argon Block/));
+    await expectEventuallyVisible(body.findByText('38.00%'));
   },
 };
 

--- a/.storybook/stories/mining/Mining.stories.ts
+++ b/.storybook/stories/mining/Mining.stories.ts
@@ -269,6 +269,7 @@ export const FirstAuctionSubmitting: Story = {
           element?.tagName === 'P' && /The current auction will begin closing in/.test(element.textContent ?? ''),
       ),
     ).toBeVisible();
+    await expect(canvas.getByText('9 hours, 23 minutes and 24 seconds')).toBeVisible();
   },
 };
 
@@ -279,6 +280,7 @@ export const FirstAuctionWinningOne: Story = {
 
     await expect(canvas.getByText('Your First Auction Is Live!')).toBeVisible();
     await expect(canvas.getByText('YOU ARE IN BID POSITION')).toBeVisible();
+    await expect(canvas.getByText(/9 hours, 23 minutes and 24 seconds\./)).toBeVisible();
   },
 };
 
@@ -289,6 +291,7 @@ export const FirstAuctionWinningMany: Story = {
 
     await expect(canvas.getByText('Your First Auction Is Live!')).toBeVisible();
     await expect(canvas.getByText('YOU ARE IN BID POSITIONS')).toBeVisible();
+    await expect(canvas.getByText(/9 hours, 23 minutes and 24 seconds\./)).toBeVisible();
   },
 };
 

--- a/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
+++ b/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
@@ -57,7 +57,7 @@ export const TreasuryMember: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(2, {
       defaultAccountId: memberAccountId,
-      firstClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(1),
       bitcoinLockCoupon: createFeeWaiver('partiallyUsed'),
       certificationProgress: createCertificationProgress({
         hasTreasuryBitcoin: true,
@@ -93,8 +93,8 @@ export const OperationsRequested: Story = {
     selectedInvite = createInvite(3, {
       defaultAccountId: memberAccountId,
       operationalAccountId,
-      firstClickedAt: new Date('2026-08-15T16:00:00.000Z'),
-      operationsUpgradeRequestedAt: new Date('2026-08-16T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(2),
+      operationsUpgradeRequestedAt: dateDaysAgo(1),
       certificationProgress: createCertificationProgress({
         hasTreasuryBitcoin: true,
         hasTreasuryBonds: true,
@@ -117,8 +117,8 @@ export const OperationsGranted: Story = {
     selectedInvite = createInvite(4, {
       defaultAccountId: memberAccountId,
       operationalAccountId,
-      firstClickedAt: new Date('2026-08-14T16:00:00.000Z'),
-      operationsUpgradedAt: new Date('2026-08-16T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(3),
+      operationsUpgradedAt: dateDaysAgo(1),
       certificationProgress: createCertificationProgress({
         hasOperationalAccount: true,
         hasTreasuryBitcoin: true,
@@ -144,7 +144,7 @@ export const OpenedNotRegistered: Story = {
   beforeEach: () => {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(5, {
-      lastClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      lastClickedAt: dateDaysAgo(1),
     });
     controller.setOperationalInvites([selectedInvite]);
   },
@@ -158,7 +158,7 @@ export const BalancesLoading: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(6, {
       defaultAccountId: memberAccountId,
-      firstClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(1),
     });
     controller.setOperationalInvites([selectedInvite]);
   },
@@ -172,7 +172,7 @@ export const BalancesUnavailable: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(7, {
       defaultAccountId: memberAccountId,
-      firstClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(1),
     });
     controller.setOperationalInvites([selectedInvite]);
     mocked(getMainchainClient).mockResolvedValue(createMemberClient(0n, new Error('Member balances are unavailable.')));
@@ -187,7 +187,7 @@ export const PreviousRuntimeFeeWaiver: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     const currentTick = MiningFrames.calculateCurrentTickFromSystemTime();
     selectedInvite = createInvite(8, {
-      lastClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      lastClickedAt: dateDaysAgo(1),
       bitcoinLockCoupon: createFeeWaiver('previousRuntime', currentTick),
     });
     controller.setOperationalInvites([selectedInvite]);
@@ -207,7 +207,7 @@ export const FeeWaiverPending: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(9, {
       defaultAccountId: memberAccountId,
-      firstClickedAt: new Date('2026-08-15T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(2),
       bitcoinLockCoupon: createFeeWaiver('pending'),
     });
     controller.setOperationalInvites([selectedInvite]);
@@ -222,7 +222,7 @@ export const FeeWaiverUsed: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     selectedInvite = createInvite(10, {
       defaultAccountId: memberAccountId,
-      firstClickedAt: new Date('2026-08-15T16:00:00.000Z'),
+      firstClickedAt: dateDaysAgo(2),
       bitcoinLockCoupon: createFeeWaiver('used'),
     });
     controller.setOperationalInvites([selectedInvite]);
@@ -240,7 +240,7 @@ export const FeeWaiverExpired: Story = {
     const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
     const currentTick = MiningFrames.calculateCurrentTickFromSystemTime();
     selectedInvite = createInvite(11, {
-      lastClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+      lastClickedAt: dateDaysAgo(1),
       bitcoinLockCoupon: createFeeWaiver('expired', currentTick),
     });
     controller.setOperationalInvites([selectedInvite]);
@@ -300,13 +300,17 @@ export const ExpirationUpdateFailed: Story = {
   },
 };
 
+function dateDaysAgo(daysAgo: number) {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1_000);
+}
+
 function createInvite(id: number, overrides: Partial<IMemberInvite> = {}): IMemberInvite {
   return {
     id,
     name: 'Morgan',
     fromName: 'Atlas Operator',
     inviteCode: `synthetic-member-details-${id}`,
-    createdAt: new Date('2026-08-14T16:00:00.000Z'),
+    createdAt: dateDaysAgo(3),
     ...overrides,
   };
 }
@@ -343,8 +347,8 @@ function createFeeWaiver(
     estimatedGiftUsd: 68,
     btcPctFee: 3.4,
     expiresAfterTicks: 7 * NetworkConfig.rewardTicksPerFrame,
-    createdAt: new Date('2026-08-14T16:00:00.000Z'),
-    updatedAt: new Date('2026-08-16T16:00:00.000Z'),
+    createdAt: dateDaysAgo(3),
+    updatedAt: dateDaysAgo(1),
     feeCreditMicrogons: originalFeeCreditMicrogons,
     ...(expirationTick == null ? {} : { expirationTick }),
     ...(uses.length ? { accountId: memberAccountId } : {}),
@@ -441,8 +445,8 @@ function createFeeWaiverUse(
       nonce: BigInt(id),
       signature: `0x${'34'.repeat(64)}`,
     },
-    createdAt: new Date(`2026-08-${14 + id}T16:00:00.000Z`),
-    updatedAt: new Date(`2026-08-${15 + id}T16:00:00.000Z`),
+    createdAt: dateDaysAgo(3 - id),
+    updatedAt: dateDaysAgo(2 - id),
   };
 }
 
@@ -452,8 +456,8 @@ function setupOperationsUpgradeAction(state: 'progress' | 'error') {
   selectedInvite = createInvite(12, {
     defaultAccountId: memberAccountId,
     operationalAccountId,
-    firstClickedAt: new Date('2026-08-15T16:00:00.000Z'),
-    operationsUpgradeRequestedAt: new Date('2026-08-16T16:00:00.000Z'),
+    firstClickedAt: dateDaysAgo(2),
+    operationsUpgradeRequestedAt: dateDaysAgo(1),
     certificationProgress: createCertificationProgress({
       hasTreasuryBitcoin: true,
       hasTreasuryBonds: true,
@@ -477,7 +481,7 @@ function setupOperationsUpgradeAction(state: 'progress' | 'error') {
 function setupExpirationUpdate(state: 'progress' | 'error') {
   const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
   selectedInvite = createInvite(13, {
-    lastClickedAt: new Date('2026-08-16T16:00:00.000Z'),
+    lastClickedAt: dateDaysAgo(1),
     bitcoinLockCoupon: createFeeWaiver(),
   });
   controller.setOperationalInvites([selectedInvite]);

--- a/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
+++ b/.storybook/stories/onboarding/MemberDetailsOverlay.stories.ts
@@ -12,6 +12,7 @@ import * as Vue from 'vue';
 import { expect, fn, mocked, userEvent, within } from 'storybook/test';
 import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
 import { expectEventuallyVisible } from '../../support/expectEventuallyVisible.ts';
+import { dateDaysAgo } from '../../support/storyDates.ts';
 import basicEmitter from '../../../src-vue/emitters/basicEmitter.ts';
 import { TopTab } from '../../../src-vue/interfaces/IConfig.ts';
 import MemberDetailsOverlay from '../../../src-vue/overlays/MemberDetailsOverlay.vue';
@@ -299,10 +300,6 @@ export const ExpirationUpdateFailed: Story = {
     await expectEventuallyVisible(canvas.findByText('Expiration update failed.'));
   },
 };
-
-function dateDaysAgo(daysAgo: number) {
-  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1_000);
-}
 
 function createInvite(id: number, overrides: Partial<IMemberInvite> = {}): IMemberInvite {
   return {

--- a/.storybook/stories/onboarding/Onboarding.stories.ts
+++ b/.storybook/stories/onboarding/Onboarding.stories.ts
@@ -7,6 +7,7 @@ import { expect, fn, mocked, within } from 'storybook/test';
 import AppScreen from '../../components/AppScreen.vue';
 import { createScenarioVault } from '../../scenarios/createScenarioVault.ts';
 import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
+import { dateDaysAgo } from '../../support/storyDates.ts';
 import {
   type IConfig,
   InstallStepErrorType,
@@ -239,6 +240,9 @@ export const MemberStates: Story = {
     controller.setOperationalInvites(createMemberInvites());
     controller.hasLoadedOperationalInvites = true;
   },
+  play: async () => {
+    await expect(await within(document.body).findByText('Created 3 days ago')).toBeVisible();
+  },
 };
 
 function setupOnboardingScenario(
@@ -387,7 +391,7 @@ function createInvite(id: number, name: string, overrides: Partial<IMemberInvite
     name,
     fromName: 'Atlas Operator',
     inviteCode: `synthetic-invite-${id}`,
-    createdAt: new Date(Date.UTC(2026, 7, 15 - id, 15, 0, 0)),
+    createdAt: dateDaysAgo(id + 2),
     ...overrides,
   };
 }

--- a/.storybook/stories/onboarding/Onboarding.stories.ts
+++ b/.storybook/stories/onboarding/Onboarding.stories.ts
@@ -224,11 +224,12 @@ export const EmptyDashboard: Story = {
 };
 
 export const MemberStates: Story = {
-  beforeEach: () => {
+  beforeEach: async () => {
     const controller = setupOnboardingScenario(OnboardingSetupStatus.Finished, {
       hasOperation: true,
       serverInstalled: true,
     });
+    await Vue.nextTick();
     controller.chainProgress = {
       ...controller.chainProgress,
       availableAccessCodes: 3,
@@ -240,8 +241,10 @@ export const MemberStates: Story = {
     controller.setOperationalInvites(createMemberInvites());
     controller.hasLoadedOperationalInvites = true;
   },
-  play: async () => {
-    await expect(await within(document.body).findByText('Created 3 days ago')).toBeVisible();
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Created 3 days ago')).toBeVisible();
   },
 };
 

--- a/.storybook/support/storyDates.ts
+++ b/.storybook/support/storyDates.ts
@@ -1,0 +1,3 @@
+export function dateDaysAgo(daysAgo: number) {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1_000);
+}


### PR DESCRIPTION
Storybook now renders Bitcoin overlays against fixed fee recommendations and member/workflow stories against deterministic time and progress fixtures, so live mempool changes, elapsed wall-clock time, and in-flight progress no longer create unrelated Chromatic diffs.

The Funding Mismatch story remains anchored to the accepted Medium / 1 sat/vbyte state; member and mining stories verify their fixed relative ages, countdowns, and workflow progress.