### PR TITLE
fix: use operator profile names across vault flows

### DIFF
--- a/.storybook/scenarios/createScenarioVault.ts
+++ b/.storybook/scenarios/createScenarioVault.ts
@@ -24,7 +24,6 @@ export function createScenarioVault(overrides: Partial<Vault> = {}): Vault {
     flexibleSecuritizationLocked: 0n,
     reservedSecuritizationSpace: 0n,
     flexibleSecuritizedSatoshis: 0,
-    name: 'Atlas Operator',
     ...overrides,
   });
 }

--- a/.storybook/scenarios/setupAppScenario.ts
+++ b/.storybook/scenarios/setupAppScenario.ts
@@ -285,6 +285,8 @@ export function setupAppScenario({ selectedTab, config: configOverrides = {} }: 
   mocked(useVaultingStats, { partial: true }).mockReturnValue({ update: fn(async () => undefined) });
   mocked(getVaults, { partial: true }).mockReturnValue({
     load: fn(async () => undefined),
+    operatorNamesByVaultId: Vue.reactive({}),
+    vaultsById: {},
     updateRevenue: fn(async () => ({
       synchedToFrame: 0,
       argonotStakingByFrame: [],
@@ -310,7 +312,7 @@ export function setupAppScenario({ selectedTab, config: configOverrides = {} }: 
     mintingAuthorities,
     globalCouncil,
     getCrosschainQueueTxInfos: fn(() => []),
-    load: fn(async () => undefined),
+    load: fn(async () => getVaults().load()),
   });
   mocked(getCrosschainHistory, { partial: true }).mockReturnValue({
     data: Vue.reactive({

--- a/.storybook/scenarios/setupBitcoinOverlayScenario.ts
+++ b/.storybook/scenarios/setupBitcoinOverlayScenario.ts
@@ -347,6 +347,7 @@ export function setupBitcoinOverlayScenario() {
   });
 
   mocked(getVaults, { partial: true }).mockReturnValue({
+    operatorNamesByVaultId: { [vault.vaultId]: 'Atlas Operator' },
     vaultsById: { [vault.vaultId]: vault },
     fetchAndCalculateRedemptionAmount: fn(async () => 825_000_000n),
     load: fn(async () => undefined),

--- a/.storybook/scenarios/setupBondPortfolioScenario.ts
+++ b/.storybook/scenarios/setupBondPortfolioScenario.ts
@@ -64,10 +64,11 @@ export function setupBondPortfolioScenario(programType: BondLot['programType']) 
     getFrameDate: fn((frameId: number) => new Date(Date.UTC(2026, 7, 15, 12 + (frameId - 10_000), 0, 0))),
   });
   mocked(getVaults).mockReturnValue({
+    operatorNamesByVaultId: { 7: 'Atlas', 12: 'Beacon' },
     vaultsById: {
-      7: { name: 'Atlas', operatorAccountId: '5AtlasOperator' },
-      12: { name: 'Beacon', operatorAccountId: '5BeaconOperator' },
-      21: { name: '', operatorAccountId: '5UnnamedOperator' },
+      7: { vaultId: 7, operatorAccountId: '5AtlasOperator' },
+      12: { vaultId: 12, operatorAccountId: '5BeaconOperator' },
+      21: { vaultId: 21, operatorAccountId: '5UnnamedOperator' },
     },
     subscribeToVault: fn(async () => fn()),
   } as unknown as ReturnType<typeof getVaults>);

--- a/.storybook/scenarios/setupOnboardingOverlayScenario.ts
+++ b/.storybook/scenarios/setupOnboardingOverlayScenario.ts
@@ -12,7 +12,6 @@ import {
   getOperationalProfileName,
   getOperationalRewardsClaimAvailability,
   loadOperationalAccount,
-  usesOperationalProfileNameRuntime,
 } from '../../src-vue/lib/OperationalAccount.ts';
 import { getArgonBonds } from '../../src-vue/stores/argonBonds.ts';
 import { getBitcoinLocks } from '../../src-vue/stores/bitcoin.ts';
@@ -24,9 +23,7 @@ import type { TransactionInfo } from '../../src-vue/lib/TransactionInfo.ts';
 import { createScenarioVault } from './createScenarioVault.ts';
 import { setupAppScenario } from './setupAppScenario.ts';
 
-export function setupOperationalProfileScenario(
-  state: 'draft' | 'vaultRequired' | 'loadError' | 'settingsFlexible' | 'settingsBasic',
-) {
+export function setupOperationalProfileScenario(state: 'draft' | 'loadError' | 'settingsFlexible' | 'settingsBasic') {
   const { controller } = setupAppScenario({ selectedTab: TopTab.Onboarding });
 
   if (state === 'settingsFlexible' || state === 'settingsBasic') {
@@ -39,7 +36,6 @@ export function setupOperationalProfileScenario(
       },
     } as unknown as Awaited<ReturnType<typeof getMainchainClient>>;
     mocked(getMainchainClient).mockResolvedValue(client);
-    mocked(usesOperationalProfileNameRuntime).mockReturnValue(true);
     mocked(loadOperationalAccount).mockResolvedValue({} as Awaited<ReturnType<typeof loadOperationalAccount>>);
     mocked(getOperationalProfileName).mockReturnValue('AtlasOperator');
     return;
@@ -56,7 +52,6 @@ export function setupOperationalProfileScenario(
     } as unknown as ReturnType<typeof getMyVault>);
   }
 
-  mocked(usesOperationalProfileNameRuntime).mockReturnValue(state === 'draft');
   mocked(loadOperationalAccount).mockResolvedValue({} as Awaited<ReturnType<typeof loadOperationalAccount>>);
   mocked(getOperationalProfileName).mockReturnValue('AtlasOperator');
   mocked(getMainchainClient).mockImplementation(async () => {
@@ -148,7 +143,6 @@ export function setupMemberInviteScenario(
 
   const currentMyVault = getMyVault();
   const createdVault = createScenarioVault({
-    name: state === 'onboardingInactive' ? 'Atlas Operator' : 'AtlasOperator',
     terms: {
       bitcoinAnnualPercentRate: BigNumber(0.034),
       bitcoinBaseFee: 2_000_000n,
@@ -175,10 +169,14 @@ export function setupMemberInviteScenario(
           ...(state === 'previousRuntime' ? { initializeFor: fn() } : {}),
         },
         treasury: { setBondLotFlexible: fn() },
-        vaults: { setName: fn() },
+        operationalAccounts: { setName: fn() },
       },
     } as unknown as Awaited<ReturnType<typeof getMainchainClient>>;
     mocked(getMainchainClient).mockResolvedValue(client);
+    mocked(loadOperationalAccount).mockResolvedValue({} as Awaited<ReturnType<typeof loadOperationalAccount>>);
+    mocked(getOperationalProfileName).mockReturnValue(
+      state === 'onboardingInactive' ? 'Atlas Operator' : 'AtlasOperator',
+    );
     mocked(getArgonBonds, { partial: true }).mockReturnValue({
       availableBondSpace: fn(() => (state === 'insufficientBondCapacity' ? 100_000_000n : 300_000_000n)),
     });

--- a/.storybook/stories/crosschain/CrosschainTransfers.stories.ts
+++ b/.storybook/stories/crosschain/CrosschainTransfers.stories.ts
@@ -6,9 +6,16 @@ import AppScreen from '../../components/AppScreen.vue';
 import { setupAppScenario } from '../../scenarios/setupAppScenario.ts';
 import { TopTab } from '../../../src-vue/interfaces/IConfig.ts';
 import { CrosschainHistory, type ICrosschainHistoryRecord } from '../../../src-vue/lib/CrosschainHistory.ts';
+import { createKnownCrosschainSourceIdentities } from '../../../src-vue/lib/CrosschainTransferView.ts';
 import CrosschainTransfers from '../../../src-vue/screens/CrosschainTransfers.vue';
 import { getCurrency } from '../../../src-vue/stores/currency.ts';
-import { getCrosschainHistory } from '../../../src-vue/stores/vaults.ts';
+import {
+  getCrosschainHistory,
+  getKnownCrosschainSourceIdentities,
+  getVaults,
+} from '../../../src-vue/stores/vaults.ts';
+import { getWalletKeys } from '../../../src-vue/stores/wallets.ts';
+import { createScenarioVault } from '../../scenarios/createScenarioVault.ts';
 
 const meta = {
   title: 'Crosschain/Overview',
@@ -34,6 +41,21 @@ export const RecoveredTransferTips: Story = {
     currency.record = currency.recordsByKey[UnitOfMeasurement.ARGN];
     currency.symbol = currency.record.symbol;
     currency.isLoaded = true;
+
+    const vault = createScenarioVault({ operatorAccountId: recoveredSourceAccount });
+    const vaults = getVaults();
+    vaults.vaultsById[vault.vaultId] = vault;
+    mocked(vaults.load).mockImplementation(async () => {
+      vaults.operatorNamesByVaultId[vault.vaultId] = 'Atlas';
+    });
+    mocked(getKnownCrosschainSourceIdentities).mockImplementation(() =>
+      createKnownCrosschainSourceIdentities({
+        networkName: 'localnet',
+        vaultsById: vaults.vaultsById,
+        operatorNamesByVaultId: vaults.operatorNamesByVaultId,
+        localAccountIds: [getWalletKeys().defaultArgonAddress],
+      }),
+    );
 
     const history = new CrosschainHistory(
       { vaultingAddress: '5SyntheticVaultingWallet' },
@@ -63,10 +85,12 @@ export const RecoveredTransferTips: Story = {
     await expect(within(dashboard).getByText('Transfer Tips')).toBeVisible();
     await expect(within(dashboard).getByText('Tips Available')).toBeVisible();
     await expect(within(dashboard).getByText('1.25 ARGN tip')).toBeVisible();
+    await expect(within(dashboard).getAllByText('Atlas')).not.toHaveLength(0);
     await expect(within(crosschainNavigation).getByText('₳1.25')).toBeVisible();
   },
 };
 
+const recoveredSourceAccount = '5source';
 const recoveredAuthorization: ICrosschainHistoryRecord = {
   accountId: '5SyntheticVaultingWallet',
   id: '0xblock:2',
@@ -79,7 +103,7 @@ const recoveredAuthorization: ICrosschainHistoryRecord = {
     transferId: '0xtransfer',
     authoritySigningKey: '0xauthority',
     authorityOwnerAccount: '5SyntheticVaultingWallet',
-    sourceAccount: '5source',
+    sourceAccount: recoveredSourceAccount,
     destinationAccount: '0xrecipient',
     moveToken: MoveToken.ARGN,
     amount: 5n * BigInt(MICROGONS_PER_ARGON),

--- a/.storybook/stories/onboarding/Onboarding.stories.ts
+++ b/.storybook/stories/onboarding/Onboarding.stories.ts
@@ -15,10 +15,7 @@ import {
   TopTab,
 } from '../../../src-vue/interfaces/IConfig.ts';
 import { Config } from '../../../src-vue/lib/Config.ts';
-import {
-  activateOperationalAccountSetup,
-  usesOperationalProfileNameRuntime,
-} from '../../../src-vue/lib/OperationalAccount.ts';
+import { activateOperationalAccountSetup } from '../../../src-vue/lib/OperationalAccount.ts';
 import { useCertificationController } from '../../../src-vue/stores/certificationController.ts';
 import { getConfig } from '../../../src-vue/stores/config.ts';
 import { getInstaller } from '../../../src-vue/stores/installer.ts';
@@ -279,7 +276,6 @@ function setupOnboardingScenario(
   const createdVault = options.hasOperation ? createScenarioVault() : null;
   const currentMyVault = getMyVault();
 
-  mocked(usesOperationalProfileNameRuntime).mockReturnValue(false);
   mocked(getMainchainClient).mockResolvedValue({
     tx: { bitcoinLocks: {}, treasury: {} },
   } as Awaited<ReturnType<typeof getMainchainClient>>);

--- a/.storybook/stories/operations/OperationalProfileOverlay.stories.ts
+++ b/.storybook/stories/operations/OperationalProfileOverlay.stories.ts
@@ -30,13 +30,6 @@ export const DraftName: Story = {
   },
 };
 
-export const VaultRequired: Story = {
-  beforeEach: () => {
-    profileRequest = { draftName: 'AtlasOperator', onSelect: () => undefined };
-    setupOperationalProfileScenario('vaultRequired');
-  },
-};
-
 export const LoadFailed: Story = {
   beforeEach: () => {
     profileRequest = { draftName: 'AtlasOperator', onSelect: () => undefined };

--- a/core/src/Vaults.ts
+++ b/core/src/Vaults.ts
@@ -1,6 +1,8 @@
 import {
   BitcoinLock,
   type IArgonQueryable,
+  type Option,
+  type PalletOperationalAccountsOperationalAccount,
   type PalletVaultsVaultFrameRevenue,
   u128,
   Vault,
@@ -37,6 +39,7 @@ export const VAULT_STATS_FORMAT_VERSION = 2;
 export class Vaults {
   public readonly vaultsById: { [id: number]: Vault } = {};
   public readonly vaultSatoshisById: { [id: number]: { lockedSatoshis: bigint; securitizedSatoshis: bigint } } = {};
+  public operatorNamesByVaultId: { [id: number]: string } = {};
   public stats?: IAllVaultStats;
 
   constructor(
@@ -69,6 +72,7 @@ export class Vaults {
           securitizedSatoshis: raw.securitizedSatoshis.toBigInt(),
         };
       }
+      await this.refreshOperatorNames({ client, vaults: Object.values(this.vaultsById) });
       this.stats ??= await this.loadStats();
 
       this.waitForLoad.resolve();
@@ -84,6 +88,7 @@ export class Vaults {
     if (!vaultOption.isSome) {
       delete this.vaultsById[vaultId];
       delete this.vaultSatoshisById[vaultId];
+      delete this.operatorNamesByVaultId[vaultId];
       return;
     }
 
@@ -95,6 +100,40 @@ export class Vaults {
       securitizedSatoshis: raw.securitizedSatoshis.toBigInt(),
     };
     return vault;
+  }
+
+  public async refreshOperatorNames(args: {
+    vaults: Pick<Vault, 'vaultId' | 'operatorAccountId'>[];
+    client?: IArgonQueryable;
+  }): Promise<void> {
+    if (!args.vaults.length) return;
+
+    try {
+      const client = args.client ?? (await this.mainchainClients.get(false));
+      const operationalAccountOptions = await client.query.operationalAccounts.operationalAccountBySubAccount.multi(
+        args.vaults.map(vault => vault.operatorAccountId),
+      );
+      const vaultsWithOperationalAccounts = [];
+
+      for (const [index, vault] of args.vaults.entries()) {
+        const operationalAccountId = operationalAccountOptions[index];
+        if (operationalAccountId?.isSome) {
+          vaultsWithOperationalAccounts.push([vault, operationalAccountId.unwrap()] as const);
+        } else {
+          this.setOperatorName(vault.vaultId);
+        }
+      }
+      if (!vaultsWithOperationalAccounts.length) return;
+
+      const profileOptions = await client.query.operationalAccounts.operationalAccounts.multi(
+        vaultsWithOperationalAccounts.map(([, operationalAccountId]) => operationalAccountId),
+      );
+      for (const [index, [vault]] of vaultsWithOperationalAccounts.entries()) {
+        this.setOperatorName(vault.vaultId, profileOptions[index]);
+      }
+    } catch (error) {
+      console.warn('[Vaults] Unable to load operator profile names', error);
+    }
   }
 
   public async subscribeToVault(vaultId: number, onUpdate: (vault: Vault) => void): Promise<() => void> {
@@ -110,6 +149,17 @@ export class Vaults {
       };
       onUpdate(this.vaultsById[vaultId]);
     });
+  }
+
+  protected setOperatorName(
+    vaultId: number,
+    profile?: Option<PalletOperationalAccountsOperationalAccount>,
+  ): string | undefined {
+    const profileName = profile?.isSome ? profile.unwrap().name : undefined;
+    const name = profileName?.isSome ? profileName.unwrap().toUtf8().trim() : undefined;
+    if (name) this.operatorNamesByVaultId[vaultId] = name;
+    else delete this.operatorNamesByVaultId[vaultId];
+    return name;
   }
 
   public async updateVaultRevenue(vaultId: number, frameRevenues: PalletVaultsVaultFrameRevenue[], skipSaving = false) {

--- a/src-vue/__test__/CrosschainTransferView.test.ts
+++ b/src-vue/__test__/CrosschainTransferView.test.ts
@@ -42,11 +42,10 @@ describe('CrosschainTransferView', () => {
     const ownOperatorAccount = `0x${'33'.repeat(32)}`;
     const upstreamOperatorAccount = `0x${'44'.repeat(32)}`;
     const createdVault = {
-      name: 'Atlas',
+      vaultId: 1,
       operatorAccountId: ownOperatorAccount,
     };
     const upstreamVault = {
-      name: 'Beacon',
       operatorAccountId: upstreamOperatorAccount,
     };
 
@@ -54,6 +53,7 @@ describe('CrosschainTransferView', () => {
       networkName: 'dev-docker',
       createdVault,
       vaultsById: { 1: createdVault, 2: upstreamVault },
+      operatorNamesByVaultId: { 1: 'Atlas', 2: 'Beacon' },
       localAccountIds: [defaultAccount, vaultingAccount],
       upstreamOperator: { name: 'Beacon', vaultId: 2 },
     });
@@ -71,10 +71,10 @@ describe('CrosschainTransferView', () => {
       networkName: 'dev-docker',
       vaultsById: {
         2: {
-          name: 'dev-docker-On-chain Operator',
           operatorAccountId: upstreamAccount,
         },
       },
+      operatorNamesByVaultId: { 2: 'dev-docker-On-chain Operator' },
       localAccountIds: [localAccount],
       upstreamOperator: { name: 'Configured Upstream', vaultId: 2 },
     });
@@ -95,10 +95,10 @@ describe('CrosschainTransferView', () => {
       networkName: 'dev-docker',
       vaultsById: {
         3: {
-          name: 'dev-docker-JC',
           operatorAccountId: sponsorVaultAccount,
         },
       },
+      operatorNamesByVaultId: { 3: 'dev-docker-JC' },
       localAccountIds: [],
       sourceUpstreamVaultAccountsByAccount: new Map([[sourceAccount, sponsorVaultAccount]]),
     });

--- a/src-vue/__test__/Financials.test.ts
+++ b/src-vue/__test__/Financials.test.ts
@@ -1842,6 +1842,7 @@ describe('financial position accounting', () => {
     const source = new VaultFinancials({
       load: vi.fn(async () => undefined),
       createdVault: { vaultId: 10, securitization: 8n, isClosed: false } as Vault,
+      vaults: { operatorNamesByVaultId: {} },
       data: {
         pendingCollectRevenue: 100n,
         argonotCommitment: { committedMicronots: 500n },

--- a/src-vue/__test__/Importer.test.ts
+++ b/src-vue/__test__/Importer.test.ts
@@ -47,7 +47,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   importMocks.getOperatorVaultId.mockResolvedValue({ isSome: false });
   importMocks.getMainchainClient.mockResolvedValue({
-    tx: { operationalAccounts: {}, vaults: { setName: vi.fn() } },
+    tx: { operationalAccounts: { setName: vi.fn() } },
   });
 });
 
@@ -60,7 +60,9 @@ it('stops background sync before importing and keeps the current database on fai
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
+        operationalAccounts: vi.fn().mockResolvedValue({
+          isSome: false,
+        }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
     },
@@ -107,6 +109,7 @@ it('restores completed mining setup from imported operational account state', as
     isOperationallyCertified: { toPrimitive: () => false },
     miningSeatAccrual: { toNumber: () => 0 },
     miningSeatAppliedTotal: { toNumber: () => 1 },
+    name: { isSome: false },
     operationalCertificationsCount: { toNumber: () => 0 },
     rewardsCollectedAmount: { toBigInt: () => 0n },
     rewardsEarnedAmount: { toBigInt: () => 0n },
@@ -321,7 +324,9 @@ it.each([
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
+        operationalAccounts: vi.fn().mockResolvedValue({
+          isSome: false,
+        }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
       crosschainTransfer: {
@@ -382,7 +387,9 @@ it('preserves Operations history without granting Crosschain access from an owne
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
+        operationalAccounts: vi.fn().mockResolvedValue({
+          isSome: false,
+        }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
       crosschainTransfer: {
@@ -435,9 +442,7 @@ it('does not infer treasury from an unattributed account hold', async () => {
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({
-          isSome: false,
-        }),
+        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
     },
@@ -497,9 +502,7 @@ it.each([
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({
-          isSome: false,
-        }),
+        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
     },
@@ -550,9 +553,7 @@ it('does not block account import when fallback index history is unavailable', a
   importMocks.getFinalizedClient.mockResolvedValue({
     query: {
       operationalAccounts: {
-        operationalAccounts: vi.fn().mockResolvedValue({
-          isSome: false,
-        }),
+        operationalAccounts: vi.fn().mockResolvedValue({ isSome: false }),
       },
       vaults: { vaultIdByOperator: importMocks.getOperatorVaultId },
     },

--- a/src-vue/__test__/MyVault.test.ts
+++ b/src-vue/__test__/MyVault.test.ts
@@ -1126,11 +1126,11 @@ describe('MyVault cosign recovery', () => {
         },
       },
       tx: {
+        operationalAccounts: {
+          setName: vi.fn(() => ({ kind: 'set-name' })),
+        },
         utility: {
           batchAll: vi.fn(() => ({ kind: 'delegate-setup' })),
-        },
-        vaults: {
-          setName: vi.fn(() => ({ kind: 'set-name' })),
         },
       },
     } as any);
@@ -1146,7 +1146,8 @@ describe('MyVault cosign recovery', () => {
       {
         load: vi.fn(async () => undefined),
         updateRevenue: vi.fn(async () => undefined),
-        vaultsById: { 7: { vaultId: 7, name: null, delegateAccountId: null } },
+        vaultsById: { 7: { vaultId: 7, delegateAccountId: null } },
+        operatorNamesByVaultId: {},
         stats: {
           synchedToFrame: 1,
           vaultsById: { 7: { vaultId: 7 } },
@@ -1191,9 +1192,9 @@ describe('MyVault cosign recovery', () => {
     });
 
     myVault.data.createdVault = myVault.vaults.vaultsById[7];
-    await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne' });
+    await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne', currentOperatorName: '' });
     await myVault.load(true);
-    const result = await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne' });
+    const result = await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne', currentOperatorName: '' });
 
     expect(result).toBe(submittedTxInfo);
     expect(submitAndWatch).toHaveBeenCalledTimes(2);
@@ -1201,7 +1202,7 @@ describe('MyVault cosign recovery', () => {
     getMainchainClient.mockRestore();
   });
 
-  it('resumes pending vault profile setup after restart without submitting it again', async () => {
+  it('resumes pending operator profile setup after restart without submitting it again', async () => {
     const pending = createTxInfo({
       extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
       status: TransactionStatus.Submitted,
@@ -1220,13 +1221,13 @@ describe('MyVault cosign recovery', () => {
       delegateAccountId: null,
     });
 
-    const result = await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne' });
+    const result = await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne', currentOperatorName: '' });
 
     expect(result).toBe(pending);
     expect(submitAndWatch).not.toHaveBeenCalled();
   });
 
-  it('does not resubmit a finalized vault profile already reflected in vault state', async () => {
+  it('does not resubmit a finalized operator profile already reflected in profile state', async () => {
     const finalized = createTxInfo({
       extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
       status: TransactionStatus.Finalized,
@@ -1243,7 +1244,6 @@ describe('MyVault cosign recovery', () => {
       operatorAccountId: myVault.walletKeys.vaultingAddress,
       delegateAccountId: delegateAddress,
     });
-    Object.defineProperty(createdVault, 'name', { value: 'OperatorOne' });
     myVault.data.createdVault = createdVault;
     vi.spyOn(myVault as any, 'buildVaultDelegateSetupTxs').mockResolvedValue({
       needsSetup: false,
@@ -1251,7 +1251,10 @@ describe('MyVault cosign recovery', () => {
     });
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue({} as any);
 
-    const result = await myVault.setupVaultInviteProfile({ operatorName: 'OperatorOne' });
+    const result = await myVault.setupVaultInviteProfile({
+      operatorName: 'OperatorOne',
+      currentOperatorName: 'OperatorOne',
+    });
 
     expect(result).toBeUndefined();
     expect(submitAndWatch).not.toHaveBeenCalled();
@@ -1269,7 +1272,6 @@ describe('MyVault cosign recovery', () => {
       tx: {
         operationalAccounts: { setName },
         utility: { batchAll },
-        vaults: {},
       },
     };
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue(client as any);
@@ -1301,11 +1303,12 @@ describe('MyVault cosign recovery', () => {
     expect(submitAndWatch).toHaveBeenCalledWith({
       tx: { kind: 'batch', txs: expect.any(Array) },
       txSigner: signer,
+      useLatestNonce: true,
       extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
       metadata: {
         vaultId: 7,
         delegateAddress,
-        vaultName: 'OperatorOne',
+        operatorName: 'OperatorOne',
       },
     });
     expect(result).toBe(submittedTxInfo);
@@ -1458,16 +1461,14 @@ describe('MyVault cosign recovery', () => {
     getMainchainClient.mockRestore();
   });
 
-  it('prepares a first member invite with the previous runtime calls in one batch', async () => {
+  it('prepares a member invite while using prior flexible-asset calls', async () => {
     const submittedTxInfo = createTxInfo({ extrinsicType: ExtrinsicType.VaultSetFlexibleAssets });
     const batchAll = vi.fn(txs => ({ kind: 'batch', txs }));
-    const setName = vi.fn(name => ({ kind: 'name', name }));
     const setAsBackfill = vi.fn((utxoId, isFlexible) => ({ kind: 'bitcoin', utxoId, isFlexible }));
     const setBondLotAsBackfill = vi.fn((bondLotId, isFlexible) => ({ kind: 'bond', bondLotId, isFlexible }));
     const client = {
       tx: {
         utility: { batchAll },
-        vaults: { setName },
         bitcoinLocks: { setAsBackfill },
         treasury: { setBondLotAsBackfill },
       },
@@ -1488,7 +1489,7 @@ describe('MyVault cosign recovery', () => {
     });
 
     const result = await myVault.prepareMemberInvite({
-      vaultName: 'OperatorOne',
+      operatorName: 'OperatorOne',
       bitcoinChanges: [
         {
           lock: {
@@ -1520,7 +1521,6 @@ describe('MyVault cosign recovery', () => {
     expect(result).toBe(submittedTxInfo);
     expect(batchAll).toHaveBeenCalledWith([
       { kind: 'delegate' },
-      { kind: 'name', name: 'OperatorOne' },
       { kind: 'bitcoin', utxoId: 11, isFlexible: true },
       { kind: 'bond', bondLotId: 22, isFlexible: true },
     ]);
@@ -1606,14 +1606,14 @@ describe('MyVault cosign recovery', () => {
   it('does not submit an empty member invite setup batch', async () => {
     const getMainchainClient = vi.spyOn(mainchainStore, 'getMainchainClient').mockResolvedValue({} as any);
     const { myVault, submitAndWatch } = createVault();
-    myVault.data.createdVault = { name: 'OperatorOne' } as Vault;
+    myVault.data.createdVault = { vaultId: 7 } as Vault;
     vi.spyOn(myVault as any, 'buildVaultDelegateSetupTxs').mockResolvedValue({
       needsSetup: false,
       txs: [],
     });
 
     const result = await myVault.prepareMemberInvite({
-      vaultName: 'OperatorOne',
+      operatorName: 'OperatorOne',
       bitcoinChanges: [],
       bondChanges: [],
     });
@@ -1670,6 +1670,7 @@ describe('MyVault cosign recovery', () => {
         load: vi.fn(async () => undefined),
         updateRevenue: vi.fn(async () => undefined),
         vaultsById: { 7: { vaultId: 7 } },
+        operatorNamesByVaultId: {},
         stats: {
           synchedToFrame: 1,
           vaultsById: { 7: { vaultId: 7 } },
@@ -2075,7 +2076,13 @@ function createVault(args?: {
       },
       ...args?.db,
     } as any),
-    { vaultsById: {}, updateVaultRevenue: vi.fn(async () => undefined) } as any,
+    {
+      vaultsById: {},
+      operatorNamesByVaultId: {},
+      subscribeToVault: vi.fn(async () => vi.fn()),
+      subscribeToOperatorName: vi.fn(async () => vi.fn()),
+      updateVaultRevenue: vi.fn(async () => undefined),
+    } as any,
     args?.walletKeys ?? createMockWalletKeys(),
     transactionTracker,
     bitcoinLocks,
@@ -2102,13 +2109,10 @@ function createTestVault(args: {
   vaultId: number;
   operatorAccountId: string;
   delegateAccountId: string | null;
-  name?: string;
 }): Vault {
   const rawVault = getOfflineRegistry().createType<ArgonPrimitivesVault>('ArgonPrimitivesVault', {
     operatorAccountId: args.operatorAccountId,
     delegateAccountId: args.delegateAccountId,
-    name: args.name ?? null,
-    lastNameChangeTick: null,
     securitization: 0n,
     securitizationTarget: 0n,
     securitizationLocked: 0n,

--- a/src-vue/__test__/OperationalAccount.test.ts
+++ b/src-vue/__test__/OperationalAccount.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi } from 'vitest';
-import { Keyring } from '@argonprotocol/mainchain';
+import { getOfflineRegistry, Keyring } from '@argonprotocol/mainchain';
 import {
   activateOperationalAccountSetup,
   canRequestOperationsUpgrade,
@@ -7,7 +7,6 @@ import {
   getOnboardingSetupStatus,
   isValidOperatorName,
   setOperationalProfileName,
-  usesOperationalProfileNameRuntime,
 } from '../lib/OperationalAccount.ts';
 import { ExtrinsicType } from '../interfaces/ITransactionRecord.ts';
 import { OnboardingSetupStatus } from '../interfaces/IConfig.ts';
@@ -23,6 +22,12 @@ vi.mock('@argonprotocol/apps-core', async importOriginal => ({
   ...(await importOriginal()),
   getVaultByOperator: appsCoreMocks.getVaultByOperator,
 }));
+
+function createOperationalAccount(name: string) {
+  return getOfflineRegistry().createType('Option<PalletOperationalAccountsOperationalAccount>', {
+    name: name || null,
+  });
+}
 
 it.each([
   {
@@ -56,8 +61,7 @@ it.each([
 
 it.each([
   {
-    runtime: 'previous runtime with a vault',
-    usesOperationalProfile: false,
+    operation: 'a vault',
     hasMiningSeats: false,
     hasVault: true,
     isServerInstalled: true,
@@ -65,40 +69,28 @@ it.each([
     expected: OnboardingSetupStatus.Finished,
   },
   {
-    runtime: 'previous runtime without a vault',
-    usesOperationalProfile: false,
+    operation: 'mining seats',
     hasMiningSeats: true,
+    hasVault: false,
+    isServerInstalled: true,
+    operatorName: 'OperatorOne',
+    expected: OnboardingSetupStatus.Finished,
+  },
+  {
+    operation: 'no active operation',
+    hasMiningSeats: false,
     hasVault: false,
     isServerInstalled: true,
     operatorName: 'OperatorOne',
     expected: OnboardingSetupStatus.Checklist,
   },
-  {
-    runtime: 'current runtime with mining seats',
-    usesOperationalProfile: true,
-    hasMiningSeats: true,
-    hasVault: false,
-    isServerInstalled: true,
-    operatorName: 'OperatorOne',
-    expected: OnboardingSetupStatus.Finished,
-  },
-  {
-    runtime: 'current runtime with a vault',
-    usesOperationalProfile: true,
-    hasMiningSeats: false,
-    hasVault: true,
-    isServerInstalled: true,
-    operatorName: 'OperatorOne',
-    expected: OnboardingSetupStatus.Finished,
-  },
-])('derives onboarding recovery for the $runtime', params => {
+])('derives onboarding recovery with $operation', params => {
   const status = getOnboardingSetupStatus({
     hasOnboardingHistory: true,
     hasMiningSeats: params.hasMiningSeats,
     hasVault: params.hasVault,
     isServerInstalled: params.isServerInstalled,
     operatorName: params.operatorName,
-    usesOperationalProfile: params.usesOperationalProfile,
   });
 
   expect(status).toBe(params.expected);
@@ -111,7 +103,6 @@ it('keeps onboarding at the blank slate without authoritative chain history', ()
     hasVault: false,
     isServerInstalled: false,
     operatorName: '',
-    usesOperationalProfile: false,
   });
 
   expect(status).toBe(OnboardingSetupStatus.None);
@@ -143,7 +134,6 @@ it('submits a current-runtime profile name with a funded linked signer', async (
     },
     tx: {
       operationalAccounts: { setName },
-      vaults: {},
     },
   };
   const transactionTracker = {
@@ -163,7 +153,6 @@ it('submits a current-runtime profile name with a funded linked signer', async (
     client: client as any,
   });
 
-  expect(usesOperationalProfileNameRuntime(client as any)).toBe(true);
   expect(setName).toHaveBeenCalledWith('OperatorOne');
   expect(transactionTracker.submitAndWatch).toHaveBeenCalledWith({
     tx,
@@ -191,7 +180,6 @@ it('resumes a pending profile name after restart without submitting it again', a
     },
     tx: {
       operationalAccounts: { setName },
-      vaults: {},
     },
   };
   const transactionTracker = {
@@ -220,18 +208,7 @@ it('resumes a pending profile name after restart without submitting it again', a
   expect(walletKeys.getVaultingKeypair).not.toHaveBeenCalled();
 });
 
-it('keeps names on vaults while both name extrinsics are available', () => {
-  const client = {
-    tx: {
-      operationalAccounts: { setName: vi.fn() },
-      vaults: { setName: vi.fn() },
-    },
-  };
-
-  expect(usesOperationalProfileNameRuntime(client as any)).toBe(false);
-});
-
-it('uses the finalized vault profile before repairing an underfunded delegate', async () => {
+it('uses the finalized operator profile before repairing an underfunded delegate', async () => {
   const profileTransaction = { tx: { id: 1 } };
   const delegateTransaction = { tx: { id: 2 } };
   const account = vi
@@ -239,28 +216,25 @@ it('uses the finalized vault profile before repairing an underfunded delegate', 
     .mockResolvedValueOnce({ data: { free: bigintCodec(999_978n) } })
     .mockResolvedValueOnce({ data: { free: bigintCodec(1_500_000n) } });
   const client = {
-    query: { system: { account } },
+    query: {
+      operationalAccounts: {
+        operationalAccounts: vi.fn().mockResolvedValue(createOperationalAccount('OperatorOne')),
+      },
+      system: { account },
+    },
     tx: {
       operationalAccounts: {},
-      vaults: { setName: vi.fn() },
     },
   };
   const createdVault = {
-    name: '',
+    vaultId: 7,
     delegateAccountId: 'delegate',
   };
-  const finalizedVault = {
-    ...createdVault,
-    name: 'OperatorOne',
-  };
-  const load = vi
-    .fn()
-    .mockResolvedValueOnce(undefined)
-    .mockImplementationOnce(async () => {
-      createdVault.name = 'OperatorOne';
-    });
+  const finalizedVault = { ...createdVault };
+  const load = vi.fn();
   const myVault = {
     createdVault,
+    vaults: { operatorNamesByVaultId: { 7: 'OperatorOne' } },
     load,
     setupVaultInviteProfile: vi.fn().mockResolvedValue(profileTransaction),
     ensureVaultDelegateReady: vi.fn().mockResolvedValue(delegateTransaction),
@@ -293,33 +267,37 @@ it('uses the finalized vault profile before repairing an underfunded delegate', 
   expect(transactions).toEqual([profileTransaction, delegateTransaction]);
 });
 
-it('restores a finalized operator name transaction when the authoritative vault query is unavailable', async () => {
+it('restores a finalized operator name transaction when the profile query initially lags', async () => {
   const profileTransaction = {
     tx: {
       id: 1,
-      metadataJson: { vaultName: 'OperatorOne' },
+      metadataJson: { operatorName: 'OperatorOne' },
     },
   };
+  let savedOperatorName = '';
   const client = {
     query: {
+      operationalAccounts: {
+        operationalAccounts: vi.fn(async () => createOperationalAccount(savedOperatorName)),
+      },
       system: {
         account: vi.fn().mockResolvedValue({ data: { free: bigintCodec(1_500_000n) } }),
       },
     },
     tx: {
       operationalAccounts: {},
-      vaults: { setName: vi.fn() },
     },
   };
   const createdVault = {
-    name: '',
+    vaultId: 7,
     delegateAccountId: 'delegate',
   };
   const myVault = {
     createdVault,
+    vaults: { operatorNamesByVaultId: {} },
     load: vi.fn(),
     setupVaultInviteProfile: vi.fn(async ({ operatorName }) => {
-      createdVault.name = operatorName;
+      savedOperatorName = operatorName;
       return profileTransaction;
     }),
     ensureVaultDelegateReady: vi.fn(),

--- a/src-vue/__test__/OperationalAccount.test.ts
+++ b/src-vue/__test__/OperationalAccount.test.ts
@@ -304,9 +304,13 @@ it('restores a finalized operator name transaction when the profile query initia
   };
   const transactionTracker = {
     load: vi.fn(),
-    findLatestTxAttempt: vi.fn().mockResolvedValue({
-      txInfo: profileTransaction,
-      txAttemptState: TxAttemptState.Finalized,
+    findLatestTxAttempt: vi.fn(async ({ extrinsicType }) => {
+      if (extrinsicType !== ExtrinsicType.VaultSetBitcoinLockDelegate) return;
+
+      return {
+        txInfo: profileTransaction,
+        txAttemptState: TxAttemptState.Finalized,
+      };
     }),
   };
   const walletKeys = {

--- a/src-vue/__test__/TreasuryAppInvite.integration.test.ts
+++ b/src-vue/__test__/TreasuryAppInvite.integration.test.ts
@@ -129,19 +129,11 @@ describe.skipIf(skipE2E).sequential('Treasury app invite flow integration', { ti
       const operatorClient = await operatorHarness.clients.get(false);
       expect(BitcoinLock.supportsInitializeFor(operatorClient)).toBe(false);
 
-      const supportsVaultName = 'setName' in operatorClient.tx.vaults;
       const expectedFromName = 'OperatorOne';
       const delegateKeypair = await operatorHarness.walletKeys.getVaultDelegateKeypair();
 
-      if (supportsVaultName) {
-        const delegateSetupTx = await operatorHarness.myVault.setupVaultInviteProfile({
-          operatorName: expectedFromName,
-        });
-        await delegateSetupTx?.txResult.waitForFinalizedBlock;
-      } else {
-        const delegateSetupTx = await operatorHarness.myVault.ensureVaultDelegateReady();
-        await delegateSetupTx?.txResult.waitForFinalizedBlock;
-      }
+      const delegateSetupTx = await operatorHarness.myVault.ensureVaultDelegateReady();
+      await delegateSetupTx?.txResult.waitForFinalizedBlock;
 
       await waitFor(45e3, 'bitcoin lock delegate ready', async () => {
         const client = await operatorHarness.clients.get(false);

--- a/src-vue/__test__/Vaults.test.ts
+++ b/src-vue/__test__/Vaults.test.ts
@@ -1,7 +1,8 @@
 import type { IAllVaultStats } from '@argonprotocol/apps-core';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Vaults } from '../lib/Vaults.ts';
 import { setMainchainClients } from '../stores/mainchain.ts';
+import { optionCodec } from '../../core/__test__/helpers/codecs.ts';
 
 class TestVaults extends Vaults {
   public async persist(stats: IAllVaultStats): Promise<void> {
@@ -42,5 +43,28 @@ describe('Vaults stats storage', () => {
 
     expect(savedStats).not.toBeNull();
     await expect(vaults.restore()).resolves.toEqual(stats);
+  });
+});
+
+describe('Vault operator names', () => {
+  it('loads requested names from operational profiles', async () => {
+    const client = {
+      query: {
+        operationalAccounts: {
+          operationalAccountBySubAccount: {
+            multi: vi.fn(async () => [optionCodec(`0x${'01'.repeat(32)}`)]),
+          },
+          operationalAccounts: {
+            multi: vi.fn(async () => [optionCodec({ name: optionCodec({ toUtf8: () => 'Atlas' }) })]),
+          },
+        },
+      },
+    };
+    setMainchainClients({ get: vi.fn(async () => client) } as any);
+    const vaults = new Vaults('dev-docker', {} as any, {} as any);
+
+    await vaults.refreshOperatorNames({ vaults: [{ vaultId: 1, operatorAccountId: `0x${'02'.repeat(32)}` }] });
+
+    expect(vaults.operatorNamesByVaultId[1]).toBe('Atlas');
   });
 });

--- a/src-vue/components/SelectAVault.vue
+++ b/src-vue/components/SelectAVault.vue
@@ -25,7 +25,9 @@
         </div>
         <div class="flex grow flex-col">
           <div class="flex flex-row items-center gap-x-2">
-            <span class="font-bold text-slate-800">{{ vault.name || 'Unnamed' }} Vault</span>
+            <span class="font-bold text-slate-800">
+              {{ vaultStore.operatorNamesByVaultId[vault.vaultId] || 'Unnamed' }} Vault
+            </span>
             <span class="font-light">({{ abbreviateAddress(vault.operatorAccountId, 10) }})</span>
           </div>
           <div class="mt-2 flex w-full flex-row gap-x-3 pb-px text-center">
@@ -74,6 +76,7 @@ import { useFinancials } from '../stores/financials.ts';
 import { getArgonBonds } from '../stores/argonBonds.ts';
 import { getMainchainClient } from '../stores/mainchain.ts';
 import { getWalletKeys } from '../stores/wallets.ts';
+import { getVaults } from '../stores/vaults.ts';
 
 const emit = defineEmits<{
   (e: 'load', vaults: Vault[]): void;
@@ -93,6 +96,7 @@ const currency = getCurrency();
 const financials = useFinancials();
 const argonBonds = getArgonBonds();
 const walletKeys = getWalletKeys();
+const vaultStore = getVaults();
 
 const { microgonToMoneyNm } = createNumeralHelpers(currency);
 

--- a/src-vue/lib/CrosschainTransferView.ts
+++ b/src-vue/lib/CrosschainTransferView.ts
@@ -30,8 +30,9 @@ export function isAccountInGlobalIssuanceCouncil(
 
 export function createKnownCrosschainSourceIdentities(args: {
   networkName: string;
-  createdVault?: Pick<Vault, 'name' | 'operatorAccountId'>;
-  vaultsById: Record<number, Pick<Vault, 'name' | 'operatorAccountId'>>;
+  createdVault?: Pick<Vault, 'vaultId' | 'operatorAccountId'>;
+  vaultsById: Record<number, Pick<Vault, 'operatorAccountId'>>;
+  operatorNamesByVaultId: Record<number, string | undefined>;
   localAccountIds: string[];
   upstreamOperator?: IConnectedVault;
   sourceUpstreamVaultAccountsByAccount?: ReadonlyMap<string, string>;
@@ -48,14 +49,15 @@ export function createKnownCrosschainSourceIdentities(args: {
     identities.set(accountId, { name: trimmedName, kind });
   };
 
-  for (const vault of Object.values(args.vaultsById)) {
-    addIdentity(vault.operatorAccountId, vault.name, 'vault');
+  for (const [vaultId, vault] of Object.entries(args.vaultsById)) {
+    addIdentity(vault.operatorAccountId, args.operatorNamesByVaultId[Number(vaultId)], 'vault');
   }
 
-  if (args.createdVault?.name?.trim()) {
-    addIdentity(args.createdVault.operatorAccountId, args.createdVault.name, 'vault');
+  const createdOperatorName = args.operatorNamesByVaultId[args.createdVault?.vaultId ?? -1];
+  if (args.createdVault && createdOperatorName) {
+    addIdentity(args.createdVault.operatorAccountId, createdOperatorName, 'vault');
     for (const accountId of args.localAccountIds) {
-      addIdentity(accountId, args.createdVault.name, 'vault');
+      addIdentity(accountId, createdOperatorName, 'vault');
     }
   } else {
     for (const accountId of args.localAccountIds) {

--- a/src-vue/lib/Importer.ts
+++ b/src-vue/lib/Importer.ts
@@ -23,7 +23,6 @@ import {
   getOnboardingSetupStatus,
   getOperationalChainProgressFromAccount,
   getOperationalProfileName,
-  usesOperationalProfileNameRuntime,
 } from './OperationalAccount.ts';
 import { findAddressActivity } from './IndexerClient.ts';
 
@@ -124,17 +123,13 @@ export default class Importer {
       operationalProgress.hasOperationalAccount || hasMiningActivity || hasVaultActivity || hasCrosschainHistory;
     hasTreasuryHistory ||= hasOperationsHistory;
 
-    const usesOperationalProfile = usesOperationalProfileNameRuntime(mainchainClient);
-    const operatorName = usesOperationalProfile
-      ? getOperationalProfileName(operationalAccount)
-      : (ownedVault?.name?.trim() ?? '');
+    const operatorName = getOperationalProfileName(operationalAccount);
     const onboardingSetupStatus = getOnboardingSetupStatus({
       hasOnboardingHistory: hasOperationsHistory,
       hasMiningSeats,
       hasVault: !!ownedVault,
       isServerInstalled: false,
       operatorName,
-      usesOperationalProfile,
     });
 
     const hasPreviousLife = hasExistingWalletValue || hasTreasuryHistory;

--- a/src-vue/lib/MyVault.ts
+++ b/src-vue/lib/MyVault.ts
@@ -418,15 +418,12 @@ export class MyVault {
         this.refreshFinalizedBitcoinCosignState(finalizedClient, vaultId),
       ]);
 
-      // update stats live
-      const sub = await client.query.vaults.vaultsById(vaultId, vault => {
-        if (!vault.isSome) return;
-
-        const raw = vault.unwrap();
-        const nextVault = new Vault(vaultId, raw, NetworkConfig.tickMillis);
-        this.vaults.vaultsById[vaultId] = nextVault;
-        this.data.createdVault = nextVault;
-      });
+      const [sub, operatorNameSub] = await Promise.all([
+        this.vaults.subscribeToVault(vaultId, nextVault => {
+          this.data.createdVault = nextVault;
+        }),
+        this.vaults.subscribeToOperatorName(vaultId, () => undefined),
+      ]);
 
       const sub2 = await client.query.vaults.lastCollectFrameByVaultId(vaultId, () => {
         this.updateCollectDeadlines();
@@ -504,7 +501,7 @@ export class MyVault {
 
       await Promise.all([this.globalCouncil.subscribe(), this.mintingAuthorities.subscribe()]);
 
-      this.#subscriptions.push(sub, sub2, sub3, sub4, sub5, sub6, sub7);
+      this.#subscriptions.push(sub, operatorNameSub, sub2, sub3, sub4, sub5, sub6, sub7);
     } finally {
       this.#isSubscribing = false;
     }
@@ -709,47 +706,15 @@ export class MyVault {
     }
   }
 
-  public async setVaultName(vaultName?: string | null): Promise<TransactionInfo | undefined> {
-    if (!this.createdVault) return;
-
-    const currentVaultName = this.createdVault.name;
-    const nextVaultName = vaultName?.trim();
-    if (!nextVaultName) {
-      throw new Error('A vault name is required to enable member invites.');
-    }
-    if (!isValidOperatorName(nextVaultName)) {
-      throw new Error(OPERATOR_NAME_REQUIREMENTS);
-    }
-    if (currentVaultName === nextVaultName) {
-      return;
-    }
-
-    return await this.#vaultQueue.add(async () => {
-      const client = await getMainchainClient(false);
-      const txSigner = await this.walletKeys.getVaultingKeypair();
-      const txInfo = await this.#transactionTracker.submitAndWatch({
-        tx: this.buildOperatorNameTx(client, nextVaultName),
-        txSigner,
-        extrinsicType: ExtrinsicType.VaultModifySettings,
-        metadata: {
-          vaultId: this.createdVault!.vaultId,
-          vaultName: nextVaultName,
-        },
-      });
-      void this.onModifySettings(txInfo);
-      return txInfo;
-    }).promise;
-  }
-
   public async setupVaultInviteProfile(args: {
     operatorName: string;
-    currentOperatorName?: string;
+    currentOperatorName: string;
   }): Promise<TransactionInfo | undefined> {
     if (!this.createdVault) return;
 
     const operatorName = args.operatorName.trim();
     if (!operatorName) {
-      throw new Error('A vault name is required to enable member invites.');
+      throw new Error('An operator name is required to enable member invites.');
     }
     if (!isValidOperatorName(operatorName)) {
       throw new Error(OPERATOR_NAME_REQUIREMENTS);
@@ -761,6 +726,8 @@ export class MyVault {
       const pendingAttempt = await this.#transactionTracker.findLatestTxAttempt<{
         vaultId?: number;
         delegateAddress?: string;
+        operatorName?: string;
+        // Persisted by app versions that stored names on vaults.
         vaultName?: string;
       }>({
         extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
@@ -769,7 +736,7 @@ export class MyVault {
           return (
             txInfo.tx.metadataJson.vaultId === vaultId &&
             txInfo.tx.metadataJson.delegateAddress === delegateAddress &&
-            txInfo.tx.metadataJson.vaultName === operatorName
+            (txInfo.tx.metadataJson.operatorName ?? txInfo.tx.metadataJson.vaultName) === operatorName
           );
         },
       });
@@ -790,9 +757,8 @@ export class MyVault {
         client,
         delegateAddress,
       });
-      const currentOperatorName = args.currentOperatorName ?? this.createdVault?.name;
-      if (currentOperatorName?.trim() !== operatorName) {
-        txs.push(this.buildOperatorNameTx(client, operatorName));
+      if (args.currentOperatorName.trim() !== operatorName) {
+        txs.push(client.tx.operationalAccounts.setName(operatorName));
       }
       if (!txs.length) return;
 
@@ -804,11 +770,12 @@ export class MyVault {
         const txInfo = await this.#transactionTracker.submitAndWatch({
           tx: client.tx.utility.batchAll(txs),
           txSigner,
+          useLatestNonce: true,
           extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
           metadata: {
             vaultId,
             delegateAddress,
-            vaultName: operatorName,
+            operatorName,
           },
         });
         deferred.resolve(txInfo);
@@ -852,10 +819,10 @@ export class MyVault {
   }
 
   public async prepareMemberInvite({
-    vaultName,
+    operatorName,
     bitcoinChanges,
     bondChanges,
-  }: IVaultFlexibleAssetChanges & { vaultName: string }): Promise<
+  }: IVaultFlexibleAssetChanges & { operatorName: string }): Promise<
     TransactionInfo<IVaultFlexibleAssetMetadata> | undefined
   > {
     const vault = this.createdVault;
@@ -863,11 +830,11 @@ export class MyVault {
       throw new Error('Create your vault before sending member invites.');
     }
 
-    const nextVaultName = vaultName.trim();
-    if (!nextVaultName) {
-      throw new Error('A vault name is required to enable member invites.');
+    const nextOperatorName = operatorName.trim();
+    if (!nextOperatorName) {
+      throw new Error('An operator name is required to enable member invites.');
     }
-    if (!isValidOperatorName(nextVaultName)) {
+    if (!isValidOperatorName(nextOperatorName)) {
       throw new Error(OPERATOR_NAME_REQUIREMENTS);
     }
 
@@ -876,10 +843,6 @@ export class MyVault {
       const signer = await this.walletKeys.getVaultingKeypair();
       const delegateAddress = await this.walletKeys.getVaultDelegateKeypair().then(x => x.address);
       const { txs } = await this.buildVaultDelegateSetupTxs({ client, delegateAddress });
-
-      if (vault.name !== nextVaultName) {
-        txs.push(this.buildOperatorNameTx(client, nextVaultName));
-      }
 
       txs.push(
         ...(await this.buildFlexibleAssetTxs({
@@ -1783,15 +1746,6 @@ export class MyVault {
       needsSetup: needsDelegateSetup || !!registerCouncilSignerTx,
       txs,
     };
-  }
-
-  private buildOperatorNameTx(client: ArgonClient, name: string): SubmittableExtrinsic {
-    const vaults = client.tx.vaults as ArgonClient['tx']['vaults'] | RuntimeSpec157.Transactions<'promise'>['vaults'];
-    if ('setName' in vaults) {
-      return vaults.setName(name);
-    }
-
-    return client.tx.operationalAccounts.setName(name);
   }
 
   private async buildFlexibleAssetTxs({

--- a/src-vue/lib/OperationalAccount.ts
+++ b/src-vue/lib/OperationalAccount.ts
@@ -211,15 +211,11 @@ export async function ensureOperationalAccountRegistered(
   });
 }
 
-export function usesOperationalProfileNameRuntime(client: ArgonClient): boolean {
-  return !('setName' in client.tx.vaults);
-}
-
 export function getOperationalProfileName(accountRaw: Option<PalletOperationalAccountsOperationalAccount>): string {
-  if (accountRaw.isNone) return '';
+  if (!accountRaw.isSome) return '';
 
   const name = accountRaw.unwrap().name;
-  return name?.isSome ? name.unwrap().toUtf8().trim() : '';
+  return name.isSome ? name.unwrap().toUtf8().trim() : '';
 }
 
 export function getOnboardingSetupStatus(args: {
@@ -228,11 +224,10 @@ export function getOnboardingSetupStatus(args: {
   hasVault: boolean;
   isServerInstalled: boolean;
   operatorName: string;
-  usesOperationalProfile: boolean;
 }): OnboardingSetupStatus {
   if (!args.hasOnboardingHistory) return OnboardingSetupStatus.None;
 
-  const hasRequiredOperation = args.usesOperationalProfile ? args.hasVault || args.hasMiningSeats : args.hasVault;
+  const hasRequiredOperation = args.hasVault || args.hasMiningSeats;
   if (args.isServerInstalled && isValidOperatorName(args.operatorName) && hasRequiredOperation) {
     return OnboardingSetupStatus.Finished;
   }
@@ -266,10 +261,6 @@ export async function setOperationalProfileName(args: {
   }
 
   const client = args.client ?? (await getMainchainClient(false));
-  if (!usesOperationalProfileNameRuntime(client)) {
-    throw new Error('The connected runtime does not support operational profile names.');
-  }
-
   await args.transactionTracker.load();
   const currentName = getOperationalProfileName(await loadOperationalAccount(args.walletKeys, client));
   if (currentName === name) return;
@@ -304,15 +295,14 @@ export async function activateOperationalAccountSetup(args: {
 }): Promise<IOperationalAccountSetup> {
   await Promise.all([args.myVault.load(), args.transactionTracker.load()]);
 
-  const usesOperationalProfile = usesOperationalProfileNameRuntime(args.client);
-  const hasVault = !!args.myVault.createdVault;
-  if (!usesOperationalProfile && !hasVault) {
-    throw new Error('Create a vault before activating member onboarding.');
-  }
+  const createdVault = args.myVault.createdVault;
+  const hasVault = !!createdVault;
+  const operationalAccount = await loadOperationalAccount(args.walletKeys, args.client);
+  const currentOperatorName = getOperationalProfileName(operationalAccount);
 
   let operatorName = args.operatorName.trim();
-  if (!operatorName && usesOperationalProfile) {
-    operatorName = getOperationalProfileName(await loadOperationalAccount(args.walletKeys, args.client));
+  if (!operatorName) {
+    operatorName = currentOperatorName;
     const setupAttempt = await args.transactionTracker.findLatestTxAttempt<{ operatorName?: string }>({
       extrinsicType: ExtrinsicType.OperationalSetProfileName,
       waitForConfirmations: 2,
@@ -322,26 +312,12 @@ export async function activateOperationalAccountSetup(args: {
     }
   }
 
-  if (!operatorName && !usesOperationalProfile) {
-    operatorName = args.myVault.createdVault?.name?.trim() ?? '';
-    const setupAttempt = await args.transactionTracker.findLatestTxAttempt<{ vaultName?: string }>({
-      extrinsicType: ExtrinsicType.VaultSetBitcoinLockDelegate,
-      waitForConfirmations: 2,
-    });
-    if (!operatorName && setupAttempt && setupAttempt.txAttemptState !== TxAttemptState.Replace) {
-      operatorName = setupAttempt.txInfo.tx.metadataJson.vaultName?.trim() ?? '';
-    }
-  }
-
   if (!isValidOperatorName(operatorName)) {
     throw new Error(OPERATOR_NAME_REQUIREMENTS);
   }
 
   let transaction: TransactionInfo | undefined;
-  if (hasVault) {
-    const currentOperatorName = usesOperationalProfile
-      ? getOperationalProfileName(await loadOperationalAccount(args.walletKeys, args.client))
-      : args.myVault.createdVault?.name;
+  if (createdVault) {
     transaction = await args.myVault.setupVaultInviteProfile({
       operatorName,
       currentOperatorName,
@@ -412,10 +388,7 @@ export async function loadOperationalAccountSetup(args: {
   walletKeys: WalletKeys;
   vault?: Vault;
 }): Promise<IOperationalAccountSetup> {
-  const usesOperationalProfile = usesOperationalProfileNameRuntime(args.client);
-  const operatorName = usesOperationalProfile
-    ? getOperationalProfileName(await loadOperationalAccount(args.walletKeys, args.client))
-    : (args.vault?.name?.trim() ?? '');
+  const operatorName = getOperationalProfileName(await loadOperationalAccount(args.walletKeys, args.client));
 
   let vaultDelegateIsReady = true;
   if (args.vault) {

--- a/src-vue/lib/OperationalAccount.ts
+++ b/src-vue/lib/OperationalAccount.ts
@@ -304,7 +304,9 @@ export async function activateOperationalAccountSetup(args: {
   if (!operatorName) {
     operatorName = currentOperatorName;
     const setupAttempt = await args.transactionTracker.findLatestTxAttempt<{ operatorName?: string }>({
-      extrinsicType: ExtrinsicType.OperationalSetProfileName,
+      extrinsicType: createdVault
+        ? ExtrinsicType.VaultSetBitcoinLockDelegate
+        : ExtrinsicType.OperationalSetProfileName,
       waitForConfirmations: 2,
     });
     if (!operatorName && setupAttempt && setupAttempt.txAttemptState !== TxAttemptState.Replace) {

--- a/src-vue/lib/Vaults.ts
+++ b/src-vue/lib/Vaults.ts
@@ -6,7 +6,7 @@ import {
   Vaults as VaultsBase,
 } from '@argonprotocol/apps-core';
 import { BaseDirectory, mkdir, readTextFile, rename, writeTextFile } from '@tauri-apps/plugin-fs';
-import { getMainchainClients } from '../stores/mainchain.ts';
+import { getMainchainClient, getMainchainClients } from '../stores/mainchain.ts';
 import { INSTANCE_NAME, NETWORK_NAME } from './Env.ts';
 
 export interface IVaultStatsStorage {
@@ -23,6 +23,29 @@ export class Vaults extends VaultsBase {
   ) {
     const clients = getMainchainClients();
     super(network, currency, miningFrames, clients);
+  }
+
+  public async subscribeToOperatorName(vaultId: number, onUpdate: (name?: string) => void): Promise<VoidFunction> {
+    try {
+      const vault = this.vaultsById[vaultId] ?? (await this.refreshVault(vaultId));
+      if (!vault) return () => undefined;
+
+      const client = await getMainchainClient(false);
+      const operationalAccountId = await client.query.operationalAccounts.operationalAccountBySubAccount(
+        vault.operatorAccountId,
+      );
+      if (!operationalAccountId.isSome) {
+        onUpdate(this.setOperatorName(vaultId));
+        return () => undefined;
+      }
+
+      return await client.query.operationalAccounts.operationalAccounts(operationalAccountId.unwrap(), profileOption =>
+        onUpdate(this.setOperatorName(vaultId, profileOption)),
+      );
+    } catch (error) {
+      console.warn(`[Vaults] Unable to subscribe to the operator profile for vault ${vaultId}`, error);
+      return () => undefined;
+    }
   }
 
   private statsDirectory() {

--- a/src-vue/lib/financials/MyVault.ts
+++ b/src-vue/lib/financials/MyVault.ts
@@ -72,6 +72,8 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
     if (!args.liveVault && !hasClosed) return [];
 
     const revenueHistory = args.revenueHistory ?? [];
+    const label =
+      (args.liveVault ? this.vault.vaults.operatorNamesByVaultId[vaultId] : undefined) ?? `Vault ${vaultId}`;
     const value = calculateVaultPositionValue({
       securitization,
       uncollectedRevenue,
@@ -106,7 +108,7 @@ export class VaultFinancials implements IFinancialPositionSource<VaultFinancialP
         'vault',
         {
           id: `vault:${vaultId}`,
-          label: args.liveVault?.name ?? `Vault ${vaultId}`,
+          label,
           lifecycle,
           startedAt: hasCompleteLifecycleTiming ? (created?.blockTime ?? args.liveVault?.openedDate) : undefined,
           endedAt,

--- a/src-vue/overlays/BondDetailOverlay.vue
+++ b/src-vue/overlays/BondDetailOverlay.vue
@@ -239,8 +239,7 @@ const bondProgramLabel = Vue.computed(() => {
     return 'Vault Bond';
   }
 
-  const vault = vaults.vaultsById[vaultId];
-  const name = vault?.name?.trim();
+  const name = vaults.operatorNamesByVaultId[vaultId];
   return name ? `${name} Vault` : `Vault #${vaultId}`;
 });
 

--- a/src-vue/overlays/BondPurchaseOverlay.vue
+++ b/src-vue/overlays/BondPurchaseOverlay.vue
@@ -81,7 +81,7 @@
       <AlertIcon class="h-18 text-yellow-700" />
       <h1 class="mt-8 text-xl font-bold text-yellow-800">{{ vaultLabel }} has no Argon Bond space</h1>
       <p class="mt-4 max-w-150 text-lg leading-relaxed font-light">
-        Contact {{ vaultName || 'the person who invited you' }} to create more Bond space.
+        Contact {{ vaultOperatorName || 'the person who invited you' }} to create more Bond space.
       </p>
     </div>
     <div v-else class="px-10 py-5">
@@ -172,7 +172,7 @@
               <template v-else>
                 {{ vaultLabel }} can only create {{ numeral(maxPurchaseAmount).format('0,0') }} Argon Bonds right now.
               </template>
-              Contact {{ vaultName || 'the person who invited you' }} to create more Bond space.
+              Contact {{ vaultOperatorName || 'the person who invited you' }} to create more Bond space.
             </span>
           </div>
           <WalletFundingCallout v-else-if="neededMicrogons" @open-wallet="openWallet">
@@ -327,10 +327,13 @@ const vaultAvailableCapacity = Vue.computed(() => {
   return argonBonds.availableBondSpace(vault.value);
 });
 
-const vaultName = Vue.computed(() => vault.value?.name?.trim() || config.upstreamOperator?.name?.trim());
+const vaultOperatorName = Vue.computed(() => {
+  const name = vaultId.value === undefined ? undefined : vaults.operatorNamesByVaultId[vaultId.value];
+  return name || config.upstreamOperator?.name?.trim();
+});
 
 const vaultLabel = Vue.computed(() => {
-  if (vaultName.value) return `${vaultName.value}’s Vault`;
+  if (vaultOperatorName.value) return `${vaultOperatorName.value}’s Vault`;
   return 'This vault';
 });
 

--- a/src-vue/overlays/MemberInviteOverlay.vue
+++ b/src-vue/overlays/MemberInviteOverlay.vue
@@ -207,11 +207,7 @@ import numeral, { createNumeralHelpers } from '../lib/numeral.ts';
 import { supportsFlexibleAssetsRuntime, type IVaultFlexibleAssetChanges } from '../lib/MyVault.ts';
 import type { TransactionInfo } from '../lib/TransactionInfo.ts';
 import { generateProgressLabel, isValidOperatorName } from '../lib/Utils.ts';
-import {
-  getOperationalProfileName,
-  loadOperationalAccount,
-  usesOperationalProfileNameRuntime,
-} from '../lib/OperationalAccount.ts';
+import { getOperationalProfileName, loadOperationalAccount } from '../lib/OperationalAccount.ts';
 import { useBasics } from '../stores/basics.ts';
 import { getBitcoinLocks } from '../stores/bitcoin.ts';
 import { getArgonBonds } from '../stores/argonBonds.ts';
@@ -416,9 +412,7 @@ async function loadInviteCapacity(preserveFeeWaiverAmount = false) {
     currentVault.activatedSecuritization() + currentVault.securitizationPendingActivation;
   supportsFlexibleAssets.value = supportsFlexibleAssetsRuntime(client);
   usesDelegatedInitialization.value = BitcoinLock.supportsInitializeFor(client);
-  operatorName.value = usesOperationalProfileNameRuntime(client)
-    ? getOperationalProfileName(await loadOperationalAccount(walletKeys, client))
-    : (currentVault.name?.trim() ?? '');
+  operatorName.value = getOperationalProfileName(await loadOperationalAccount(walletKeys, client));
 
   let projectedFlexibleSecuritizationLocked: bigint | undefined;
   if (flexibleAssetChanges.value) {
@@ -499,7 +493,7 @@ async function submitInvite() {
     let inviteSetupTransaction: TransactionInfo | undefined;
     if (flexibleAssetChanges.value) {
       inviteSetupTransaction = await myVault.prepareMemberInvite({
-        vaultName: fromName,
+        operatorName: fromName,
         ...flexibleAssetChanges.value,
       });
     } else {

--- a/src-vue/overlays/OperationalProfileOverlay.vue
+++ b/src-vue/overlays/OperationalProfileOverlay.vue
@@ -51,10 +51,6 @@
         Loading...
       </div>
 
-      <div v-else-if="requiresVault && !hasVault" class="text-center my-16 text-slate-700/50">
-        You need to create a vault before setting up your profile.
-      </div>
-
       <div v-else class="pt-2">
         <div v-if="errorMessage" class="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
           {{ errorMessage }}
@@ -127,7 +123,6 @@ import {
   isValidOperatorName,
   loadOperationalAccount,
   setOperationalProfileName,
-  usesOperationalProfileNameRuntime,
 } from '../lib/OperationalAccount.ts';
 import { useBasics } from '../stores/basics.ts';
 import { useCertificationController } from '../stores/certificationController.ts';
@@ -142,7 +137,7 @@ import {
   normalizeOperatorNameInput,
   OPERATOR_NAME_REQUIREMENTS,
 } from '../lib/Utils.ts';
-import { MyVault, supportsFlexibleAssetsRuntime } from '../lib/MyVault.ts';
+import { supportsFlexibleAssetsRuntime } from '../lib/MyVault.ts';
 
 const basics = useBasics();
 const controller = useCertificationController();
@@ -156,7 +151,6 @@ const isSaving = Vue.ref(false);
 const errorMessage = Vue.ref('');
 const operatorName = Vue.ref('');
 const operatorNameInputNotice = Vue.ref('');
-const requiresVault = Vue.ref(true);
 const setupTxInfo = Vue.ref<TransactionInfo | null>(null);
 const setupProgressPct = Vue.ref(0);
 const setupProgressMessage = Vue.ref('');
@@ -169,10 +163,6 @@ let unsubSetupProgress: (() => void) | undefined;
 let selectDraftName: ((operatorName: string) => void) | undefined;
 let openRequestId = 0;
 
-const hasVault = Vue.computed(() => {
-  return !!myVault.createdVault?.vaultId;
-});
-
 async function load(request?: IOperationalProfileRequest) {
   const profileRequest = request && 'draftName' in request ? request : undefined;
   errorMessage.value = '';
@@ -182,15 +172,8 @@ async function load(request?: IOperationalProfileRequest) {
 
   try {
     const client = await getMainchainClient(false);
-    requiresVault.value = !usesOperationalProfileNameRuntime(client);
-
-    if (requiresVault.value) {
-      await myVault.load();
-      operatorName.value = profileRequest?.draftName || myVault.createdVault?.name || '';
-    } else {
-      const savedName = getOperationalProfileName(await loadOperationalAccount(walletKeys, client));
-      operatorName.value = profileRequest?.draftName || savedName;
-    }
+    const savedName = getOperationalProfileName(await loadOperationalAccount(walletKeys, client));
+    operatorName.value = profileRequest?.draftName || savedName;
   } catch (error) {
     operatorName.value = profileRequest?.draftName ?? '';
     errorMessage.value = error instanceof Error ? error.message : 'Unable to load your profile right now.';
@@ -229,21 +212,12 @@ async function saveProfile() {
 
   try {
     const client = await getMainchainClient(false);
-    let txInfo: TransactionInfo | undefined;
-    if (usesOperationalProfileNameRuntime(client)) {
-      txInfo = await setOperationalProfileName({ transactionTracker, walletKeys, name: nextOperatorName, client });
-    } else {
-      await myVault.load();
-      const createdVault = myVault.createdVault;
-      if (!createdVault) {
-        throw new Error('You need to create a vault before saving your profile.');
-      }
-      const delegateAddress = await walletKeys.getVaultDelegateKeypair().then(keypair => keypair.address);
-      const delegateIsReady = await MyVault.isVaultDelegateReady(client, createdVault, delegateAddress);
-      txInfo = delegateIsReady
-        ? await myVault.setVaultName(nextOperatorName)
-        : await myVault.setupVaultInviteProfile({ operatorName: nextOperatorName });
-    }
+    const txInfo = await setOperationalProfileName({
+      transactionTracker,
+      walletKeys,
+      name: nextOperatorName,
+      client,
+    });
     await waitForSetupTransaction(txInfo);
     controller.operatorName = nextOperatorName;
 

--- a/src-vue/overlays/VaultsOverlay.vue
+++ b/src-vue/overlays/VaultsOverlay.vue
@@ -48,10 +48,12 @@ import { useBasics } from '../stores/basics.ts';
 import { getConfig } from '../stores/config.ts';
 import { Vault } from '@argonprotocol/mainchain';
 import { useFinancials } from '../stores/financials.ts';
+import { getVaults } from '../stores/vaults.ts';
 
 const basics = useBasics();
 const financials = useFinancials();
 const config = getConfig();
+const vaults = getVaults();
 
 const isOpen = Vue.ref(false);
 const tmpVault = Vue.ref<Vault>();
@@ -71,7 +73,7 @@ async function saveVault() {
   if (!vault) return;
 
   config.upstreamOperator = {
-    name: vault.name ?? '',
+    name: vaults.operatorNamesByVaultId[vault.vaultId] ?? '',
     vaultId: vault.vaultId,
     accountId: config.upstreamOperator?.accountId,
   };

--- a/src-vue/overlays/bitcoin-locking/LockStart.vue
+++ b/src-vue/overlays/bitcoin-locking/LockStart.vue
@@ -304,7 +304,7 @@ const { microgonToArgonNm, microgonToNm } = createNumeralHelpers(currency);
 const argonSymbol = currency.recordsByKey[UnitOfMeasurement.ARGN].symbol;
 const usdSymbol = currency.recordsByKey[UnitOfMeasurement.USD].symbol;
 const vaultLabel = Vue.computed(() => {
-  const name = props.vault.name?.trim();
+  const name = vaults.operatorNamesByVaultId[props.vault.vaultId];
   if (name) return `${name}’s Vault`;
   return 'This vault';
 });

--- a/src-vue/screens/onboarding-screen/SetupChecklist.vue
+++ b/src-vue/screens/onboarding-screen/SetupChecklist.vue
@@ -71,7 +71,7 @@
             <Checkbox :isChecked="hasRequiredOperation" />
             <div class="px-4 text-slate-600">
               <h2 class="text-argon-600 relative inline-block text-2xl font-bold">
-                Create a Vault<template v-if="!usesOperationalProfile">*</template> or Win Mining Seats
+                Create a Vault or Win Mining Seats
               </h2>
               <p v-if="hasRequiredOperation">Your operation is ready to begin onboarding members.</p>
               <p v-else>
@@ -84,7 +84,6 @@
                   winning mining seats
                 </button>.
               </p>
-              <p v-if="!usesOperationalProfile" class="text-xs">* currently required.</p>
             </div>
           </div>
         </section>
@@ -108,7 +107,6 @@
 
 <script setup lang="ts">
 import * as Vue from 'vue';
-import { getVaultByOperator } from '@argonprotocol/apps-core';
 import { ArrowLeftIcon } from '@heroicons/vue/24/outline';
 import Checkbox from '../../components/Checkbox.vue';
 import basicEmitter from '../../emitters/basicEmitter.ts';
@@ -117,7 +115,6 @@ import {
   getOperationalProfileName,
   isValidOperatorName,
   loadOperationalAccount,
-  usesOperationalProfileNameRuntime,
 } from '../../lib/OperationalAccount.ts';
 import { OperationalStepId, useCertificationController } from '../../stores/certificationController.ts';
 import { getConfig } from '../../stores/config.ts';
@@ -134,7 +131,6 @@ const controller = useCertificationController();
 const myVault = getMyVault();
 const walletKeys = getWalletKeys();
 
-const usesOperationalProfile = Vue.ref(false);
 const isLoaded = Vue.ref(false);
 const errorMessage = Vue.ref('');
 
@@ -143,7 +139,7 @@ const hasVaultOrMiningSeats = Vue.computed(() => {
 });
 
 const hasRequiredOperation = Vue.computed(() => {
-  return usesOperationalProfile.value ? hasVaultOrMiningSeats.value : !!myVault.createdVault;
+  return hasVaultOrMiningSeats.value;
 });
 
 const canContinue = Vue.computed(() => {
@@ -194,22 +190,12 @@ function goBack() {
 Vue.onMounted(async () => {
   try {
     const client = await getMainchainClient(false);
-    usesOperationalProfile.value = usesOperationalProfileNameRuntime(client);
 
     await myVault.load();
-    if (controller.onboardingOperatorNameDraft == null && usesOperationalProfile.value) {
+    if (controller.onboardingOperatorNameDraft == null) {
       controller.onboardingOperatorNameDraft = getOperationalProfileName(
         await loadOperationalAccount(walletKeys, client),
       );
-    } else if (controller.onboardingOperatorNameDraft == null) {
-      controller.onboardingOperatorNameDraft = myVault.createdVault?.name ?? '';
-      if (!controller.onboardingOperatorNameDraft) {
-        const ownedVault = await getVaultByOperator({
-          client,
-          operatorAddress: walletKeys.vaultingAddress,
-        });
-        controller.onboardingOperatorNameDraft = ownedVault?.name ?? '';
-      }
     }
   } catch (error) {
     errorMessage.value = error instanceof Error ? error.message : 'Unable to load your operation right now.';

--- a/src-vue/screens/treasury-screens/components/BondRecord.vue
+++ b/src-vue/screens/treasury-screens/components/BondRecord.vue
@@ -133,8 +133,7 @@ const vaultLabel = Vue.computed(() => {
     return 'Vault Bond';
   }
 
-  const vault = vaults.vaultsById[vaultId];
-  const name = vault?.name?.trim();
+  const name = vaults.operatorNamesByVaultId[vaultId];
   return name ? `${name} Vault` : `Vault #${vaultId}`;
 });
 </script>

--- a/src-vue/screens/treasury-screens/components/DebtRecord.vue
+++ b/src-vue/screens/treasury-screens/components/DebtRecord.vue
@@ -62,8 +62,7 @@ const emit = defineEmits<{
 const isActionHovered = Vue.ref(false);
 const lockRecord = Vue.computed(() => props.lockSummary.record);
 const vaultLabel = Vue.computed(() => {
-  const vault = vaults.vaultsById[props.lockSummary.record.vaultId];
-  const name = vault?.name?.trim();
+  const name = vaults.operatorNamesByVaultId[props.lockSummary.record.vaultId];
   return name ? `${name} Vault` : `Vault #${props.lockSummary.record.vaultId}`;
 });
 const mismatchAcceptProgress = Vue.computed(() => {

--- a/src-vue/stores/certificationController.ts
+++ b/src-vue/stores/certificationController.ts
@@ -23,7 +23,6 @@ import {
   type IOperationalChainProgress,
   type IOperationalRewardConfig,
   subscribeOperationalAccount,
-  usesOperationalProfileNameRuntime,
 } from '../lib/OperationalAccount.ts';
 import { getBitcoinLocks } from './bitcoin.ts';
 import { getServerApiClient } from './server.ts';
@@ -667,10 +666,7 @@ export const useCertificationController = defineStore('certificationController',
                 getVaultByOperator({ client: finalizedClient, operatorAddress: walletKeys.vaultingAddress }),
               ]);
               const onboardingProgress = getOperationalChainProgressFromAccount(accountRaw, rewardConfig.value);
-              const usesOperationalProfile = usesOperationalProfileNameRuntime(client);
-              const recoveredOperatorName = usesOperationalProfile
-                ? getOperationalProfileName(accountRaw)
-                : (ownedVault?.name?.trim() ?? '');
+              const recoveredOperatorName = getOperationalProfileName(accountRaw);
               operatorName.value = recoveredOperatorName;
               const setupStatus = getOnboardingSetupStatus({
                 hasOnboardingHistory:
@@ -682,7 +678,6 @@ export const useCertificationController = defineStore('certificationController',
                 hasVault: !!ownedVault,
                 isServerInstalled: config.isServerInstalled,
                 operatorName: recoveredOperatorName,
-                usesOperationalProfile,
               });
 
               let recoveredSetupStatus = setupStatus;

--- a/src-vue/stores/treasuryController.ts
+++ b/src-vue/stores/treasuryController.ts
@@ -1,6 +1,5 @@
 import * as Vue from 'vue';
 import { defineStore } from 'pinia';
-import type { Vault } from '@argonprotocol/mainchain';
 import basicEmitter from '../emitters/basicEmitter.ts';
 import { type Config, getConfig } from './config.ts';
 import { getWalletsForArgon, getWalletKeys } from './wallets.ts';
@@ -8,7 +7,6 @@ import { getDbPromise } from './helpers/dbPromise.ts';
 import { createDeferred } from '@argonprotocol/apps-core';
 import handleFatalError from './helpers/handleFatalError.ts';
 import Importer from '../lib/Importer.ts';
-import { getVaults } from './vaults.ts';
 
 export const useTreasuryController = defineStore('treasuryController', () => {
   const isLoaded = Vue.ref(false);
@@ -17,13 +15,10 @@ export const useTreasuryController = defineStore('treasuryController', () => {
   const dbPromise = getDbPromise();
   const config = getConfig();
   const walletKeys = getWalletKeys();
-  const vaults = getVaults();
 
   const isImporting = Vue.ref(false);
   const stopSuggestingBotTour = Vue.ref(false);
   const stopSuggestingVaultTour = Vue.ref(false);
-  let selectedVaultSubscriptionKey = 0;
-  let unsubSelectedVault: (() => void) | undefined;
 
   async function load() {
     await config.isLoadedPromise;
@@ -31,21 +26,6 @@ export const useTreasuryController = defineStore('treasuryController', () => {
     await walletsForArgon.load();
     isLoaded.value = true;
     isLoadedResolve();
-  }
-
-  function syncUpstreamOperatorName(vault: Vault) {
-    const upstreamOperator = config.upstreamOperator;
-    if (!upstreamOperator || upstreamOperator.vaultId !== vault.vaultId) return;
-    if (upstreamOperator.name) return;
-
-    const nextName = vault.name;
-    if (!nextName) return;
-
-    config.upstreamOperator = {
-      ...upstreamOperator,
-      name: nextName,
-    };
-    void config.save();
   }
 
   async function importFromMnemonic(mnemonic: string) {
@@ -57,45 +37,6 @@ export const useTreasuryController = defineStore('treasuryController', () => {
       isImporting.value = false;
     }
   }
-
-  Vue.watch(
-    () => (config.isLoaded ? (config.upstreamOperator?.vaultId ?? 0) : 0),
-    vaultId => {
-      selectedVaultSubscriptionKey += 1;
-      const subscriptionKey = selectedVaultSubscriptionKey;
-
-      unsubSelectedVault?.();
-      unsubSelectedVault = undefined;
-
-      if (!vaultId) return;
-
-      void (async () => {
-        await vaults.load().catch(() => null);
-        if (subscriptionKey !== selectedVaultSubscriptionKey) return;
-
-        const vault = vaults.vaultsById[vaultId];
-        if (vault) {
-          syncUpstreamOperatorName(vault);
-        }
-
-        const unsub = await vaults.subscribeToVault(vaultId, syncUpstreamOperatorName).catch(() => undefined);
-        if (!unsub) return;
-        if (subscriptionKey !== selectedVaultSubscriptionKey) {
-          unsub();
-          return;
-        }
-
-        unsubSelectedVault = unsub;
-      })();
-    },
-    { immediate: true },
-  );
-
-  Vue.onScopeDispose(() => {
-    selectedVaultSubscriptionKey += 1;
-    unsubSelectedVault?.();
-    unsubSelectedVault = undefined;
-  });
 
   load().catch(handleFatalError.bind('useTreasuryController'));
 

--- a/src-vue/stores/vaults.ts
+++ b/src-vue/stores/vaults.ts
@@ -40,15 +40,14 @@ export function getVaults(): Vaults {
 
         void vaults
           .subscribeToOperatorName(vaultId, name => {
-            if (!isCurrent) return;
+            if (!isCurrent || !name) return;
 
             const upstreamOperator = config.upstreamOperator;
             if (!upstreamOperator || upstreamOperator.vaultId !== vaultId) return;
 
-            const currentName = name ?? '';
-            if (upstreamOperator.name === currentName) return;
+            if (upstreamOperator.name === name) return;
 
-            config.upstreamOperator = { ...upstreamOperator, name: currentName };
+            config.upstreamOperator = { ...upstreamOperator, name };
             void config.save();
           })
           .then(nextUnsubscribe => {

--- a/src-vue/stores/vaults.ts
+++ b/src-vue/stores/vaults.ts
@@ -24,6 +24,41 @@ let crosschainHistory: CrosschainHistory;
 export function getVaults(): Vaults {
   if (!vaults) {
     vaults = new Vaults(NETWORK_NAME, getCurrency(), getMiningFrames());
+    vaults.operatorNamesByVaultId = reactive(vaults.operatorNamesByVaultId);
+
+    const config = getConfig();
+    watch(
+      () => (config.isLoaded ? config.upstreamOperator?.vaultId : undefined),
+      (vaultId, _, onCleanup) => {
+        let isCurrent = true;
+        let unsubscribe: VoidFunction | undefined;
+        onCleanup(() => {
+          isCurrent = false;
+          unsubscribe?.();
+        });
+        if (!vaultId) return;
+
+        void vaults
+          .subscribeToOperatorName(vaultId, name => {
+            if (!isCurrent) return;
+
+            const upstreamOperator = config.upstreamOperator;
+            if (!upstreamOperator || upstreamOperator.vaultId !== vaultId) return;
+
+            const currentName = name ?? '';
+            if (upstreamOperator.name === currentName) return;
+
+            config.upstreamOperator = { ...upstreamOperator, name: currentName };
+            void config.save();
+          })
+          .then(nextUnsubscribe => {
+            unsubscribe = nextUnsubscribe;
+            if (!isCurrent) unsubscribe();
+          })
+          .catch(error => console.warn(`[Vaults] Unable to subscribe to upstream vault ${vaultId}`, error));
+      },
+      { immediate: true },
+    );
   }
 
   return vaults;
@@ -118,6 +153,7 @@ export function getKnownCrosschainSourceIdentities() {
     networkName: NETWORK_NAME,
     createdVault: vault.createdVault ?? undefined,
     vaultsById: vault.vaults.vaultsById,
+    operatorNamesByVaultId: vault.vaults.operatorNamesByVaultId,
     localAccountIds: [walletKeys.defaultArgonAddress, walletKeys.vaultingAddress, walletKeys.operationalAddress],
     upstreamOperator: config.upstreamOperator,
     sourceUpstreamVaultAccountsByAccount: vault.mintingAuthorities.data.sourceUpstreamVaultAccountsByAccount,


### PR DESCRIPTION
## Summary

Vault labels and onboarding now use the operational-account profile as the single source of truth. Names load with vault data, stay current for the local and selected upstream operator, and flow through crosschain history, bonds, Bitcoin locks, and financial labels.

The obsolete vault-name runtime path is removed. Mining-only operators can set a profile without creating a vault, while pending setup transactions from older app versions can still resume from their stored metadata.

The combined vault delegate and profile transaction now reserves the latest nonce so onboarding does not collide with an in-flight bootstrap transaction.

## Validation

- Affected vault, onboarding, import, and crosschain tests pass.
- Storybook interactions pass, including the recovered crosschain name state, and the production Storybook build completes.
