### PR TITLE
fix: recover financial history from older runtimes

### DIFF
--- a/core/src/BondLot.ts
+++ b/core/src/BondLot.ts
@@ -132,7 +132,7 @@ export class BondLot {
       releaseFrame: lot.releaseFrameId.isSome ? lot.releaseFrameId.unwrap().toNumber() : null,
       releaseReason: lot.releaseReason.isSome ? lot.releaseReason.unwrap().type : undefined,
       isReleasing: lot.releaseReason.isSome,
-      isFlexible: 'isFlexible' in lot ? lot.isFlexible.valueOf() : lot.isBackfill.valueOf(),
+      isFlexible: Boolean(lot.get('isFlexible')?.valueOf() ?? lot.get('isBackfill')?.valueOf()),
       isOwn: accountId === ownAddress,
       canRelease: accountId === ownAddress,
     });

--- a/src-vue/__test__/BitcoinLocks.history.test.ts
+++ b/src-vue/__test__/BitcoinLocks.history.test.ts
@@ -255,29 +255,45 @@ describe('BitcoinLocks historical event replay', () => {
     expect(activeLocks).toHaveBeenCalledWith([7, 8]);
   });
 
-  it('replays securitization and candidate-funding transitions', async () => {
+  it('rebuilds current snapshot economics before replaying historical ratchets', async () => {
     const accountId = encodeAddress(new Uint8Array(32).fill(0x33));
+    const api = {
+      query: {
+        bitcoinUtxos: {
+          confirmedBitcoinBlockTip: vi.fn(async () => optionCodec({ blockHeight: numberCodec(600) })),
+        },
+        bitcoinLocks: {
+          utxoIdsByOwnerAccount: { keys: vi.fn(async () => [{ args: [{}, numberCodec(7)] }]) },
+          locksByUtxoId: {
+            multi: vi.fn(async () => [
+              optionCodec({ liquidityPromised: bigintCodec(1_400n), lockedTargetPrice: bigintCodec(1_500n) }),
+            ]),
+          },
+        },
+      },
+    };
     const store = createStore({
-      blockWatch: { getApi: vi.fn(async () => ({})) } as unknown as BlockWatch,
+      blockWatch: { getApi: vi.fn(async () => api) } as unknown as BlockWatch,
       walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
     });
     const record = createLock({
       uuid: 'pre-funding-history',
       utxoId: 7,
-      status: BitcoinLockStatus.LockPendingFunding,
+      status: BitcoinLockStatus.LockedAndIsMinting,
       createdAt: '2026-01-01T00:00:00Z',
     });
-    record.liquidityPromised = 1_000n;
-    record.lockedTargetPrice = 1_000n;
+    record.liquidityPromised = 1_400n;
+    record.lockedTargetPrice = 1_500n;
     record.lockDetails = new BitcoinLock({
-      ...createHistoricalLock({ accountId, liquidityPromised: 1_000n }),
-      isFunded: false,
+      ...createHistoricalLock({ accountId, liquidityPromised: 1_400n, lockedTargetPrice: 1_500n }),
+      utxoId: 7,
     });
     record.ratchets = [
       {
-        mintAmount: 1_000n,
-        mintPending: 1_000n,
-        lockedTargetPrice: 1_000n,
+        mintAmount: 1_400n,
+        mintPending: 0n,
+        liquidityPromised: 1_400n,
+        lockedTargetPrice: 1_500n,
         securityFee: 20n,
         txFee: 11n,
         burned: 0n,
@@ -295,8 +311,7 @@ describe('BitcoinLocks historical event replay', () => {
     vi.mocked(BitcoinLockHistory.getHistoricalBitcoinLock)
       .mockResolvedValueOnce(
         new BitcoinLock({
-          ...createHistoricalLock({ accountId, liquidityPromised: 1_100n, lockedTargetPrice: 1_100n }),
-          satoshis: 11_000n,
+          ...createHistoricalLock({ accountId, liquidityPromised: 1_000n, lockedTargetPrice: 1_000n }),
           isFunded: false,
         }),
       )
@@ -307,30 +322,30 @@ describe('BitcoinLocks historical event replay', () => {
         }),
       );
     vi.spyOn(BitcoinLock.prototype, 'getFundingUtxoRef').mockResolvedValue(undefined);
+    vi.spyOn(BitcoinLock, 'get')
+      .mockResolvedValueOnce(
+        new BitcoinLock(createHistoricalLock({ accountId, liquidityPromised: 1_200n, lockedTargetPrice: 1_300n })),
+      )
+      .mockResolvedValueOnce(
+        new BitcoinLock(createHistoricalLock({ accountId, liquidityPromised: 1_400n, lockedTargetPrice: 1_500n })),
+      );
 
-    await store.recovery.recoverBlock(historyBlock(152), [
-      historyEvent(147, 'bitcoinLocks', 'SecuritizationIncreased', {
+    await store.recovery.recoverBlock(historyBlock(151), [
+      historyEvent(157, 'bitcoinLocks', 'BitcoinLockCreated', {
         utxoId: 7,
         vaultId: 1,
-        newSatoshis: 11_000n,
+        liquidityPromised: 1_000n,
+        securitization: 1_000n,
+        lockedTargetPrice: 1_000n,
         accountId,
+        securityFee: 20n,
       }),
     ]);
 
-    expect(record).toMatchObject({
-      status: BitcoinLockStatus.LockPendingFunding,
-      satoshis: 11_000n,
-      liquidityPromised: 1_100n,
-      lockedTargetPrice: 1_100n,
-    });
-    expect(record.ratchets[0]).toMatchObject({
-      mintAmount: 1_100n,
-      mintPending: 1_100n,
-      lockedTargetPrice: 1_100n,
-    });
+    expect(record.ratchets[0].liquidityPromised).toBeUndefined();
 
     await store.recovery.recoverBlock(historyBlock(153), [
-      historyEvent(147, 'bitcoinLocks', 'UtxoFundedFromCandidate', {
+      historyEvent(157, 'bitcoinLocks', 'UtxoFundedFromCandidate', {
         utxoId: 7,
         utxoRef: { txid: `0x${'44'.repeat(32)}`, outputIndex: 2 },
         vaultId: 1,
@@ -350,7 +365,43 @@ describe('BitcoinLocks historical event replay', () => {
       lockedTargetPrice: 1_050n,
     });
 
-    expect(table.saveRecoveredHistory).toHaveBeenCalledTimes(2);
+    await store.recovery.recoverBlock(historyBlock(154), [
+      historyEvent(158, 'bitcoinLocks', 'BitcoinLockRatcheted', {
+        utxoId: 7,
+        vaultId: 1,
+        liquidityPromised: 1_200n,
+        oldTargetPrice: 1_050n,
+        securityFee: 25n,
+        newTargetPrice: 1_300n,
+        amountBurned: 0n,
+        accountId,
+      }),
+      historyEvent(
+        158,
+        'bitcoinLocks',
+        'BitcoinLockRatcheted',
+        {
+          utxoId: 7,
+          vaultId: 1,
+          liquidityPromised: 1_400n,
+          oldTargetPrice: 1_300n,
+          securityFee: 30n,
+          newTargetPrice: 1_500n,
+          amountBurned: 0n,
+          accountId,
+        },
+        3,
+      ),
+    ]);
+
+    expect(record.ratchets).toEqual([
+      expect.objectContaining({ mintAmount: 1_050n, lockedTargetPrice: 1_050n }),
+      expect.objectContaining({ mintAmount: 150n, lockedTargetPrice: 1_300n }),
+      expect.objectContaining({ mintAmount: 200n, lockedTargetPrice: 1_500n }),
+    ]);
+    await expect(store.recovery.findMissingActiveLockIds(api as never)).resolves.toEqual([]);
+
+    expect(table.saveRecoveredHistory).toHaveBeenCalledTimes(4);
   });
 
   it('expires an unfunded lock when its UTXO is no longer watched', async () => {
@@ -525,6 +576,116 @@ describe('BitcoinLocks historical event replay', () => {
       burned: 800n,
     });
     expect(saveRecoveredHistory).toHaveBeenCalledWith(recovered);
+  });
+
+  it('recovers a pre-158 promise reset but rejects the regression in newer history', async () => {
+    const accountId = encodeAddress(new Uint8Array(32).fill(0x42));
+    const record = createLock({
+      uuid: 'legacy-up-ratchet',
+      utxoId: 7,
+      status: BitcoinLockStatus.LockedAndMinted,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    record.liquidityPromised = 800n;
+    record.lockedTargetPrice = 1_400n;
+    record.ratchets = [
+      {
+        mintAmount: 1_000n,
+        mintPending: 0n,
+        lockedTargetPrice: 1_000n,
+        securityFee: 20n,
+        txFee: 11n,
+        burned: 0n,
+        blockHeight: 151,
+        extrinsicIndex: 2,
+        oracleBitcoinBlockHeight: 500,
+      },
+    ];
+    const api = {
+      runtimeVersion: { specVersion: numberCodec(156) },
+      query: {
+        bitcoinUtxos: {
+          confirmedBitcoinBlockTip: vi.fn(async () => optionCodec({ blockHeight: numberCodec(600) })),
+        },
+        priceIndex: {
+          current: vi.fn(async () =>
+            optionCodec({
+              btcUsdPrice: bigintCodec(1_000_000_000_000_000_000n),
+              argonotUsdPrice: bigintCodec(1_000_000_000_000_000_000n),
+              argonUsdPrice: bigintCodec(500_000_000_000_000_000n),
+              argonUsdTargetPrice: bigintCodec(1_000_000_000_000_000_000n),
+              argonTimeWeightedAverageLiquidity: bigintCodec(1_000_000_000_000_000_000n),
+              tick: numberCodec(152),
+            }),
+          ),
+        },
+        bitcoinLocks: {
+          utxoIdsByOwnerAccount: { keys: vi.fn(async () => [{ args: [{}, numberCodec(7)] }]) },
+          locksByUtxoId: {
+            multi: vi.fn(async () => [
+              optionCodec({ liquidityPromised: bigintCodec(800n), lockedTargetPrice: bigintCodec(1_400n) }),
+            ]),
+          },
+        },
+      },
+    };
+    const newerApi = { ...api, runtimeVersion: { specVersion: numberCodec(158) } };
+    const store = createStore({
+      blockWatch: {
+        getApi: vi.fn().mockResolvedValueOnce(api).mockResolvedValueOnce(newerApi),
+      } as unknown as BlockWatch,
+      walletKeys: { defaultArgonAddress: accountId } as WalletKeys,
+    });
+    store.data.locksByUtxoId[7] = record;
+    const saveRecoveredHistory = vi.fn(async () => undefined);
+    vi.spyOn(store, 'getTable').mockResolvedValue({
+      getByUtxoId: vi.fn(async () => record),
+      saveRecoveredHistory,
+    } as never);
+    vi.spyOn(BitcoinLock, 'get').mockResolvedValue(
+      new BitcoinLock(createHistoricalLock({ accountId, liquidityPromised: 800n, lockedTargetPrice: 1_400n })),
+    );
+
+    await store.recovery.recoverBlock(historyBlock(152), [
+      historyEvent(156, 'bitcoinLocks', 'BitcoinLockRatcheted', {
+        utxoId: 7,
+        vaultId: 1,
+        liquidityPromised: 800n,
+        oldTargetPrice: 1_000n,
+        securityFee: 25n,
+        newTargetPrice: 1_400n,
+        amountBurned: 0n,
+        accountId,
+      }),
+    ]);
+
+    const recovered = store.data.locksByUtxoId[7];
+    expect(recovered).toMatchObject({ liquidityPromised: 800n, lockedTargetPrice: 1_400n });
+    expect(recovered.ratchets.at(-1)).toMatchObject({
+      mintAmount: 540n,
+      mintPending: 540n,
+      liquidityPromised: 800n,
+      lockedTargetPrice: 1_400n,
+    });
+    await expect(store.recovery.findMissingActiveLockIds(api as never)).resolves.toEqual([]);
+    expect(saveRecoveredHistory).toHaveBeenCalledWith(recovered);
+
+    await expect(
+      store.recovery.recoverBlock(historyBlock(153), [
+        historyEvent(158, 'bitcoinLocks', 'BitcoinLockRatcheted', {
+          utxoId: 7,
+          vaultId: 1,
+          liquidityPromised: 700n,
+          oldTargetPrice: 1_400n,
+          securityFee: 30n,
+          newTargetPrice: 1_500n,
+          amountBurned: 0n,
+          accountId,
+        }),
+      ]),
+    ).rejects.toThrow('Bitcoin lock 7 up-ratchet reduced its promised liquidity');
+    expect(store.data.locksByUtxoId[7]).toBe(recovered);
+    expect(saveRecoveredHistory).toHaveBeenCalledTimes(1);
   });
 
   it('finishes creation provenance after finalization persisted but history save failed', async () => {

--- a/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
+++ b/src-vue/__test__/FinancialHistorySpecBoundaries.test.ts
@@ -232,7 +232,7 @@ describe('financial history spec boundaries', () => {
     ]);
   });
 
-  it.each([151, 155, 156])('recovers the spec %s BondLot storage shape', async specVersion => {
+  it.each([151, 155, 156, 157])('recovers the spec %s BondLot storage shape', async specVersion => {
     const db = await createTestDb();
     const lot = createBondLot(specVersion);
     const lotOption = optionCodec(lot);
@@ -323,6 +323,31 @@ function createBondLot(specVersion: number) {
       releaseFrameId: 'Option<u64>',
       releaseReason: 'Option<PalletTreasuryBondReleaseReason>',
     },
+    AppBondLotSpec156: {
+      owner: 'AccountId32',
+      program: 'PalletTreasuryBondProgram',
+      bonds: 'Compact<u32>',
+      createdFrameId: 'Compact<u64>',
+      participatedFrames: 'Compact<u32>',
+      lastFrameEarningsFrameId: 'Option<u64>',
+      lastFrameEarnings: 'Option<u128>',
+      cumulativeEarnings: 'Compact<u128>',
+      releaseFrameId: 'Option<u64>',
+      releaseReason: 'Option<PalletTreasuryBondReleaseReason>',
+    },
+    AppBondLotSpec157: {
+      owner: 'AccountId32',
+      program: 'PalletTreasuryBondProgram',
+      bonds: 'Compact<u32>',
+      createdFrameId: 'Compact<u64>',
+      participatedFrames: 'Compact<u32>',
+      lastFrameEarningsFrameId: 'Option<u64>',
+      lastFrameEarnings: 'Option<u128>',
+      cumulativeEarnings: 'Compact<u128>',
+      releaseFrameId: 'Option<u64>',
+      releaseReason: 'Option<PalletTreasuryBondReleaseReason>',
+      isBackfill: 'bool',
+    },
   });
   const value = {
     owner: accountId,
@@ -345,6 +370,19 @@ function createBondLot(specVersion: number) {
       ...value,
       sharingPercent: 250_000,
       bonusPercent: 100_000,
+    });
+  }
+  if (specVersion === 156) {
+    return registry.createType('AppBondLotSpec156', {
+      ...value,
+      program: { Vault: { vaultId: 4, sharingPercent: 300_000, bonusPercent: 150_000 } },
+    });
+  }
+  if (specVersion === 157) {
+    return registry.createType('AppBondLotSpec157', {
+      ...value,
+      program: { Vault: { vaultId: 4, sharingPercent: 300_000, bonusPercent: 150_000 } },
+      isBackfill: true,
     });
   }
   return registry.createType('PalletTreasuryBondLot', {

--- a/src-vue/lib/recovery/BitcoinLocks.ts
+++ b/src-vue/lib/recovery/BitcoinLocks.ts
@@ -1,5 +1,6 @@
 import {
   BitcoinLock,
+  PriceIndex,
   u8aEq,
   u8aToHex,
   type ApiDecoration,
@@ -424,6 +425,8 @@ export class BitcoinLockRecovery {
                 lockedTargetPrice: creationTargetPrice,
                 extrinsicIndex,
               };
+              // The active-lock fallback stores current liquidity here; the creation event restores the real baseline.
+              delete recovered.ratchets[creationRatchetIndex].liquidityPromised;
               recovered.lockDetails = chainLock;
               await this.saveRecoveredHistory(table, recovered, new Date(block.blockTime));
               this.applyRecoveredRecord(recovered);
@@ -1049,10 +1052,17 @@ export class BitcoinLockRecovery {
     }
 
     const isUpRatchet = lockedTargetPrice > oldTargetPrice;
-    if (isUpRatchet && cumulativeLiquidity < previousLiquidity) {
-      throw new Error(`Bitcoin lock ${record.utxoId} up-ratchet reduced its promised liquidity`);
+    let mintAmount = isUpRatchet ? cumulativeLiquidity - previousLiquidity : cumulativeLiquidity;
+    // Before runtime spec 158 (v1.4.12, 2026-08-13), upward ratchets recorded a fresh total while minting only the increment.
+    if (mintAmount < 0n) {
+      if (api.runtimeVersion.specVersion.toNumber() >= 158) {
+        throw new Error(`Bitcoin lock ${record.utxoId} up-ratchet reduced its promised liquidity`);
+      }
+      mintAmount = BitcoinLock.calculateRedemptionAmount(
+        await new PriceIndex().load(api),
+        lockedTargetPrice - oldTargetPrice,
+      );
     }
-    const mintAmount = isUpRatchet ? cumulativeLiquidity - previousLiquidity : cumulativeLiquidity;
     const burned = readRequiredEventBigInt(event, ['amountBurned'], block);
     if (!this.isRetiredHistoryRecord(recovered) && recovered.status !== BitcoinLockStatus.Releasing) {
       recovered.status = BitcoinLockStatus.LockedAndIsMinting;
@@ -1224,11 +1234,18 @@ export class BitcoinLockRecovery {
     for (let index = 0; index < record.ratchets.length; index += 1) {
       const ratchet = record.ratchets[index];
       recoveredLiquidity = this.getRatchetLiquidity(record.ratchets, index);
-      const expectedMint =
-        previousTargetPrice === undefined || ratchet.lockedTargetPrice < previousTargetPrice
-          ? recoveredLiquidity
-          : recoveredLiquidity - this.getRatchetLiquidity(record.ratchets, index - 1);
-      if (expectedMint < 0n || ratchet.mintAmount !== expectedMint) return false;
+      const previousLiquidity = this.getRatchetLiquidity(record.ratchets, index - 1);
+      let expectedMint = recoveredLiquidity;
+      if (previousTargetPrice !== undefined) {
+        if (ratchet.lockedTargetPrice >= previousTargetPrice) {
+          expectedMint -= previousLiquidity;
+        }
+      }
+      if (expectedMint < 0n) {
+        if (ratchet.mintAmount <= 0n) return false;
+      } else if (ratchet.mintAmount !== expectedMint) {
+        return false;
+      }
       if (ratchet.mintPending < 0n || ratchet.mintPending > ratchet.mintAmount) return false;
       previousTargetPrice = ratchet.lockedTargetPrice;
     }


### PR DESCRIPTION
## Summary

Financial history recovery now reads bond lots and replays Bitcoin lock changes across the runtime formats retained in mainnet history. It rebuilds each lock's creation baseline before applying later ratchets, and handles the upward-ratchet accounting used before runtime spec 158 (v1.4.12, 2026-08-13), so valid active locks no longer fail final recovery validation.

## Validation

Regression coverage confirms that current snapshots are replaced with authoritative creation values, subsequent ratchets reconstruct the complete lock economics, and old bond shapes load through the same stable model.
