### PR TITLE
fix: trust node sync status for bot readiness

### DIFF
--- a/bot/src/Bot.ts
+++ b/bot/src/Bot.ts
@@ -407,12 +407,8 @@ export default class Bot {
     if (!bitcoinBlockNumbers.mainNode) return false;
     if (bitcoinBlockNumbers.localNode < bitcoinBlockNumbers.mainNode) return false;
 
-    const argonBlockNumbers = await DockerStatus.getArgonBlockNumbers();
-    if (!argonBlockNumbers.mainNode) return false;
-    if (argonBlockNumbers.localNode < argonBlockNumbers.mainNode) return false;
-
-    const isArgonMinerReady = await DockerStatus.isArgonMinerReady();
-    if (!isArgonMinerReady) return false;
+    const argonSyncPercent = await DockerStatus.getArgonSyncPercent();
+    if (argonSyncPercent !== 100) return false;
 
     return true;
   }

--- a/bot/src/DockerStatus.ts
+++ b/bot/src/DockerStatus.ts
@@ -18,13 +18,15 @@ export class DockerStatus {
     }
   }
 
-  public static async isArgonMinerReady(): Promise<boolean> {
+  public static async getArgonSyncPercent(): Promise<number> {
     try {
-      const result = await fetch(`${routerApi}/argon/iscomplete`).then(res => res.text());
-      return result === 'true';
+      const syncStatus = await fetch(`${routerApi}/argon/syncstatus`).then(
+        res => res.json() as Promise<ILatestBlocks & { syncPercent: number }>,
+      );
+      return syncStatus.syncPercent;
     } catch (e) {
-      console.error('isArgonMinerReady Error:', e);
-      return false;
+      console.error('getArgonSyncPercent Error:', e);
+      return 0;
     }
   }
 


### PR DESCRIPTION
Upstream bot startup no longer stalls when a healthy Argon node is one block behind a continuously advancing archive tip. Readiness now follows the router's node-backed sync status, preserving its completion guard without comparing independent block-height samples.

Live validation reproduced the one-block-behind case with `syncPercent: 100`, and the corrected readiness check returned `true`. The focused router tests and bot build pass.
