### PR TITLE
fix: align crosschain transfer tips

### DIFF
--- a/.storybook/scenarios/setupAppScenario.ts
+++ b/.storybook/scenarios/setupAppScenario.ts
@@ -41,7 +41,12 @@ import { useTour } from '../../src-vue/stores/tour.ts';
 import { getTransactionTracker } from '../../src-vue/stores/transactions.ts';
 import { useVaultingAssetBreakdown } from '../../src-vue/stores/vaultingAssetBreakdown.ts';
 import { useVaultingStats } from '../../src-vue/stores/vaultingStats.ts';
-import { getMyVault, getVaults } from '../../src-vue/stores/vaults.ts';
+import {
+  getCrosschainHistory,
+  getKnownCrosschainSourceIdentities,
+  getMyVault,
+  getVaults,
+} from '../../src-vue/stores/vaults.ts';
 import { getWalletKeys, useWallets } from '../../src-vue/stores/wallets.ts';
 
 type ScenarioOptions = {
@@ -303,9 +308,21 @@ export function setupAppScenario({ selectedTab, config: configOverrides = {} }: 
     createdVault: null,
     mintingAuthorities,
     globalCouncil,
-    getCrosschainQueueNetEarnings: fn(() => 0n),
+    getCrosschainQueueTxInfos: fn(() => []),
     load: fn(async () => undefined),
   });
+  mocked(getCrosschainHistory, { partial: true }).mockReturnValue({
+    data: Vue.reactive({
+      records: [],
+      isSyncing: false,
+      coverageComplete: true,
+    }),
+    refresh: fn(async () => undefined),
+    hasSeenRecipient: fn(() => false),
+    getSponsoredTransferValue: fn(() => 0n),
+    getTransferTips: fn(() => 0n),
+  });
+  mocked(getKnownCrosschainSourceIdentities).mockReturnValue(new Map());
   mocked(useTour, { partial: true }).mockReturnValue({ registerPositionCheck: fn() });
 
   const controller = useCertificationController();

--- a/.storybook/stories/crosschain/CrosschainTransfers.stories.ts
+++ b/.storybook/stories/crosschain/CrosschainTransfers.stories.ts
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { MICROGONS_PER_ARGON, MoveToken, UnitOfMeasurement } from '@argonprotocol/apps-core';
+import * as Vue from 'vue';
+import { expect, fn, mocked, within } from 'storybook/test';
+import AppScreen from '../../components/AppScreen.vue';
+import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
+import { TopTab } from '../../../src-vue/interfaces/IConfig.ts';
+import { CrosschainHistory, type ICrosschainHistoryRecord } from '../../../src-vue/lib/CrosschainHistory.ts';
+import CrosschainTransfers from '../../../src-vue/screens/CrosschainTransfers.vue';
+import { getCurrency } from '../../../src-vue/stores/currency.ts';
+import { getCrosschainHistory } from '../../../src-vue/stores/vaults.ts';
+
+const meta = {
+  title: 'Crosschain/Overview',
+  component: CrosschainTransfers,
+  render: () => ({
+    components: { AppScreen, CrosschainTransfers },
+    template: '<AppScreen><CrosschainTransfers /></AppScreen>',
+  }),
+} satisfies Meta<typeof CrosschainTransfers>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RecoveredTransferTips: Story = {
+  beforeEach: () => {
+    setupAppScenario({
+      selectedTab: TopTab.CrosschainTransfers,
+      config: { hasActivatedCrosschain: true },
+    });
+
+    const currency = getCurrency();
+    currency._key = UnitOfMeasurement.ARGN;
+    currency.record = currency.recordsByKey[UnitOfMeasurement.ARGN];
+    currency.symbol = currency.record.symbol;
+    currency.isLoaded = true;
+
+    const history = new CrosschainHistory(
+      { vaultingAddress: '5SyntheticVaultingWallet' },
+      {
+        start: fn(async () => undefined),
+        finalizedBlockHeader: { blockNumber: 10 },
+      } as any,
+      undefined,
+      fn(async () => ({
+        blocks: [],
+        asOfBlock: 10,
+        definitionVersion: 1,
+        coverage: { fromBlock: 0, toBlock: 10, gaps: [] },
+      })),
+    );
+    history.data = Vue.reactive(history.data) as typeof history.data;
+    history.data.records = [recoveredAuthorization];
+
+    mocked(getCrosschainHistory).mockReturnValue(history);
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dashboard = canvas.getByTestId('CrosschainTransfersDashboard');
+    const crosschainNavigation = canvas.getByTestId('LeftBar.goto(TopTab.CrosschainTransfers)');
+
+    await expect(dashboard).toBeVisible();
+    await expect(within(dashboard).getByText('Transfer Tips')).toBeVisible();
+    await expect(within(dashboard).getByText('Tips Available')).toBeVisible();
+    await expect(within(dashboard).getByText('1.25 ARGN tip')).toBeVisible();
+    await expect(within(crosschainNavigation).getByText('₳1.25')).toBeVisible();
+  },
+};
+
+const recoveredAuthorization: ICrosschainHistoryRecord = {
+  accountId: '5SyntheticVaultingWallet',
+  id: '0xblock:2',
+  blockNumber: 10,
+  blockTime: new Date('2026-08-15T12:00:00.000Z'),
+  extrinsicIndex: 1,
+  eventIndex: 2,
+  details: {
+    kind: 'transferAuthorization',
+    transferId: '0xtransfer',
+    authoritySigningKey: '0xauthority',
+    authorityOwnerAccount: '5SyntheticVaultingWallet',
+    sourceAccount: '5source',
+    destinationAccount: '0xrecipient',
+    moveToken: MoveToken.ARGN,
+    amount: 5n * BigInt(MICROGONS_PER_ARGON),
+    tip: 1_250_000n,
+    microgonCollateral: 10n * BigInt(MICROGONS_PER_ARGON),
+    micronotCollateral: 1_000_000n,
+  },
+};

--- a/src-vue/__test__/CrosschainHistory.test.ts
+++ b/src-vue/__test__/CrosschainHistory.test.ts
@@ -193,6 +193,37 @@ describe('CrosschainHistory', () => {
     expect(history.getSponsoredTransferValue(4_000_000n)).toBe(13_000_000n);
   });
 
+  it('totals transfer tips without including minting-authority relay activity', () => {
+    const firstAuthorization = transferAuthorizationRecord();
+    const firstAuthorizationDetails = firstAuthorization.details as Extract<
+      ICrosschainHistoryRecord['details'],
+      { kind: 'transferAuthorization' }
+    >;
+    const secondAuthorization: ICrosschainHistoryRecord = {
+      ...firstAuthorization,
+      id: '0xblock:3',
+      details: {
+        ...firstAuthorizationDetails,
+        transferId: '0xsecond-transfer',
+        tip: 75_000n,
+      },
+    };
+    const authorityRelay: ICrosschainHistoryRecord = {
+      ...firstAuthorization,
+      id: '0xblock:4',
+      details: {
+        kind: 'authorityLifecycle',
+        action: 'registered',
+        authoritySigningKey: '0xrelayed-authority',
+        queueNonce: 4n,
+      },
+    };
+    const history = new CrosschainHistory({ vaultingAddress: firstAuthorization.accountId }, {} as any);
+    history.data.records = [firstAuthorization, secondAuthorization, authorityRelay];
+
+    expect(history.getTransferTips()).toBe(125_000n);
+  });
+
   it('keeps this wallet council signatures in its crosschain history', async () => {
     const block = {
       blockNumber: 10,
@@ -318,7 +349,7 @@ function transferAuthorizationRecord(): ICrosschainHistoryRecord {
       destinationAccount: '0xrecipient',
       moveToken: MoveToken.ARGN,
       amount: 5_000_000n,
-      reward: 50_000n,
+      tip: 50_000n,
       microgonCollateral: 10_000_000n,
       micronotCollateral: 1_000_000n,
     },

--- a/src-vue/__test__/CrosschainHistory.test.ts
+++ b/src-vue/__test__/CrosschainHistory.test.ts
@@ -218,10 +218,20 @@ describe('CrosschainHistory', () => {
         queueNonce: 4n,
       },
     };
+    const legacyAuthorization: ICrosschainHistoryRecord = {
+      ...firstAuthorization,
+      id: '0xblock:5',
+      details: {
+        ...firstAuthorizationDetails,
+        tip: undefined,
+        reward: 25_000n,
+        transferId: '0xlegacy-transfer',
+      },
+    };
     const history = new CrosschainHistory({ vaultingAddress: firstAuthorization.accountId }, {} as any);
-    history.data.records = [firstAuthorization, secondAuthorization, authorityRelay];
+    history.data.records = [firstAuthorization, secondAuthorization, authorityRelay, legacyAuthorization];
 
-    expect(history.getTransferTips()).toBe(125_000n);
+    expect(history.getTransferTips()).toBe(150_000n);
   });
 
   it('keeps this wallet council signatures in its crosschain history', async () => {

--- a/src-vue/__test__/FinancialCacheTable.test.ts
+++ b/src-vue/__test__/FinancialCacheTable.test.ts
@@ -65,7 +65,7 @@ describe('FinancialCacheTable', () => {
             destinationAccount: '0xrecipient',
             moveToken: MoveToken.ARGN,
             amount: 5_000_000n,
-            reward: 50_000n,
+            tip: 50_000n,
             microgonCollateral: 10_000_000n,
             micronotCollateral: 1_000_000n,
           },

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -79,48 +79,6 @@ describe('MyVault crosschain queue history', () => {
 
     expect(myVault.getCrosschainQueueTxInfos()).toEqual([authorize, councilApproval, collectedCouncilApproval]);
   });
-
-  it('calculates finalized minting-authorization rewards net of their transaction fees', () => {
-    const finalizedAuthorization = createTxInfo({
-      id: 1,
-      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
-      status: TransactionStatus.Finalized,
-      txFeePlusTip: 1_000_000n,
-      metadataJson: {
-        actionType: 'authorizeTransfer',
-        authorizations: [{ mintingAuthorityTip: 5_000_000n }, { mintingAuthorityTip: 3_000_000n }],
-      },
-    });
-    const partiallyCompletedAuthorization = createTxInfo({
-      id: 2,
-      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
-      status: TransactionStatus.Finalized,
-      txFeePlusTip: 500_000n,
-      blockExtrinsicErrorJson: { message: 'Batch interrupted', batchInterruptedIndex: 2 },
-      metadataJson: {
-        actionType: 'authorizeTransfer',
-        authorizations: [
-          { mintingAuthorityTip: 3_000_000n },
-          { mintingAuthorityTip: 4_000_000n },
-          { mintingAuthorityTip: 5_000_000n },
-        ],
-      },
-    });
-    const pendingAuthorization = createTxInfo({
-      id: 3,
-      extrinsicType: ExtrinsicType.CrosschainTransferAuthorize,
-      txFeePlusTip: 250_000n,
-      metadataJson: {
-        actionType: 'authorizeTransfer',
-        authorizations: [{ mintingAuthorityTip: 10_000_000n }],
-      },
-    });
-    const { myVault } = createVault({
-      txInfos: [finalizedAuthorization, partiallyCompletedAuthorization, pendingAuthorization],
-    });
-
-    expect(myVault.getCrosschainQueueNetEarnings()).toBe(13_500_000n);
-  });
 });
 
 describe('MyVault cosign recovery', () => {

--- a/src-vue/components/CrosschainHistoryRows.vue
+++ b/src-vue/components/CrosschainHistoryRows.vue
@@ -20,7 +20,7 @@
           <div class="font-mono font-semibold text-slate-700">
             {{ formatTokenAmount(record.details.amount, record.details.moveToken) }}
           </div>
-          <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(record.details.reward) }} ARGN earned</div>
+          <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(record.details.tip) }} ARGN tip</div>
         </div>
         <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
       </summary>

--- a/src-vue/components/CrosschainHistoryRows.vue
+++ b/src-vue/components/CrosschainHistoryRows.vue
@@ -20,7 +20,9 @@
           <div class="font-mono font-semibold text-slate-700">
             {{ formatTokenAmount(record.details.amount, record.details.moveToken) }}
           </div>
-          <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(record.details.tip) }} ARGN tip</div>
+          <div class="mt-0.5 text-xs text-slate-500">
+            {{ formatArgon(record.details.tip ?? record.details.reward ?? 0n) }} ARGN tip
+          </div>
         </div>
         <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
       </summary>

--- a/src-vue/lib/CrosschainHistory.ts
+++ b/src-vue/lib/CrosschainHistory.ts
@@ -21,7 +21,7 @@ export type ICrosschainHistoryDetails =
       destinationAccount: string;
       moveToken: MoveToken.ARGN | MoveToken.ARGNOT;
       amount: bigint;
-      reward: bigint;
+      tip: bigint;
       microgonCollateral: bigint;
       micronotCollateral: bigint;
     }
@@ -128,6 +128,12 @@ export class CrosschainHistory {
 
       if (record.details.moveToken === MoveToken.ARGN) return total + record.details.amount;
       return total + (record.details.amount * microgonsPerArgonot) / BigInt(MICRONOTS_PER_ARGONOT);
+    }, 0n);
+  }
+
+  public getTransferTips() {
+    return this.data.records.reduce((total, record) => {
+      return record.details.kind === 'transferAuthorization' ? total + record.details.tip : total;
     }, 0n);
   }
 
@@ -352,7 +358,7 @@ export class CrosschainHistory {
         destinationAccount: transfer.destinationAccount.toHex(),
         moveToken: transfer.asset.isArgon ? MoveToken.ARGN : MoveToken.ARGNOT,
         amount: transfer.amount.toBigInt(),
-        reward: transfer.mintingAuthorityTip.toBigInt(),
+        tip: transfer.mintingAuthorityTip.toBigInt(),
         microgonCollateral: event.data.microgonCollateral.toBigInt(),
         micronotCollateral: event.data.micronotCollateral.toBigInt(),
       };

--- a/src-vue/lib/CrosschainHistory.ts
+++ b/src-vue/lib/CrosschainHistory.ts
@@ -21,7 +21,9 @@ export type ICrosschainHistoryDetails =
       destinationAccount: string;
       moveToken: MoveToken.ARGN | MoveToken.ARGNOT;
       amount: bigint;
-      tip: bigint;
+      tip?: bigint;
+      /** Cached records from before the transfer-tip rename. */
+      reward?: bigint;
       microgonCollateral: bigint;
       micronotCollateral: bigint;
     }
@@ -131,9 +133,10 @@ export class CrosschainHistory {
     }, 0n);
   }
 
-  public getTransferTips() {
+  public getTransferTips(): bigint {
     return this.data.records.reduce((total, record) => {
-      return record.details.kind === 'transferAuthorization' ? total + record.details.tip : total;
+      if (record.details.kind !== 'transferAuthorization') return total;
+      return total + (record.details.tip ?? record.details.reward ?? 0n);
     }, 0n);
   }
 

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -56,7 +56,7 @@ import { ExtrinsicType } from './db/TransactionsTable.ts';
 import { computeCollectDeadline } from './VaultDeadlineWatcher.ts';
 import { WalletKeys } from './WalletKeys.ts';
 import { GlobalCouncil } from './GlobalCouncil.ts';
-import { MintingAuthorities, type IMintingAuthorityAuthorizeMetadata } from './MintingAuthorities.ts';
+import { MintingAuthorities } from './MintingAuthorities.ts';
 import { Config } from './Config.ts';
 import { ICollectOrphanCosignMetadata, IVaultCollectMetadata, VaultCollectBuilder } from './VaultCollectBuilder.ts';
 import { getSpendableDefaultArgonMicrogons } from './WalletForArgon.ts';
@@ -392,24 +392,6 @@ export class MyVault {
         (metadata.actionType === 'approveCouncil' || (metadata.councilApprovalCount ?? 0) > 0)
       );
     });
-  }
-
-  public getCrosschainQueueNetEarnings(): bigint {
-    return this.getCrosschainQueueTxInfos().reduce((netEarnings, { tx }) => {
-      if (!tx.isFinalized || tx.extrinsicType !== ExtrinsicType.CrosschainTransferAuthorize) {
-        return netEarnings;
-      }
-
-      const metadata = tx.metadataJson as IMintingAuthorityAuthorizeMetadata;
-      const completedAuthorizationCount = tx.blockExtrinsicErrorJson
-        ? (tx.blockExtrinsicErrorJson.batchInterruptedIndex ?? 0)
-        : metadata.authorizations.length;
-      const earnedRewards = metadata.authorizations
-        .slice(0, completedAuthorizationCount)
-        .reduce((total, authorization) => total + authorization.mintingAuthorityTip, 0n);
-
-      return netEarnings + earnedRewards - (tx.txFeePlusTip ?? 0n);
-    }, 0n);
   }
 
   public getBitcoinReleaseRequestTxInfo(utxoId: number): TransactionInfo<any> | undefined {

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -347,7 +347,7 @@
                   </div>
                 </div>
                 <div v-if="currency.isLoaded" class="opacity-60">
-                  {{ currency.symbol }}{{ microgonToMoneyNm(crosschainNetEarnings).format('0,0.00') }}
+                  {{ currency.symbol }}{{ microgonToMoneyNm(crosschainHistory.getTransferTips()).format('0,0.00') }}
                 </div>
               </div>
             </article>
@@ -552,7 +552,7 @@ import WalletSelector from '../wallets/components/WalletSelector.vue';
 import WalletActions from '../wallets/components/WalletActions.vue';
 import CertificationIcon from '../assets/certification.svg';
 import { ArrowsRightLeftIcon } from '@heroicons/vue/24/outline';
-import { getMyVault } from '../stores/vaults.ts';
+import { getCrosschainHistory, getMyVault } from '../stores/vaults.ts';
 import { getCrosschainAccessState } from '../lib/CrosschainTransferView.ts';
 
 const controller = useCertificationController();
@@ -565,6 +565,7 @@ const financials = useFinancials();
 const miningAssets = useMiningAssetBreakdown();
 const vaultingAssets = useVaultingAssetBreakdown();
 const myVault = getMyVault();
+const crosschainHistory = getCrosschainHistory();
 const { microgonToArgonNm, microgonToMoneyNm, micronotToArgonotNm, micronotToMoneyNm, satToMoneyNm } =
   createNumeralHelpers(currency);
 
@@ -628,8 +629,6 @@ const hasCrosschainAction = Vue.computed(() => {
     myVault.globalCouncil.data.pendingApprovals.length > 0
   );
 });
-
-const crosschainNetEarnings = Vue.computed(() => myVault.getCrosschainQueueNetEarnings());
 
 const showCrosschainNavigation = Vue.computed(() => {
   return getCrosschainAccessState({

--- a/src-vue/navigation/LeftBar.vue
+++ b/src-vue/navigation/LeftBar.vue
@@ -347,7 +347,7 @@
                   </div>
                 </div>
                 <div v-if="currency.isLoaded" class="opacity-60">
-                  {{ currency.symbol }}{{ microgonToMoneyNm(crosschainHistory.getTransferTips()).format('0,0.00') }}
+                  {{ currency.symbol }}{{ microgonToMoneyNm(crosschainTransferTips).format('0,0.00') }}
                 </div>
               </div>
             </article>
@@ -580,6 +580,8 @@ const hasActiveCoupon = Vue.computed(() => {
   const expiresAt = bitcoinLockCoupons.currentCoupon?.expiresAt;
   return expiresAt != null && new Date(expiresAt).getTime() > now.value;
 });
+
+const crosschainTransferTips = Vue.computed(() => crosschainHistory.getTransferTips());
 
 const walletSelections = Vue.computed(() => {
   return getAvailableWalletSelections(wallets.walletRecords, [], config.hasExtensionOperations);

--- a/src-vue/screens/crosschain-transfers-screen/Dashboard.vue
+++ b/src-vue/screens/crosschain-transfers-screen/Dashboard.vue
@@ -32,16 +32,16 @@
           <label>Total Signed</label>
         </div>
       </Tooltip>
-      <Tooltip :asChild="true" content="Transfer-authorization rewards recovered from your signing history, before fees.">
+      <Tooltip :asChild="true" content="Transfer tips recovered from your signing history, before fees.">
         <div box stat-box class="flex w-1/5 cursor-help flex-col">
-          <span>₳{{ formatArgon(historicalRewardsEarned) }}</span>
-          <label>Rewards Earned</label>
+          <span>₳{{ formatArgon(crosschainHistory.getTransferTips()) }}</span>
+          <label>Transfer Tips</label>
         </div>
       </Tooltip>
-      <Tooltip :asChild="true" content="Rewards offered by transfer requests currently available to your minting authorities.">
+      <Tooltip :asChild="true" content="Tips offered by transfer requests currently available to your minting authorities.">
         <div box stat-box class="flex w-1/5 cursor-help flex-col">
-          <span>₳{{ formatArgon(availableRewards) }}</span>
-          <label>Rewards Available</label>
+          <span>₳{{ formatArgon(availableTips) }}</span>
+          <label>Tips Available</label>
         </div>
       </Tooltip>
     </section>
@@ -135,7 +135,7 @@
               </div>
               <div v-if="row.amount !== undefined" class="shrink-0 text-right">
                 <div class="font-mono font-semibold text-slate-700">{{ formatTokenAmount(row.amount, row.moveToken) }}</div>
-                <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(row.reward ?? 0n) }} ARGN reward</div>
+                <div class="mt-0.5 text-xs text-slate-500">{{ formatArgon(row.tip ?? 0n) }} ARGN tip</div>
               </div>
               <div class="text-slate-400 transition-transform group-open:rotate-90">›</div>
             </summary>
@@ -176,7 +176,7 @@
                 <template v-if="selectedAuthorizations.length">
                   {{ formatArgon(selectedMicrogonCollateral) }} ARGN +
                   {{ formatArgonot(selectedMicronotCollateral) }} ARGNOT collateral for
-                  {{ formatArgon(selectedRewardMicrogons) }} ARGN reward
+                  {{ formatArgon(selectedTipMicrogons) }} ARGN tip
                 </template>
                 <template v-else>Select one or more transfer requests to fund.</template>
               </div>
@@ -198,7 +198,7 @@
         class="flex min-h-32 flex-col items-center justify-center px-8 text-center text-slate-500">
         <div class="text-lg font-semibold text-slate-600">No minting authority is registered</div>
         <p class="mt-1 max-w-2xl text-sm">
-          A minting authority is required to fund transfer requests and earn authorization rewards. Use Add Authority
+          A minting authority is required to fund transfer requests and earn authorization tips. Use Add Authority
           above to register one.
         </p>
       </div>
@@ -415,7 +415,7 @@ type ITransferQueueRow = {
   transferId: string;
   moveToken?: MoveToken.ARGN | MoveToken.ARGNOT;
   amount?: bigint;
-  reward?: bigint;
+  tip?: bigint;
   sourceAccount?: string;
   sourceIdentity?: ICrosschainSourceIdentity;
   destinationAccount?: string;
@@ -636,7 +636,7 @@ const selectedMicrogonCollateral = Vue.computed(() => {
 const selectedMicronotCollateral = Vue.computed(() => {
   return selectedAuthorizations.value.reduce((total, authorization) => total + authorization.micronotCollateral, 0n);
 });
-const selectedRewardMicrogons = Vue.computed(() => {
+const selectedTipMicrogons = Vue.computed(() => {
   return selectedAuthorizations.value.reduce((total, authorization) => total + authorization.mintingAuthorityTip, 0n);
 });
 const fundingTransferCount = Vue.computed(() => {
@@ -646,12 +646,7 @@ const fundingTransferCount = Vue.computed(() => {
     activeFundingTxInfos.value.flatMap(({ tx }) => tx.metadataJson.authorizations.map(({ transferId }) => transferId)),
   ).size;
 });
-const historicalRewardsEarned = Vue.computed(() => {
-  return crosschainHistory.data.records.reduce((total, record) => {
-    return record.details.kind === 'transferAuthorization' ? total + record.details.reward : total;
-  }, 0n);
-});
-const availableRewards = Vue.computed(() => {
+const availableTips = Vue.computed(() => {
   return myVault.mintingAuthorities.data.pendingMintingAuthorizations.reduce(
     (total, authorization) => total + authorization.mintingAuthorityTip,
     0n,
@@ -765,7 +760,7 @@ function toPendingAuthorizationRow(authorization: IMintingAuthorityAuthorization
     needsAction: true,
     moveToken: authorization.moveToken,
     amount: authorization.finalizeRequest.amount,
-    reward: authorization.mintingAuthorityTip,
+    tip: authorization.mintingAuthorityTip,
     transferId: authorization.transferId,
     sourceAccount: authorization.sourceAccount,
     sourceIdentity: knownSourceIdentities.value.get(authorization.sourceAccount),
@@ -793,7 +788,7 @@ function toBackedTransferRow(transfer: IMintingAuthorityBackedTransfer): ITransf
     needsAction: false,
     moveToken: transfer.moveToken,
     amount: transfer.amount,
-    reward: transfer.mintingAuthorityTip,
+    tip: transfer.mintingAuthorityTip,
     transferId: transfer.transferId,
     sourceAccount: transfer.sourceAccount,
     sourceIdentity: knownSourceIdentities.value.get(transfer.sourceAccount),
@@ -824,7 +819,7 @@ function toPendingSubmissionRow(
     waitingFor: 'Argon finalization',
     needsAction: false,
     transferId,
-    reward: authorization?.mintingAuthorityTip,
+    tip: authorization?.mintingAuthorityTip,
     microgonCollateral: authorization?.microgonCollateral,
     micronotCollateral: authorization?.micronotCollateral,
     argonBlockHeight: txInfo.tx.blockHeight,

--- a/src-vue/stores/__mocks__/vaults.ts
+++ b/src-vue/stores/__mocks__/vaults.ts
@@ -1,5 +1,12 @@
 import { fn } from 'storybook/test';
-import type { getMyVault as getMyVaultOriginal, getVaults as getVaultsOriginal } from '../vaults.ts';
+import type {
+  getCrosschainHistory as getCrosschainHistoryOriginal,
+  getKnownCrosschainSourceIdentities as getKnownCrosschainSourceIdentitiesOriginal,
+  getMyVault as getMyVaultOriginal,
+  getVaults as getVaultsOriginal,
+} from '../vaults.ts';
 
 export const getVaults = fn<typeof getVaultsOriginal>();
 export const getMyVault = fn<typeof getMyVaultOriginal>();
+export const getCrosschainHistory = fn<typeof getCrosschainHistoryOriginal>();
+export const getKnownCrosschainSourceIdentities = fn<typeof getKnownCrosschainSourceIdentitiesOriginal>();


### PR DESCRIPTION
## Summary

Crosschain transfer-tip totals now match between the dashboard and LeftBar because both use recovered transfer authorization history. Minting-authority registration reimbursements remain excluded, and the transfer workflow consistently describes these amounts as tips.

## Validation

- Confirmed the dashboard, transfer history, and Crosschain navigation render the same recovered tip total.
- Confirmed minting-authority lifecycle activity does not enter the transfer-tip total.
