### PR TITLE
fix: recover autobidders after missed frame changes

### DIFF
--- a/bot/__test__/AutoBidder.test.ts
+++ b/bot/__test__/AutoBidder.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTypedEventEmitter } from '@argonprotocol/apps-core';
 import { AutoBidder } from '../src/AutoBidder.ts';
 
 const onBiddingStart = Object.getOwnPropertyDescriptor(AutoBidder.prototype, 'onBiddingStart')!.value as (
@@ -109,5 +110,62 @@ describe('AutoBidder', () => {
 
     expect(planMiningBidProxySetup).not.toHaveBeenCalled();
     expect(createBidderParams).toHaveBeenCalledWith(12);
+  });
+
+  it('reconciles a stale bidder when a new frame arrives without a cohort notification', async () => {
+    const client = {
+      queryMulti: vi.fn().mockResolvedValue(() => undefined),
+      query: {
+        miningSlot: {
+          isNextSlotBiddingOpen: vi.fn().mockResolvedValue({ isFalse: false }),
+          nextFrameId: vi.fn().mockResolvedValue({ toNumber: () => 539 }),
+        },
+      },
+    };
+    const miningFrames = {
+      events: createTypedEventEmitter<{
+        'on-frame': (frame: { frameId: number; blockNumber: number; blockHash: string }) => void;
+      }>(),
+    };
+    const autoBidder = new AutoBidder(
+      {
+        isProxy: false,
+        registerKeys: vi.fn(),
+      } as any,
+      {
+        prunedClientOrArchivePromise: Promise.resolve(client),
+      } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      miningFrames as any,
+    );
+    const staleBidder = {
+      isBiddingOpen: true,
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const createBidderParams = vi.fn().mockResolvedValue({ maxSeats: 0 });
+    Object.assign(autoBidder, {
+      biddingCalculator: {
+        load: vi.fn(),
+        unload: vi.fn(),
+      },
+      cohortBiddersByActivationFrameId: new Map([[537, staleBidder]]),
+      nextCohortActivationFrameId: 537,
+      createBidderParams,
+    });
+
+    await autoBidder.start('ws://argon-miner:9944');
+
+    miningFrames.events.emit('on-frame', {
+      frameId: 538,
+      blockNumber: 876_000,
+      blockHash: '0xframe538',
+    });
+    await (autoBidder as any).lifecycleQueue;
+
+    expect(autoBidder.currentBidder).toBeUndefined();
+    expect(staleBidder.stop).toHaveBeenCalledOnce();
+    expect(createBidderParams).toHaveBeenCalledWith(539);
   });
 });

--- a/bot/src/AutoBidder.ts
+++ b/bot/src/AutoBidder.ts
@@ -31,6 +31,7 @@ export class AutoBidder {
   private nextCohortActivationFrameId: number | null = null;
   private isStopped = false;
   private unsubscribe?: () => void;
+  private unsubscribeFrame?: () => void;
   private biddingCalculator?: BiddingCalculator;
   private onUpdatedFn?: () => void;
   private localRpcUrl?: string;
@@ -67,12 +68,17 @@ export class AutoBidder {
     if (this.unsubscribe) {
       this.unsubscribe();
     }
+    this.unsubscribeFrame?.();
     const { unsubscribe } = await this.mining.onCohortChange({
       onBiddingStart: cohortActivationFrameId =>
         this.queueLifecycle(() => this.onBiddingStart(cohortActivationFrameId)),
       onBiddingEnd: cohortActivationFrameId => this.queueLifecycle(() => this.onBiddingEnd(cohortActivationFrameId)),
     });
     this.unsubscribe = unsubscribe;
+    this.unsubscribeFrame = this.miningFrames.events.on('on-frame', () => {
+      if (this.isStopped) return;
+      void this.queueLifecycle(() => this.reloadActiveCohort());
+    });
 
     if (!this.biddingRules || !this.biddingCalculator) {
       return;
@@ -92,6 +98,8 @@ export class AutoBidder {
     console.log('AUTOBIDDER STOPPING');
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    this.unsubscribeFrame?.();
+    this.unsubscribeFrame = undefined;
     if (this.pendingProxyRetryTimeout) {
       clearTimeout(this.pendingProxyRetryTimeout);
       this.pendingProxyRetryTimeout = undefined;
@@ -176,6 +184,12 @@ export class AutoBidder {
 
   private async onBiddingStart(cohortActivationFrameId: number) {
     if (this.isStopped || !this.biddingRules || !this.biddingCalculator) return;
+    if (
+      this.nextCohortActivationFrameId === cohortActivationFrameId &&
+      this.cohortBiddersByActivationFrameId.has(cohortActivationFrameId)
+    ) {
+      return;
+    }
 
     try {
       if (this.accountset.isProxy) {
@@ -337,7 +351,14 @@ export class AutoBidder {
     }
 
     const cohortActivationFrameId = await this.mining.fetchNextFrameId(client);
-    await this.onBiddingEnd(cohortActivationFrameId, false);
+    if (
+      this.nextCohortActivationFrameId === cohortActivationFrameId &&
+      this.cohortBiddersByActivationFrameId.has(cohortActivationFrameId)
+    ) {
+      return;
+    }
+
+    await this.stopActiveBidders(false);
     await this.onBiddingStart(cohortActivationFrameId);
   }
 }


### PR DESCRIPTION
The mining bot now recovers when a cohort transition notification is missed instead of continuing to bid against an expired cohort. Each BlockWatch-derived frame transition reconciles the autobidder with authoritative chain state, while duplicate signals remain idempotent and serialized.

The regression recreates the missed-notification state and verifies that the stale bidder is stopped before the current cohort starts.
