### PR TITLE
fix: recover securitization transaction progress

### DIFF
--- a/.storybook/stories/vaulting/SecuritizationOverlay.stories.ts
+++ b/.storybook/stories/vaulting/SecuritizationOverlay.stories.ts
@@ -1,0 +1,250 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { TxResult, type ArgonClient } from '@argonprotocol/mainchain';
+import * as Vue from 'vue';
+import { expect, fn, mocked, spyOn, userEvent, waitFor, within } from 'storybook/test';
+import { TopTab } from '../../../src-vue/interfaces/IConfig.ts';
+import type { IVaultIncreaseAllocationMetadata } from '../../../src-vue/lib/MyVault.ts';
+import { TransactionInfo } from '../../../src-vue/lib/TransactionInfo.ts';
+import {
+  ExtrinsicType,
+  TransactionStatus,
+  type ITransactionRecord,
+} from '../../../src-vue/lib/db/TransactionsTable.ts';
+import basicEmitter from '../../../src-vue/emitters/basicEmitter.ts';
+import SecuritizationOverlay from '../../../src-vue/overlays/SecuritizationOverlay.vue';
+import { getCurrency } from '../../../src-vue/stores/currency.ts';
+import { getMainchainClient } from '../../../src-vue/stores/mainchain.ts';
+import { useVaultingAssetBreakdown } from '../../../src-vue/stores/vaultingAssetBreakdown.ts';
+import { getMyVault } from '../../../src-vue/stores/vaults.ts';
+import { createScenarioVault } from '../../scenarios/createScenarioVault.ts';
+import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
+
+const meta = {
+  title: 'Vaulting/Securitization',
+  component: SecuritizationOverlay,
+  render: () => ({
+    components: { SecuritizationOverlay },
+    setup() {
+      Vue.onMounted(() => basicEmitter.emit('openSecuritizationOverlay'));
+    },
+    template: '<SecuritizationOverlay />',
+  }),
+} satisfies Meta<typeof SecuritizationOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Ready: Story = {
+  beforeEach: () => setupSecuritizationScenario(),
+};
+
+export const Remove: Story = {
+  beforeEach: () => setupSecuritizationScenario(),
+  play: async () => {
+    const body = within(document.body);
+    const [argonInput] = await body.findAllByTestId('input-number');
+
+    await userEvent.click(argonInput);
+    await userEvent.keyboard('{ArrowDown}');
+
+    await waitFor(() => expect(body.getAllByText('Removing 1 ARGN').at(-1)).toBeVisible());
+    await waitFor(() => expect(body.getAllByRole('button', { name: 'Update Securitization' }).at(-1)).toBeEnabled());
+  },
+};
+
+export const Submit: Story = {
+  beforeEach: () => setupSecuritizationScenario(),
+  play: async () => {
+    const body = await submitWalletMaximum();
+
+    await waitFor(() => expect(body.getAllByText('Waiting for 3rd Block…').at(-1)).toBeVisible());
+    await waitFor(() => expect(body.getAllByText('Securitization').at(-1)).toBeVisible());
+  },
+};
+
+export const RestoredPending: Story = {
+  beforeEach: () => setupSecuritizationScenario('restoring'),
+  play: async () => {
+    const body = within(document.body);
+    getMyVault().data.pendingAllocateTxInfo = createSecuritizationTransaction();
+
+    await waitFor(() => expect(body.getAllByText('Waiting for 3rd Block…').at(-1)).toBeVisible());
+    await Promise.resolve();
+    await Promise.resolve();
+    await expect(body.queryByText('A securitization change is required')).not.toBeInTheDocument();
+    await expect(body.queryByText('ERROR')).not.toBeInTheDocument();
+    await waitFor(() => expect(body.getAllByText('Adding 500 ARGN').at(-1)).toBeVisible());
+    await waitFor(() => expect(body.getAllByRole('button', { name: 'Update Securitization' }).at(-1)).toBeDisabled());
+  },
+};
+
+export const Completed: Story = {
+  beforeEach: () => setupSecuritizationScenario('completed'),
+  play: async () => {
+    const body = within(document.body);
+    const txInfo = createSecuritizationTransaction();
+    getMyVault().data.pendingAllocateTxInfo = txInfo;
+
+    await waitFor(() => expect(body.getAllByText('Waiting for 3rd Block…').at(-1)).toBeVisible());
+
+    getMyVault().data.pendingAllocateTxInfo = null;
+
+    await waitFor(() => expect(body.queryByText('Waiting for 3rd Block…')).not.toBeInTheDocument());
+    await waitFor(() => expect(body.getAllByText('Securitization').at(-1)).toBeVisible());
+    await waitFor(() => expect(body.getAllByRole('button', { name: 'Update Securitization' }).at(-1)).toBeDisabled());
+  },
+};
+
+export const Submitting: Story = {
+  beforeEach: () => setupSecuritizationScenario('submitting'),
+  play: async () => {
+    const body = await submitWalletMaximum();
+
+    await expect(body.findByRole('button', { name: 'Submitting…' })).resolves.toBeDisabled();
+    const cancelButton = await body.findByRole('button', { name: 'Cancel' });
+    await expect(cancelButton).toBeEnabled();
+    await userEvent.click(cancelButton);
+    await waitFor(() => expect(body.queryByText('Securitization')).not.toBeInTheDocument());
+  },
+};
+
+export const SubmitFailed: Story = {
+  beforeEach: () => setupSecuritizationScenario('error'),
+  play: async () => {
+    const body = await submitWalletMaximum();
+
+    await waitFor(() =>
+      expect(body.getAllByText('The securitization transaction could not be submitted.').at(-1)).toBeVisible(),
+    );
+    await expect(body.findByRole('button', { name: 'Update Securitization' })).resolves.toBeEnabled();
+  },
+};
+
+function setupSecuritizationScenario(state: 'ready' | 'submitting' | 'error' | 'restoring' | 'completed' = 'ready') {
+  const { wallets } = setupAppScenario({ selectedTab: TopTab.Vaulting });
+  const createdVault = createScenarioVault();
+  const currency = getCurrency();
+  const currentMyVault = getMyVault();
+  const pendingTxInfo = createSecuritizationTransaction();
+  let securityMicrogons = createdVault.securitization;
+  if (state === 'restoring') securityMicrogons = 1_200_000_000n;
+  if (state === 'completed') {
+    securityMicrogons = pendingTxInfo.tx.metadataJson.securitizationMicrogons ?? createdVault.securitization;
+  }
+
+  const myVaultData = Vue.shallowReactive({
+    ...currentMyVault.data,
+    createdVault,
+    pendingAllocateTxInfo: null,
+  } as typeof currentMyVault.data);
+  const setVaultSecuritization = fn(async () => {
+    if (state === 'submitting') return await new Promise<TransactionInfo>(() => undefined);
+    if (state === 'error') throw new Error('The securitization transaction could not be submitted.');
+
+    myVaultData.pendingAllocateTxInfo = pendingTxInfo;
+    return pendingTxInfo;
+  });
+
+  wallets.defaultArgonSpendableMicrogons = 1_000_000_000n;
+  wallets.defaultArgonWallet.availableMicrogons = 1_000_000_000n;
+
+  mocked(getMyVault).mockReturnValue({
+    ...currentMyVault,
+    data: myVaultData,
+    createdVault,
+    vaultId: createdVault.vaultId,
+    buildSecuritizationTx: fn(async () => {
+      if (state === 'restoring') throw new Error('A securitization change is required');
+      return {
+        paymentInfo: fn(async () => ({ partialFee: { toBigInt: () => 10_000n } })),
+      };
+    }),
+    setVaultSecuritization,
+  } as unknown as ReturnType<typeof getMyVault>);
+  mocked(useVaultingAssetBreakdown, { partial: true }).mockReturnValue(
+    Vue.reactive({
+      securityMicrogons,
+      securityMicronots: 0n,
+      securityMicronotsActivated: 0n,
+    }),
+  );
+  mocked(getMainchainClient).mockResolvedValue({} as Awaited<ReturnType<typeof getMainchainClient>>);
+  mocked(getCurrency, { partial: true }).mockReturnValue(
+    Object.assign(currency, {
+      fetchMicrogonsInCirculation: fn(async () => 10_000_000_000n),
+      fetchMicronotsInCirculation: fn(async () => 5_000_000_000n),
+    }),
+  );
+}
+
+function createSecuritizationTransaction(): TransactionInfo<IVaultIncreaseAllocationMetadata> {
+  const submittedAtTime = new Date('2026-08-20T12:00:00.000Z');
+  const tx: ITransactionRecord = {
+    id: 42,
+    status: TransactionStatus.InBlock,
+    extrinsicHash: '0xsynthetic',
+    extrinsicMethodJson: {},
+    extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
+    metadataJson: {
+      securitizationMicrogons: 2_500_000_000n,
+      securitizationChangeMicrogons: 500_000_000n,
+      vaultId: 7,
+    },
+    accountAddress: '5SyntheticVaultingWallet',
+    submittedAtTime,
+    submittedAtBlockHeight: 18_510,
+    submissionErrorJson: undefined,
+    txTip: 0n,
+    txFeePlusTip: 10_000n,
+    blockHeight: 18_511,
+    blockHash: '0xsyntheticblock',
+    blockTime: submittedAtTime,
+    blockExtrinsicIndex: 1,
+    blockExtrinsicEventsJson: [],
+    blockExtrinsicErrorJson: undefined,
+    finalizedHeadHeight: 18_512,
+    finalizedHeadTime: submittedAtTime,
+    isFinalized: false,
+    createdAt: submittedAtTime,
+    updatedAt: submittedAtTime,
+  };
+  const txResult = new TxResult({} as ArgonClient, {
+    accountAddress: tx.accountAddress,
+    method: tx.extrinsicMethodJson,
+    nonce: 0,
+    signedHash: tx.extrinsicHash,
+    submittedTime: tx.submittedAtTime,
+    submittedAtBlockNumber: tx.submittedAtBlockHeight,
+  });
+  const info = new TransactionInfo<IVaultIncreaseAllocationMetadata>({ tx, txResult });
+  spyOn(info, 'getStatus').mockReturnValue({
+    progressPct: 54,
+    confirmations: 1,
+    expectedConfirmations: 4,
+    error: undefined,
+    isFinalized: false,
+    isMaxed: false,
+  });
+  spyOn(info, 'subscribeToProgress').mockImplementation(callback => {
+    queueMicrotask(() =>
+      callback({
+        progressPct: 54,
+        progressMessage: 'Waiting for 3rd Block…',
+        confirmations: 1,
+        expectedConfirmations: 4,
+        isMaxed: false,
+      }),
+    );
+    return fn();
+  });
+  return info;
+}
+
+async function submitWalletMaximum() {
+  const body = within(document.body);
+  const walletMaximumButtons = await body.findAllByRole('button', { name: 'Wallet Max' });
+  await userEvent.click(walletMaximumButtons[0]);
+  await expect(body.queryByText(/Your wallet needs another .* ARGN/)).not.toBeInTheDocument();
+  await userEvent.click(await body.findByRole('button', { name: 'Update Securitization' }));
+  return body;
+}

--- a/.storybook/stories/vaulting/SecuritizationOverlay.stories.ts
+++ b/.storybook/stories/vaulting/SecuritizationOverlay.stories.ts
@@ -78,6 +78,21 @@ export const RestoredPending: Story = {
   },
 };
 
+export const RestoredPendingFromPreviousVersion: Story = {
+  beforeEach: () => setupSecuritizationScenario('restoring'),
+  play: async () => {
+    const body = within(document.body);
+    const txInfo = createSecuritizationTransaction();
+    delete txInfo.tx.metadataJson.securitizationChangeMicrogons;
+    txInfo.tx.metadataJson.committedMicronots = 750_000_000n;
+
+    getMyVault().data.pendingAllocateTxInfo = txInfo;
+
+    await waitFor(() => expect(body.getAllByText('Adding 1,300 ARGN').at(-1)).toBeVisible());
+    await waitFor(() => expect(body.getAllByText('Adding 750 ARGNOT').at(-1)).toBeVisible());
+  },
+};
+
 export const Completed: Story = {
   beforeEach: () => setupSecuritizationScenario('completed'),
   play: async () => {

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { targetVaultDelegateBalance, type MiningFrames } from '@argonprotocol/apps-core';
 import { reactive } from 'vue';
-import { MyVault } from '../lib/MyVault.ts';
+import { MyVault, type IVaultIncreaseAllocationMetadata } from '../lib/MyVault.ts';
 import type BitcoinLocks from '../lib/BitcoinLocks.ts';
 import { TransactionInfo } from '../lib/TransactionInfo.ts';
 import { TxAttemptState, type TransactionTracker } from '../lib/TransactionTracker.ts';
@@ -37,6 +37,7 @@ type IMyVaultTestTarget = {
   trackTxResultFee(txResult: unknown): Promise<void>;
   recordFee(txResult: { finalFee?: bigint; finalFeeTip?: bigint }): void;
   onVaultCreated(txInfo: TransactionInfo<{ masterXpubPath: string }>): Promise<Vault>;
+  onIncreaseVaultSecuritization(txInfo: TransactionInfo<IVaultIncreaseAllocationMetadata>): Promise<void>;
 };
 
 describe('MyVaultRecovery', () => {
@@ -604,6 +605,7 @@ describe('MyVault cosign recovery', () => {
       securitization: 1_000n,
       securitizationRatio: 1,
     } as any;
+    myVault.data.argonotCommitment.committedMicronots = 100n;
     const buildSecuritizationTx = vi
       .spyOn(myVault as unknown as { buildSecuritizationTx: MyVault['buildSecuritizationTx'] }, 'buildSecuritizationTx')
       .mockResolvedValue(tx as any);
@@ -656,7 +658,9 @@ describe('MyVault cosign recovery', () => {
       extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
       metadata: {
         securitizationMicrogons: 1_100n,
+        securitizationChangeMicrogons: 100n,
         committedMicronots: 350n,
+        argonotChangeMicronots: 250n,
         vaultId: 7,
         moveFrom: 'VaultingHold',
         moveTo: 'VaultingSecurity',
@@ -665,6 +669,39 @@ describe('MyVault cosign recovery', () => {
     expect(result).toBe(txResultInfo);
 
     getMainchainClient.mockRestore();
+  });
+
+  it('publishes the current securitization transaction until its post-processing finishes', async () => {
+    const finalizationResolvers: Array<() => void> = [];
+    const createPendingTxInfo = (id: number) => {
+      const waitForFinalizedBlock = new Promise<void>(resolve => finalizationResolvers.push(resolve));
+      return {
+        tx: { id },
+        txResult: { waitForFinalizedBlock },
+        createPostProcessor: vi.fn(() => ({ resolve: vi.fn(), reject: vi.fn() })),
+      } as unknown as TransactionInfo<IVaultIncreaseAllocationMetadata>;
+    };
+    const firstTxInfo = createPendingTxInfo(41);
+    const secondTxInfo = createPendingTxInfo(42);
+    const { myVault } = createVault();
+    myVault.data = reactive(myVault.data) as typeof myVault.data;
+    const testVault = myVault as unknown as IMyVaultTestTarget;
+    vi.spyOn(testVault, 'trackTxResultFee').mockResolvedValue(undefined);
+    vi.spyOn(myVault, 'recordFinalizedVaultCapital').mockResolvedValue(undefined);
+
+    const firstProcessing = testVault.onIncreaseVaultSecuritization(firstTxInfo);
+    expect(myVault.data.pendingAllocateTxInfo?.tx.id).toBe(41);
+
+    const secondProcessing = testVault.onIncreaseVaultSecuritization(secondTxInfo);
+    expect(myVault.data.pendingAllocateTxInfo?.tx.id).toBe(42);
+
+    finalizationResolvers[0]();
+    await firstProcessing;
+    expect(myVault.data.pendingAllocateTxInfo?.tx.id).toBe(42);
+
+    finalizationResolvers[1]();
+    await secondProcessing;
+    expect(myVault.data.pendingAllocateTxInfo).toBeNull();
   });
 
   it('uses the selected final ARGN and ARGNOT securitization amounts', async () => {

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -88,7 +88,9 @@ export type IVaultInitialAllocateMetadata = {
 
 export type IVaultIncreaseAllocationMetadata = {
   securitizationMicrogons?: bigint;
+  securitizationChangeMicrogons?: bigint;
   committedMicronots?: bigint;
+  argonotChangeMicronots?: bigint;
   addedSecuritizationMicrogons?: bigint;
   addedMicronots?: bigint;
   vaultId: number;
@@ -310,7 +312,7 @@ export class MyVault {
         } else if (tx.extrinsicType === ExtrinsicType.VaultModifySettings) {
           void this.onModifySettings(txInfo);
         } else if (tx.extrinsicType === ExtrinsicType.VaultIncreaseAllocation) {
-          void this.onIncreaseVaultSecuritization(txInfo);
+          void this.onIncreaseVaultSecuritization(txInfo as TransactionInfo<IVaultIncreaseAllocationMetadata>);
         } else if (tx.extrinsicType === ExtrinsicType.VaultCosignBitcoinRelease) {
           void this.onCosignResult(txInfo);
         } else if (tx.extrinsicType === ExtrinsicType.VaultCosignOrphanedUtxoRelease) {
@@ -2184,6 +2186,8 @@ export class MyVault {
     if (!vault) {
       throw new Error('No vault created to get changes needed');
     }
+    const currentSecuritizationMicrogons = vault.securitization;
+    const currentCommittedMicronots = this.data.argonotCommitment.committedMicronots;
 
     const change: Parameters<MyVault['buildSecuritizationTx']>[0] = {};
     if (args.securitizationMicrogons !== undefined) {
@@ -2206,16 +2210,17 @@ export class MyVault {
     };
     if (args.securitizationMicrogons !== undefined) {
       metadata.securitizationMicrogons = args.securitizationMicrogons;
+      metadata.securitizationChangeMicrogons = args.securitizationMicrogons - currentSecuritizationMicrogons;
     }
     if (args.committedMicronots !== undefined) {
       metadata.committedMicronots = args.committedMicronots;
+      metadata.argonotChangeMicronots = args.committedMicronots - currentCommittedMicronots;
     }
     const info = await this.#transactionTracker.trackTxResult({
       txResult,
       extrinsicType: ExtrinsicType.VaultIncreaseAllocation,
       metadata,
     });
-    this.data.pendingAllocateTxInfo = info;
     void this.onIncreaseVaultSecuritization(info);
     return info;
   }
@@ -2258,7 +2263,10 @@ export class MyVault {
     return txs.length === 1 ? txs[0] : client.tx.utility.batchAll(txs);
   }
 
-  private async onIncreaseVaultSecuritization(txInfo: TransactionInfo): Promise<void> {
+  private async onIncreaseVaultSecuritization(
+    txInfo: TransactionInfo<IVaultIncreaseAllocationMetadata>,
+  ): Promise<void> {
+    this.data.pendingAllocateTxInfo = txInfo;
     const { txResult } = txInfo;
     const postProcessor = txInfo.createPostProcessor();
     try {
@@ -2270,7 +2278,9 @@ export class MyVault {
       postProcessor.reject(error as Error);
       throw error;
     } finally {
-      this.data.pendingAllocateTxInfo = null;
+      if (this.data.pendingAllocateTxInfo?.tx.id === txInfo.tx.id) {
+        this.data.pendingAllocateTxInfo = null;
+      }
     }
   }
 

--- a/src-vue/overlays/SecuritizationOverlay.vue
+++ b/src-vue/overlays/SecuritizationOverlay.vue
@@ -208,13 +208,21 @@ const finalArgonotTarget = Vue.computed(() => {
 
 const securitizationChangeMicrogons = Vue.computed(() => {
   if (pendingTransaction.value) {
-    return pendingTransaction.value.tx.metadataJson.securitizationChangeMicrogons ?? 0n;
+    const metadata = pendingTransaction.value.tx.metadataJson;
+    return (
+      metadata.securitizationChangeMicrogons ??
+      (metadata.securitizationMicrogons ?? vaultingAssets.securityMicrogons) - vaultingAssets.securityMicrogons
+    );
   }
   return securitizationMicrogons.value - vaultingAssets.securityMicrogons;
 });
 const argonotChangeMicronots = Vue.computed(() => {
   if (pendingTransaction.value) {
-    return pendingTransaction.value.tx.metadataJson.argonotChangeMicronots ?? 0n;
+    const metadata = pendingTransaction.value.tx.metadataJson;
+    return (
+      metadata.argonotChangeMicronots ??
+      (metadata.committedMicronots ?? vaultingAssets.securityMicronots) - vaultingAssets.securityMicronots
+    );
   }
   return committedMicronots.value - vaultingAssets.securityMicronots;
 });

--- a/src-vue/overlays/SecuritizationOverlay.vue
+++ b/src-vue/overlays/SecuritizationOverlay.vue
@@ -39,7 +39,7 @@
           <button
             type="button"
             class="text-argon-600 hover:text-argon-700 cursor-pointer text-sm font-semibold disabled:cursor-not-allowed disabled:text-slate-300"
-            :disabled="isProcessing || hasCompleted"
+            :disabled="isProcessing"
             @click="useWalletMaximum"
           >
             Wallet Max
@@ -51,7 +51,7 @@
           :min="0n"
           suffix=" ARGN"
           class="w-full"
-          :disabled="isProcessing || hasCompleted"
+          :disabled="isProcessing"
           @change="updateFee"
         />
 
@@ -65,7 +65,7 @@
             <button
               type="button"
               class="text-argon-600 hover:text-argon-700 cursor-pointer text-sm font-semibold disabled:cursor-not-allowed disabled:text-slate-300"
-              :disabled="isProcessing || hasCompleted || wallets.defaultArgonWallet.totalMicronots <= 0n"
+              :disabled="isProcessing || wallets.defaultArgonWallet.totalMicronots <= 0n"
               @click="useArgonotWalletMaximum"
             >
               Wallet Max
@@ -77,7 +77,7 @@
             :min="0n"
             suffix=" ARGNOT"
             class="w-full"
-            :disabled="isProcessing || hasCompleted"
+            :disabled="isProcessing"
             @change="updateFee"
           />
 
@@ -104,7 +104,7 @@
         </div>
 
         <div
-          v-if="walletShortfall > 0n || argonotWalletShortfall > 0n"
+          v-if="!isProcessing && (walletShortfall > 0n || argonotWalletShortfall > 0n)"
           class="mt-4 flex items-center gap-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
         >
           <ExclamationCircleIcon class="size-5 shrink-0" />
@@ -120,7 +120,7 @@
           </button>
         </div>
 
-        <div v-if="isProcessing || hasCompleted" class="mt-8 rounded-md border border-slate-200 px-6 py-7">
+        <div v-if="isProcessing" class="mt-8 rounded-md border border-slate-200 px-6 py-7">
           <ProgressBar :progress="progressPct" :hasError="!!transactionError" />
           <div class="mt-3 text-center text-sm text-slate-500">{{ progressLabel }}</div>
         </div>
@@ -139,10 +139,9 @@
           class="rounded-md border border-slate-300 px-6 py-2.5 font-semibold text-slate-600 hover:bg-slate-50"
           @click="closeOverlay"
         >
-          {{ hasCompleted ? 'Close' : 'Cancel' }}
+          Cancel
         </button>
         <button
-          v-if="!hasCompleted"
           type="button"
           class="bg-argon-button hover:bg-argon-button-hover rounded-md px-8 py-2.5 font-semibold text-white disabled:cursor-default disabled:opacity-40"
           :disabled="
@@ -150,12 +149,11 @@
             !hasSecuritizationChange ||
             walletShortfall > 0n ||
             argonotWalletShortfall > 0n ||
-            argonotEncumbranceShortfall > 0n ||
-            !!transactionError
+            argonotEncumbranceShortfall > 0n
           "
           @click="updateSecuritization"
         >
-          Update Securitization
+          {{ isSubmitting ? 'Submitting…' : 'Update Securitization' }}
         </button>
       </div>
     </div>
@@ -169,15 +167,10 @@ import { bigIntMax, NetworkConfig, TreasuryBonds } from '@argonprotocol/apps-cor
 import basicEmitter from '../emitters/basicEmitter.ts';
 import InputToken from '../components/InputToken.vue';
 import ProgressBar from '../components/ProgressBar.vue';
-import type { IVaultIncreaseAllocationMetadata } from '../lib/MyVault.ts';
-import type { TransactionInfo } from '../lib/TransactionInfo.ts';
 import { WalletType } from '../lib/Wallet.ts';
-import { ExtrinsicType, TransactionStatus } from '../lib/db/TransactionsTable.ts';
 import { createNumeralHelpers } from '../lib/numeral.ts';
-import { getArgonBonds } from '../stores/argonBonds.ts';
 import { getCurrency } from '../stores/currency.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
-import { getTransactionTracker } from '../stores/transactions.ts';
 import { getMyVault } from '../stores/vaults.ts';
 import { useWallets } from '../stores/wallets.ts';
 import { useVaultingAssetBreakdown } from '../stores/vaultingAssetBreakdown.ts';
@@ -186,8 +179,6 @@ import OverlayBase from './OverlayBase.vue';
 const currency = getCurrency();
 const wallets = useWallets();
 const myVault = getMyVault();
-const argonBonds = getArgonBonds();
-const transactionTracker = getTransactionTracker();
 const vaultingAssets = useVaultingAssetBreakdown();
 const { microgonToArgonNm, micronotToArgonotNm } = createNumeralHelpers(currency);
 
@@ -198,13 +189,14 @@ const committedMicronots = Vue.ref(0n);
 const totalArgonIssuanceMicrogons = Vue.ref(0n);
 const totalArgonotIssuanceMicronots = Vue.ref(0n);
 const txFee = Vue.ref(0n);
-const isProcessing = Vue.ref(false);
-const hasCompleted = Vue.ref(false);
+const isSubmitting = Vue.ref(false);
 const progressPct = Vue.ref(0);
 const progressLabel = Vue.ref('');
 const transactionError = Vue.ref('');
 const circulationError = Vue.ref('');
-let unsubscribeProgress: VoidFunction | undefined;
+
+const pendingTransaction = Vue.computed(() => myVault.data.pendingAllocateTxInfo);
+const isProcessing = Vue.computed(() => isSubmitting.value || !!pendingTransaction.value);
 
 const finalArgonotTarget = Vue.computed(() => {
   return TreasuryBonds.getVaultArgonotSecuritizationTarget({
@@ -215,9 +207,15 @@ const finalArgonotTarget = Vue.computed(() => {
 });
 
 const securitizationChangeMicrogons = Vue.computed(() => {
+  if (pendingTransaction.value) {
+    return pendingTransaction.value.tx.metadataJson.securitizationChangeMicrogons ?? 0n;
+  }
   return securitizationMicrogons.value - vaultingAssets.securityMicrogons;
 });
 const argonotChangeMicronots = Vue.computed(() => {
+  if (pendingTransaction.value) {
+    return pendingTransaction.value.tx.metadataJson.argonotChangeMicronots ?? 0n;
+  }
   return committedMicronots.value - vaultingAssets.securityMicronots;
 });
 
@@ -244,31 +242,26 @@ function closeOverlay() {
 }
 
 function openOverlay(request?: { returnToInvite?: boolean }) {
+  const pendingMetadata = pendingTransaction.value?.tx.metadataJson;
   returnToInvite.value = request?.returnToInvite ?? false;
   isOpen.value = true;
-  if (!isProcessing.value) {
-    securitizationMicrogons.value = vaultingAssets.securityMicrogons;
-    committedMicronots.value = vaultingAssets.securityMicronots;
-    txFee.value = 0n;
-    hasCompleted.value = false;
-    progressPct.value = 0;
-    progressLabel.value = '';
-    transactionError.value = '';
-    circulationError.value = '';
-    void recoverPendingTransaction();
+  securitizationMicrogons.value = pendingMetadata?.securitizationMicrogons ?? vaultingAssets.securityMicrogons;
+  committedMicronots.value = pendingMetadata?.committedMicronots ?? vaultingAssets.securityMicronots;
+  txFee.value = 0n;
+  transactionError.value = '';
+  circulationError.value = '';
 
-    void Promise.all([currency.fetchMicrogonsInCirculation(), currency.fetchMicronotsInCirculation()])
-      .then(([argonIssuance, argonotIssuance]) => {
-        totalArgonIssuanceMicrogons.value = argonIssuance;
-        totalArgonotIssuanceMicronots.value = argonotIssuance;
-      })
-      .catch(error => {
-        circulationError.value =
-          error instanceof Error
-            ? `Unable to load current token circulation: ${error.message}`
-            : 'Unable to load current token circulation.';
-      });
-  }
+  void Promise.all([currency.fetchMicrogonsInCirculation(), currency.fetchMicronotsInCirculation()])
+    .then(([argonIssuance, argonotIssuance]) => {
+      totalArgonIssuanceMicrogons.value = argonIssuance;
+      totalArgonotIssuanceMicronots.value = argonotIssuance;
+    })
+    .catch(error => {
+      circulationError.value =
+        error instanceof Error
+          ? `Unable to load current token circulation: ${error.message}`
+          : 'Unable to load current token circulation.';
+    });
 }
 
 function goBackToInvite() {
@@ -300,6 +293,8 @@ async function useArgonotWalletMaximum() {
 }
 
 async function updateFee() {
+  if (isProcessing.value) return;
+
   transactionError.value = '';
   if (!hasSecuritizationChange.value || argonotEncumbranceShortfall.value > 0n) {
     txFee.value = 0n;
@@ -338,7 +333,7 @@ async function updateSecuritization() {
     return;
   }
 
-  isProcessing.value = true;
+  isSubmitting.value = true;
   progressPct.value = 0;
   progressLabel.value = 'Preparing transaction…';
 
@@ -351,71 +346,45 @@ async function updateSecuritization() {
       change.committedMicronots = committedMicronots.value;
     }
 
-    const info = await myVault.setVaultSecuritization(change);
-    trackTransaction(info);
+    await myVault.setVaultSecuritization(change);
   } catch (error) {
     transactionError.value = error instanceof Error ? error.message : 'Unable to update securitization.';
-    isProcessing.value = false;
+  } finally {
+    isSubmitting.value = false;
   }
 }
 
-function trackTransaction(info: TransactionInfo) {
-  isProcessing.value = true;
-  hasCompleted.value = false;
-  transactionError.value = '';
-  unsubscribeProgress?.();
-  unsubscribeProgress = info.subscribeToProgress(async (progress, error) => {
-    progressPct.value = progress.progressPct;
-    progressLabel.value = progress.progressMessage;
-
-    if (error) {
-      transactionError.value = error.message ?? 'Unable to update securitization.';
-      isProcessing.value = false;
+Vue.watch(
+  pendingTransaction,
+  (txInfo, _, onCleanup) => {
+    if (!txInfo) {
+      progressPct.value = 0;
+      progressLabel.value = '';
       return;
     }
-    if (progress.progressPct < 100 || hasCompleted.value) return;
 
-    try {
-      const vault = myVault.createdVault;
-      await Promise.all([
-        myVault.load(true),
-        vault
-          ? argonBonds.refreshVault({
-              vaultId: vault.vaultId,
-              operatorAddress: vault.operatorAccountId,
-              accountId: myVault.walletKeys.vaultingAddress,
-            })
-          : Promise.resolve(),
-      ]);
-      hasCompleted.value = true;
-      progressLabel.value = 'Securitization updated.';
-    } catch (refreshError) {
-      transactionError.value =
-        refreshError instanceof Error
-          ? `Securitization was updated, but the latest vault state could not be loaded: ${refreshError.message}`
-          : 'Securitization was updated, but the latest vault state could not be loaded.';
-    } finally {
-      isProcessing.value = false;
+    transactionError.value = '';
+    if (isOpen.value) {
+      securitizationMicrogons.value =
+        txInfo.tx.metadataJson.securitizationMicrogons ?? vaultingAssets.securityMicrogons;
+      committedMicronots.value = txInfo.tx.metadataJson.committedMicronots ?? vaultingAssets.securityMicronots;
+      txFee.value = 0n;
     }
-  });
-}
+    const status = txInfo.getStatus();
+    progressPct.value = status.progressPct;
+    progressLabel.value = status.isFinalized ? 'Finalizing securitization details…' : 'Waiting for transaction status…';
 
-async function recoverPendingTransaction() {
-  await transactionTracker.load();
-  const vaultId = myVault.vaultId;
-  if (vaultId == null) return;
-
-  const pending = transactionTracker.findLatestTxInfo<IVaultIncreaseAllocationMetadata>(candidate => {
-    if (candidate.tx.extrinsicType !== ExtrinsicType.VaultIncreaseAllocation) return false;
-    if (candidate.tx.metadataJson.vaultId !== vaultId) return false;
-    return candidate.tx.status === TransactionStatus.Submitted || candidate.tx.status === TransactionStatus.InBlock;
-  });
-  if (!pending) return;
-
-  securitizationMicrogons.value = pending.tx.metadataJson.securitizationMicrogons ?? vaultingAssets.securityMicrogons;
-  committedMicronots.value = pending.tx.metadataJson.committedMicronots ?? vaultingAssets.securityMicronots;
-  trackTransaction(pending);
-}
+    const unsubscribe = txInfo.subscribeToProgress((progress, error) => {
+      progressPct.value = progress.progressPct;
+      progressLabel.value = progress.progressMessage;
+      if (error) {
+        transactionError.value = error.message;
+      }
+    });
+    onCleanup(unsubscribe);
+  },
+  { immediate: true },
+);
 
 function formatArgons(microgons: bigint) {
   return microgonToArgonNm(microgons).format('0,0.[00]');
@@ -434,7 +403,6 @@ function formatAdjustment(amount: bigint, formatter: (value: bigint) => string, 
 basicEmitter.on('openSecuritizationOverlay', openOverlay);
 
 Vue.onBeforeUnmount(() => {
-  unsubscribeProgress?.();
   basicEmitter.off('openSecuritizationOverlay', openOverlay);
 });
 </script>


### PR DESCRIPTION
## Summary

Securitization progress now survives app reloads and clears when post-processing finishes, while the overlay remains open for further edits. The tracked vault transaction is the source of truth for pending amounts and progress, the short interval before tracking begins is represented separately as submission, and transactions persisted by earlier app versions recover their pending ARGN and ARGNOT adjustments from stored targets.

## Validation

Validated removal, submission, reload recovery, previous-version recovery, and completion states. All 245 Storybook interactions and 42 MyVault tests passed, along with typechecking and the Storybook production build.